### PR TITLE
Add template variables documentation and UI architecture guide

### DIFF
--- a/.claude/skills/writing-auth0-docs/SKILL.md
+++ b/.claude/skills/writing-auth0-docs/SKILL.md
@@ -29,7 +29,8 @@ Use this skill when actively authoring new public Auth0 product documentation or
 | Grammar, tense, pronouns, punctuation | [writing-mechanics.md](reference/writing-mechanics.md) |
 | Tables, notes, callouts, code blocks | [formatting.md](reference/formatting.md) |
 | Terminology, capitalization, UI wording | [word-lists.md](reference/word-lists.md) |
-| Links, images, code, placeholders, UI text | [other-conventions.md](reference/other-conventions.md) |
+| Links, images, code, UI text | [other-conventions.md](reference/other-conventions.md) |
+| Placeholders and template variables | [placeholders-and-template-variables.md](reference/placeholders-and-template-variables.md) |
 | Translation-ready writing | [writing-for-translation.md](reference/writing-for-translation.md) |
 | Deprecations, compliance, Early Access | [operational-policies-and-regulatory-articles.md](reference/operational-policies-and-regulatory-articles.md) |
 | Overview and external resources | [auth0-docs-style-guide.md](reference/auth0-docs-style-guide.md), [references-and-resources.md](reference/references-and-resources.md) |
@@ -43,6 +44,7 @@ Use this skill when actively authoring new public Auth0 product documentation or
 
 **While writing:**
 - Voice/tone: Clear, approachable, user-focused
+- Personalization: Use template variables (e.g., `{{yourDomain}}`) for tenant/client values
 - Grammar: Present tense, active voice, imperative mood for instructions
 - Headings: Sentence case (not title case)
 - Language: Inclusive, accessible, avoid idioms/jargon

--- a/.claude/skills/writing-auth0-docs/reference/formatting.md
+++ b/.claude/skills/writing-auth0-docs/reference/formatting.md
@@ -27,30 +27,15 @@ When giving only the month and year, don't use a comma.
 | --- |
 | She was hired in January 2017. |
 
-## Document variables
+## Document variables and placeholders
 
-When writing docs you can use the following variables instead of hard-coding these values. You can use `${variableName}` within any document to reference the value.
+Auth0 documentation uses several types of variables and placeholders to represent dynamic values. For complete guidance on all variable types, catalogs, and usage guidelines, read [Placeholders & Template Variables](placeholders-and-template-variables.md).
 
-### Common variables
+**Summary of variable types:**
 
-| **Variable** | **Description** | **Default Value** |
-| --- | --- | --- |
-| `manage_url` | The URL to the management portal. | `https://manage.auth0.com` |
-| `auth0js_url` | The URL to the auth0.js CDN location. |   |
-| `auth0js_urlv8` | The URL to the auth0.js v8 CDN location. |   |
-| `lock_url` | The URL to the Lock script CDN location. |   |
-| `env.DOMAIN_URL_SUPPORT` | Support Center URL | `https://support.auth0.com` |
-
-### User-specific variables
-
-| **Variable** | **Description** | **Default Value** |
-| --- | --- | --- |
-| `account.appName` | The name of the current Auth0 app. | `YOUR_APP_NAME` |
-| `account.tenant` | The name of the current Auth0 tenant. | `YOUR_TENANT` |
-| `account.namespace` | The name of the current Auth0 namespace. | `YOUR_NAMESPACE` |
-| `account.clientId` | The Client ID of the current Auth0 app. | `YOUR_CLIENT_ID` |
-| `account.clientSecret` | The Client Secret of the current Auth0 app. | `YOUR_CLIENT_SECRET` |
-| `account.callback` | The first callback URL of the current Auth0 app. | `http://YOUR_APP.auth0.com/callback` |
+1. **Dynamic Template Variables** (`{{doubleCurly}}`): Auto-populate from logged-in user's session
+2. **Build-time Document Variables** (`${dollar}`): Replaced during build process
+3. **Static Placeholders** (`{singleCurly}` or `<ANGLE>`): Manual replacement by users
 
 ## Endpoint names
 
