### PR TITLE
fix: Fixed the SDK initialisation snippet for Android SDK

### DIFF
--- a/main/docs/quickstart/native/android/index.mdx
+++ b/main/docs/quickstart/native/android/index.mdx
@@ -43,7 +43,7 @@ title: Add Login to Your Android Application
     ```kotlin app/build.gradle.kts lines
     dependencies {   
         // Auth0 SDK
-        implementation("com.auth0.android:auth0:3.10.0")
+        implementation("com.auth0.android:auth0:3.11.0")
     }
     ```
 
@@ -128,7 +128,7 @@ title: Add Login to Your Android Application
             super.onCreate(savedInstanceState)
             
             // Initialize Auth0
-            auth0 = Auth0(
+            auth0 = Auth0.getInstance(
                 getString(R.string.com_auth0_client_id),
                 getString(R.string.com_auth0_domain)
             )


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR updates the code snippet for initialising the Android SDK. The current code uses an older initialisation method which is no longer valid since version 3.0.0 of Android SDK


### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not the default branch
