### PR TITLE
new auth_for_aa links

### DIFF
--- a/auth4genai/components.mdx
+++ b/auth4genai/components.mdx
@@ -60,16 +60,6 @@ print(baz)
   </Tab>
 </Tabs>
 
-## Developer Preview Banner
-
-<Columns cols={1}>
-<Card href="https://auth0.com/signup?onboard_app=genai" icon={<img src="https://mintlify-assets.b-cdn.net/auth0/bannerimage.png" alt="Developer Preview Program" />} title="Developer Preview Program">
-
-Auth0 for AI Agents is currently available in Developer Preview. Join today to start building secure AI agents and provide feedback to shape the platform's future.
-
-</Card>
-</Columns>
-
 ## Card
 
 <Card title="I am a Heading">

--- a/auth4genai/docs.json
+++ b/auth4genai/docs.json
@@ -319,13 +319,13 @@
     "links": [
       {
         "label": "Start building",
-        "href": "https://auth0.com/signup?onboard_app=genai&ocid=7014z000001NyoxAAC-aPA4z0000008OZeGAM"
+        "href": "https://auth0.com/signup?onboard_app=auth_for_aa&ocid=701KZ000000cXXxYAM-aPA4z0000008OZeGAM"
       }
     ],
     "primary": {
       "type": "button",
       "label": "Log in",
-      "href": "https://manage.auth0.com/login?onboard_app=genai"
+      "href": "https://manage.auth0.com/login?onboard_app=auth_for_aa"
     }
   },
   "footer": {

--- a/auth4genai/intro/overview.mdx
+++ b/auth4genai/intro/overview.mdx
@@ -152,17 +152,3 @@ Explore samples and SDKs for the different frameworks supported by Auth0 for AI 
     title="Genkit"
   />
 </Columns>
-
-## Developer Preview
-
-Auth0 for AI Agents provides a robust identity and access management platform designed on top of industry standards to secure every layer of your AI agent stack. We offer solutions for common challenges, such as insecurely hardcoded API keys, lack of user consent in agent-led workflows, and weak authorization in RAG pipelines.
-Auth0 for AI Agents works out of the box with popular AI frameworks like LangChain, LlamaIndex, Genkit, and the Vercel AI SDK, enabling developers to build and deploy secure AI-powered applications that users can trust.
-
-<Columns cols={1}>
-    <Card href="https://auth0.com/signup?onboard_app=genai" icon={<img src="https://mintlify-assets.b-cdn.net/auth0/bannerimage.png" alt="Developer Preview Program" />} title="Developer Preview Program">
-
-    Auth0 for AI Agents is currently available in Developer Preview. Join today to start building secure AI agents and provide feedback to shape the platform's future.
-
-    </Card>
-
-</Columns>

--- a/auth4genai/snippets/get-started/prerequisites/account-app-steps.jsx
+++ b/auth4genai/snippets/get-started/prerequisites/account-app-steps.jsx
@@ -12,7 +12,7 @@ export const AccountAndAppSteps = ({
     <Step title="Create an Auth0 Account">
       To continue with this quickstart, you need to have an{" "}
       <a
-        href="https://auth0.com/signup?onboard_app=genai&ocid=7014z000001NyoxAAC-aPA4z0000008OZeGAM"
+        href="https://auth0.com/signup?onboard_app=auth_for_aa&ocid=701KZ000000cXXxYAM-aPA4z0000008OZeGAM"
         target="_blank"
       >
         Auth0 account.


### PR DESCRIPTION
## Summary
Updates Auth0 signup links across the Auth4GenAI documentation to use the new tracking parameters for the auth_for_aa onboarding flow, and removes developer preview banners.

## Changes
- Updated signup link in `auth4genai/snippets/get-started/prerequisites/account-app-steps.jsx`
- Updated signup tracking parameters in `auth4genai/docs.json`
- Removed Developer Preview section from `auth4genai/intro/overview.mdx`
- Removed Developer Preview Banner section from `auth4genai/components.mdx`

### Link Changes
**Before:** `https://auth0.com/signup?onboard_app=genai&ocid=...`
**After:** `https://auth0.com/signup?onboard_app=auth_for_aa&ocid=701KZ000000cXXxYAM-aPA4z0000008OZeGAM`

## Files Changed
- `auth4genai/components.mdx` - Removed Developer Preview banner
- `auth4genai/docs.json` - Updated signup tracking parameters
- `auth4genai/intro/overview.mdx` - Removed Developer Preview section
- `auth4genai/snippets/get-started/prerequisites/account-app-steps.jsx` - Updated prerequisites signup link

## Impact
- Ensures consistent tracking of signups originating from the Auth4GenAI documentation
- Routes users through the appropriate onboarding experience
- Removes developer preview messaging as the product moves forward