### PR TITLE
Remove table class definition to fix overflow

### DIFF
--- a/main/docs/manage-users/user-accounts/user-profiles/user-profile-structure.mdx
+++ b/main/docs/manage-users/user-accounts/user-profiles/user-profile-structure.mdx
@@ -23,7 +23,7 @@ By default, user profile attributes provided by <Tooltip tip="Identity Provider 
 
 To be able to edit the `name`, `nickname`, `given_name`, `family_name`, or `picture` root attributes on the normalized user profile, you must [configure your connection sync with Auth0](/docs/manage-users/user-accounts/user-profiles/configure-connection-sync-with-auth0) so that user attributes will be updated from the identity provider only on user profile creation. These root attributes will then be available to be edited individually or by bulk imports
 
-<table class="table"><thead>
+<table><thead>
 <tr>
 <th>Name</th>
 <th>Type</th>
@@ -311,7 +311,7 @@ This is true for all Auth0 database connections. When Auth0 DB is not the source
 
 </Callout>
 
-<table class="table"><thead>
+<table><thead>
 <tr>
 <th>Field</th>
 <th>Type</th>


### PR DESCRIPTION
the `table` class styling is a little funky. this is a small band-aid to fix the gnarly table wrapping on this page:

https://auth0.com/docs/manage-users/user-accounts/user-profiles/user-profile-structure