### PR TITLE
feat: add opt-out banner

### DIFF
--- a/ui/src/components/ui/opt-out-banner.tsx
+++ b/ui/src/components/ui/opt-out-banner.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useRef } from "react";
+import { Button } from "./button";
+import { config } from '../../lib/config';
+
+function OptOutBanner() {
+  const bannerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const updateBodyPadding = () => {
+      if (bannerRef.current) {
+        const height = bannerRef.current.offsetHeight;
+        document.body.style.paddingTop = `${height}px`;
+        // Update CSS custom property for other components that might need it
+        document.documentElement.style.setProperty('--opt-out-banner-height', `${height}px`);
+      }
+    };
+
+    // Initial setup
+    updateBodyPadding();
+
+    // Update on window resize
+    const handleResize = () => {
+      updateBodyPadding();
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    // Use ResizeObserver for more precise height changes
+    const resizeObserver = new ResizeObserver(() => {
+      updateBodyPadding();
+    });
+
+    if (bannerRef.current) {
+      resizeObserver.observe(bannerRef.current);
+    }
+
+    return () => {
+      // Cleanup
+      document.body.style.paddingTop = '';
+      document.documentElement.style.removeProperty('--opt-out-banner-height');
+      window.removeEventListener('resize', handleResize);
+      resizeObserver.disconnect();
+    };
+  }, []);
+
+  return (
+    <div
+      ref={bannerRef}
+      className="adu:top-banner adu:font-aeonik adu:text-xs adu:fixed adu:top-0 adu:left-0 adu:right-0 adu:z-[9999] adu:bg-black adu:text-white adu:p-2"
+    >
+      <p className="adu:banner-text adu:text-center adu:flex adu:flex-wrap adu:items-center adu:justify-center adu:gap-2">
+        🚀 We've rolled out a new docs experience - faster, cleaner, and a better developer experience.
+        <Button variant="secondary" onClick={() => setCookieAndRefresh()}>
+          Switch to old version
+        </Button>
+      </p>
+    </div>
+  );
+}
+
+async function setCookieAndRefresh() {
+  console.log('Setting cookie and refreshing');
+   try {
+    // Make API call to set the UI preference
+    const response = await fetch(`${config.apiBaseUrl}/rollout/consent`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ choice: 'opt_out' }),
+      credentials: 'include', // Important for cookies
+    });
+
+    if (response.ok) {
+      // Refresh the page to apply the new UI
+      window.location.reload();
+    } else {
+      console.error('Failed to update consent');
+    }
+  } catch (error) {
+    console.error('Error!', error);
+}
+}
+
+export { OptOutBanner };

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -13,11 +13,13 @@ import {
 import { initOneTrust } from './lib/one-trust';
 import { userLogin, getCurrentUser } from './lib/api';
 import { AppStoreProvider } from './components/ui/app-store-provider';
+import { OptOutBanner } from './components/ui/opt-out-banner';
 
 function main() {
   initOneTrust();
   createRoot(document.getElementById('root')!).render(
     <StrictMode>
+      <OptOutBanner />
       <AppStoreProvider>
         <div className="adu:bg-page adu:flex adu:flex-col adu:items-start adu:gap-8 adu:p-4">
           <Button


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR adds an `opt-out` banner that will update the users `docs_version` cookie to v1 to force them to the old version


### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - Auth0 Community post
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

1. switch to UI directory
2. pnpm install
3. pnpm dev
4. See banner loaded on UI test page 

Screenshots show full width vs. smallest width and the responsiveness

<img width="1840" height="1191" alt="Screenshot 2025-10-10 at 10 01 59 AM" src="https://github.com/user-attachments/assets/01ec211b-d6c8-4ef7-8779-9f9fa01cebe2" />
<img width="612" height="1191" alt="Screenshot 2025-10-10 at 10 02 05 AM" src="https://github.com/user-attachments/assets/82bc3656-31a8-4833-806e-9bb5c163b39f" />


- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
