### PR TITLE
AIDX-328 Use Resource Server client for MCP server in CTE sample

### DIFF
--- a/auth4genai/mcp/get-started/call-your-apis-on-users-behalf.mdx
+++ b/auth4genai/mcp/get-started/call-your-apis-on-users-behalf.mdx
@@ -53,7 +53,7 @@ auth0 api post clients --data '{
   "token_exchange": {
     "allow_any_profile_of_type": ["custom_authentication"]
   }
-}' | jq -r '"{\"client_id\":\"" + .client_id + "\",\"client_secret\": \"" +  .client_secret + "\"}"' > auth0-app-details.json
+}' | jq -c '{client_id, client_secret}' > auth0-app-details.json
 ```
 
 The output of the command will be a JSON object with the `client_id` and `client_secret` of the newly created client, which will be used in the next steps to configure the MCP server environment.


### PR DESCRIPTION
### Description
Updated the MCP server client configuration:
- `"app_type": "resource_server"`
- `resource_server_identifier` for associating this client with a resource server
- `client_credentials` grant type
- `token_exchange` property for custom token exchange grant

<img width="1480" height="759" alt="image" src="https://github.com/user-attachments/assets/41f72ca0-5d91-49c3-af40-f7ddb8d18a3d" />


### References
https://auth0team.atlassian.net/browse/AIDX-328

### Testing
<img width="1555" height="760" alt="image" src="https://github.com/user-attachments/assets/6c262abb-edce-4b92-bd19-b4033336bd8f" />

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