@@ -100,5 +85,5 @@ Use the following guidelines:
 
 ## Variables
 
-We use generic variables in many code samples, but we are also able to create variables that auto-populate certain user or tenant values as long as the reader is logged in to the docs application.
+For comprehensive information on using variables and placeholders in code samples, including dynamic auto-population for logged-in users, read [Placeholders & Template Variables](placeholders-and-template-variables.md).
 

--- a/.claude/skills/writing-auth0-docs/reference/other-conventions.md
+++ b/.claude/skills/writing-auth0-docs/reference/other-conventions.md
@@ -58,39 +58,18 @@ if (foo bar) {
 }
 ```
 
-### Placeholders
+### Placeholders and template variables
 
-Use curly braces `{}` to indicate a variable that’s part of a URL path: `{yourDomain}`, `/api/v2/clients/{clientId}`
+Auth0 documentation uses several types of placeholders to represent values that vary by user, tenant, or context. For comprehensive guidance on choosing and formatting placeholders, read [Placeholders & Template Variables](placeholders-and-template-variables.md).
 
-Use angle brackets `<>` with capitalized letters separated by underscores to indicate a variable that’s a user-provided value: `<YOUR_MANAGEMENT_API_TOKEN>`
+**Quick reference:**
 
-Properly-formatted example:
+- Use `{{doubleCurly}}` for dynamic template variables that auto-populate: `{{yourDomain}}`, `{{yourClientId}}`
+- Use `{singleCurly}` for URL path variables: `{yourDomain}`, `/api/v2/clients/{clientId}`
+- Use `<ANGLE_BRACKETS>` for user-provided values: `<YOUR_MANAGEMENT_API_TOKEN>`
+- Use `${dollar}` for build-time document variables: `${manage_url}`, `${auth0js_url}`
 
-```java
-curl --request PATCH 'https://{yourDomain}/api/v2/clients/{clientId}' \
---header 'Content-Type: application/json' \
---header 'Authorization: Bearer <YOUR_MANAGEMENT_API_TOKEN>' \
---data '{
-    "grant_types": [
-        "authorization_code"
-    ]
-}'
-```
-
-Example with code formatting that’s not recommended:
-
-```java
-curl --request PATCH 'https://{yourDomain}/api/v2/clients/<clientId>' \
---header 'Content-Type: application/json' \
---header 'Authorization: Bearer <your-management-api-token>' \
---data '{
-    "grant_types": [
-        "authorization_code"
-    ]
-}'
-```
-
-Reference: [Google Developer Style Guide](https://developers.google.com/style/placeholders)
+See also: [Google Developer Style Guide on Placeholders](https://developers.google.com/style/placeholders)
 
 ### Cross-references and links
 

--- a/.claude/skills/writing-auth0-docs/reference/placeholders-and-template-variables.md
+++ b/.claude/skills/writing-auth0-docs/reference/placeholders-and-template-variables.md
@@ -1,0 +1,254 @@
+# Placeholders & Template Variables
+
+This guide covers all placeholder and variable conventions used in Auth0 documentation, including dynamic template variables that auto-populate for logged-in users and static placeholders that users manually replace.
+
+## Overview
+
+Auth0 documentation uses three types of placeholders to represent values that vary by user, tenant, or context:
+
+1. **Dynamic Template Variables** (`{{doubleCurly}}`): Auto-populate from user's session for logged-in readers
+2. **Build-time Document Variables** (`${dollar}`): Replaced during build process with static values
+3. **Static Placeholders** (`{singleCurly}` or `<ANGLE>`): Manual replacement by users when copying code
+
+This personalization reduces friction by allowing developers to copy and paste code snippets directly into their projects without manually locating and swapping configuration values.
+
+## Dynamic Template Variables (`{{doubleCurly}}`)
+
+Dynamic template variables automatically populate with values from the user's **current session context** when they are logged into the docs site. This context is determined by three factors:
+
+1.  **User Authentication**: The identity of the user logged into the docs site.
+2.  **Selected Tenant**: The Auth0 tenant currently active in the user's session.
+3.  **Selected Resources**: The specific Application (Client) or API (Resource Server) the user has selected in the docs site navigation or profile menu.
+
+If a user switches tenants or selects a different application in the docs UI, all template variables on the page update immediately to reflect the new context.
+
+### Variable Catalog
+
+The following variables are available for use in prose, code blocks, and tables.
+
+| Variable | Description | Origin |
+| :--- | :--- | :--- |
+| `{{yourAppName}}` | The name of the currently selected Auth0 Application. | Selected Application |
+| `{{userName}}` | The display name of the authenticated user. | User Profile |
+| `{{yourTenant}}` | The name of the currently selected Auth0 Tenant. | Selected Tenant |
+| `{{yourDomain}}` | The Domain/Namespace of the current Tenant (e.g., `dev-abc.auth0.com`). | Selected Tenant |
+| `{{yourClientId}}` | The Client ID of the selected Application. | Selected Application |
+| `{{yourClientSecret}}` | The Client Secret of the selected Application. | Selected Application |
+| `{{https://yourApp/callback}}` | The first Callback URL configured for the selected Application. | Selected Application |
+| `{{yourApiIdentifier}}` | The Identifier (Audience) of the selected API. | Selected API |
+| `{{yourConnectionName}}` | Reserved for connection name selection. | *Reserved* |
+
+## Usage Guidelines
+
+### Inline text
+
+Use template variables in paragraphs to provide context-aware instructions. Wrap the variable name in double curly braces `{{ }}`.
+
+**Example Markdown:**
+```markdown
+To configure your application, use the domain **{{yourDomain}}**.
+````
+
+**Rendered Output (Logged In):**
+
+> To configure your application, use the domain **dev-tenant.us.auth0.com**.
+
+**Rendered Output (Logged Out):**
+
+> To configure your application, use the domain **{yourDomain}**.
+
+### Code blocks
+
+Standard Markdown code blocks (triple backticks) do **not** support dynamic variable replacement. To use variables in code, you must use the `<AuthCodeBlock>` component.
+
+Define the code snippet as an exported constant string, then pass it to the component.
+
+**Example MDX:**
+
+```jsx
+import {AuthCodeBlock} from "/snippets/AuthCodeBlock.jsx";
+
+export const sdkConfig = `const auth0 = new Auth0Client({
+  domain: '{{yourDomain}}',
+  client_id: '{{yourClientId}}'
+});`;
+
+<AuthCodeBlock children={sdkConfig} language="javascript" />
+```
+
+### Tables
+
+You can use variables within Markdown tables to create configuration reference guides.
+
+**Example Markdown:**
+
+```markdown
+| Parameter | Value | Description |
+| :--- | :--- | :--- |
+| Domain | `{{yourDomain}}` | Your tenant domain. |
+| Client ID | `{{yourClientId}}` | Your application's ID. |
+```
+
+## Behavior and States
+
+It is important to understand how variables render in different user states to ensuring the documentation remains readable for everyone.
+
+### Logged out state
+
+When a user is not logged in, the system cannot retrieve session data. In this state, the variable is rendered as a literal string wrapped in single braces (e.g., `{yourDomain}`). This serves as a generic placeholder.
+
+### Missing context state
+
+A user may be logged in but has not created or selected a specific resource required by the variable.
+
+* **Example:** A user is logged in but has no Applications defined in their tenant.
+* **Result:** The variable `{{yourClientId}}` will fall back to its default placeholder text (`{yourClientId}`).
+
+### Secret masking
+
+The `{{yourClientSecret}}` variable is sensitive.
+
+* It is only populated if the user has the necessary permissions to view secrets.
+* If the user does not have permission, or if the session has expired, it renders as the default placeholder.
+
+## Best Practices
+
+### Writing for fallbacks
+
+Write surrounding text that makes grammatical sense regardless of whether the variable is replaced or rendered as a placeholder.
+
+* ✅ **Preferred:** "Enter your domain: `{{yourDomain}}`."
+* ❌ **Discouraged:** "Your domain is `{{yourDomain}}`." (This reads poorly when logged out: "Your domain is {yourDomain}").
+
+### Security awareness
+
+Be mindful when using `{{yourClientSecret}}`.
+
+* **Do not** use this variable in code examples for Single Page Applications (SPAs), Mobile Apps, or Native Apps. These client types cannot securely store secrets.
+* **Do** use this variable in backend/server-side code examples (Regular Web Apps, Machine-to-Machine) where the secret remains secure.
+
+### Consistency
+
+Always use the exact variable name and capitalization defined in the catalog.
+
+* ✅ `{{yourClientId}}`
+* ❌ `{{yourClientid}}`
+* ❌ `{{clientID}}`
+
+## Build-time Document Variables (`${dollar}`)
+
+Build-time document variables use the `${variableName}` syntax and are replaced during the documentation build process with static values. These are used for system-wide constants like CDN URLs, dashboard URLs, and other infrastructure references.
+
+### Common Variables
+
+| Variable | Description | Default Value |
+| :--- | :--- | :--- |
+| `${manage_url}` | The URL to the management portal. | `https://manage.auth0.com` |
+| `${auth0js_url}` | The URL to the auth0.js CDN location. | *(Version-specific)* |
+| `${auth0js_urlv8}` | The URL to the auth0.js v8 CDN location. | *(Version-specific)* |
+| `${lock_url}` | The URL to the Lock script CDN location. | *(Version-specific)* |
+| `${env.DOMAIN_URL_SUPPORT}` | Support Center URL | `https://support.auth0.com` |
+
+### Legacy User-specific Variables
+
+The following `${account.*}` variables are legacy syntax that has been superseded by the `{{doubleCurly}}` dynamic template variables documented above. **Do not use these in new documentation.**
+
+| Variable | Modern Equivalent |
+| :--- | :--- |
+| `${account.appName}` | `{{yourAppName}}` |
+| `${account.tenant}` | `{{yourTenant}}` |
+| `${account.namespace}` | `{{yourDomain}}` |
+| `${account.clientId}` | `{{yourClientId}}` |
+| `${account.clientSecret}` | `{{yourClientSecret}}` |
+| `${account.callback}` | `{{https://yourApp/callback}}` |
+
+## Static Placeholders (`{singleCurly}` or `<ANGLE>`)
+
+Static placeholders are used in code examples to indicate values that users must manually replace when copying code. Unlike dynamic template variables, these **do not** auto-populate and serve as visual markers for user-provided values.
+
+### When to Use Each Syntax
+
+Use different bracket styles based on the context and type of value:
+
+#### Curly Braces `{singleCurly}` for URL Path Variables
+
+Use single curly braces for variables that are **part of a URL path or API endpoint**.
+
+* ✅ `{yourDomain}` - Domain in URLs
+* ✅ `{clientId}` - Client ID in API paths
+* ✅ `/api/v2/clients/{clientId}` - Path parameters in REST endpoints
+
+**Formatting convention:**
+- Use camelCase
+- No underscores or hyphens
+- Descriptive but concise
+
+#### Angle Brackets `<ANGLE>` for User-Provided Values
+
+Use angle brackets with uppercase letters and underscores for **user-provided configuration values** like tokens, secrets, and environment-specific settings.
+
+* ✅ `<YOUR_MANAGEMENT_API_TOKEN>` - API tokens
+* ✅ `<YOUR_CUSTOM_VALUE>` - Configuration values
+* ✅ `<YOUR_TENANT_NAME>` - Environment-specific names
+
+**Formatting convention:**
+- ALL_UPPERCASE
+- Use underscores for word separation
+- Prefix with `YOUR_` when appropriate
+
+### Complete Example
+
+Properly-formatted code example using both conventions:
+
+```bash
+curl --request PATCH 'https://{yourDomain}/api/v2/clients/{clientId}' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Bearer <YOUR_MANAGEMENT_API_TOKEN>' \
+--data '{
+    "grant_types": [
+        "authorization_code"
+    ]
+}'
+```
+
+### What to Avoid
+
+❌ **Discouraged** - Mixing conventions incorrectly:
+
+```bash
+# Don't use angle brackets for path variables
+curl 'https://{yourDomain}/api/v2/clients/<clientId>'
+
+# Don't use lowercase with angle brackets
+curl --header 'Authorization: Bearer <your-management-api-token>'
+
+# Don't use inconsistent capitalization
+curl 'https://{yourDomain}/api/v2/clients/{ClientId}'
+```
+
+## Choosing the Right Placeholder Type
+
+Use this decision tree when adding placeholders to documentation:
+
+1. **Does this value come from the user's Auth0 tenant/app?**
+   - Yes, and should auto-populate when logged in? → Use `{{doubleCurly}}` dynamic template variables
+   - Yes, but is for legacy content only? → Migrate to `{{doubleCurly}}` syntax
+   - No, continue to step 2
+
+2. **Is this a system-wide constant (CDN URL, dashboard URL)?**
+   - Yes → Use `${dollar}` build-time variable
+   - No, continue to step 3
+
+3. **Is this part of a URL path or API endpoint?**
+   - Yes → Use `{singleCurly}` static placeholder
+   - No → Use `<ANGLE_BRACKET>` static placeholder
+
+### Examples
+
+| Value Type | Correct Syntax | Example |
+| :--- | :--- | :--- |
+| User's tenant domain (dynamic) | `{{yourDomain}}` | `https://{{yourDomain}}/authorize` |
+| User's client ID (dynamic) | `{{yourClientId}}` | `client_id: '{{yourClientId}}'` |
+| Dashboard URL (build-time) | `${manage_url}` | Navigate to `${manage_url}` |
+| API path parameter (static) | `{clientId}` | `GET /api/v2/clients/{clientId}` |
+| API token (static, user-provided) | `<YOUR_API_TOKEN>` | `Authorization: Bearer <YOUR_API_TOKEN>` |


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for the template variables system used throughout Auth0 documentation sites:

- **New Claude Code Skill Reference**: Added `template-variables.md` covering usage guidelines, variable catalog, behavior states, and best practices for using dynamic placeholders like `{{yourDomain}}` and `{{yourClientId}}`
- **Updated Skill Index**: Added reference link to the new template variables guide in the writing-auth0-docs skill
- **UI Library Architecture Documentation**: Added extensive architecture section to ui/README.md detailing:
  - MobX store hierarchy and responsibilities
  - Configuration and API lifecycle
  - Request resolution flow
  - Store initialization sequences
  - Template variable mapping system
  - Complete variable catalog with source stores

## Context

Template variables are a core feature that personalizes documentation for logged-in users by dynamically replacing placeholders with values from their session context. This documentation makes it easier for:
- Technical writers to understand when and how to use template variables
- Claude Code to properly apply variables when authoring new documentation
- Developers working on the UI library to understand the store architecture and variable system

## Documentation Includes

- Sequence diagrams for initialization and context switching flows
- Mermaid diagrams showing store hierarchy and variable data flow
- Tables cataloging all available variables and their sources
- Usage examples for inline text, code blocks, and tables
- Best practices for fallback states and security considerations

## Test Plan

- [x] Verify template-variables.md renders correctly in the skill reference
- [x] Confirm SKILL.md table links correctly to new reference
- [x] Review README.md renders mermaid diagrams properly on GitHub