### PR TITLE
Fixed redirects from old interactive quickstarts

### DIFF
--- a/main/docs.json
+++ b/main/docs.json
@@ -7402,35 +7402,35 @@
   "redirects": [
     {
       "source": "/docs/quickstart/spa/react/interactive",
-      "destination": "docs/quickstart/spa/react"
+      "destination": "/docs/quickstart/spa/react"
     },
     {
       "source": "/docs/quickstart/spa/vanillajs/interactive",
-      "destination": "docs/quickstart/spa/vanillajs"
+      "destination": "/docs/quickstart/spa/vanillajs"
     },
     {
       "source": "/docs/quickstart/spa/vuejs/interactive",
-      "destination": "docs/quickstart/spa/vuejs"
+      "destination": "/docs/quickstart/spa/vuejs"
     },
     {
       "source": "/docs/quickstart/spa/angular/interactive",
-      "destination": "docs/quickstart/spa/angular"
+      "destination": "/docs/quickstart/spa/angular"
     },
     {
       "source": "/docs/quickstart/webapp/nextjs/interactive",
-      "destination": "docs/quickstart/webapp/nextjs"
+      "destination": "/docs/quickstart/webapp/nextjs"
     },
     {
       "source": "/docs/quickstart/native/ios-swift/interactive",
-      "destination": "docs/quickstart/native/ios-swift"
+      "destination": "/docs/quickstart/native/ios-swift"
     },
     {
       "source": "/docs/quickstart/native/android/interactive",
-      "destination": "docs/quickstart/native/android"
+      "destination": "/docs/quickstart/native/android"
     },
     {
       "source": "/docs/quickstart/spa/flutter/interactive",
-      "destination": "docs/quickstart/spa/flutter"
+      "destination": "/docs/quickstart/spa/flutter"
     }
   ]
 }


### PR DESCRIPTION
### Description
Redirects from /interactive paths should now work


### Testing
- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
