### PR TITLE
fix: broken images in snippets

### DIFF
--- a/auth4genai/snippets/get-started/prerequisites/account-linking.jsx
+++ b/auth4genai/snippets/get-started/prerequisites/account-linking.jsx
@@ -59,7 +59,7 @@ export const Prerequisites = ({
           to save the changes.
           <Frame>
             <img
-              src="/img/app_enabled_user_creation.png"
+              src="/ai/docs/img/app_enabled_user_creation.png"
               alt="Enable Auth0 Management API"
             />
           </Frame>
@@ -766,7 +766,7 @@ function sha256(str) {
           </ul>
           <Frame>
             <img
-              src="/img/account_linking_action_secrets.png"
+              src="/ai/docs/img/account_linking_action_secrets.png"
               alt="Enable Auth0 Management API"
             />
           </Frame>
@@ -795,7 +795,7 @@ function sha256(str) {
           </ul>
           <Frame>
             <img
-              src="/img/account_linking_action_deps.png"
+              src="/ai/docs/img/account_linking_action_deps.png"
               alt="Enable Auth0 Management API"
             />
           </Frame>
@@ -812,7 +812,7 @@ function sha256(str) {
           <br />
           <Frame>
             <img
-              src="/img/account_linking_post_login.png"
+              src="/ai/docs/img/account_linking_post_login.png"
               alt="Attach Account Linking Action to Post Login Trigger"
             />
           </Frame>

--- a/auth4genai/snippets/get-started/prerequisites/async-auth.jsx
+++ b/auth4genai/snippets/get-started/prerequisites/async-auth.jsx
@@ -80,7 +80,7 @@ export const Prerequisites = ({
           lists the factors the user is enrolled in:
           <Frame>
             <img
-              src="/img/user_enrolled_in_auth0_guardian.png"
+              src="/ai/docs/img/user_enrolled_in_auth0_guardian.png"
               alt="User Enrolled in Auth0 Guardian"
             />
           </Frame>
@@ -88,7 +88,7 @@ export const Prerequisites = ({
           email:
           <Frame>
             <img
-              src="/img/enroll_user_in_auth0_guardian.png"
+              src="/ai/docs/img/enroll_user_in_auth0_guardian.png"
               alt="Enable Guardian Push Screenshot"
             />
           </Frame>


### PR DESCRIPTION
These images appear to work on local, but are broken on the hosted deployment. Looks looks like the custom components being rendered by the MDX engine aren't picking up the custom asset prefix set by Mintlify.

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.
>
> Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc.
>
> If the UI is being changed, please provide screenshots.


### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - Auth0 Community post
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
