### PR TITLE
fix: align access control list reference to specs

### DIFF
--- a/main/docs/secure/tenant-access-control-list/reference.mdx
+++ b/main/docs/secure/tenant-access-control-list/reference.mdx
@@ -15,23 +15,29 @@ Tenant Access Control List (ACL) supports advanced customization through configu
 
 ## Signals
 
+<ParamField path="asns" type="string[]">
+List of Autonomous System Numbers (ASNs)
+</ParamField>
 <ParamField path="ipv4_cidrs" type="string[]">
 List of IPv4 addresses or CIDR ranges.
 </ParamField>
 <ParamField path="ipv6_cidrs" type="string[]">
 List of IPv6 addresses or CIDR ranges.
 </ParamField>
-<ParamField path="geo_country_code" type="string">
-ISO 3166-1 alpha-2 country code.
+<ParamField path="geo_country_codes" type="string[]">
+List of ISO 3166-1 alpha-2 country code.
 </ParamField>
-<ParamField path="geo_subdivision_code" type="string">
-ISO 3166-2 subdivision code.
+<ParamField path="geo_subdivision_codes" type="string[]">
+List of ISO 3166-2 subdivision code.
 </ParamField>
-<ParamField path="ja_fingerprint" type="string">
-TSL client fingerprint.
+<ParamField path="ja3_fingerprints" type="string[]">
+List of JA3 TLS Fingerprints.
 </ParamField>
-<ParamField path="user_agent" type="string">
-Client device or browser.
+<ParamField path="ja4_fingerprints" type="string[]">
+List of JA4 TLS Fingerprints.
+</ParamField>
+<ParamField path="user_agents" type="string[]">
+List of client device or browser.
 </ParamField>
 
 ## Conditions


### PR DESCRIPTION
Noticed a few typos here and this updates the reference to match the API specification:

https://auth0.com/docs/api/management/v2/network-acls/post-network-acls

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.
>
> Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc.
>
> If the UI is being changed, please provide screenshots.


### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - Auth0 Community post
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
