### PR TITLE
fix: broken B2C_Project_Planning.pdf links

### DIFF
--- a/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer.mdx
+++ b/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer.mdx
@@ -17,7 +17,7 @@ Il existe de nombreuses façons différentes d’intégrer Auth0 dans l’archit
 
 Nous fournissons un guide de planification en format PDF que vous pouvez télécharger; vous pouvez vous y référer pour de plus amples détails concernant nos stratégies recommandées.
 
-[B2C IAM Project Planning Guide](//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
 
 ## Débuter
 

--- a/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/architecture.mdx
+++ b/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/architecture.mdx
@@ -107,4 +107,4 @@ Vous pouvez également tirer parti de nos [Listes de contrôle de mise en œuvre
 
 Nous fournissons un guide de planification en format PDF que vous pouvez télécharger; vous pouvez vous y référer pour de plus amples détails concernant nos stratégies recommandées.
 
-[B2C IAM Project Planning Guide](//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/authentication.mdx
+++ b/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/authentication.mdx
@@ -198,4 +198,4 @@ Bien que le flux de travail MFA utilisant des technologies telles que Guardian o
 
 Nous fournissons un guide de planification en format PDF que vous pouvez télécharger; vous pouvez vous y référer pour de plus amples détails concernant nos stratégies recommandées.
 
-[B2C IAM Project Planning Guide](//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/authorization.mdx
+++ b/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/authorization.mdx
@@ -137,4 +137,4 @@ Cadre d’applications d’autorisation qui définit les protocoles d’autorisa
 
 Nous fournissons un guide de planification en format PDF que vous pouvez télécharger; vous pouvez vous y référer pour de plus amples détails concernant nos stratégies recommandées.
 
-[B2C IAM Project Planning Guide](//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/branding.mdx
+++ b/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/branding.mdx
@@ -89,4 +89,4 @@ Si vous avez besoin d’une personnalisation plus complète, vous pouvez égalem
 
 Nous fournissons un guide de planification en format PDF que vous pouvez télécharger; vous pouvez vous y référer pour de plus amples détails concernant nos stratégies recommandées.
 
-[B2C IAM Project Planning Guide](//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/deployment.mdx
+++ b/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/deployment.mdx
@@ -48,4 +48,4 @@ Il est conseillé d’utiliser des variables pour contenir des valeurs spécifiq
 
 Nous fournissons un guide de planification en format PDF que vous pouvez télécharger; vous pouvez vous y référer pour de plus amples détails concernant nos stratégies recommandées.
 
-[B2C IAM Project Planning Guide](//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/launch.mdx
+++ b/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/launch.mdx
@@ -22,4 +22,4 @@ Utilisez ce guide pour préparer le lancement de votre application. Nous avons i
 
 Nous fournissons un guide de planification en format PDF que vous pouvez télécharger; vous pouvez vous y référer pour de plus amples détails concernant nos stratégies recommandées.
 
-[B2C IAM Project Planning Guide](//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/launch/compliance-readiness.mdx
+++ b/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/launch/compliance-readiness.mdx
@@ -55,4 +55,4 @@ Les ressources supplémentaires qui peuvent être utiles pour vos exigences de c
 
 Nous fournissons un guide de planification en format PDF que vous pouvez télécharger; vous pouvez vous y référer pour de plus amples détails concernant nos stratégies recommandées.
 
-[B2C IAM Project Planning Guide](//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/launch/launch-day.mdx
+++ b/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/launch/launch-day.mdx
@@ -125,4 +125,4 @@ Si vous avez eu une période bêta, il peut être utile d’examiner les résult
 
 Nous fournissons un guide de planification en format PDF que vous pouvez télécharger; vous pouvez vous y référer pour de plus amples détails concernant nos stratégies recommandées.
 
-[B2C IAM Project Planning Guide](//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/launch/operations-readiness.mdx
+++ b/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/launch/operations-readiness.mdx
@@ -195,4 +195,4 @@ Un autre point qui n’est pas une exigence absolue, mais qui est également rec
 
 Nous fournissons un guide de planification en format PDF que vous pouvez télécharger; vous pouvez vous y référer pour de plus amples détails concernant nos stratégies recommandées.
 
-[B2C IAM Project Planning Guide](//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/launch/support-readiness.mdx
+++ b/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/launch/support-readiness.mdx
@@ -93,4 +93,4 @@ Vous devez vous préparer à [dépanner les problèmes de base](/docs/fr-ca/trou
 
 Nous fournissons un guide de planification en format PDF que vous pouvez télécharger; vous pouvez vous y référer pour de plus amples détails concernant nos stratégies recommandées.
 
-[B2C IAM Project Planning Guide](//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/launch/tenant-check.mdx
+++ b/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/launch/tenant-check.mdx
@@ -188,4 +188,4 @@ La détection d’anomalies est gérée en coulisses par Auth0 et constitue une 
 
 Nous fournissons un guide de planification en format PDF que vous pouvez télécharger; vous pouvez vous y référer pour de plus amples détails concernant nos stratégies recommandées.
 
-[B2C IAM Project Planning Guide](//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/launch/testing.mdx
+++ b/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/launch/testing.mdx
@@ -77,4 +77,4 @@ Principal produit d’Auth0 pour configurer vos services." cta="Voir le glossair
 
 Nous fournissons un guide de planification en format PDF que vous pouvez télécharger; vous pouvez vous y référer pour de plus amples détails concernant nos stratégies recommandées.
 
-[B2C IAM Project Planning Guide](//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/logout.mdx
+++ b/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/logout.mdx
@@ -54,4 +54,4 @@ Il n’est pas courant que tous les utilisateurs enclenchent le processus de dé
 
 Nous fournissons un guide de planification en format PDF que vous pouvez télécharger; vous pouvez vous y référer pour de plus amples détails concernant nos stratégies recommandées.
 
-[B2C IAM Project Planning Guide](//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/operations.mdx
+++ b/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/operations.mdx
@@ -103,4 +103,4 @@ Auth0 fournit des informations sur les changements apportés au service dans le�
 
 Nous fournissons un guide de planification en format PDF que vous pouvez télécharger; vous pouvez vous y référer pour de plus amples détails concernant nos stratégies recommandées.
 
-[B2C IAM Project Planning Guide](//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/profile-management.mdx
+++ b/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/profile-management.mdx
@@ -138,4 +138,4 @@ Auth0 est capable de prendre en charge diverses exigences liées à la protectio
 
 Nous fournissons un guide de planification en format PDF que vous pouvez télécharger; vous pouvez vous y référer pour de plus amples détails concernant nos stratégies recommandées.
 
-[B2C IAM Project Planning Guide](//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/provisioning.mdx
+++ b/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/provisioning.mdx
@@ -62,4 +62,4 @@ L’inscription via un réseau social est synonyme de connexion via [authentific
 
 Nous fournissons un guide de planification en format PDF que vous pouvez télécharger; vous pouvez vous y référer pour de plus amples détails concernant nos stratégies recommandées.
 
-[B2C IAM Project Planning Guide](//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/quality-assurance.mdx
+++ b/main/docs/fr-ca/get-started/architecture-scenarios/business-to-consumer/quality-assurance.mdx
@@ -50,4 +50,4 @@ Pour trouver un équilibre entre la [politique de test de charge](/docs/fr-ca/
 
 Nous fournissons un guide de planification en format PDF que vous pouvez télécharger; vous pouvez vous y référer pour de plus amples détails concernant nos stratégies recommandées.
 
-[B2C IAM Project Planning Guide](//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer.mdx
+++ b/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer.mdx
@@ -17,7 +17,7 @@ Auth0をCIAMプロジェクトのアーキテクチャに統合する方法は�
 
 当社では、PDF形式の計画ガイダンスを提供しています。ダウンロードして、推奨される戦略の詳細を参照してください。
 
-[B2C IAM Project Planning Guide](/docs//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
 
 ## はじめに
 

--- a/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/architecture.mdx
+++ b/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/architecture.mdx
@@ -127,4 +127,4 @@ Auth0テナント用のカスタムドメイン（または`CNAME`）を作成�
 
 当社では、PDF形式の計画ガイダンスを提供しています。ダウンロードして、推奨される戦略の詳細を参照してください。
 
-[B2C IAM Project Planning Guide](/docs//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/authentication.mdx
+++ b/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/authentication.mdx
@@ -228,4 +228,4 @@ GuardianやGoogle Authenticatorなどの技術を使ったMFAのワークフロ�
 
 当社では、PDF形式の計画ガイダンスを提供しています。ダウンロードして、推奨される戦略の詳細を参照してください。
 
-[B2C IAM Project Planning Guide](/docs//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/authorization.mdx
+++ b/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/authorization.mdx
@@ -159,4 +159,4 @@ APIを呼び出すために、ユーザー対話型セッションのないア�
 
 当社では、PDF形式の計画ガイダンスを提供しています。ダウンロードして、推奨される戦略の詳細を参照してください。
 
-[B2C IAM Project Planning Guide](/docs//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/branding.mdx
+++ b/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/branding.mdx
@@ -104,4 +104,4 @@ Auth0は、ユーザー通知を送信し、安全なID管理に必要な機能�
 
 当社では、PDF形式の計画ガイダンスを提供しています。ダウンロードして、推奨される戦略の詳細を参照してください。
 
-[B2C IAM Project Planning Guide](/docs//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/deployment.mdx
+++ b/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/deployment.mdx
@@ -53,4 +53,4 @@ Auth0を使用すると、カスタム[拡張性](/docs/ja-jp/customize/extensio
 
 当社では、PDF形式の計画ガイダンスを提供しています。ダウンロードして、推奨される戦略の詳細を参照してください。
 
-[B2C IAM Project Planning Guide](/docs//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/launch.mdx
+++ b/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/launch.mdx
@@ -22,4 +22,4 @@ permalink: "launch"
 
 当社では、PDF形式の計画ガイダンスを提供しています。ダウンロードして、推奨される戦略の詳細を参照してください。
 
-[B2C IAM Project Planning Guide](/docs//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/launch/compliance-readiness.mdx
+++ b/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/launch/compliance-readiness.mdx
@@ -52,4 +52,4 @@ permalink: "compliance-readiness"
 
 当社では、PDF形式の計画ガイダンスを提供しています。ダウンロードして、推奨される戦略の詳細を参照してください。
 
-[B2C IAM Project Planning Guide](/docs//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/launch/launch-day.mdx
+++ b/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/launch/launch-day.mdx
@@ -125,4 +125,4 @@ permalink: "launch-day"
 
 当社では、PDF形式の計画ガイダンスを提供しています。ダウンロードして、推奨される戦略の詳細を参照してください。
 
-[B2C IAM Project Planning Guide](/docs//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/launch/operations-readiness.mdx
+++ b/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/launch/operations-readiness.mdx
@@ -219,4 +219,4 @@ Auth0 [［Data Tenant Restore policy（データテナントリストアポリ�
 
 当社では、PDF形式の計画ガイダンスを提供しています。ダウンロードして、推奨される戦略の詳細を参照してください。
 
-[B2C IAM Project Planning Guide](/docs//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/launch/support-readiness.mdx
+++ b/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/launch/support-readiness.mdx
@@ -90,4 +90,4 @@ Auth0はフィードバックやAuth0ユーザーからのアイデアを歓迎�
 
 当社では、PDF形式の計画ガイダンスを提供しています。ダウンロードして、推奨される戦略の詳細を参照してください。
 
-[B2C IAM Project Planning Guide](/docs//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/launch/tenant-check.mdx
+++ b/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/launch/tenant-check.mdx
@@ -199,4 +199,4 @@ Auth0では異常の検出を水面下で行っており、お客様の製品に
 
 当社では、PDF形式の計画ガイダンスを提供しています。ダウンロードして、推奨される戦略の詳細を参照してください。
 
-[B2C IAM Project Planning Guide](/docs//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/launch/testing.mdx
+++ b/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/launch/testing.mdx
@@ -78,4 +78,4 @@ Auth0の[負荷テストポリシー](/docs/ja-jp/troubleshoot/customer-support/
 
 当社では、PDF形式の計画ガイダンスを提供しています。ダウンロードして、推奨される戦略の詳細を参照してください。
 
-[B2C IAM Project Planning Guide](/docs//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/logout.mdx
+++ b/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/logout.mdx
@@ -54,4 +54,4 @@ permalink: "logout"
 
 当社では、PDF形式の計画ガイダンスを提供しています。ダウンロードして、推奨される戦略の詳細を参照してください。
 
-[B2C IAM Project Planning Guide](/docs//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/operations.mdx
+++ b/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/operations.mdx
@@ -129,4 +129,4 @@ Auth0はサービスに対する変更の情報をAuth0の[変更履歴](https:/
 
 当社では、PDF形式の計画ガイダンスを提供しています。ダウンロードして、推奨される戦略の詳細を参照してください。
 
-[B2C IAM Project Planning Guide](/docs//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/profile-management.mdx
+++ b/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/profile-management.mdx
@@ -142,4 +142,4 @@ Auth0には、サインアップ時に同意通知やデータ保護へのリン
 
 当社では、PDF形式の計画ガイダンスを提供しています。ダウンロードして、推奨される戦略の詳細を参照してください。
 
-[B2C IAM Project Planning Guide](/docs//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/provisioning.mdx
+++ b/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/provisioning.mdx
@@ -74,4 +74,4 @@ Auth0[「ユニバーサルログイン」](/docs/ja-jp/universal-login)とAuth0
 
 当社では、PDF形式の計画ガイダンスを提供しています。ダウンロードして、推奨される戦略の詳細を参照してください。
 
-[B2C IAM Project Planning Guide](/docs//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)

--- a/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/quality-assurance.mdx
+++ b/main/docs/ja-jp/get-started/architecture-scenarios/business-to-consumer/quality-assurance.mdx
@@ -53,4 +53,4 @@ Auth0の[負荷テストポリシー](/docs/ja-jp/troubleshoot/customer-support/
 
 当社では、PDF形式の計画ガイダンスを提供しています。ダウンロードして、推奨される戦略の詳細を参照してください。
 
-[B2C IAM Project Planning Guide](/docs//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)
+[B2C IAM Project Planning Guide](https://assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf)


### PR DESCRIPTION
### Description

Fixes broken protocol relative and site absolute links for:
- `//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf`
- `/docs//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf`

and converts to protocol absolute URLs like the other pages:
`//assets.ctfassets.net/cdy7uua7fh8z/3er1aEQ7Ul0q3c9leJWczR/b1f18b4c16abb7e78b01e4eb2b52bb8e/B2C_Project_Planning.pdf` 

Notes for reviewers, as this may be handy for others:
```bash
cd main/
mint broken-links > broken_links.txt
awk -v rx='/api/(authentication|management/v2|v2)|docs/(ja-jp|fr-ca)' '
  NR<=3 {next}                                 # Skip first 3 lines
  /^[[:space:]]*$/ {next}                      # Skip empty lines
  !/^(README|docs\/)|⎿/ {b=b $0; next}         # If line is a wrap, append to buffer
  {if(b) P(b); b=$0}                           # Process buffer, start new
  END {P(b)}                                   # Process trailing buffer

  function P(s) {
    if(s ~ rx) return                          # Check Exclusions
    if(s ~ /^(README|docs\/)/) {h=s; p=0}      # Capture Header
    else {if(!p){print h; p=1} print s}        # Print Header (once) + Link
  }
' broken_links.txt
```