### PR TITLE
Add link checker GitHub workflow

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,95 @@
+name: Link Checker
+run-name: Link Checker (${{ github.event_name }} • ${{ github.ref_name }})
+
+on:
+  pull_request:
+    paths:
+    # Only run when docs files change in either site
+    - 'main/**/*.md'
+    - 'main/**/*.mdx'
+    - 'main/**/*.jsx'
+    - 'auth4genai/**/*.md'
+    - 'auth4genai/**/*.mdx'
+    - 'auth4genai/**/*.jsx'
+  workflow_dispatch: {} # Manual run (full scan for both sites)
+
+concurrency:
+  # One link-check run per ref; newer runs cancel older ones on the same branch/PR
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  link-check:
+    name: Link Checker (${{ matrix.site.name }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # required by checkout and changed-files
+
+    strategy:
+      # If one site fails (auth0 vs auth0-genai), do not cancel the other
+      fail-fast: false
+      matrix:
+        site:
+        - name: auth0
+          path: main
+        - name: auth0-genai
+          path: auth4genai
+
+    steps:
+    - name: Checkout repo
+      # https://github.com/actions/checkout
+      # Pin to v6.0.0 tag commit for supply-chain safety
+      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+
+    - name: Get changed files
+      # Only needed on PRs; for manual runs we always scan everything
+      if: github.event_name == 'pull_request'
+      id: changed
+      # https://github.com/yumemi-inc/changed-files
+      # Pin to v3.2.0 tag commit for supply-chain safety
+      uses: yumemi-inc/changed-files@50f2544ad88b4f274eace9689431b7281132304c # v3.2.0
+      with:
+        # Only consider docs files in the current site (from the matrix)
+        patterns: |
+          ${{ matrix.site.path }}/**/*.md
+          ${{ matrix.site.path }}/**/*.mdx
+          ${{ matrix.site.path }}/**/*.jsx
+        # Ignore deletions; we care about content that still exists
+        statuses: 'added|modified|renamed'
+        # Plain space-separated list, easier to feed into lychee args
+        format: 'plain'
+
+    - name: Decide Lychee targets
+      id: targets
+      # Run if:
+      # - not a PR (manual full scan), OR
+      # - PR with at least one changed file in this site
+      if: >
+        github.event_name != 'pull_request' ||
+        steps.changed.outputs.files != ''
+      run: |
+        # On PRs, use the list of changed files from the previous step.
+        # On manual runs, scan the whole docs tree for that site.
+        echo "targets=${{ github.event_name == 'pull_request' && steps.changed.outputs.files || format('''{0}/**/*.md'' ''{0}/**/*.mdx'' ''{0}/**/*.jsx''', matrix.site.path) }}" >> "$GITHUB_OUTPUT"
+
+    - name: Run Lychee on target
+      id: lychee
+      # Skip if we somehow ended up with no targets
+      if: steps.targets.outputs.targets != ''
+      # https://github.com/lycheeverse/lychee-action
+      # Pin to v2.7.0 tag commit
+      uses: lycheeverse/lychee-action@a8c4c7cb88f0c7386610c35eb25108e448569cb0 # v2.7.0
+      continue-on-error: true # let the job finish and report even if links are broken
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # used for GitHub API calls (e.g. rate limits, private links)
+      with:
+        fail: false # FIXME: Once the config, links, and fixes have stabilized, we should enable for hard block. For now this is just informative
+        # Important bits:
+        # - --root-dir ties file:// URLs to the correct site root
+        # - --format detailed + --verbose for useful CI logs
+        # - ${targets} is either changed files (PR) or whole tree (manual run)
+        args: >
+          --root-dir "$(pwd)/${{ matrix.site.path }}"
+          --format detailed
+          --verbose
+          ${{ steps.targets.outputs.targets }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ temp/
 *.py
 
 .vite
+
+.lycheecache

--- a/README.md
+++ b/README.md
@@ -63,3 +63,56 @@ pnpm add -g mint
 - **Custom port**: `mint dev --port 3333`
 
 For more details, see the [Mintlify CLI documentation](https://mintlify.com/docs/installation).
+
+## Link Checking
+
+We use [Lychee](https://lychee.cli.rs/) to check for broken links across both documentation sites (`main/` and `auth4genai/`).  
+All configuration and exclusions live in [`lychee.toml`](lychee.toml), and both local runs and CI use the same rules.
+
+### Local Usage
+
+There are two recommended ways to check links locally, depending on what you want to validate.
+
+#### 1. Check links as they behave on auth0.com
+
+This mode asks Lychee to treat absolute paths like `/docs/...` as if they were being loaded from the live site.  
+It is useful when you want to confirm that public links resolve correctly through redirects, locale routing, or dynamically rendered pages.
+
+**Main docs:**
+```bash
+lychee --format detailed --verbose --base-url https://auth0.com \
+  'main/**/*.md' 'main/**/*.mdx' 'main/**/*.jsx'
+````
+
+**Auth0 for AI Agents docs:**
+
+```bash
+lychee --format detailed --verbose --base-url https://auth0.com/ai/docs \
+  'auth4genai/**/*.md' 'auth4genai/**/*.mdx' 'auth4genai/**/*.jsx'
+```
+
+#### 2. Check links against the local filesystem
+
+This mode validates only links that actually exist in the repo.
+It is useful when you’re working on local references (images, snippets, relative paths) and want to ensure nothing in the tree is broken.
+
+**Main docs:**
+
+```bash
+lychee --format detailed --verbose --root-dir "$(pwd)/main" \
+  'main/**/*.md' 'main/**/*.mdx' 'main/**/*.jsx'
+```
+
+**Auth0 for AI Agents docs:**
+
+```bash
+lychee --format detailed --verbose --root-dir "$(pwd)/auth4genai" \
+  'auth4genai/**/*.md' 'auth4genai/**/*.mdx' 'auth4genai/**/*.jsx'
+```
+
+### Notes
+
+* You can combine `--base-url` and glob patterns however you like; the examples above are the patterns used in CI.
+* Any URLs that need to be ignored should be added to `lychee.toml`, not passed on the command line.
+* Lychee caches results locally, so repeat runs are much faster.
+* Mintlify already checks internal routes during `mint dev`, so Lychee is mainly for external links and static references.

--- a/auth4genai/.vale/README.md
+++ b/auth4genai/.vale/README.md
@@ -54,7 +54,7 @@ Vale parses `.mdx` files using `mdx2vast`. The parser automatically ignores:
 * JSX components and JSX blocks
 * fenced code blocks
 * inline backtick code
-* URLs (see [URL handling](https://vale.sh/docs/topics/urls))
+* URLs (see Vale’s URL handling notes: https://github.com/errata-ai/vale/issues/320)
 * single-line `{ ... }` JavaScript expressions
 
 These defaults help avoid false positives in pages that combine prose with examples, components, and structured metadata.

--- a/auth4genai/how-tos/analyze-strava-activities.mdx
+++ b/auth4genai/how-tos/analyze-strava-activities.mdx
@@ -4,7 +4,7 @@ description: Learn how to use Auth0 for AI Agents SDKs to analyze Strava activit
 mode: "wide"
 ---
 
-Use the [Vercel AI SDK](https://sdk.vercel./introduction), OpenAI GPT-4, and the Auth0 Next.js SDK to analyze user fitness activity from Strava.
+Use the [Vercel AI SDK](https://ai-sdk.dev/docs/introduction), OpenAI GPT-4, and the Auth0 Next.js SDK to analyze user fitness activity from Strava.
 
 <Card title="Prerequisites">
 Before using this example, make sure you:

--- a/auth4genai/how-tos/create-spotify-playlist.mdx
+++ b/auth4genai/how-tos/create-spotify-playlist.mdx
@@ -4,7 +4,7 @@ description: Learn how to use Auth0 for AI Agents SDKs to create a Spotify playl
 mode: "wide"
 ---
 
-Use the [Vercel AI SDK](https://sdk.vercel./introduction), OpenAI GPT-4, and the Auth0 Next.js SDK to create personalized Spotify playlists based on user input like mood, vibe, or activity.
+Use the [Vercel AI SDK](https://ai-sdk.dev/docs/introduction), OpenAI GPT-4, and the Auth0 Next.js SDK to create personalized Spotify playlists based on user input like mood, vibe, or activity.
 
 <Card title="Prerequisites">
 Before using this example, make sure you:

--- a/auth4genai/snippets/get-started/vercel-ai-next-js/user-authentication.mdx
+++ b/auth4genai/snippets/get-started/vercel-ai-next-js/user-authentication.mdx
@@ -67,7 +67,7 @@ Sign up for your application to create a new user account. You will then see a w
   >
 ### Install Auth0 Next.js SDK
 
-In the root directory of your project, install the [Auth0 Next.js SDK](http://next.js/):
+In the root directory of your project, install the [Auth0 Next.js SDK](https://github.com/auth0/nextjs-auth0):
 
 ```bash wrap lines
 npm i @auth0/nextjs-auth0@4

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,359 @@
+# lychee.toml
+#
+# Central configuration for Lychee in this repo.
+# Local runs and CI both read from this file so link-checking behaves the same everywhere.
+# For usage examples and recommended CLI flags, see the top-level README.
+#
+# Note: this file only defines rules (accepted codes, exclusions, etc.).
+# It does not replace CLI options like --root-dir or --base-url, which are set in CI.
+#
+# The exclusion list is intentionally long. Many external vendors block bots,
+# serve dynamic content, or require authentication, so the list grows over time.
+#
+# Lychee reference: https://lychee.cli.rs/guides/config/
+cache = true
+
+# CI friendly: disable progress bar (equivalent of --no-progress)
+no_progress = true
+
+# Treat these HTTP response codes as success.
+# 200–299: Standard successful responses.
+# 301: Temporary allowance; TODO: remove once baseline is clean and all redirects are updated in docs.
+# 302, 307: Used heavily in auth flows and login-gated vendor docs; prevents noisy false positives.
+# 403: Many vendor docs and API reference pages block unauthenticated bots; the URL is valid even though Lychee cannot fetch it.
+# 429: Third-party sites often rate-limit bots; not meaningful as link failures.
+accept = ["200..=299", "301", "302", "307", "403", "429"]
+
+# Fallback extensions to apply when a URL does not specify one.
+# For this repo, Mintlify uses MD and MDX.
+fallback_extensions = ["md", "mdx"]
+
+# Exclude all private IPs from checking.
+# Equivalent to setting `exclude_private`, `exclude_link_local`, and
+# `exclude_loopback` to true.
+exclude_all_private = true
+
+# Enable the checking of fragments in links.
+# TODO: After basic URL baseline is clean, start checking fragments
+include_fragments = false
+
+# URL-level exclusions. These are regular expressions, same as --exclude and .lycheeignore.
+exclude = [
+
+    #
+    # Root-relative URLs and local file:// links
+    #
+
+    # In CI we only care about external HTTP(S) links.
+    # With --root-dir, Mintlify-style root-relative paths (like /docs/...) are
+    # resolved by Lychee to file:// URLs under main/ and auth4genai/.
+    # Those local routes are already validated by Mintlify itself, so we exclude
+    # all file:// links in those trees here to avoid noisy false positives.
+    # This applies to local runs as well; if you ever need to check file:// links,
+    # run Lychee with a different config or override excludes on the CLI.
+    '^file://.*/main/',
+    '^file://.*/auth4genai/',
+
+    #
+    # Third-party sites that aggressively block or rate-limit bots
+    #
+
+    # All npmjs links (often 403 / bot-blocking)
+    '^https?://(www\.)?npmjs\.com/',
+    '^https?://(www\.)?npmjs\.org/', # Redirects to https://www.npmjs.com/
+
+    # LinkedIn (often 999 / 403 to automated clients)
+    '^https?://(www\.)?linkedin\.com/',
+
+    # Cloudflare support (bot-blocking)
+    '^https://support\.cloudflare\.com/',
+
+    # Azure portal (requires login)
+    '^https://portal\.azure\.com/',
+
+    # Constant Contact login (requires authentication / 403 to bots)
+    '^https://login\.constantcontact\.com/',
+
+    #
+    # Auth0 properties that require authentication or are internal
+    #
+
+    # Auth0 Dashboard and Manage (requires interactive login)
+    '^https?://manage\.auth0\.com/',
+
+    # Auth0 Support (some pages gated / 302 to login)
+    '^https://support\.auth0\.com/',
+
+    # Auth0 Community (older posts can 404; rate-limited)
+    '^https://community\.auth0\.com/',
+
+    # Test/example URLs in component demos
+    '^https://auth0\.com/bar',
+
+    # FGA Dashboard (requires authentication)
+    '^https://dashboard\.fga\.dev',
+
+    # Teams / accounts (requires authentication)
+    '^https://accounts\.auth0\.com',
+
+    # Security Trust Center (requires authentication and redirects to https://security.okta.com/)
+    '^https://auth0\.com/security',
+
+    #
+    # Anchors on dynamically rendered docs
+    #
+
+    # Top-level Auth0 homepage anchors (conflict with --base-url not being doc-relative)
+    '^https://auth0\.com/#',
+
+    # Management API v2 reference (dynamically loaded; redirects)
+    '^https://auth0\.com/docs/api/v2.*#',
+
+    # Authentication API reference (all locales; dynamically loaded)
+    '^https://auth0\.com/docs(?:/(fr-ca|ja-jp))?/api/authentication.*#',
+
+    # Management API v2 reference (all locales; dynamically loaded)
+    '^https://auth0\.com/docs(?:/(fr-ca|ja-jp))?/api/management/v2.*#',
+
+    #
+    # Internal / company-only resources
+    #
+
+    # Internal Oktawiki (requires Okta auth)
+    '^https://oktawiki\.atlassian\.net/',
+
+    #
+    # API-only / non-browsable endpoints
+    #
+
+    # OpenAI Platform (requires login / bot protection)
+    '^https://platform\.openai\.com/',
+
+    # Google Cloud Console & APIs dashboard (requires login)
+    '^https://console\.cloud\.google\.com/',
+    '^https://console\.developers\.google\.com/',
+
+    # Microsoft Graph API endpoints (not meant for direct browser navigation)
+    '^https://graph\.microsoft\.com/',
+
+    # Snapchat auth endpoints (API-only)
+    '^https://auth\.snapchat\.com/',
+
+    #
+    # Fake / example hosts used in docs
+    #
+
+    # Example API audiences and hosts used in doc contents
+    '^http://acme-api/',
+    '^https://quickstarts/api',
+    '^https://hs256\.test\.api',
+    '^https://rs256\.test\.api',
+    'travel0\.net',
+
+    # Ephemeral ngrok tunnels used in examples (usually dead)
+    '^https?://[^/]*\.ngrok\.io/',
+
+    # Custom schemes
+    '^myapp://callback',
+
+    #
+    # Non-resolvable logical identifiers, token types, etc.
+    #
+
+    '^http://schemas\.auth0\.com',
+    '^http://schema\.auth0\.com',
+    '^http://schemas\.xmlsoap\.org',
+    '^https://aws\.amazon\.com/SAML/Attributes',
+    '^http://auth0\.com/oauth/token-type',
+
+    #
+    # Dynamic / templated URLs
+    #
+
+    # Any URL containing an encoded { ... } block (e.g. %7Bhref%7D, %7Bimg%7D, ${...} encodings)
+    '%7B.*%7D',
+
+    # Any URL containing literal curly braces (templated routes etc.)
+    '\{.*\}',
+
+    # Shell-style placeholder variables that haven’t been expanded (e.g. $manage_url)
+    '\$manage_url',
+
+    #
+    # Known 503s (Service Unavailable)
+    #
+
+    # XML Encryption algorithm URIs (anchors used as identifiers)
+    "^https?://www\\.w3\\.org/2001/04/xmlenc#",
+
+    # XML Encryption core 2002 REC page (often returns 503)
+    "^https?://www\\.w3\\.org/TR/2002/REC-xmlenc-core-20021210/",
+
+    # WebCrypto spec
+    "^https://www\\.w3\\.org/TR/WebCryptoAPI/?$",
+
+    # WebAuthn specs (v2, v3, generic)
+    "^https://www\\.w3\\.org/TR/webauthn(-[23])?/",
+
+    # OpenID Foundation whitepaper PDF (frequent 503)
+    "^https://openid\\.net/wordpress-content/uploads/2022/03/OIDF-Whitepaper_Open-Banking-Open-Data-and-Financial-Grade-APIs_2022-03-16\\.pdf$",
+
+    #
+    # Known bad cert / flaky external sites
+    #
+
+    # Constant Contact KB – currently failing TLS / blocked to bots
+    "^https?://knowledgebase\\.constantcontact\\.com/",
+
+    #
+    # Known broken or legacy URLs (exact-match)
+    #
+
+    '^http://cm\.help\.alterian\.com/CM404/Default\.htm#Customer_Analytics/Import_Export/Data_Import\.htm$',
+    '^http://github\.com/osdiab%EF%BC%89$',
+    '^http://https//manage\.auth0\.com/#/api$',
+    '^http://schema\.auth0\.xn\-\-com\)\-y83cma2xsfm252aji0g\./$',
+    '^http://status\.mandrillapp\.com/$',
+    '^http://upstart\.ubuntu\.com/$',
+    '^http://www\.matteocollina\.com/$',
+    '^http://www\.microsoft\.com/en\-us/download/details\.aspx\?id=44020$',
+    '^http://xn\-\-localhost\)\-z73isb0lxm9gu998dezog\.xn\-\-httpslocalhosthttps\-ft2rfa34l0b5jsg2e9arc14a8begny9jpdvb43copcs5y2a19efknb38ap6afkm1c6c92bdb85531ckytb3o1bkf1c702aex0cykems5e0w1bxbz3a1wqalps\./$',
+    '^https://app\.mailjet\.com/account/api_keys$',
+    '^https://app\.mailjet\.com/template$',
+    '^https://auth\.com/profile$',
+    '^https://auth0\-1\.wistia\.com/medias/5kshjcduya$',
+    '^https://auth0\-1\.wistia\.com/medias/tet170a1vt$',
+    '^https://auth0\.com/%E5%90%8C%E3%81%98',
+    '^https://auth0\.com/architecture\-scenarios/multiple\-organization\-architecture$',
+    '^https://auth0\.com/blog/newsletter$',
+    '^https://auth0\.com/blog/on\-the\-nature\-of\-oauth2\-scopes/%EF%BC%89%E3%82%92%E3%81%94%E8%A6%A7%E3%81%8F%E3%81%A0%E3%81%95%E3%81%84%E3%80%82$',
+    '^https://auth0\.com/configure\-akamai\-supplemental\-signals$',
+    '^https://auth0\.com/customize/actions/write\-your\-first\-action$',
+    '^https://auth0\.com/dashboard/reference/settings\-tenant#settings$',
+    '^https://auth0\.com/docs//assets\.ctfassets\.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning\.pdf$',
+    '^https://auth0\.com/docs//assets\.ctfassets\.net/cdy7uua7fh8z/63F0WOPJdVzsPMxV1Xvp8x/7a329487c5e890d8e820f6a48983b46a/B2B_Project_Planning\.pdf$',
+    '^https://auth0\.com/docs/authenticate/login/auth0\-universal\-login#accessibility$',
+    '^https://auth0\.com/docs/fr\-ca/secure/multi\-factor\-authentication/auth0\-guardian/guardian\-for\-ios\-sdk$',
+    '^https://auth0\.com/docs/get\-started/architecture\-scenarios/implementation\-resources$',
+    '^https://auth0\.com/docs/images/cdy7uua7fh8z/2Cip8jFt1IhR24t5Q4V4KZ/749eb4107b1b8ad60dbabf4066fea151/file_type_icons\-02\.png$',
+    '^https://auth0\.com/docs/ja\-jp/support/policies$',
+    '^https://auth0\.com/docs/package/v2/timesheets\-mobile_android\.zip$',
+    '^https://auth0\.com/flows/concepts/client\-credentials$',
+    '^https://auth0\.com/libraries$',
+    '^https://auth0\.com/LICENSE$',
+    '^https://auth0\.com/protocols/oidc$',
+    '^https://auth0\.com/reference$',
+    '^https://auth0\.com/secure/sender\-constraining/configure\-sender\-constraining$',
+    '^https://auth0\.com/secure/sender\-constraining/demonstrating\-proof\-of\-possession\-dpop$',
+    '^https://auth0\.com/secure/sender\-constraining/mtls\-sender\-constraining$',
+    '^https://auth0\.com/sso/current$',
+    '^https://auth0\.com/tenant\-access\-control\-list$',
+    '^https://auth0\.com/tenant\-access\-control\-list/configure\-rules$',
+    '^https://auth0\.com/tenant\-access\-control\-list/reference$',
+    '^https://auth0\.com/tenant\-access\-control\-list/use\-cases$',
+    '^https://auth0\.com/troubleshoot/product\-lifecycle/past\-migrations#avoid\-pinning\-or\-fingerprinting\-tls\-certificates\-for\-auth0\-endpoints$',
+    '^https://auth0\.com/use\-akamai\-supplemental\-signals\-actions$',
+    '^https://auth0\.github\.io/auth0\-spa\-js/interfaces/gettokensilentlyoptions\.html$',
+    '^https://auth0\.github\.io/universal\-login/classes/Classes\.LoginId\.html$',
+    '^https://avocadolabs\.dev/recordings/why\-and\-how\-we\-built\-auth0\-marketplace/$',
+    '^https://azure\.microsoft\.com/en\-us/features/azure\-portal/$',
+    '^https://azure\.microsoft\.com/en\-us/free$',
+    '^https://azure\.microsoft\.com/en\-us/global\-infrastructure/geographies/$',
+    '^https://azure\.microsoft\.com/en\-us/services/api-management/$',
+    '^https://bintray\.com/auth0/android/auth0$',
+    '^https://bintray\.com/auth0/android/guardian$',
+    '^https://bintray\.com/auth0/android/lock\-facebook$',
+    '^https://bintray\.com/auth0/android/lock\-google$',
+    '^https://bintray\.com/bintray/jcenter$',
+    '^https://caddyserver\.com/v2$',
+    '^https://cdn2\.auth0\.com/1\.14553\.0/img/share\-image\.png$',
+    '^https://cdn2\.auth0\.com/docs/1\.14567\.0/media/platforms/flutter\.jpeg$',
+    '^https://cdn2\.auth0\.com/docs/ja\-jp/1\.14567\.0/img/share\-image\.png$',
+    '^https://cloudsecurityalliance\.org/star/registry/auth0/$',
+    '^https://collaborationhelp\.cisco\.com/article/en\-us/lfu88u$',
+    '^https://core\.telegram\.org/#bot\-api$',
+    '^https://core\.telegram\.org/bots$',
+    '^https://core\.telegram\.org/method/messages\.sendMessage$',
+    '^https://developer\.mozilla\.org/en\-US/docs/Mozilla/Integrated_authentication$',
+    '^https://developer\.okta\.com/docs/guides/submit\-app\-overview/%20$',
+    '^https://developer\.tiktok\.com/$',
+    '^https://developers\.facebook\.com/docs/apis\-and\-sdks/$',
+    '^https://developers\.facebook\.com/status/$',
+    '^https://developers\.tiktok\.com/doc/getting\-started\-faq/$',
+    '^https://developers\.tiktok\.com/doc/login\-kit\-manage\-user\-access\-tokens/$',
+    '^https://developers\.tiktok\.com/doc/login\-kit\-web/$',
+    '^https://developers\.tiktok\.com/doc/tiktok\-api\-v2\-get\-user\-info/$',
+    '^https://docs\.pingidentity\.com/r/en\-us/pingfederate\-120/pf_ident_provid_sso_config$',
+    '^https://documentation\.pingidentity\.com/pingfederate/pf84/#gettingStartedGuide/concept/gettingStarted\.html$',
+    '^https://documentation\.pingidentity\.com/pingfederate/pf84/index\.shtml#concept_digitalSignatureSettings\.html$',
+    '^https://firebase\.google\.com/docs/cloud\-messaging/concept\-options$',
+    '^https://gist\.github\.com/panva/652c61e7d847e0ed99926c324fa91b36$',
+    '^https://github\.com/auth0\-extensions/auth0\-logs\-to\-provider/blob/master/server/lib/senders/appinsights\.js$',
+    '^https://github\.com/auth0\-extensions/auth0\-logs\-to\-provider/blob/master/server/lib/senders/blobstorage\.js$',
+    '^https://github\.com/auth0\-samples/auth0\-aspnetcore\-mvc\-samples/tree/netcore2\.1$',
+    '^https://github\.com/auth0/auth0\-aws/tree/master/examples/api\-gateway/client$',
+    '^https://github\.com/auth0/Auth0\.Android/blob/master/auth0/src/main/java/com/auth0/android/result/Credentials\.java$',
+    '^https://github\.com/auth0/jwt\-auth\-bundle/tree/3\.x\.x\-dev$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/assets/js/lock\-init\.js#L22$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/examples/auth0_auth_scope\.php$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/examples/auth0_authorize_state\.php$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/examples/auth0_authorize_url_params\.php$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/examples/auth0_authorize_url\.php$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/examples/auth0_before_login\.php$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/examples/auth0_create_user_data\.php$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/examples/auth0_die_on_login_output\.php$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/examples/auth0_get_auto_login_connection\.php$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/examples/auth0_get_wp_user\.php$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/examples/auth0_jwt_leeway\.php$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/examples/auth0_jwt_max_age\.php$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/examples/auth0_lock_options\.php$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/examples/auth0_login_css\.php$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/examples/auth0_login_form_tpl\.php$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/examples/auth0_logout_url\.php$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/examples/auth0_migration_ws_authenticated\.php$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/examples/auth0_nonce_cookie_name\.php$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/examples/auth0_settings_constant_prefix\.php$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/examples/auth0_settings_fields\.php$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/examples/auth0_slo_return_to\.php$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/examples/auth0_state_cookie_name\.php$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/examples/auth0_use_management_api_for_userinfo\.php$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/examples/auth0_user_login\.php$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/examples/auth0_verify_email_page\.php$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/examples/wp_auth0_get_option\.php$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/examples/wpa0_should_create_user\.php$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/examples/wpa0_user_created\.php$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/lib/WP_Auth0_CustomDBLib\.php$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/lib/WP_Auth0_Lock\.php$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/lib/WP_Auth0_LoginManager\.php#L148$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/lib/WP_Auth0_LoginManager\.php#L90$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/lib/WP_Auth0_Routes\.php#L138$',
+    '^https://github\.com/auth0/wp\-auth0/blob/master/MIGRATE\-v3\-TO\-v4\.md$',
+    '^https://github\.com/auth0/wp\-auth0/issues/494$',
+    '^https://github\.com/auth0/wp\-auth0/tree/master/examples$',
+    '^https://github\.com/Runscope/requestbin$',
+    '^https://github\.com/undefined/undefined/tree/master/01\-Login$',
+    '^https://help\.marketingcloud\.com/en/documentation/exacttarget/subscribers/subscribers_for_interactive_marketing_hub/imports/importing_subscribers/$',
+    '^https://login/$',
+    '^https://manage\.auth0/$',
+    '^https://marketplace\.auth0\.com/integrations/telesign\-sms\-provider$',
+    '^https://marketplace\.auth0\.com/integrations/verosint\-log\-stream$',
+    '^https://marketplace\.auth0\.com/integrations/vonage\-sms\-provider$',
+    '^https://www\.nginx\.com/products/nginx/?',
+    '^https://smtp4dev\.codeplex\.com/$',
+    '^https://support\.onelogin\.com/hc/en\-us/articles/201174464\-Attribute\-macros$',
+    '^https://techdocs\.akamai\.com/api\-definitions/docs/add\-api\-resources$',
+    '^https://techdocs\.akamai\.com/api\-definitions/docs/register\-api$',
+    '^https://techdocs\.akamai\.com/content\-protector/docs/forward\-bot\-results\-to\-origin$',
+    '^https://test\.xn\-\-app\)\-753cxdwb8etduh5fqdv603d8zsh/$',
+    '^https://tools\.android\.com/tech\-docs/new\-build\-system/user\-guide$',
+    '^https://www\.browserling\.com/tools/bcrypt$',
+    '^https://www\.facebook\.com/business/m/one\-sheeters/gdpr\-developer\-faqs$',
+    '^https://www\.hhs\.gov/hipaa/for\-professionals/special\-topics/HITECH\-act\-enforcement\-interim\-final\-rule/index\.html$',
+    '^https://www\.hhs\.gov/hipaa/index\.html$',
+    '^https://www\.ibm\.com/support/knowledgecenter/en/SSPREK_9\.0\.4/com\.ibm\.isam\.doc/config/concept/fed_SAML20_bindings\.html$',
+    '^https://www\.sap\.com/about/cloud\-trust\-center/cloud\-service\-status\.html$',
+    '^https://www\.sendsafely\.com/%20$',
+    '^https://www\.twilio\.com/docs/sms/services/services\-send\-messages$',
+    '^https://www\.twilio\.com/help/faq/twilio\-basics/what\-is\-an\-application\-sid$',
+    '^https://www\.twilio\.com/learn/voice\-and\-video/toll\-fraud$',
+]

--- a/main/README.md
+++ b/main/README.md
@@ -37,4 +37,4 @@ If you find a bug or inaccuracy in the documentation content, please report it i
 
 ## License
 
-This project is licensed under the MIT license. See the [LICENSE](LICENSE) file for more info.
+This project is licensed under the MIT license. See the [LICENSE](../LICENSE) file for more info.


### PR DESCRIPTION
## 📝 Before you begin

By opening this PR, you agree to the terms of the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). For guidance on creating a high-quality PR, see the [Contributing Guidelines](CONTRIBUTING.md).

## ✏️ Changes

This PR wires up automated external-link checking for both the `main` and `auth4genai` Mintlify docs using Lychee. It adds a GitHub Actions workflow, centralizes link-check configuration in `lychee.toml`, and updates the READMEs so people know how to run the checks locally.

- **Problem solved**: Catch broken external links (404s, bad certs, consistent 503s, etc.) in docs before they reach production
- **Docs/UI areas affected**: Both `main/` and `auth4genai/` documentation sites
- **Scope**: Adds a CI workflow, shared Lychee config, and documentation updates

## 📁 Documentation scope

**Docs site(s) affected**

- [x] `main/`
- [x] `auth4genai/`

**Other areas**

- [ ] Shared UI library (`ui/`)
- [x] GitHub workflows (`.github/workflows/`)
- [ ] Tooling or scripts (`tools/`)

**Type of change**

- [ ] New page or major section
- [x] Update to existing content
- [ ] Navigation or structure change
- [ ] Code examples or snippets
- [ ] UI component or Mintlify configuration
- [x] GitHub workflows (`.github/workflows/`)
- [ ] Scripts or tooling (`tools/`)

**Paths**:
- `.github/workflows/link-check.yml`
- `lychee.toml`
- `auth4genai/README.md`
- `main/README.md`

## 🔗 References

- [Lychee link checker](https://github.com/lycheeverse/lychee)
- [Lychee config reference](https://lychee.cli.rs/guides/config/)

## 🎯 Testing

**Local validation**

- [ ] Content-only change (no build or navigation impact)
- [ ] `mint dev` in affected folders
- [ ] `mint broken-links` (when applicable)
- [ ] `mint a11y` (when applicable)
- [ ] `npm run build` in `ui/` (for UI changes)

**Style and structure**

- [x] Follows the Contributing Guidelines
- [x] Uses correct Auth0 terminology
- [x] Code blocks include language and filenames when needed

**Repo checks**

- [ ] All required GitHub checks are passing
- [x] The correct base branch is used

**Notes**: Workflow exercised via manual dispatch and PRs. Currently configured as warning-only (`continue-on-error: true`, `fail: false`) while excludes settle.

## 🔄 Redirects

Not applicable – no URL changes.

## 🌍 Internationalization (main docs only)

- [x] Not applicable – no English content changes in `main/`

## 🧩 Impact and dependencies

**User-facing impact**

- New automated checks for external links in both documentation trees
- Two separate checks appear in PR status:
  - `Link Checker (auth0)`
  - `Link Checker (auth0-genai)`
- Checks are non-blocking for now; they surface broken links but do not prevent merges

**Dependencies**

None.

## 🚀 Deployment

- [x] Safe to deploy on merge

## 📝 Follow-up

- [ ] No follow-up needed
- [x] Follow-up work required

**Next steps**:

- Tighten `exclude` patterns in `lychee.toml` as more noisy URLs show up
- Decide when to make the checks required / blocking
- Consider enabling fragment checking (`include_fragments = true`) once the baseline is stable

## 💬 Additional context

### What’s included

#### GitHub Actions workflow

A new workflow at `.github/workflows/link-check.yml` that:

- runs on pull requests that touch docs in `main/` or `auth4genai/`
- can be run manually via **workflow_dispatch** (full scan for both sites)
- uses a simple matrix to run separately for:
  - `auth0` → `main/`
  - `auth0-genai` → `auth4genai/`
- on PRs:
  - uses [`yumemi-inc/changed-files`](https://github.com/yumemi-inc/changed-files) to detect changed `.md`, `.mdx`, `.jsx` files per site
  - only runs Lychee on files that actually changed
- on manual runs:
  - scans `**/*.md`, `**/*.mdx`, `**/*.jsx` for each site
- runs Lychee via [`lycheeverse/lychee-action`](https://github.com/lycheeverse/lychee-action) with `--root-dir` set to the site root, so root-relative paths resolve correctly against the filesystem
- pins all actions to specific commit hashes

Each site shows up as its own check in the PR UI:

- `Link Checker (auth0)`
- `Link Checker (auth0-genai)`

#### Lychee configuration

`lychee.toml` now holds all shared config:

- enables caching (`cache = true`) and disables progress output for CI
- defines `accept` codes for common “not really broken” responses (302, 307, 403, 429)
- sets fallback extensions for Mintlify (`md`, `mdx`)
- turns off fragment checking for now (`include_fragments = false`)
- centralizes a curated `exclude` list that filters out:
  - URLs that require authentication (Auth0 Dashboard, Oktawiki, etc.)
  - sites that consistently block or throttle bots (npmjs.com, LinkedIn, Cloudflare, Constant Contact KB, some W3C / OpenID PDFs)
  - API-only endpoints and placeholders
  - root-relative `file://` URLs that cannot be resolved reliably in this repo

This replaces ad hoc ignores and keeps CI + local runs using the same rules.

#### Documentation updates

`main/README.md` and `auth4genai/README.md` now include:

- a short section on how to run Lychee locally with:
  - `--base-url` when you care about how links behave on `auth0.com` / `auth0.com/ai/docs`
  - `--root-dir` when you want to validate links against the local repo layout

### Usage

#### Automated

Lychee runs automatically:

- on pull requests that touch `main/**/*.md[x|jsx]` or `auth4genai/**/*.md[x|jsx]`
- per site, via the `auth0` / `auth0-genai` matrix

Each run respects `lychee.toml`.

#### Manual

From the Actions tab:

1. Open **Link Checker**
2. Click **Run workflow** (no inputs)
3. Wait for:
   - `Link Checker (auth0)`
   - `Link Checker (auth0-genai)`

Both sites are scanned in full.

#### Local examples

Against live `auth0.com` docs (external behavior):

```bash
lychee --format detailed --verbose \
  --base-url https://auth0.com \
  'main/**/*.md' 'main/**/*.mdx' 'main/**/*.jsx'
````

Against the local `main/` tree (filesystem behavior):

```bash
lychee --format detailed --verbose \
  --root-dir "$(pwd)/main" \
  'main/**/*.md' 'main/**/*.mdx' 'main/**/*.jsx'
```

Swap `main` for `auth4genai` and `https://auth0.com/ai/docs` if you want to target the AI docs.

Lychee will pick up `lychee.toml` automatically in all these cases.
