### PR TITLE
refactor: standardizes temporary override for <CardGroup> component styling

### DIFF
--- a/auth4genai/style.css
+++ b/auth4genai/style.css
@@ -269,8 +269,8 @@ html[style*="color-scheme: dark"] {
   max-width: 50%;
 }
 
-/* FIXME: Override for both the original SDK cards and the custom cards */
-[data-component-part="card-icon"] img,
-.custom-card-icon img {
-  margin: 0 !important;
+/* FIXME: Temporary override for both the original SDK cards and the custom cards due to large margin in Mintlify's latest changes to their <CardGroup> component styling */
+.prose :where(img):not(:where([class~=not-prose],[class~=not-prose] *)) {
+  margin-top: 0;
+  margin-bottom: 0;
 }

--- a/main/docs/css/styles.css
+++ b/main/docs/css/styles.css
@@ -683,7 +683,7 @@ a.card[href^="http"]::after {
   color: #000 !important;
 }
 
-/* FIXME: Override for both the original SDK cards and the custom cards */
+/* FIXME: Temporary override for both the original SDK cards and the custom cards due to large margin in Mintlify's latest changes to their <CardGroup> component styling */
 .prose :where(img):not(:where([class~=not-prose],[class~=not-prose] *)) {
     margin-top: 0;
     margin-bottom: 0;


### PR DESCRIPTION
refactor: standardizes temporary override for both the original SDK cards and the custom cards due to large margin in Mintlifys latest changes to their <CardGroup> component styling

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.
>
> Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc.
>
> If the UI is being changed, please provide screenshots.


### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - Auth0 Community post
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
