### PR TITLE
docs(mcp): update section title and copy for accessing protected MCP servers

### DIFF
--- a/auth4genai/mcp/intro/overview.mdx
+++ b/auth4genai/mcp/intro/overview.mdx
@@ -27,11 +27,11 @@ The [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) is an open 
 
 Auth0's **Auth for MCP** lets developers securely and easily implement the authorization parts of the MCP spec with OAuth 2.1 and OpenID Connect. It provides sign in, standards based discovery and client registration, resource scoped tokens, and token exchange so you can control which agents connect, which resources they can access, and which actions they can perform.
 
-### User authentication
+### Accessing a Protected MCP Server
 
-Require users to sign in before they or their AI agents connect to MCP servers. Auth0 Universal Login supports social, enterprise, and custom identity providers so users can sign in with existing credentials. Access tokens issued by Auth0 include identity details that MCP servers can validate on every request.
+When an MCP server is protected with Auth0, clients and AI agents must first obtain an OAuth 2.0 access token to access it. Auth0 manages the authorization flow, ensuring the user authenticates with their chosen identity provider such as Okta, Entra ID, Ping, or Google Workspace, and delegates limited permissions to the agent.
 
-For enterprise environments, you can use your organization's identity provider and Single Sign-On (SSO) to authenticate users to your MCP servers. Auth0 connects to Okta, Entra ID, Ping, Google Workspace, and other IdPs so employees authenticate with existing credentials before any MCP interaction begins.
+The MCP client then uses the issued token to call the server. Auth0 handles authentication, token issuance and delegation of permissions. The MCP server then validates the token and enforces the authorization decisions represented in it.
 
 <Card
   title="Learn more about the benefits of using Auth for MCP"


### PR DESCRIPTION
## Summary

Updates the "User authentication" section in the MCP overview page to "Accessing a Protected MCP Server" with clearer, more accurate copy that explains the OAuth flow and responsibilities.

## Changes Made

**Section Title:** 
- Changed from "User authentication" → "Accessing a Protected MCP Server"

**Content Updates:**
- Clarified that clients must obtain OAuth 2.0 access tokens before accessing protected MCP servers
- Explained Auth0's role: manages authorization flow, handles user authentication, and delegates permissions
- Explained MCP server's role: validates tokens and enforces authorization decisions
- Simplified language to be more direct and developer-friendly
- Removed redundant enterprise SSO paragraph (covered elsewhere)

## Key Points

The new copy clearly separates responsibilities:
1. **Auth0**: Handles authentication, token issuance, and permission delegation
2. **MCP Server**: Validates tokens and enforces authorization decisions

This addresses the feedback that the previous "User authentication" section was confusing since the MCP server doesn't authenticate users - it only validates tokens.

## Test Plan

- [x] Verify section displays correctly on overview page
- [x] Confirm content accurately describes the OAuth flow
- [x] Check that title and content flow well with surrounding sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)