### PR TITLE
fix: bump versions for ai js sdks

### DIFF
--- a/auth4genai/snippets/get-started/langchain-next-js/async-auth.mdx
+++ b/auth4genai/snippets/get-started/langchain-next-js/async-auth.mdx
@@ -23,7 +23,7 @@ In the root directory of your project, install the following dependencies:
 - `langgraph-nextjs-api-passthrough`: API passthrough for LangGraph.
 
 ```bash wrap lines
-npm install @auth0/ai-langchain@3.5.0 @langchain/core@0.3.77 @langchain/langgraph@0.4.4 @langchain/openai@0.6.13 langchain@0.3.12 langgraph-nextjs-api-passthrough@0.1.4
+npm install @auth0/ai-langchain@4 @langchain/core@0.3.77 @langchain/langgraph@0.4.4 @langchain/openai@0.6.13 langchain@0.3.12 langgraph-nextjs-api-passthrough@0.1.4
 ```
 ### Update the environment file
 

--- a/auth4genai/snippets/get-started/langchain-next-js/auth-for-rag.mdx
+++ b/auth4genai/snippets/get-started/langchain-next-js/auth-for-rag.mdx
@@ -24,7 +24,7 @@ In the root directory of your project, install the following dependencies:
 - `langgraph-nextjs-api-passthrough`: API passthrough for LangGraph.
 
 ```bash wrap lines
-npm install @auth0/ai-langchain@3.5.0 @langchain/core@0.3.77 @langchain/langgraph@0.4.4 @langchain/openai@0.6.13 langchain@0.3.12 langgraph-nextjs-api-passthrough@0.1.4
+npm install @auth0/ai-langchain@4 @langchain/core@0.3.77 @langchain/langgraph@0.4.4 @langchain/openai@0.6.13 langchain@0.3.12 langgraph-nextjs-api-passthrough@0.1.4
 ```
 
 ### Update the environment file

--- a/auth4genai/snippets/get-started/langchain-next-js/call-others-api.mdx
+++ b/auth4genai/snippets/get-started/langchain-next-js/call-others-api.mdx
@@ -96,7 +96,7 @@ In the root directory of your project, install the following packages:
 - `langgraph-nextjs-api-passthrough`: API passthrough for LangGraph.
 
 ```bash wrap lines
-npm install @auth0/ai-langchain@3.5.0 @langchain/community@0.3.53 @langchain/core@0.3.77 @langchain/langgraph@0.4.4 @langchain/openai@0.6.13 langchain@0.3.12 langgraph-nextjs-api-passthrough@0.1.4
+npm install @auth0/ai-langchain@4 @langchain/community@0.3.53 @langchain/core@0.3.77 @langchain/langgraph@0.4.4 @langchain/openai@0.6.13 langchain@0.3.12 langgraph-nextjs-api-passthrough@0.1.4
 ```
 
 ### Update your environment file

--- a/auth4genai/snippets/get-started/langchain-node-js/auth-for-rag.mdx
+++ b/auth4genai/snippets/get-started/langchain-node-js/auth-for-rag.mdx
@@ -9,7 +9,7 @@ As a first step, let's get all dependencies installed:
 
 ```bash Create a new Node.js project wrap lines
 npm init -y
-npm install langchain@0.3 @langchain/langgraph@0.2 @auth0/ai-langchain@3 dotenv@16
+npm install langchain@0.3 @langchain/langgraph@0.2 @auth0/ai-langchain@4 dotenv@16
 ```
 
 import SetupFGAStore from "/snippets/get-started/common/setup-fga-store.mdx";

--- a/auth4genai/snippets/get-started/vercel-ai-next-js/async-auth.mdx
+++ b/auth4genai/snippets/get-started/vercel-ai-next-js/async-auth.mdx
@@ -22,7 +22,7 @@ In the root directory of your project, install the following dependencies:
 - `zod`: TypeScript-first schema validation library.
 
 ```bash wrap lines
-npm install @auth0/ai-vercel@3 ai@4 @ai-sdk/openai@1 @ai-sdk/react@1 zod@3
+npm install @auth0/ai-vercel@4 ai@4 @ai-sdk/openai@1 @ai-sdk/react@1 zod@3
 ```
 
 ### Update the environment file

--- a/auth4genai/snippets/get-started/vercel-ai-next-js/auth-for-rag.mdx
+++ b/auth4genai/snippets/get-started/vercel-ai-next-js/auth-for-rag.mdx
@@ -22,7 +22,7 @@ In the root directory of your project, install the following dependencies:
 - `zod`: TypeScript-first schema validation library.
 
 ```bash wrap lines
-npm install @auth0/ai-vercel@3 ai@4 @ai-sdk/openai@1 @ai-sdk/react@1 zod@3
+npm install @auth0/ai-vercel@4 ai@4 @ai-sdk/openai@1 @ai-sdk/react@1 zod@3
 ```
 
 ### Update the environment file

--- a/auth4genai/snippets/get-started/vercel-ai-next-js/call-others-api.mdx
+++ b/auth4genai/snippets/get-started/vercel-ai-next-js/call-others-api.mdx
@@ -81,7 +81,7 @@ In the root directory of your project, install the following packages:
 - `googleapis`: Node.js client for Google APIs that supports authentication and authorization with OAuth 2.0.
 
 ```bash wrap lines
-npm install @auth0/ai-vercel@3 ai@4 @ai-sdk/openai@1 @ai-sdk/react@1 zod@3 googleapis@148
+npm install @auth0/ai-vercel@4 ai@4 @ai-sdk/openai@1 @ai-sdk/react@1 zod@3 googleapis@148
 ```
 
 ### Update your environment file

--- a/auth4genai/snippets/get-started/vercel-ai-node-js/async-auth.mdx
+++ b/auth4genai/snippets/get-started/vercel-ai-node-js/async-auth.mdx
@@ -16,7 +16,7 @@ Install the following dependencies:
 
 ```bash Create a new Node.js project wrap lines
 npm init -y
-npm i auth0@4 @auth0/ai-vercel@2 zod@3 ai@4 @ai-sdk/openai@1 dotenv@16
+npm i auth0@4 @auth0/ai-vercel@4 zod@3 ai@4 @ai-sdk/openai@1 dotenv@16
 ```
 
 Add the below to `package.json`:


### PR DESCRIPTION
### Description

After new versions of AI SDKs were published, need to bump a few references to the previous major versions.

Specifically:
- https://www.npmjs.com/package/@auth0/ai-langchain/v/4.0.0
- https://www.npmjs.com/package/@auth0/ai-vercel/v/4.0.0


### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - Auth0 Community post
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
