### PR TITLE
fix: artifact-hub logo links

### DIFF
--- a/main/docs/artifact-hub.mdx
+++ b/main/docs/artifact-hub.mdx
@@ -93,8 +93,8 @@ mode: "custom"
             </div>
             <div className="flex items-center justify-between pt-2">
               <div className="flex items-center">
-                <img src="/logo/light.svg" alt="Auth0 Logo" className="h-12 w-12 dark:hidden" />
-                <img src="/logo/dark.svg" alt="Auth0 Logo" className="h-12 w-12 hidden dark:block" />
+                <img src="/docs/logo/light.svg" alt="Auth0 Logo" className="h-12 w-12 dark:hidden" />
+                <img src="/docs/logo/dark.svg" alt="Auth0 Logo" className="h-12 w-12 hidden dark:block" />
               </div>
               <div className="flex items-center">
                 <svg className="h-5 w-5 text-gray-400 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -125,8 +125,8 @@ mode: "custom"
             </div>
             <div className="flex items-center justify-between pt-2">
               <div className="flex items-center">
-                <img src="/logo/light.svg" alt="Auth0 Logo" className="h-12 w-12 dark:hidden" />
-                <img src="/logo/dark.svg" alt="Auth0 Logo" className="h-12 w-12 hidden dark:block" />
+                <img src="/docs/logo/light.svg" alt="Auth0 Logo" className="h-12 w-12 dark:hidden" />
+                <img src="/docs/logo/dark.svg" alt="Auth0 Logo" className="h-12 w-12 hidden dark:block" />
               </div>
               <div className="flex items-center">
                 <svg className="h-5 w-5 text-gray-400 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -158,8 +158,8 @@ mode: "custom"
             </div>
             <div className="flex items-center justify-between pt-2">
               <div className="flex items-center">
-                <img src="/logo/light.svg" alt="Auth0 Logo" className="h-12 w-12 dark:hidden" />
-                <img src="/logo/dark.svg" alt="Auth0 Logo" className="h-12 w-12 hidden dark:block" />
+                <img src="/docs/logo/light.svg" alt="Auth0 Logo" className="h-12 w-12 dark:hidden" />
+                <img src="/docs/logo/dark.svg" alt="Auth0 Logo" className="h-12 w-12 hidden dark:block" />
               </div>
               <div className="flex items-center">
                 <svg className="h-5 w-5 text-gray-400 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
### Description

Fixes broken `artifact-hub` logo links.

<img width="1175" height="335" alt="image" src="https://github.com/user-attachments/assets/501e1ef1-4108-4ceb-90a6-a174c9f7fa1d" />
<img width="1190" height="246" alt="image" src="https://github.com/user-attachments/assets/0035f284-4d5e-47fe-bd56-4ff48b826fa6" />

