### PR TITLE
Adding canonical url metadata tag for our custom domain

### DIFF
--- a/auth4genai/docs.json
+++ b/auth4genai/docs.json
@@ -1,6 +1,12 @@
 {
   "$schema": "https://mintlify.com/docs.json",
   "theme": "mint",
+  "seo": {
+    "metatags": {
+      "og:url": "https://auth0.com/ai/docs",
+      "canonical": "https://auth0.com/ai/docs"
+    }
+  },
   "name": "Auth0",
   "colors": {
     "primary": "#6742D5",


### PR DESCRIPTION
There is a bug when using a mobile device and sharing the [auth0.com/ai/docs](http://auth0.com/ai/docs) pages, the Mintlify link is being shared instead.
For example, when on this page: https://auth0.com/ai/docs/intro/overview, the sharing link is this: https://auth0-genai.mintlify-ai-docs.com/ai/docs/intro/overview

The fix is to set canonical url for our custom domain as per response from Minlify. Also mentioned in their docs here: https://www.mintlify.com/docs/optimize/seo

This PR adds that to the site's docs.json.