### PR TITLE
feat: calling-others-apis, adds LangGraph.js + React SPA quickstart

### DIFF
--- a/auth4genai/get-started/call-others-apis-on-users-behalf.mdx
+++ b/auth4genai/get-started/call-others-apis-on-users-behalf.mdx
@@ -8,7 +8,7 @@ import VercelCallOthersApi from "/snippets/get-started/vercel-ai-next-js/call-ot
 import ReactSpaVercelCallOthersApi from "/snippets/get-started/vercel-ai-react-spa-js/call-others-api.mdx";
 import LangChainNextjsCallOthersApi from "/snippets/get-started/langchain-next-js/call-others-api.mdx";
 import FastApiCallOthersApi from "/snippets/get-started/langchain-fastapi-py/call-others-api.mdx";
-import ReactSpaLangGraphCallOthersApi from "/snippets/get-started/langgraph-js-react-spa-js/call-others-api.mdx";
+import LangChainReactSpaJsCallOthersApi from "/snippets/get-started/langchain-react-spa-js/call-others-api.mdx";
 
 Use Auth0 SDKs to fetch access tokens for social and enterprise identity providers from Auth0's [Token Vault](https://auth0.com/docs/secure/tokens/token-vault). Using these access tokens, AI agents integrated with the application can call third-party APIs to perform tasks on the user's behalf.
 
@@ -45,7 +45,7 @@ By the end of this quickstart, you should have an AI application integrated with
     <ReactSpaVercelCallOthersApi />
   </Tab>
   <Tab title="Langgraph.js + React SPA" icon="https://mintlify-assets.b-cdn.net/auth0/langchain.svg">
-    <ReactSpaLangGraphCallOthersApi />
+    <LangChainReactSpaJsCallOthersApi />
   </Tab>
 </Tabs>
 

--- a/auth4genai/get-started/call-others-apis-on-users-behalf.mdx
+++ b/auth4genai/get-started/call-others-apis-on-users-behalf.mdx
@@ -8,6 +8,7 @@ import VercelCallOthersApi from "/snippets/get-started/vercel-ai-next-js/call-ot
 import ReactSpaVercelCallOthersApi from "/snippets/get-started/vercel-ai-react-spa-js/call-others-api.mdx";
 import LangChainNextjsCallOthersApi from "/snippets/get-started/langchain-next-js/call-others-api.mdx";
 import FastApiCallOthersApi from "/snippets/get-started/langchain-fastapi-py/call-others-api.mdx";
+import ReactSpaLangGraphCallOthersApi from "/snippets/get-started/langgraph-js-react-spa-js/call-others-api.mdx";
 
 Use Auth0 SDKs to fetch access tokens for social and enterprise identity providers from Auth0's [Token Vault](https://auth0.com/docs/secure/tokens/token-vault). Using these access tokens, AI agents integrated with the application can call third-party APIs to perform tasks on the user's behalf.
 
@@ -42,6 +43,9 @@ By the end of this quickstart, you should have an AI application integrated with
     icon="https://mintlify-assets.b-cdn.net/auth0/vercel.svg"
   >
     <ReactSpaVercelCallOthersApi />
+  </Tab>
+  <Tab title="Langgraph.js + React SPA" icon="https://mintlify-assets.b-cdn.net/auth0/langchain.svg">
+    <ReactSpaLangGraphCallOthersApi />
   </Tab>
 </Tabs>
 

--- a/auth4genai/snippets/get-started/langchain-next-js/async-auth.mdx
+++ b/auth4genai/snippets/get-started/langchain-next-js/async-auth.mdx
@@ -204,7 +204,7 @@ Update the `.env.local` file with the following variables:
 
 ```bash .env.local wrap lines
 # ... existing variables
-# You can use any provider of your choice supported by Vercel AI
+# You can use any provider of your choice supported by the LangGraph SDK
 OPENAI_API_KEY="YOUR_API_KEY"
 
 # API

--- a/auth4genai/snippets/get-started/langchain-next-js/call-others-api.mdx
+++ b/auth4genai/snippets/get-started/langchain-next-js/call-others-api.mdx
@@ -7,7 +7,7 @@ import { AccountAndAppSteps } from "/snippets/get-started/prerequisites/account-
   <Tab
     title="Use sample app (recommended)"
   >
-  
+
 ### Clone sample app
 Clone this sample app from the [Auth0 AI samples](https://github.com/auth0-samples/auth0-ai-samples) repository:
 
@@ -27,8 +27,8 @@ AUTH0_DOMAIN='<your-auth0-domain>'
 AUTH0_CLIENT_ID='<your-auth0-application-client-id>'
 AUTH0_CLIENT_SECRET='<your-auth0-application-client-secret>'
 
-# OpenAI API Key or any provider supported by the Vercel AI SDK
-OPENAI_API_KEY="YOUR_API_KEY"  
+# OpenAI API Key or any provider supported by the LangGraph SDK
+OPENAI_API_KEY="YOUR_API_KEY"
 
 # LANGGRAPH
 LANGGRAPH_API_URL=http://localhost:54367
@@ -42,7 +42,7 @@ Next, run this command to generate a random 32 byte value and copy it to the `AU
 openssl rand -hex 32
 ```
 
-Lastly, set your OpenAI API key or use any provider supported by the Vercel AI SDK:
+Lastly, set your OpenAI API key or use any provider supported by the LangGraph SDK:
 ```bash .env.local wrap lines
 OPENAI_API_KEY="YOUR_API_KEY"
 ```
@@ -99,7 +99,7 @@ AUTH0_DOMAIN='<your-auth0-domain>'
 AUTH0_CLIENT_ID='<your-auth0-application-client-id>'
 AUTH0_CLIENT_SECRET='<your-auth0-application-client-secret>'
 
-# OpenAI API Key or any provider supported by the Vercel AI SDK
+# OpenAI API Key or any provider supported by the LangGraph SDK
 OPENAI_API_KEY="YOUR_API_KEY"
 
 # LANGGRAPH
@@ -115,7 +115,10 @@ Next, run this command to generate a random 32 byte value and copy it to the `AU
 openssl rand -hex 32
 ```
 
-Lastly, set your OpenAI API key or use any provider supported by the Vercel AI SDK:
+Lastly, set your OpenAI API key or use any provider supported by the LangGraph SDK:
+```bash .env.local wrap lines
+OPENAI_API_KEY="YOUR_API_KEY"
+```
 
 ### Set up Token Vault for Google social connection
 
@@ -196,7 +199,7 @@ Once the user is authenticated, you can fetch an access token from Token Vault u
 Once you've obtained the access token for a connection, you can use it with an AI agent to fetch data during a tool call and provide contextual data in its response.
 This example uses `GmailSearch` from the `@langchain/community` tools. This tool will use the access token provided by Token Vault to query for emails.
 
-Update your tool call to request an access token, as shown in the following example: 
+Update your tool call to request an access token, as shown in the following example:
 
 ```ts src/lib/agent.ts wrap lines highlight={2-3,8-12,16,23}
 //...

--- a/auth4genai/snippets/get-started/langchain-next-js/call-your-api.mdx
+++ b/auth4genai/snippets/get-started/langchain-next-js/call-your-api.mdx
@@ -138,7 +138,7 @@ You need an API Key from OpenAI or another provider to use an LLM. Add that API 
 
 ```bash .env.local wrap lines
 # ...
-# You can use any provider of your choice supported by Vercel AI
+# You can use any provider of your choice supported by the LangGraph SDK
 OPENAI_API_KEY="YOUR_API_KEY"
 ```
 

--- a/auth4genai/snippets/get-started/langchain-react-spa-js/call-others-api.mdx
+++ b/auth4genai/snippets/get-started/langchain-react-spa-js/call-others-api.mdx
@@ -22,9 +22,9 @@ import { AccountAndAppSteps } from "/snippets/get-started/prerequisites/account-
 
 This integration provides a robust, secure foundation for authenticating users and enabling AI agents to act on their behalf using third-party APIs. Here are some key features of this example:
 
