### PR TITLE
Fix #223: <em> tags don't render inside <td> tags after <code> blocks

### DIFF
--- a/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-event-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-event-object.mdx
@@ -23,8 +23,8 @@ The `event` object for the post-login Actions trigger provides contextual inform
     
     <tr>
       <td>
-        <code>event.authentication</code><br/>
-        <em>(Optional)</em>
+        <p><code>event.authentication</code></p>
+        <p><em>(Optional)</em></p>
       </td>
       <td>
         Details about authentication signals obtained during the login flow.<br/>
@@ -295,8 +295,8 @@ The `event` object for the post-login Actions trigger provides contextual inform
     
     <tr>
       <td>
-        <code>event.authorization</code><br/>
-        <em>(Optional)</em>
+        <p><code>event.authorization</code></p>
+        <p><em>(Optional)</em></p>
       </td>
       <td>
         An object containing information describing the authorization granted to the user who is logging in.<br/>
@@ -363,8 +363,8 @@ The `event` object for the post-login Actions trigger provides contextual inform
     
     <tr>
       <td>
-        <code>event.organization</code><br/>
-        <em>(Optional)</em>
+        <p><code>event.organization</code></p>
+        <p><em>(Optional)</em></p>
       </td>
       <td>
         Details about the Organization associated with the current transaction.<br/>
@@ -384,8 +384,8 @@ The `event` object for the post-login Actions trigger provides contextual inform
     
     <tr>
       <td>
-        <code>event.prompt</code><br/>
-        <em>(Optional)</em>
+        <p><code>event.prompt</code></p>
+        <p><em>(Optional)</em></p>
       </td>
       <td>
         Collected data from rendered custom prompts.<br/>
@@ -401,8 +401,8 @@ The `event` object for the post-login Actions trigger provides contextual inform
     
     <tr>
       <td>
-        <code>event.refresh_token</code><br/>
-        <em>(Optional)</em>
+        <p><code>event.refresh_token</code></p>
+        <p><em>(Optional)</em></p>
       </td>
       <td>
         [Enterprise Customers] The current refresh token.<br/>
@@ -489,8 +489,8 @@ The `event` object for the post-login Actions trigger provides contextual inform
     
     <tr>
       <td>
-        <code>event.resource_server</code><br/>
-        <em>(Optional)</em>
+        <p><code>event.resource_server</code></p>
+        <p><em>(Optional)</em></p>
       </td>
       <td>
         Details about the resource server to which access is being requested.<br/>
@@ -504,8 +504,8 @@ The `event` object for the post-login Actions trigger provides contextual inform
     
     <tr>
       <td>
-        <code>event.security_context</code><br/>
-        <em>(Optional)</em>
+        <p><code>event.security_context</code></p>
+        <p><em>(Optional)</em></p>
       </td>
       <td>
         An object containing fingerprint signatures. Available only when traffic is handled through the Auth0 Edge (default Auth0-managed proxy layer); may be missing in other routing scenarios.<br/>
@@ -520,8 +520,8 @@ The `event` object for the post-login Actions trigger provides contextual inform
     
     <tr>
       <td>
-        <code>event.session</code><br/>
-        <em>(Optional)</em>
+        <p><code>event.session</code></p>
+        <p><em>(Optional)</em></p>
       </td>
       <td>
         The current login session.<br/>
@@ -575,8 +575,8 @@ The `event` object for the post-login Actions trigger provides contextual inform
     
     <tr>
       <td>
-        <code>event.session_transfer_token</code><br/>
-        <em>(Optional)</em>
+        <p><code>event.session_transfer_token</code></p>
+        <p><em>(Optional)</em></p>
       </td>
       <td>
         [Private Early Access] Details of the current session transfer token used to establish SSO from a native app to a web app.<br/>
@@ -639,8 +639,8 @@ The `event` object for the post-login Actions trigger provides contextual inform
     
     <tr>
       <td>
-        <code>event.transaction</code><br/>
-        <em>(Optional)</em>
+        <p><code>event.transaction</code></p>
+        <p><em>(Optional)</em></p>
       </td>
       <td>
         Details about the current transaction.<br/>


### PR DESCRIPTION
### Description

Post-Login `event.authentication` is not being labeled as `(optional)`, despite documented as such.

Documentation: https://github.com/auth0/docs-v2/blob/4784c92376128ccf40e6e4b96301a2d013df766d/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-event-object.mdx?plain=1#L25-L28

Live doc link: https://auth0.com/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-event-object

#### Before Screenshot:
<img width="692" height="498" alt="Screenshot_20251103_225648" src="https://github.com/user-attachments/assets/e845cbb4-e333-4a5a-900a-9c9ff8777a65" />

## Fix

Since, `<em>` is an inline element, it needs to be wrapped inside a block level `<p>` element in order to display properly inside `<td>` elements. This solution matches what's done in post-user-registration-event-object.
https://github.com/auth0/docs-v2/blob/4784c92376128ccf40e6e4b96301a2d013df766d/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/post-user-registration-trigger/post-user-registration-event-object.mdx?plain=1#L51-L54

#### After Screenshot:
<img width="1888" height="827" alt="Screenshot_20251104_132045" src="https://github.com/user-attachments/assets/d2bbd617-cd25-4b31-a952-fea9546875f6" />

### Testing

Go to http://localhost:3000/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-event-object

Check that *(Optional)* appears under `event.authentication`.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
