### PR TITLE
Correct typo

### DIFF
--- a/main/docs/get-started/applications/dynamic-client-registration.mdx
+++ b/main/docs/get-started/applications/dynamic-client-registration.mdx
@@ -523,7 +523,7 @@ If you need API access, then following the authentication, you need to extract t
 
 ## Use Tenant Access Control List (ACL)
 
-Auth0 provides [Tenant Access Control List (ACL)](/docs/secure/tenant-access-control-list) to manage traffic. For the `/oidc/register` endpoint, you can add the `drc` scope to an ACL rule to help manage rquests. To learn more, read [Reference](/docs/secure/tenant-access-control-list/reference).
+Auth0 provides [Tenant Access Control List (ACL)](/docs/secure/tenant-access-control-list) to manage traffic. For the `/oidc/register` endpoint, you can add the `dcr` scope to an ACL rule to help manage requests. To learn more, read [Reference](/docs/secure/tenant-access-control-list/reference).
 
 ## Learn more
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR fixes two typos in the Tenant ACL documentation for Dynamic Application Registration.


### References

<img width="1266" height="306" alt="image" src="https://github.com/user-attachments/assets/7f1bece9-ad26-414a-be46-1d59af3d2191" />


### Testing

After building and serving locally with `mint dev`, going to http://localhost:3000/docs/get-started/applications/dynamic-client-registration#use-tenant-access-control-list-acl should show the following.

<img width="633" height="153" alt="image" src="https://github.com/user-attachments/assets/4cc5f15f-8a1b-4e07-bf17-6ae3b432e4c5" />


### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