-1. **Modern Toolset**: Uses a modern stack with React, Vite, LangGraph.js, and Auth0 AI SDK to create an interactive chat interface that integrates with Google Calendar and the [LangGraph.js ReAct Memory Agent](https://github.com/langchain-ai/memory-agent-js).
+1. **Modern Toolset**: Uses a modern stack with React, Vite, LangGraph.js, and the Auth0 AI SDK to create an interactive chat interface that integrates with Google Calendar and the [LangGraph.js ReAct Memory Agent](https://github.com/langchain-ai/memory-agent-js).
 2. **Client-Side Authorization**: Client login and step-up authorization are handled client-side using `@auth0/auth0-spa-js`. No backend proxy required, and client streaming calls are made directly to the LangGraph API.
-3. **Token Vault**: Token Vault performs token exchanges & securely manages tokens, allowing seamless third-party API access to AI Agents with user approved access and finely scoped authorization for each API.
+3. **Token Vault**: Token Vault performs token exchanges and securely manages tokens, allowing seamless, user-approved third-party API access to AI agents and finely scoped authorization for each API.
 4. **Interrupt Handling**: The React client manages tool access errors and step-up authorization using interrupts that trigger a pop-up for re-authorization.
 5. **LangGraph Custom Auth**: The auth integration with LangGraph.js leverages LangGraph's [custom auth support](https://docs.langchain.com/langgraph-platform/custom-auth), ensuring secure and authenticated API calls both with the LangGraph Platform and self-hosted deployments.
 
@@ -89,13 +89,13 @@ VITE_LANGGRAPH_API_URL=http://localhost:2024
 
 1. Start the Vite frontend and LangGraph API server using Turbo: `npm run dev`.
 2. Navigate to `http://localhost:5173`.
-3. Hit the "Sign In with Auth0" button and login into your application with Google credentials on the Universal Login screen.
-4. Enter the Agent Chat form options for the `Deployment URL` (e.g., `http://localhost:2024` or your LangGraph Platform Deployment's Resource URL), and the `Graph ID` of the agent to use (e.g., `memory_agent`), and hit the "Continue" button.
+3. Hit the **Sign In with Auth0** button and log in to your application with Google credentials on the Universal Login screen.
+4. Enter the Agent Chat form options for the `Deployment URL` (e.g., `http://localhost:2024` or your LangGraph Platform Deployment's Resource URL), and the `Graph ID` of the agent to use (e.g., `memory_agent`), and hit the **Continue** button.
 5. Ask your AI agent about your calendar with a prompt, such as "Can you check my calendar for availability tomorrow at 3pm?".
 
 The application will automatically prompt for additional calendar permissions when needed using Auth0's step-up authorization flow.
 
-That's it! You've successfully setup and run the React SPA + LangGraph API sample app.
+That's it! You've successfully set up and run the React SPA + LangGraph API sample app.
 
   </Tab>
   <Tab title="Integrate into your app">
@@ -160,7 +160,7 @@ VITE_LANGGRAPH_API_URL=http://localhost:2024
 
 #### Auth0 Client Configuration
 
-Create `src/lib/auth0.ts` for Auth0 SPA JS client setup:
+Create the `src/lib/auth0.ts` file to set up the Auth0 SPA JS client:
 
 ```tsx src/lib/auth0.ts wrap lines
 import { Auth0Client, createAuth0Client, User } from "@auth0/auth0-spa-js";
@@ -240,7 +240,7 @@ export const getUser = async (): Promise<User | undefined> => {
 
 #### React Context Provider Setup
 
-Create `src/providers/Auth0.tsx` to configure the React context provider for Auth0:
+Create the `src/providers/Auth0.tsx` file to configure the React context provider for Auth0:
 ```tsx src/providers/Auth0.tsx wrap lines
 import React, { ReactNode, useEffect, useRef, useState } from "react";
 import { Auth0Context, Auth0ContextType } from "@/contexts/auth0-context";
@@ -456,13 +456,13 @@ export default function ChatInterface() {
 }
 ```
 
-#### Step Up Authorization with Auth0 Interrupts
+#### Step-up Authorization with Auth0 Interrupts
 
 The Auth0 AI and Auth0 SPA JS SDKs include sophisticated interrupt handling for step-up authorization scenarios, particularly when accessing third-party APIs through Auth0's Token Vault. This enables agents to request additional permissions dynamically during conversations.
 
 ##### Implementing Interrupts
 
-When an agent tool requires access to a third-party service (like Google Calendar) that the user hasn't previously authorized, LangGraph can raise a `FederatedConnectionInterrupt`. The frontend handles these interrupts by displaying an authorization popup.
+When an agent tool requires access to a third-party service (like Google Calendar) that the user hasn't previously authorized, LangGraph can raise a `FederatedConnectionInterrupt`. The frontend handles these interrupts by displaying an authorization pop-up.
 
 1. Interrupt Detection in Chat Interface
 
@@ -513,7 +513,7 @@ export function Auth0InterruptHandler({
 
 3. Federated Connection Popup
 
-The FederatedConnectionPopup component handles the OAuth flow for third-party connections.
+The `FederatedConnectionPopup` component handles the OAuth flow for third-party connections.
 
 Create `src/components/FederatedConnectionPopup.tsx` to display the authorization prompt:
 
@@ -757,7 +757,7 @@ Great job! You've now set up the backend LangGraph API server with Auth0 AI SDK 
 ### Test your application
 Start your application. If you are already logged in, make sure to log out and log back in using Google. Then, ask your AI agent to list the upcoming events in your Google Calendar!
 
-That's it! You successfully integrated integrated third-party API access using Token Vault into your React SPA + LangGraph.js project.
+That's it! You successfully integrated third-party API access using Token Vault into your React SPA + LangGraph.js project.
 
 ### View a complete example
 Want to see how it all comes together? Explore or clone the fully implemented sample application on [GitHub](https://github.com/auth0-samples/auth0-ai-samples/tree/main/calling-apis-on-users-behalf/others-api/langchain-react-spa-js).

--- a/auth4genai/snippets/get-started/langchain-react-spa-js/call-others-api.mdx
+++ b/auth4genai/snippets/get-started/langchain-react-spa-js/call-others-api.mdx
@@ -32,11 +32,11 @@ This integration provides a robust, secure foundation for authenticating users a
   <Tab title="Use sample app(recommended)">
 
 ### Clone sample app
-Clone this sample app from the [Auth0 AI JS](https://github.com/auth0-lab/auth0-ai-js.git) repository:
+Clone this sample app from the [Auth0 AI samples](https://github.com/auth0-samples/auth0-ai-samples.git) repository:
 
 ```bash wrap lines
-git clone https://github.com/auth0-lab/auth0-ai-js.git
-cd auth0-ai-js/examples/calling-apis/spa-with-backend-api/react-langgraph-api
+git clone https://github.com/auth0-samples/auth0-ai-samples.git
+cd auth0-ai-samples/calling-apis-on-users-behalf/others-api/langchain-react-spa-js
 ```
 
 The project is divided into two parts:
@@ -760,6 +760,6 @@ Start your application. If you are already logged in, make sure to log out and l
 That's it! You successfully integrated integrated third-party API access using Token Vault into your React SPA + LangGraph.js project.
 
 ### View a complete example
-Want to see how it all comes together? Explore or clone the fully implemented sample application on [GitHub](https://github.com/auth0-lab/auth0-ai-js/tree/main/examples/calling-apis/spa-with-backend-api/react-langgraph-api).
+Want to see how it all comes together? Explore or clone the fully implemented sample application on [GitHub](https://github.com/auth0-samples/auth0-ai-samples/tree/main/calling-apis-on-users-behalf/others-api/langchain-react-spa-js).
   </Tab>
 </Tabs>

--- a/auth4genai/snippets/get-started/langchain-react-spa-js/call-others-api.mdx
+++ b/auth4genai/snippets/get-started/langchain-react-spa-js/call-others-api.mdx
@@ -59,11 +59,6 @@ Add separate `.env` files with environment variables for the backend LangGraph A
 
 Copy `apps/agents/.env.example` to `apps/agents/.env` and update the values:
 ```bash .env wrap lines
-# LangSmith (optional)
-# LANGSMITH_API_KEY=""
-# LANGSMITH_TRACING_V2="true"
-# LANGSMITH_PROJECT="default"
-
 # LLM Provider (choose one)
 ANTHROPIC_API_KEY=your-anthropic-key
 OPENAI_API_KEY=your-openai-key
@@ -130,11 +125,6 @@ Add separate `.env` files with environment variables for the client and the Lang
 
 In the backend directory of your project, add the following variables to your environment file:
 ```bash .env wrap lines
-# LangSmith (optional)
-# LANGSMITH_API_KEY=""
-# LANGSMITH_TRACING_V2="true"
-# LANGSMITH_PROJECT="default"
-
 # LLM Provider (choose one)
 ANTHROPIC_API_KEY=your-anthropic-key
 OPENAI_API_KEY=your-openai-key

--- a/auth4genai/snippets/get-started/langchain-react-spa-js/call-others-api.mdx
+++ b/auth4genai/snippets/get-started/langchain-react-spa-js/call-others-api.mdx
@@ -59,8 +59,7 @@ Add separate `.env` files with environment variables for the backend LangGraph A
 
 Copy `apps/agents/.env.example` to `apps/agents/.env` and update the values:
 ```bash .env wrap lines
-# LLM Provider (choose one)
-ANTHROPIC_API_KEY=your-anthropic-key
+# OpenAI API Key or any provider supported by the LangGraph SDK
 OPENAI_API_KEY=your-openai-key
 
 # Auth0 Configuration
@@ -68,6 +67,15 @@ AUTH0_DOMAIN=your-auth0-domain.auth0.com
 AUTH0_AUDIENCE=your-api-identifier
 AUTH0_CUSTOM_API_CLIENT_ID=your-custom-api-client-id
 AUTH0_CUSTOM_API_CLIENT_SECRET=your-custom-api-client-secret
+```
+To get your Auth0 Custom API Client's `AUTH0_DOMAIN`, `AUTH0_CUSTOM_API_CLIENT_ID`, and `AUTH0_CUSTOM_API_CLIENT_SECRET`, navigate to the **Applications** section in the Auth0 Dashboard and select your Custom API Client application from the list. Then, navigate to the **Settings** tab. You'll find these values in the **Basic Information** section at the top.
+Copy each value to the matching setting.
+
+To get the `AUTH0_AUDIENCE`, next hit the **Configure API** button in the top right to navigate to your Custom API Client's **API**. The Identifier will be listed in the **Settings** tab and should be provided as the `AUTH0_AUDIENCE`.
+
+Lastly, set your OpenAI API key or use any provider supported by the LangGraph SDK:
+```bash .env.local wrap lines
+OPENAI_API_KEY="YOUR_API_KEY"
 ```
 
 #### Frontend (apps/web/.env)
@@ -77,6 +85,15 @@ Copy `apps/web/.env.example` to `apps/web/.env` and update the values:
 VITE_AUTH0_DOMAIN=your-auth0-domain.auth0.com
 VITE_AUTH0_CLIENT_ID=your-spa-client-id
 VITE_AUTH0_AUDIENCE=your-api-identifier
+VITE_LANGGRAPH_API_URL=http://localhost:2024
+```
+To get your Auth0 SPA's `VITE_AUTH0_DOMAIN`, and `VITE_AUTH0_CLIENT_ID`, navigate to the **Applications** section in the Auth0 Dashboard and select your Single Page application from the list. Then, navigate to the **Settings** tab. You'll find these values in the **Basic Information** section at the top.
+Copy each value to the matching setting.
+
+The `VITE_AUTH0_AUDIENCE` should match the `AUTH0_AUDIENCE`, and the Identifier of the Custom API client's API you created above.
+
+Lastly, `VITE_LANGGRAPH_API_URL` set your LangGraph API URL, depending on where you are running the LangGraph API server. If you are running it locally, use `http://localhost:2024`. If you are using a LangGraph Platform deployment, use your deployment's Resource URL (e.g. `https://your.domain.us.langgraph.app`).
+```bash .env.local wrap lines
 VITE_LANGGRAPH_API_URL=http://localhost:2024
 ```
 
@@ -125,8 +142,7 @@ Add separate `.env` files with environment variables for the client and the Lang
 
 In the backend directory of your project, add the following variables to your environment file:
 ```bash .env wrap lines
-# LLM Provider (choose one)
-ANTHROPIC_API_KEY=your-anthropic-key
+# OpenAI API Key or any provider supported by the LangGraph SDK
 OPENAI_API_KEY=your-openai-key
 
 # Auth0 Configuration
@@ -135,6 +151,17 @@ AUTH0_AUDIENCE=your-api-identifier
 AUTH0_CUSTOM_API_CLIENT_ID=your-custom-api-client-id
 AUTH0_CUSTOM_API_CLIENT_SECRET=your-custom-api-client-secret
 ```
+To get your Auth0 Custom API Client's `AUTH0_DOMAIN`, `AUTH0_CUSTOM_API_CLIENT_ID`, and `AUTH0_CUSTOM_API_CLIENT_SECRET`, navigate to the **Applications** section in the Auth0 Dashboard and select your Custom API Client application from the list. Then, navigate to the **Settings** tab. You'll find these values in the **Basic Information** section at the top.
+Copy each value to the matching setting.
+
+To get the `AUTH0_AUDIENCE`, next hit the **Configure API** button in the top right to navigate to your Custom API Client's **API**. The Identifier will be listed in the **Settings** tab and should be provided as the `AUTH0_AUDIENCE`.
+
+Lastly, set your OpenAI API key or use any provider supported by the LangGraph SDK:
+```bash .env.local wrap lines
+OPENAI_API_KEY="YOUR_API_KEY"
+```
+
+#### Frontend (apps/web/.env)
 
 In the frontend directory of your project, add the following variables to your environment file:
 
@@ -143,6 +170,15 @@ Copy `apps/web/.env.example` to `apps/web/.env` and update the values:
 VITE_AUTH0_DOMAIN=your-auth0-domain.auth0.com
 VITE_AUTH0_CLIENT_ID=your-spa-client-id
 VITE_AUTH0_AUDIENCE=your-api-identifier
+VITE_LANGGRAPH_API_URL=http://localhost:2024
+```
+To get your Auth0 SPA's `VITE_AUTH0_DOMAIN`, and `VITE_AUTH0_CLIENT_ID`, navigate to the **Applications** section in the Auth0 Dashboard and select your Single Page application from the list. Then, navigate to the **Settings** tab. You'll find these values in the **Basic Information** section at the top.
+Copy each value to the matching setting.
+
+The `VITE_AUTH0_AUDIENCE` should match the `AUTH0_AUDIENCE`, and the Identifier of the Custom API client's API you created above.
+
+Lastly, `VITE_LANGGRAPH_API_URL` set your LangGraph API URL, depending on where you are running the LangGraph API server. If you are running it locally, use `http://localhost:2024`. If you are using a LangGraph Platform deployment, use your deployment's Resource URL (e.g. `https://your.domain.us.langgraph.app`).
+```bash .env.local wrap lines
 VITE_LANGGRAPH_API_URL=http://localhost:2024
 ```
 

--- a/auth4genai/snippets/get-started/langgraph-js-react-spa-js/call-others-api.mdx
+++ b/auth4genai/snippets/get-started/langgraph-js-react-spa-js/call-others-api.mdx
@@ -376,33 +376,44 @@ createRoot(document.getElementById("root")!).render(
 
 #### Client-Side Chat Component Integration
 
-Use the Auth0 context in your components:
+Use the Auth0 context with the LangGraph's streaming capabilities in your Chat components:
 
 ```tsx src/components/Chat.tsx wrap lines
 import { useAuth0 } from "@/hooks/useAuth0";
+import { useStream } from "@langchain/langgraph-sdk/react";
 
 export default function ChatInterface() {
   const { user, isLoading, isAuthenticated, login, logout, getToken } = useAuth0();
+  const [accessToken, setAccessToken] = useState<string | null>(null);
+  const apiUrl = import.meta.env.VITE_LANGGRAPH_API_URL || "http://localhost:2024";
 
-  // Handle direct API calls to LangGraph with JWT token
-  const sendMessage = async (content: string) => {
-    if (!isAuthenticated) return;
+  // Get access token when authenticated
+  useEffect(() => {
+    if (isAuthenticated) {
+      getToken().then(setAccessToken).catch(console.error);
+    }
+  }, [isAuthenticated, getToken]);
 
-    const token = await getToken();
-    const response = await fetch(`${VITE_LANGGRAPH_API_URL}/threads/${threadId}/runs/stream`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${token}`
-      },
-      body: JSON.stringify({
-        input: content,
-        context: { userId: user?.sub },
-      }),
+  // Initialize LangGraph stream with Auth0 token
+  const stream = useStream({
+    apiUrl,
+    assistantId: "memory_agent",
+    defaultHeaders: accessToken
+      ? { Authorization: `Bearer ${accessToken}` }
+      : undefined,
+  });
+
+  const sendMessage = (content: string) => {
+    if (!isAuthenticated || !content.trim()) return;
+
+    stream.submit({
+      messages: [{
+        type: "human",
+        content,
+        // User context available in agent workflows
+        metadata: { userId: user?.sub }
+      }]
     });
-
-    const data = await response.json();
-    // ... handle response
   };
 
   if (isLoading) return <div>Loading...</div>;
@@ -422,7 +433,24 @@ export default function ChatInterface() {
         <span>Welcome, {user?.name}</span>
         <button onClick={() => logout()}>Logout</button>
       </header>
-      {/* ... rest of chat UI */}
+
+      <div className="messages">
+        {stream.messages?.map((msg, i) => (
+          <div key={i}>{msg.content}</div>
+        ))}
+      </div>
+
+      <form onSubmit={(e) => {
+        e.preventDefault();
+        const input = new FormData(e.target).get('message');
+        sendMessage(input as string);
+        e.target.reset();
+      }}>
+        <input name="message" placeholder="Type a message..." />
+        <button type="submit" disabled={stream.isLoading}>
+          Send
+        </button>
+      </form>
     </div>
   );
 }

--- a/auth4genai/snippets/get-started/langgraph-js-react-spa-js/call-others-api.mdx
+++ b/auth4genai/snippets/get-started/langgraph-js-react-spa-js/call-others-api.mdx
@@ -1,0 +1,737 @@
+import { Prerequisites } from "/snippets/get-started/prerequisites/call-others-api.jsx";
+import { AccountAndAppSteps } from "/snippets/get-started/prerequisites/account-app-steps.jsx";
+
+<Prerequisites
+  createAuth0ApplicationStep={{
+    applicationType: "Single Page Web Applications",
+    callbackUrl: "http://localhost:5173",
+    logoutUrl: "http://localhost:5173",
+    allowedWebOrigins: "http://localhost:5173",
+  }}
+  refreshTokenGrantStep={{
+    applicationName: "Single Page Web Application",
+  }}
+  createAuth0ApiStep={{}}
+  createResourceServerClientStep={{}}
+  tokenExchangeGrantStep={{
+    applicationName: "Single Page Web Application",
+  }}
+/>
+
+### Key features of this React SPA + LangGraph.js example
+
+This integration provides a robust, secure foundation for authenticating users and enabling AI agents to act on their behalf using third-party APIs. Here are some key features of this example:
+
+1. **Modern Toolset**: Uses a modern stack with React, Vite, LangGraph.js, and Auth0 AI SDK to create an interactive chat interface that integrates with Google Calendar and the [LangGraph.js ReAct Memory Agent](https://github.com/langchain-ai/memory-agent-js).
+2. **Client-Side Authorization**: Client login and step-up authorization are handled client-side using `@auth0/auth0-spa-js`. No backend proxy required, and client streaming calls are made directly to the LangGraph API.
+3. **Token Vault**: Token Vault performs token exchanges & securely manages tokens, allowing seamless third-party API access to AI Agents with user approved access and finely scoped authorization for each API.
+4. **Interrupt Handling**: The React client manages tool access errors and step-up authorization using interrupts that trigger a pop-up for re-authorization.
+5. **LangGraph Custom Auth**: The auth integration with LangGraph.js leverages LangGraph's [custom auth support](https://docs.langchain.com/langgraph-platform/custom-auth), ensuring secure and authenticated API calls both with the LangGraph Platform and self-hosted deployments.
+
+<Tabs>
+  <Tab title="Use sample app(recommended)">
+
+### Clone sample app
+Clone this sample app from the [Auth0 AI JS](https://github.com/auth0-lab/auth0-ai-js.git) repository:
+
+```bash wrap lines
+git clone https://github.com/auth0-lab/auth0-ai-js.git
+cd auth0-ai-js/examples/calling-apis/spa-with-backend-api/react-langgraph-api
+```
+
+The project is divided into two parts:
+- `apps/agents`: contains the backend LangGraph API server using LangGraph CLI, LangGraph SDKs, and Auth0 AI SDKs.
+- `apps/web`: contains the frontend code for the web app, written in React as a Vite SPA.
+
+### Install dependencies
+
+To install all the frontend and backend dependencies, navigate to the root directory of the project and run the following command:
+```bash wrap lines
+# Install all frontend & backend dependencies from the root directory of the project.
+npm install
+```
+
+### Create the environment files
+
+Add separate `.env` files with environment variables for the backend LangGraph API server and the frontend.
+
+#### Backend LangGraph API Server (apps/agents/.env)
+
+Copy `apps/agents/.env.example` to `apps/agents/.env` and update the values:
+```bash .env wrap lines
+# LangSmith (optional)
+# LANGSMITH_API_KEY=""
+# LANGSMITH_TRACING_V2="true"
+# LANGSMITH_PROJECT="default"
+
+# LLM Provider (choose one)
+ANTHROPIC_API_KEY=your-anthropic-key
+OPENAI_API_KEY=your-openai-key
+
+# Auth0 Configuration
+AUTH0_DOMAIN=your-auth0-domain.auth0.com
+AUTH0_AUDIENCE=your-api-identifier
+AUTH0_CUSTOM_API_CLIENT_ID=your-custom-api-client-id
+AUTH0_CUSTOM_API_CLIENT_SECRET=your-custom-api-client-secret
+```
+
+#### Frontend (apps/web/.env)
+
+Copy `apps/web/.env.example` to `apps/web/.env` and update the values:
+```bash .env wrap lines
+VITE_AUTH0_DOMAIN=your-auth0-domain.auth0.com
+VITE_AUTH0_CLIENT_ID=your-spa-client-id
+VITE_AUTH0_AUDIENCE=your-api-identifier
+VITE_LANGGRAPH_API_URL=http://localhost:2024
+```
+
+### Run your application
+
+1. Start the Vite frontend and LangGraph API server using Turbo: `npm run dev`.
+2. Navigate to `http://localhost:5173`.
+3. Hit the "Sign In with Auth0" button and login into your application with Google credentials on the Universal Login screen.
+4. Enter the Agent Chat form options for the `Deployment URL` (e.g., `http://localhost:2024` or your LangGraph Platform Deployment's Resource URL), and the `Graph ID` of the agent to use (e.g., `memory_agent`), and hit the "Continue" button.
+5. Ask your AI agent about your calendar with a prompt, such as "Can you check my calendar for availability tomorrow at 3pm?".
+
+The application will automatically prompt for additional calendar permissions when needed using Auth0's step-up authorization flow.
+
+That's it! You've successfully setup and run the React SPA + LangGraph API sample app.
+
+  </Tab>
+  <Tab title="Integrate into your app">
+
+### Install packages
+
+Ensure you have installed the following client and server dependencies in your project:
+
+**Frontend client dependencies:**
+
+- `@auth0/auth0-spa-js`: Auth0 SPA SDK for client-side authentication
+- `@auth0/ai`: [Auth0 AI SDK](https://github.com/auth0-lab/auth0-ai-js/tree/main/packages/ai) built for GenAI applications
+- `@langchain/core`: contains the core LangChain abstractions and schemas for LangChain.js
+- `@langchain/langgraph`, `@langchain/langgraph-api`, `@langchain/langgraph-sdk`: Core [LangGraph.js SDK](https://github.com/langchain-ai/langgraphjs/tree/main) for interacting with LangGraph APIs
+
+**Backend LangGraph API Server dependencies:**
+
+- `@langchain/core`: contains the core LangChain abstractions and schemas for LangChain.js
+- `@langchain/langgraph`, `@langchain/langgraph-sdk`: Core [LangGraph.js SDK](https://github.com/langchain-ai/langgraphjs/tree/main) libraries for constructing a State Graph and defining LangGraph tools.
+- `@langchain/openai`: used when interfacing with the OpenAI series of models from LangGraph agents (alternatively, you can use `@langchain/anthropic` for accessing Anthropic models).
+- `@langchain/langgraph-cli`: the [LangGraph CLI](https://docs.langchain.com/langgraph-platform/cli) is used for self-hosted LangGraph API server deployments or commonly as a local LangGraph API server during development
+- `@auth0/ai`, `@auth0/ai-langchain`: [Auth0 AI SDK](https://github.com/auth0-lab/auth0-ai-js/tree/main/packages/ai)'s built for interfacing with Token Vault and your LangGraph API tools.
+- `googleapis`: Node.js client for Google APIs
+- `jose`: JavaScript Object Signing and Encryption library for JWT verification
+
+
+### Update the environment files
+
+Add separate `.env` files with environment variables for the client and the LangGraph API server.
+
+#### Backend LangGraph API Server (server/.env)
+
+In the backend directory of your project, add the following variables to your environment file:
+```bash .env wrap lines
+# LangSmith (optional)
+# LANGSMITH_API_KEY=""
+# LANGSMITH_TRACING_V2="true"
+# LANGSMITH_PROJECT="default"
+
+# LLM Provider (choose one)
+ANTHROPIC_API_KEY=your-anthropic-key
+OPENAI_API_KEY=your-openai-key
+
+# Auth0 Configuration
+AUTH0_DOMAIN=your-auth0-domain.auth0.com
+AUTH0_AUDIENCE=your-api-identifier
+AUTH0_CUSTOM_API_CLIENT_ID=your-custom-api-client-id
+AUTH0_CUSTOM_API_CLIENT_SECRET=your-custom-api-client-secret
+```
+
+In the frontend directory of your project, add the following variables to your environment file:
+
+Copy `apps/web/.env.example` to `apps/web/.env` and update the values:
+```bash .env wrap lines
+VITE_AUTH0_DOMAIN=your-auth0-domain.auth0.com
+VITE_AUTH0_CLIENT_ID=your-spa-client-id
+VITE_AUTH0_AUDIENCE=your-api-identifier
+VITE_LANGGRAPH_API_URL=http://localhost:2024
+```
+
+### Frontend React SPA with Vite Auth0 Implementation
+
+#### Auth0 Client Configuration
+
+Create `src/lib/auth0.ts` for Auth0 SPA JS client setup:
+
+```tsx src/lib/auth0.ts wrap lines
+import { Auth0Client, createAuth0Client, User } from "@auth0/auth0-spa-js";
+
+// Auth0 configuration
+const AUTH0_DOMAIN = import.meta.env.VITE_AUTH0_DOMAIN;
+const AUTH0_CLIENT_ID = import.meta.env.VITE_AUTH0_CLIENT_ID;
+const AUTH0_AUDIENCE = import.meta.env.VITE_AUTH0_AUDIENCE;
+
+if (!AUTH0_DOMAIN || !AUTH0_CLIENT_ID) {
+  throw new Error(
+    "Missing Auth0 configuration. Please check your environment variables.",
+  );
+}
+
+let auth0Client: Auth0Client | null = null;
+
+export const initAuth0 = async (): Promise<Auth0Client> => {
+  if (auth0Client) {
+    return auth0Client;
+  }
+
+  auth0Client = await createAuth0Client({
+    domain: AUTH0_DOMAIN,
+    clientId: AUTH0_CLIENT_ID,
+    authorizationParams: {
+      redirect_uri: window.location.origin,
+      audience: AUTH0_AUDIENCE,
+      scope: "openid profile email", // Basic scopes
+    },
+  });
+
+  return auth0Client;
+};
+
+export const getAuth0Client = (): Auth0Client => {
+  if (!auth0Client) {
+    throw new Error("Auth0 client not initialized. Call initAuth0() first.");
+  }
+  return auth0Client;
+};
+
+export const login = async (targetUrl?: string) => {
+  const client = getAuth0Client();
+  await client.loginWithRedirect({
+    authorizationParams: {
+      redirect_uri: window.location.origin,
+    },
+    appState: targetUrl ? { targetUrl } : undefined,
+  });
+};
+
+export const logout = async () => {
+  const client = getAuth0Client();
+  await client.logout({
+    logoutParams: {
+      returnTo: window.location.origin,
+    },
+  });
+};
+
+export const getToken = async (): Promise<string> => {
+  const client = getAuth0Client();
+  return await client.getTokenSilently();
+};
+
+export const isAuthenticated = async (): Promise<boolean> => {
+  const client = getAuth0Client();
+  return await client.isAuthenticated();
+};
+
+export const getUser = async (): Promise<User | undefined> => {
+  const client = getAuth0Client();
+  return await client.getUser();
+};
+```
+
+#### React Context Provider Setup
+
+Create `src/providers/Auth0.tsx` to configure the React context provider for Auth0:
+```tsx src/providers/Auth0.tsx wrap lines
+import React, { ReactNode, useEffect, useRef, useState } from "react";
+import { Auth0Context, Auth0ContextType } from "@/contexts/auth0-context";
+import {
+  getToken,
+  getUser,
+  initAuth0,
+  isAuthenticated,
+  login,
+  logout,
+} from "@/lib/auth0";
+import { User } from "@auth0/auth0-spa-js";
+
+interface Auth0ProviderProps {
+  children: ReactNode;
+}
+
+export const Auth0Provider: React.FC<Auth0ProviderProps> = ({ children }) => {
+  const [isLoading, setIsLoading] = useState(true);
+  const [isAuthenticatedState, setIsAuthenticatedState] = useState(false);
+  const [user, setUser] = useState<User | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const initRef = useRef(false);
+
+  useEffect(() => {
+    // Prevent double execution in React Strict Mode
+    if (initRef.current) return;
+    initRef.current = true;
+
+    const initializeAuth0 = async () => {
+      try {
+        setIsLoading(true);
+        await initAuth0();
+
+        // Handle redirect callback
+        if (
+          window.location.search.includes("code=") &&
+          window.location.search.includes("state=")
+        ) {
+          const client = await initAuth0();
+          await client.handleRedirectCallback();
+          window.history.replaceState(
+            {},
+            document.title,
+            window.location.pathname,
+          );
+        }
+
+        const authenticated = await isAuthenticated();
+        setIsAuthenticatedState(authenticated);
+
+        if (authenticated) {
+          const userData = await getUser();
+          setUser(userData as User);
+        }
+      } catch (err) {
+        console.error("Auth0 initialization error:", err);
+        setError(err instanceof Error ? err.message : "Authentication error");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    initializeAuth0();
+  }, []);
+
+  const contextValue: Auth0ContextType = {
+    isLoading,
+    isAuthenticated: isAuthenticatedState,
+    user,
+    error,
+    login: async (targetUrl?: string) => {
+      try {
+        setError(null);
+        await login(targetUrl);
+      } catch (err) {
+        console.error("Login error:", err);
+        setError(err instanceof Error ? err.message : "Login failed");
+      }
+    },
+    logout: async () => {
+      try {
+        setError(null);
+        await logout();
+        setIsAuthenticatedState(false);
+        setUser(null);
+      } catch (err) {
+        console.error("Logout error:", err);
+        setError(err instanceof Error ? err.message : "Logout failed");
+      }
+    },
+    getToken,
+  };
+
+  return (
+    <Auth0Context.Provider value={contextValue}>
+      {children}
+    </Auth0Context.Provider>
+  );
+};
+```
+
+#### Wrap the React Application with the Auth0 Provider
+
+In `src/main.tsx`, wrap your application with the `Auth0Provider`:
+
+```tsx src/main.tsx wrap lines
+import "./index.css";
+import { NuqsAdapter } from "nuqs/adapters/react-router/v6";
+import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import { Toaster } from "@/components/ui/sonner";
+import App from "./App.tsx";
+import { Auth0Provider } from "./providers/Auth0.tsx";
+import { StreamProvider } from "./providers/Stream.tsx";
+import { ThreadProvider } from "./providers/Thread.tsx";
+
+createRoot(document.getElementById("root")!).render(
+  <BrowserRouter>
+    <NuqsAdapter>
+      <Auth0Provider>
+        <ThreadProvider>
+          <StreamProvider>
+            <App />
+          </StreamProvider>
+        </ThreadProvider>
+      </Auth0Provider>
+      <Toaster />
+    </NuqsAdapter>
+  </BrowserRouter>,
+);
+```
+
+#### Client-Side Chat Component Integration
+
+Use the Auth0 context in your components:
+
+```tsx src/components/Chat.tsx wrap lines
+import { useAuth0 } from "@/hooks/useAuth0";
+
+export default function ChatInterface() {
+  const { user, isLoading, isAuthenticated, login, logout, getToken } = useAuth0();
+
+  // Handle direct API calls to LangGraph with JWT token
+  const sendMessage = async (content: string) => {
+    if (!isAuthenticated) return;
+
+    const token = await getToken();
+    const response = await fetch(`${VITE_LANGGRAPH_API_URL}/threads/${threadId}/runs/stream`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      },
+      body: JSON.stringify({
+        input: content,
+        context: { userId: user?.sub },
+      }),
+    });
+
+    const data = await response.json();
+    // ... handle response
+  };
+
+  if (isLoading) return <div>Loading...</div>;
+
+  if (!isAuthenticated) {
+    return (
+      <div>
+        <h1>Welcome to LangGraph Chat</h1>
+        <button onClick={() => login()}>Login with Auth0</button>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <header>
+        <span>Welcome, {user?.name}</span>
+        <button onClick={() => logout()}>Logout</button>
+      </header>
+      {/* ... rest of chat UI */}
+    </div>
+  );
+}
+```
+
+#### Step Up Authorization with Auth0 Interrupts
+
+The Auth0 AI and Auth0 SPA JS SDKs include sophisticated interrupt handling for step-up authorization scenarios, particularly when accessing third-party APIs through Auth0's Token Vault. This enables agents to request additional permissions dynamically during conversations.
+
+##### Implementing Interrupts
+
+When an agent tool requires access to a third-party service (like Google Calendar) that the user hasn't previously authorized, LangGraph can raise a `FederatedConnectionInterrupt`. The frontend handles these interrupts by displaying an authorization popup.
+
+1. Interrupt Detection in Chat Interface
+
+In your chat message rendering logic, check for Auth0 interrupts:
+```tsx src/components/Chat.tsx wrap lines
+// In your chat message component
+{threadInterrupt &&
+  Auth0Interrupt.isInterrupt(threadInterrupt.value) &&
+  isLastMessage ? (
+    <Auth0InterruptHandler
+      interrupt={threadInterrupt.value}
+      onResume={() => thread.submit(null)}
+    />
+  ) : null}
+```
+
+2. Auth0 Interrupt Handler Component
+
+Create `src/components/Auth0InterruptHandler.tsx` to manage the interrupt UI:
+
+```tsx src/components/Auth0InterruptHandler.tsx wrap lines
+import { Auth0Interrupt } from "@auth0/ai/interrupts";
+import { FederatedConnectionInterrupt } from "@auth0/ai/interrupts";
+import { FederatedConnectionPopup } from "./FederatedConnectionPopup";
+
+interface Auth0InterruptHandlerProps {
+  interrupt: Auth0Interrupt;
+  onResume: () => void;
+}
+
+export function Auth0InterruptHandler({
+  interrupt,
+  onResume,
+}: Auth0InterruptHandlerProps) {
+  // Handle FederatedConnectionInterrupt
+  if (FederatedConnectionInterrupt.isInterrupt(interrupt)) {
+    return (
+      <FederatedConnectionPopup
+        interrupt={interrupt as FederatedConnectionInterrupt}
+        onResume={onResume}
+      />
+    );
+  }
+
+  return null;
+}
+```
+
+3. Federated Connection Popup
+
+The FederatedConnectionPopup component handles the OAuth flow for third-party connections.
+
+Create `src/components/FederatedConnectionPopup.tsx` to display the authorization prompt:
+
+```tsx src/components/FederatedConnectionPopup.tsx wrap lines
+// apps/web/src/components/auth0/FederatedConnectionPopup.tsx
+import { useState } from "react";
+import { FederatedConnectionInterrupt } from "@auth0/ai/interrupts";
+import { useAuth0 } from "@/hooks/useAuth0";
+
+interface FederatedConnectionPopupProps {
+  interrupt: FederatedConnectionInterrupt;
+  onResume: () => void;
+}
+
+export function FederatedConnectionPopup({
+  interrupt,
+  onResume,
+}: FederatedConnectionPopupProps) {
+  const [isConnecting, setIsConnecting] = useState(false);
+  const { getToken } = useAuth0();
+
+  const handleConnect = async () => {
+    try {
+      setIsConnecting(true);
+
+      // Get the current access token
+      const accessToken = await getToken();
+
+      // Construct Auth0 authorization URL with additional scopes
+      const authUrl = new URL(`https://${process.env.VITE_AUTH0_DOMAIN}/authorize`);
+      authUrl.searchParams.set('client_id', process.env.VITE_AUTH0_CLIENT_ID!);
+      authUrl.searchParams.set('response_type', 'code');
+      authUrl.searchParams.set('redirect_uri', window.location.origin);
+      authUrl.searchParams.set('scope', interrupt.scopes.join(' '));
+      authUrl.searchParams.set('connection', interrupt.connection);
+      authUrl.searchParams.set('state', 'step-up-auth');
+
+      // Open popup window for authorization
+      const popup = window.open(
+        authUrl.toString(),
+        'auth-popup',
+        'width=500,height=600,scrollbars=yes'
+      );
+
+      // Listen for popup completion
+      const checkClosed = setInterval(() => {
+        if (popup?.closed) {
+          clearInterval(checkClosed);
+          setIsConnecting(false);
+          // Resume the conversation after authorization
+          onResume();
+        }
+      }, 1000);
+
+    } catch (error) {
+      console.error('Connection error:', error);
+      setIsConnecting(false);
+    }
+  };
+
+  return (
+    <div className="border rounded-lg p-4 bg-blue-50">
+      <h3 className="font-semibold mb-2">Additional Permission Required</h3>
+      <p className="text-sm text-gray-600 mb-4">
+        To continue, this agent needs access to your {interrupt.connection} account.
+      </p>
+      <div className="flex gap-2">
+        <button
+          onClick={handleConnect}
+          disabled={isConnecting}
+          className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 disabled:opacity-50"
+        >
+          {isConnecting ? 'Connecting...' : `Connect ${interrupt.connection}`}
+        </button>
+        <button
+          onClick={onResume}
+          className="border border-gray-300 px-4 py-2 rounded hover:bg-gray-50"
+        >
+          Skip
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+You've now implemented step-up authorization handling in your React SPA using Auth0 interrupts!
+
+Now when step-up authorization is required, the user will see a prompt in the chat window asking them to authorize.
+
+### Backend LangGraph API Implementation with Auth0 AI SDK Integration
+
+Next, set up the backend LangGraph API server to define the agent and tools, integrating Auth0 AI SDKs for secure third-party API access.
+
+#### LangGraph Custom Authentication
+
+LangGraph supports custom authentication to validate incoming tokens and extract user context. This enables user-specific authorization and auditing within your LangGraph applications.
+
+Configure your LangGraph deployment to accept Auth0 tokens by setting up custom authentication. See the [LangGraph Custom Auth documentation](https://docs.langchain.com/langgraph-platform/custom-auth) for detailed setup.
+
+Example Custom Auth Handler:
+```ts src/auth.ts wrap lines
+import { createRemoteJWKSet, jwtVerify } from "jose";
+const { Auth, HTTPException } = require("@langchain/langgraph-sdk/auth");
+
+const AUTH0_DOMAIN = process.env.AUTH0_DOMAIN;
+const AUTH0_AUDIENCE = process.env.AUTH0_AUDIENCE;
+
+// JWKS endpoint for Auth0
+const JWKS = createRemoteJWKSet(
+  new URL(`https://${AUTH0_DOMAIN}/.well-known/jwks.json`)
+);
+
+const auth = new Auth();
+
+auth.authenticate(async (request: Request) => {
+  const authHeader = request.headers.get("Authorization");
+  const xApiKeyHeader = request.headers.get("x-api-key");
+
+  // LangGraph Platform converts Authorization to x-api-key automatically
+  let token = xApiKeyHeader ?? authHeader;
+
+  if (token && token.startsWith("Bearer ")) {
+    token = token.substring(7);
+  }
+
+  const { payload } = await jwtVerify(token, JWKS, {
+    issuer: `https://${AUTH0_DOMAIN}/`,
+    audience: AUTH0_AUDIENCE,
+  });
+
+  return {
+    identity: payload.sub!,
+    email: payload.email as string,
+    permissions: typeof payload.scope === "string" ? payload.scope.split(" ") : [],
+    auth_type: "auth0",
+    getRawAccessToken: () => token,
+    ...payload,
+  };
+});
+
+export { auth as authHandler };
+```
+
+Then you can reference the custom auth handler in your `langgraph.json` file:
+
+```json langgraph.json wrap lines
+{
+  "node_version": "20",
+  "dependencies": ["."],
+  "graphs": {
+    "memory_agent": "./src/memory-agent/graph.ts:graph"
+  },
+  "auth": {
+    "path": "./src/auth.ts:authHandler"
+  },
+  "env": ".env"
+}
+```
+
+#### Token Vault Integration with Agent Tools
+
+Create the Auth0 AI `withTokenForConnection` wrapper to securely fetch access tokens from Token Vault for your tools:
+
+```ts src/auth0-ai.ts wrap lines
+import { SUBJECT_TOKEN_TYPES } from "@auth0/ai";
+import { Auth0AI } from "@auth0/ai-langchain";
+
+const auth0AI = new Auth0AI({
+  auth0: {
+    domain: process.env.AUTH0_DOMAIN!,
+    clientId: process.env.AUTH0_CUSTOM_API_CLIENT_ID!,
+    clientSecret: process.env.AUTH0_CUSTOM_API_CLIENT_SECRET!,
+  },
+});
+
+export const withGoogleCalendar = auth0AI.withTokenForConnection({
+  connection: "google-oauth2",
+  scopes: ["https://www.googleapis.com/auth/calendar.freebusy"],
+  accessToken: async (_, config) => {
+    return config.configurable?.langgraph_auth_user?.getRawAccessToken();
+  },
+  subjectTokenType: SUBJECT_TOKEN_TYPES.SUBJECT_TYPE_ACCESS_TOKEN,
+});
+```
+
+Then reference the Auth0 Token Vault wrapper above in the tool's definition:
+
+```ts src/tools/google-calendar.ts wrap lines
+import { addHours, formatISO } from "date-fns";
+import { GaxiosError } from "gaxios";
+import { google } from "googleapis";
+
+import { getAccessTokenForConnection } from "@auth0/ai-langchain";
+import { FederatedConnectionError } from "@auth0/ai/interrupts";
+import { tool } from "@langchain/core/tools";
+
+import { withGoogleCalendar } from "../../auth0-ai";
+
+export const checkUsersCalendar = withGoogleCalendar(
+  tool(
+    async ({ date }) => {
+      try {
+        const accessToken = getAccessTokenForConnection();
+
+        const calendar = google.calendar("v3");
+        const auth = new google.auth.OAuth2();
+
+        auth.setCredentials({
+          access_token: accessToken,
+        });
+
+        const response = await calendar.freebusy.query({
+          auth,
+          requestBody: {
+            timeMin: formatISO(date),
+            timeMax: addHours(date, 1).toISOString(),
+            timeZone: "UTC",
+            items: [{ id: "primary" }],
+          },
+        });
+
+        return {
+          available: response.data?.calendars?.primary?.busy?.length === 0,
+        };
+      } catch (err) {
+        if (err instanceof GaxiosError && err.status === 401) {
+          throw new FederatedConnectionError(
+            `Authorization required to access the Federated Connection`
+          );
+        }
+        throw err;
+      }
+    },
+  )
+);
+```
+
+Great job! You've now set up the backend LangGraph API server with Auth0 AI SDK integration for secure third-party API access with your LangGraph tools.
+
+### Test your application
+Start your application. If you are already logged in, make sure to log out and log back in using Google. Then, ask your AI agent to list the upcoming events in your Google Calendar!
+
+That's it! You successfully integrated integrated third-party API access using Token Vault into your React SPA + LangGraph.js project.
+
+### View a complete example
+Want to see how it all comes together? Explore or clone the fully implemented sample application on [GitHub](https://github.com/auth0-lab/auth0-ai-js/tree/main/examples/calling-apis/spa-with-backend-api/react-langgraph-api).
+  </Tab>
+</Tabs>

--- a/auth4genai/snippets/get-started/vercel-ai-react-spa-js/call-others-api.mdx
+++ b/auth4genai/snippets/get-started/vercel-ai-react-spa-js/call-others-api.mdx
@@ -22,9 +22,9 @@ import { AccountAndAppSteps } from "/snippets/get-started/prerequisites/account-
 
 This integration provides a robust, secure foundation for authenticating users and enabling AI agents to act on their behalf using third-party APIs. Here are some key features of this example:
 
-1. **Modern Toolset**: Uses a modern stack with React, Vite, Vercel AI SDK, and Auth0 AI SDK to create an interactive chat interface that integrates with Google Calendar.
+1. **Modern Toolset**: Uses a modern stack with React, Vite, the Vercel AI SDK, and the Auth0 AI SDK to create an interactive chat interface that integrates with Google Calendar.
 2. **Client-Side Authorization**: Client login and step-up authorization are handled client-side using `@auth0/auth0-spa-js`. No backend proxy required.
-3. **Token Vault**: Token Vault performs token exchanges & securely manages tokens, allowing seamless third-party API access to AI Agents with user approved access and finely scoped authorization for each API.
+3. **Token Vault**: Token Vault performs token exchanges and securely manages tokens, allowing seamless, user-approved third-party API access to AI Agents and finely scoped authorization for each API.
 4. **Interrupt Handling**: The React client manages tool access errors and step-up authorization using interrupts that trigger a pop-up for re-authorization.
 
 <Tabs>
@@ -78,12 +78,12 @@ PORT=3001
 
 1. Start the client and server using Turbo: `npm run dev`.
 2. Navigate to `http://localhost:5173`.
-3. Hit the "Log In" button and login into your application with Google credentials using the Auth0 Universal Login screen.
+3. Hit the **Log In** button and log in to your application with Google credentials using the Auth0 Universal Login screen.
 4. Ask your AI agent about your calendar with a prompt, such as "Can you list my available calendars?".
 
 The application will automatically prompt for additional calendar permissions when needed using Auth0's step-up authorization flow.
 
-That's it! You've successfully setup and run the React SPA + Vercel AI sample app.
+That's it! You've successfully set up and run the React SPA + Vercel AI sample app.
 
   </Tab>
   <Tab title="Integrate into your app">
@@ -608,7 +608,7 @@ Now when step-up authorization is required, the user will see a prompt in the ch
 ### Test your application
 Start your application. If you are already logged in, make sure to log out and log back in using Google. Then, ask your AI agent to list the upcoming events in your Google Calendar!
 
-That's it! You successfully integrated integrated third-party API access using Token Vault into your project.
+That's it! You successfully integrated third-party API access using Token Vault into your project.
 
 ### View a complete example
 Want to see how it all comes together? Explore or clone the fully implemented sample application on [GitHub](https://github.com/auth0-lab/auth0-ai-js/tree/main/examples/calling-apis/spa-with-backend-api/react-hono-ai-sdk).

--- a/auth4genai/snippets/get-started/vercel-ai-react-spa-js/call-others-api.mdx
+++ b/auth4genai/snippets/get-started/vercel-ai-react-spa-js/call-others-api.mdx
@@ -54,6 +54,26 @@ npm install
 
 Add separate `.env` files with environment variables for the client and server.
 
+#### Server (server/.env)
+
+```bash .env wrap lines
+AUTH0_DOMAIN=your-auth0-domain
+AUTH0_CUSTOM_API_CLIENT_ID=your-custom-api-client-id
+AUTH0_CUSTOM_API_CLIENT_SECRET=your-custom-api-client-secret
+AUTH0_AUDIENCE=your-api-identifier
+OPENAI_API_KEY=your-openai-api-key
+PORT=3001
+```
+To get your Auth0 Custom API Client's `AUTH0_DOMAIN`, `AUTH0_CUSTOM_API_CLIENT_ID`, and `AUTH0_CUSTOM_API_CLIENT_SECRET`, navigate to the **Applications** section in the Auth0 Dashboard and select your Custom API Client application from the list. Then, navigate to the **Settings** tab. You'll find these values in the **Basic Information** section at the top.
+Copy each value to the matching setting.
+
+To get the `AUTH0_AUDIENCE`, next hit the **Configure API** button in the top right to navigate to your Custom API Client's **API**. The Identifier will be listed in the **Settings** tab and should be provided as the `AUTH0_AUDIENCE`.
+
+Lastly, set your OpenAI API key or use any provider supported by the Vercel AI SDK:
+```bash .env.local wrap lines
+OPENAI_API_KEY="YOUR_API_KEY"
+```
+
 #### Client (client/.env)
 
 ```bash .env wrap lines
@@ -62,16 +82,14 @@ VITE_AUTH0_CLIENT_ID=your-spa-client-id
 VITE_AUTH0_AUDIENCE=your-api-identifier
 VITE_API_URL=http://localhost:3001
 ```
+To get your Auth0 SPA's `VITE_AUTH0_DOMAIN`, and `VITE_AUTH0_CLIENT_ID`, navigate to the **Applications** section in the Auth0 Dashboard and select your Single Page application from the list. Then, navigate to the **Settings** tab. You'll find these values in the **Basic Information** section at the top.
+Copy each value to the matching setting.
 
-#### Server (server/.env)
+The `VITE_AUTH0_AUDIENCE` should match the `AUTH0_AUDIENCE`, and the Identifier of the Custom API client's API you created above.
 
-```bash .env wrap lines
-AUTH0_DOMAIN=your-auth0-domain
-AUTH0_AUDIENCE=your-api-identifier
-AUTH0_CLIENT_ID=your-resource-server-client-id
-AUTH0_CLIENT_SECRET=your-resource-server-client-secret
-OPENAI_API_KEY=your-openai-api-key
-PORT=3001
+Lastly, `VITE_API_URL` should target the location of your Hono API server.
+```bash .env.local wrap lines
+VITE_API_URL=http://localhost:3001
 ```
 
 ### Run your application
@@ -112,6 +130,26 @@ Ensure you have installed the following client and server dependencies in your p
 
 Add separate `.env` files with environment variables for the client and server.
 
+#### Server (server/.env)
+
+```bash .env wrap lines
+AUTH0_DOMAIN=your-auth0-domain
+AUTH0_CUSTOM_API_CLIENT_ID=your-custom-api-client-id
+AUTH0_CUSTOM_API_CLIENT_SECRET=your-custom-api-client-secret
+AUTH0_AUDIENCE=your-api-identifier
+OPENAI_API_KEY=your-openai-api-key
+PORT=3001
+```
+To get your Auth0 Custom API Client's `AUTH0_DOMAIN`, `AUTH0_CUSTOM_API_CLIENT_ID`, and `AUTH0_CUSTOM_API_CLIENT_SECRET`, navigate to the **Applications** section in the Auth0 Dashboard and select your Custom API Client application from the list. Then, navigate to the **Settings** tab. You'll find these values in the **Basic Information** section at the top.
+Copy each value to the matching setting.
+
+To get the `AUTH0_AUDIENCE`, next hit the **Configure API** button in the top right to navigate to your Custom API Client's **API**. The Identifier will be listed in the **Settings** tab and should be provided as the `AUTH0_AUDIENCE`.
+
+Lastly, set your OpenAI API key or use any provider supported by the Vercel AI SDK:
+```bash .env.local wrap lines
+OPENAI_API_KEY="YOUR_API_KEY"
+```
+
 #### Client (client/.env)
 
 ```bash .env wrap lines
@@ -120,16 +158,14 @@ VITE_AUTH0_CLIENT_ID=your-spa-client-id
 VITE_AUTH0_AUDIENCE=your-api-identifier
 VITE_API_URL=http://localhost:3001
 ```
+To get your Auth0 SPA's `VITE_AUTH0_DOMAIN`, and `VITE_AUTH0_CLIENT_ID`, navigate to the **Applications** section in the Auth0 Dashboard and select your Single Page application from the list. Then, navigate to the **Settings** tab. You'll find these values in the **Basic Information** section at the top.
+Copy each value to the matching setting.
 
-#### Server (server/.env)
+The `VITE_AUTH0_AUDIENCE` should match the `AUTH0_AUDIENCE`, and the Identifier of the Custom API client's API you created above.
 
-```bash .env wrap lines
-AUTH0_DOMAIN=your-auth0-domain
-AUTH0_AUDIENCE=your-api-identifier
-AUTH0_CLIENT_ID=your-resource-server-client-id
-AUTH0_CLIENT_SECRET=your-resource-server-client-secret
-OPENAI_API_KEY=your-openai-api-key
-PORT=3001
+Lastly, `VITE_API_URL` should target the location of your Hono API server.
+```bash .env.local wrap lines
+VITE_API_URL=http://localhost:3001
 ```
 
 ### Configure the SPA for step-up authorization
@@ -300,12 +336,12 @@ import { Auth0AI } from "@auth0/ai-vercel";
 import type { Context } from "hono";
 
 import type { ToolWrapper } from "@auth0/ai-vercel";
-// Create an Auth0AI instance configured with reserver client credentials
+// Create an Auth0AI instance configured with Custom API client credentials
 const auth0AI = new Auth0AI({
   auth0: {
     domain: process.env.AUTH0_DOMAIN!,
-    clientId: process.env.AUTH0_CUSTOM_API_CLIENT_ID!, // Resource server client ID for token exchange
-    clientSecret: process.env.AUTH0_CUSTOM_API_CLIENT_SECRET!, // Resource server client secret
+    clientId: process.env.AUTH0_CUSTOM_API_CLIENT_ID!,
+    clientSecret: process.env.AUTH0_CUSTOM_API_CLIENT_SECRET!,
   },
 });
 

--- a/auth4genai/snippets/get-started/vercel-ai-react-spa-js/call-others-api.mdx
+++ b/auth4genai/snippets/get-started/vercel-ai-react-spa-js/call-others-api.mdx
@@ -31,11 +31,11 @@ This integration provides a robust, secure foundation for authenticating users a
   <Tab title="Use sample app(recommended)">
 
 ### Clone sample app
-Clone this sample app from the [Auth0 AI JS](https://github.com/auth0-lab/auth0-ai-js.git) repository:
+Clone this sample app from the [Auth0 AI JS](https://github.com/auth0-samples/auth0-ai-samples.git) repository:
 
 ```bash wrap lines
-git clone https://github.com/auth0-lab/auth0-ai-js.git
-cd auth0-ai-js/examples/calling-apis/spa-with-backend-api/react-hono-ai-sdk
+git clone https://github.com/auth0-samples/auth0-ai-samples.git
+cd auth0-ai-samples/call-apis-on-users-behalf/others-api/vercel-react-spa-js/
 ```
 
 The project is divided into two parts:
@@ -611,7 +611,7 @@ Start your application. If you are already logged in, make sure to log out and l
 That's it! You successfully integrated third-party API access using Token Vault into your project.
 
 ### View a complete example
-Want to see how it all comes together? Explore or clone the fully implemented sample application on [GitHub](https://github.com/auth0-lab/auth0-ai-js/tree/main/examples/calling-apis/spa-with-backend-api/react-hono-ai-sdk).
+Want to see how it all comes together? Explore or clone the fully implemented sample application on [GitHub](https://github.com/auth0-samples/auth0-ai-samples/tree/main/call-apis-on-users-behalf/others-api/vercel-react-spa-js/).
   </Tab>
 </Tabs>
 

--- a/auth4genai/snippets/get-started/vercel-ai-react-spa-js/call-others-api.mdx
+++ b/auth4genai/snippets/get-started/vercel-ai-react-spa-js/call-others-api.mdx
@@ -4,7 +4,7 @@ import { AccountAndAppSteps } from "/snippets/get-started/prerequisites/account-
 <Prerequisites
   createAuth0ApplicationStep={{
     applicationType: "Single Page Web Applications",
-    callbackUrl: "http://localhost:5173/auth/callback",
+    callbackUrl: "http://localhost:5173",
     logoutUrl: "http://localhost:5173",
     allowedWebOrigins: "http://localhost:5173",
   }}
@@ -18,27 +18,79 @@ import { AccountAndAppSteps } from "/snippets/get-started/prerequisites/account-
   }}
 />
 
-### Key differences from Next.js approach
+### Key features of this React SPA + Vercel AI example
 
-This React SPA implementation differs from the <a href="/get-started/call-others-apis-on-users-behalf#vercel-ai-%2B-next-js" target="_blank">Next.js example</a> in a few important ways:
+This integration provides a robust, secure foundation for authenticating users and enabling AI agents to act on their behalf using third-party APIs. Here are some key features of this example:
 
-1. **Token Vault Access Token Exchange**: Instead of using refresh tokens, the React SPA implementation exchanges the SPA's access token for a third-party access token.
-2. **Client-Side Authorization**: Client login and step-up authorization are handled client-side using `@auth0/auth0-spa-js`.
-3. **Resource Server Client**: Requires a special Resource Server Client configured for token exchange with Token Vault.
+1. **Modern Toolset**: Uses a modern stack with React, Vite, Vercel AI SDK, and Auth0 AI SDK to create an interactive chat interface that integrates with Google Calendar.
+2. **Client-Side Authorization**: Client login and step-up authorization are handled client-side using `@auth0/auth0-spa-js`. No backend proxy required.
+3. **Token Vault**: Token Vault performs token exchanges & securely manages tokens, allowing seamless third-party API access to AI Agents with user approved access and finely scoped authorization for each API.
 4. **Interrupt Handling**: The React client manages tool access errors and step-up authorization using interrupts that trigger a pop-up for re-authorization.
 
-### Prepare React SPA + Hono API
+<Tabs>
+  <Tab title="Use sample app(recommended)">
 
-**Recommended**: To use this example, clone the [Auth0 AI JS](https://github.com/auth0-lab/auth0-ai-js.git) repository:
+### Clone sample app
+Clone this sample app from the [Auth0 AI JS](https://github.com/auth0-lab/auth0-ai-js.git) repository:
 
 ```bash wrap lines
 git clone https://github.com/auth0-lab/auth0-ai-js.git
 cd auth0-ai-js/examples/calling-apis/spa-with-backend-api/react-hono-ai-sdk
 ```
 
+The project is divided into two parts:
+- `server/`: Hono API server using Vercel AI SDK and Auth0 AI SDK.
+- `client/`: contains the frontend code for the web app, written in React as a Vite SPA.
+
 ### Install dependencies
 
-In the root directory of your project, you have the following client and server dependencies:
+To install all the client and server dependencies, navigate to the root directory of the project and run the following command:
+```bash wrap lines
+# Install all client & server dependencies from the root directory of the project.
+npm install
+```
+
+### Create the environment files
+
+Add separate `.env` files with environment variables for the client and server.
+
+#### Client (client/.env)
+
+```bash .env wrap lines
+VITE_AUTH0_DOMAIN=your-auth0-domain
+VITE_AUTH0_CLIENT_ID=your-spa-client-id
+VITE_AUTH0_AUDIENCE=your-api-identifier
+VITE_API_URL=http://localhost:3001
+```
+
+#### Server (server/.env)
+
+```bash .env wrap lines
+AUTH0_DOMAIN=your-auth0-domain
+AUTH0_AUDIENCE=your-api-identifier
+AUTH0_CLIENT_ID=your-resource-server-client-id
+AUTH0_CLIENT_SECRET=your-resource-server-client-secret
+OPENAI_API_KEY=your-openai-api-key
+PORT=3001
+```
+
+### Run your application
+
+1. Start the client and server using Turbo: `npm run dev`.
+2. Navigate to `http://localhost:5173`.
+3. Hit the "Log In" button and login into your application with Google credentials using the Auth0 Universal Login screen.
+4. Ask your AI agent about your calendar with a prompt, such as "Can you list my available calendars?".
+
+The application will automatically prompt for additional calendar permissions when needed using Auth0's step-up authorization flow.
+
+That's it! You've successfully setup and run the React SPA + Vercel AI sample app.
+
+  </Tab>
+  <Tab title="Integrate into your app">
+
+### Install packages
+
+Ensure you have installed the following client and server dependencies in your project:
 
 **Client dependencies:**
 
@@ -54,11 +106,7 @@ In the root directory of your project, you have the following client and server 
 - `@ai-sdk/openai`: [OpenAI](https://sdk.vercel.ai/providers/ai-sdk-providers/openai) provider
 - `googleapis`: Node.js client for Google APIs
 - `jose`: JavaScript Object Signing and Encryption library for JWT verification
-To install all the client and server dependencies, navigate to the root directory of your project and run the following command:
-```bash wrap lines
-# Install all client & server dependencies from the root directory of the project.
-npm install
-```
+
 
 ### Update the environment files
 
@@ -555,14 +603,23 @@ function MessageBubble({ message }: { message: Message }) {
 }
 ```
 
+Now when step-up authorization is required, the user will see a prompt in the chat window asking them to authorize.
+
 ### Test your application
+Start your application. If you are already logged in, make sure to log out and log back in using Google. Then, ask your AI agent to list the upcoming events in your Google Calendar!
 
-1. Start the client and server using Turbo: `npm run dev`.
-2. Navigate to `http://localhost:5173`.
-3. Log in with Google and ask your AI agent about your calendar.
+That's it! You successfully integrated integrated third-party API access using Token Vault into your project.
 
-The application will automatically prompt for additional calendar permissions when needed using Auth0's step-up authorization flow.
+### View a complete example
+Want to see how it all comes together? Explore or clone the fully implemented sample application on [GitHub](https://github.com/auth0-lab/auth0-ai-js/tree/main/examples/calling-apis/spa-with-backend-api/react-hono-ai-sdk).
+  </Tab>
+</Tabs>
 
-That's it! You've successfully integrated federated connections with access tokens into your React SPA + Vercel AI application.
 
-Explore [the example app on GitHub](https://github.com/auth0-lab/auth0-ai-js/tree/main/examples/calling-apis/spa-with-backend-api/react-hono-ai-sdk).
+
+
+
+
+
+
+


### PR DESCRIPTION

### Description

Adds new Getting Started material for LangGraph.js + React SPA example, added in:
https://github.com/auth0-samples/auth0-ai-samples/pull/10
https://github.com/auth0-lab/auth0-ai-js/pull/267

note: will need rebase of this around the time of merge:
https://github.com/auth0/docs-v2/pull/75

This will ensure the tabs do not become overloaded, and we can showcase underneath LangGraph -> Calling third-party Party APIs -> React SPA.

### References

https://auth0team.atlassian.net/browse/AIDX-111

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
