### PR TITLE
fix: use correct url for dotnet

### DIFF
--- a/main/snippets/home.jsx
+++ b/main/snippets/home.jsx
@@ -128,7 +128,7 @@ export const LanguageGrid = () => {
     {
       img: "dotnet.svg",
       label: ".NET",
-      href: "/docs/quickstart/backend/dotnet",
+      href: "/docs/quickstart/backend/aspnet-core-webapi/interactive",
     },
     {
       img: "python.svg",


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Updating the url for dotnet on landing page
