### PR TITLE
docs(mcp): update Cloudflare MCP guide sidebar title

### DIFF
--- a/auth4genai/mcp/guides/cloudflare-mcp.mdx
+++ b/auth4genai/mcp/guides/cloudflare-mcp.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Secure MCP Servers with Auth0 and Cloudflare"
 description: "Learn how to use Auth0 and Cloudflare to secure MCP servers."
-sidebarTitle: "Cloudflare MCP Servers"
+sidebarTitle: "Secure Cloudflare MCP Servers"
 ---
 
 Auth0 has collaborated with Cloudflare to help developers secure remote MCP servers powered by [Cloudflare Workers](https://developers.cloudflare.com/workers/). With the pace of MCP adoption rapidly increasing, Cloudflare has [added features to its platform](https://blog.cloudflare.com/remote-model-context-protocol-servers-mcp/) that handle the hard parts of building remote MCP servers, like `workers-oauth-provider`, an OAuth Provider that makes authorization easy. By securing your MCP server with Auth0, AI applications can now interact with an external API by connecting through the remote MCP server and make API calls on behalf of an authenticated user.

--- a/auth4genai/mcp/guides/registering-your-mcp-client-application.mdx
+++ b/auth4genai/mcp/guides/registering-your-mcp-client-application.mdx
@@ -1,7 +1,7 @@
 ---
-title: Registering your MCP Client Application
+title: Register your MCP Client Application
 description: Register MCP clients so AI Agents can safely connect to your resources using OAuth 2.1.
-sidebarTitle: Registering your MCP Client Application
+sidebarTitle: Register your MCP Client Application
 ---
 
 Before your MCP client application can interact with a protected MCP server, it must be registered with an authorization server like Auth0. This registration process provides the client with a unique `client_id` and credentials, establishing a trusted identity for the OAuth 2.1 flow.


### PR DESCRIPTION
## Summary

Normalized MCP guide titles to follow Auth0 style guidelines by removing gerund forms and improving clarity.

## Changes

### 1. cloudflare-mcp.mdx
Updated sidebar title for better scannability:
```diff
- sidebarTitle: "Cloudflare MCP Servers"
+ sidebarTitle: "Secure Cloudflare MCP Servers"
```

### 2. registering-your-mcp-client-application.mdx
Removed gerund form from title and sidebar:
```diff
- title: "Registering your MCP Client Application"
- sidebarTitle: "Registering your MCP Client Application"
+ title: "Register your MCP Client Application"
+ sidebarTitle: "Register your MCP Client Application"
```

## Rationale

Per the Auth0 QuickStart and Guide writing standards:

### Style Guidelines for Headings
- ✅ Use simple tense, **not progressive or gerund forms**
- ✅ Make sidebar titles scannable and self-explanatory
- ✅ Use action-oriented, task-focused language
- ✅ Match existing patterns in navigation

### Why These Changes

**Cloudflare MCP guide progression:**
1. ❌ "Cloudflare MCP Servers" - vague, no action indicated
2. ❌ "Secure with Auth0 and Cloudflare" - incomplete, secure *what*?
3. ✅ **"Secure Cloudflare MCP Servers"** - clear action, specific object, scannable

**Registering MCP Client guide:**
- ❌ "**Registering** your MCP Client Application" - gerund form violates style guidelines
- ✅ "**Register** your MCP Client Application" - simple tense, action-oriented

Both now match the pattern of other guide titles like:
- "**Test** your MCP Server with MCP Inspector"
- "**Enable** Resource Parameter Compatibility Profile"

## Capitalization Note

Maintained title case capitalization ("MCP Client Application", "MCP Servers") for consistency with existing guide titles in this section.

However, Auth0 style guidelines recommend sentence case (only capitalize first word, acronyms, and proper nouns). Technically these should be:
- "Secure Cloudflare MCP servers"
- "Register your MCP client application"

We maintained title case to avoid mixing capitalization styles within the same navigation section. **Recommendation:** Normalize all MCP guide titles to sentence case in a future PR.

## Test Plan

- [ ] Verify "Secure Cloudflare MCP Servers" displays correctly in sidebar
- [ ] Verify "Register your MCP Client Application" displays correctly in sidebar
- [ ] Confirm both pages render with updated titles
- [ ] Test that pages are accessible at expected URLs
- [ ] Verify titles are scannable when viewing guide list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1105" height="919" alt="image" src="https://github.com/user-attachments/assets/28e7eb3f-6c9f-40f6-9b5d-2f7ee4c07692" />
