### PR TITLE
Updated SDK support status and libraries list

### DIFF
--- a/main/docs/libraries.mdx
+++ b/main/docs/libraries.mdx
@@ -19,51 +19,6 @@ Need to protect a JavaScript application that runs entirely in a browser? Choose
 
 <Columns cols={2}>
   <SectionCard item={{
-    name: "Angular",
-    subtext: "auth0-angular",
-    logo: "angular.svg",
-    date: "Jan 16, 2024",
-    badge: "v2.2.3",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-angular" },
-      {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-angular-samples/tree/main/Standalone",
-      },
-      { label: "Quickstart", url: "/docs/quickstart/spa/angular/interactive" },
-    ],
-  }}/>
-  <SectionCard item={{
-    name: "Flutter (Web)",
-    subtext: "auth0-flutter",
-    logo: "flutter.svg",
-    date: "Jul 10, 2024",
-    badge: "v2.2.3",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-flutter" },
-      {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-flutter-samples/tree/main/sample",
-      },
-      { label: "Quickstart", url: "/docs/quickstart/spa/flutter/interactive" },
-    ],
-  }}/>
-  <SectionCard item={{
-    name: "JavaScript",
-    subtext: "auth0-spa-js",
-    logo: "javascript.svg",
-    date: "May 29, 2024",
-    badge: "v2.2.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-spa-js" },
-      {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-javascript-samples/tree/master/01-Login",
-      },
-      { label: "Quickstart", url: "/docs/quickstart/spa/vanillajs/interactive" },
-    ],
-  }}/>
-  <SectionCard item={{
     name: "React",
     subtext: "auth0-react",
     logo: "react.svg",
@@ -93,6 +48,51 @@ Need to protect a JavaScript application that runs entirely in a browser? Choose
       { label: "Quickstart", url: "/docs/quickstart/spa/vuejs/interactive" },
     ],
   }}/>
+  <SectionCard item={{
+    name: "Angular",
+    subtext: "auth0-angular",
+    logo: "angular.svg",
+    date: "Jan 16, 2024",
+    badge: "v2.2.3",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/auth0-angular" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-angular-samples/tree/main/Standalone",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/spa/angular/interactive" },
+    ],
+  }}/>
+  <SectionCard item={{
+    name: "JavaScript",
+    subtext: "auth0-spa-js",
+    logo: "javascript.svg",
+    date: "May 29, 2024",
+    badge: "v2.2.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/auth0-spa-js" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-javascript-samples/tree/master/01-Login",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/spa/vanillajs/interactive" },
+    ],
+  }}/>
+  <SectionCard item={{
+    name: "Flutter (Web)",
+    subtext: "auth0-flutter",
+    logo: "flutter.svg",
+    date: "Jul 10, 2024",
+    badge: "v2.2.3",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/auth0-flutter" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-flutter-samples/tree/main/sample",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/spa/flutter/interactive" },
+    ],
+  }}/>
 
 </Columns>
 
@@ -102,18 +102,50 @@ Have a traditional web application that runs on a server? Auth0 maintains these 
 
 <Columns cols={2}>
   <SectionCard item={{
-    name: "ASP.NET Core Blazor Server",
-    subtext: "auth0-aspnetcore-authentication",
-    logo: "dotnet.svg",
-    date: "Jan 25, 2024",
-    badge: "1.4.1",
+    name: "Next.js",
+    subtext: "nextjs-auth0",
+    logo: "nextjs.svg",
+    date: "Jul 1, 2024",
+    badge: "v4.8.0",
     links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-aspnetcore-authentication" },
+      { label: "Github", url: "https://github.com/auth0/nextjs-auth0/" },
       {
         label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-aspnetcore-blazor-server-samples/tree/main/Quickstart/Sample",
+        url: "https://github.com/auth0-samples/auth0-nextjs-samples/tree/main/Sample-01",
       },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/aspnet-core-blazor-server/interactive" },
+      { label: "Quickstart", url: "/docs/quickstart/webapp/nextjs/interactive" },
+    ],
+  }}/>
+
+  <SectionCard item={{
+    name: "Express",
+    subtext: "express-openid-connect",
+    logo: "nodejs.svg",
+    date: "May 6, 2024",
+    badge: "v2.18.1",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/express-openid-connect" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-express-webapp-sample/tree/master/01-Login",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/webapp/express/interactive" },
+    ],
+  }}/>
+
+  <SectionCard item={{
+    name: "Nuxt",
+    subtext: "auth0-nuxt",
+    logo: "nuxt.svg",
+    date: "Nov 15, 2024",
+    badge: "v0.3.3",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/auth0-nuxt" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-nuxt-samples",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/webapp/nuxt" },
     ],
   }}/>
 
@@ -134,18 +166,98 @@ Have a traditional web application that runs on a server? Auth0 maintains these 
   }}/>
 
   <SectionCard item={{
-    name: "Express",
-    subtext: "express-openid-connect",
-    logo: "nodejs.svg",
-    date: "May 6, 2024",
-    badge: "v2.18.1",
+    name: "ASP.NET Core Blazor",
+    subtext: "auth0-aspnetcore-authentication",
+    logo: "dotnet.svg",
+    date: "Jan 25, 2024",
+    badge: "1.4.1",
     links: [
-      { label: "Github", url: "https://github.com/auth0/express-openid-connect" },
+      { label: "Github", url: "https://github.com/auth0/auth0-aspnetcore-authentication" },
       {
         label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-express-webapp-sample/tree/master/01-Login",
+        url: "https://github.com/auth0-samples/auth0-aspnetcore-blazor-server-samples/tree/main/Quickstart/Sample",
       },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/express/interactive" },
+      { label: "Quickstart", url: "/docs/quickstart/webapp/aspnet-core-blazor-server/interactive" },
+    ],
+  }}/>
+
+  <SectionCard item={{
+    name: "Laravel",
+    subtext: "laravel-auth0",
+    logo: "laravel.svg",
+    date: "May 16, 2024",
+    badge: "7.17.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/laravel-auth0" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/laravel/tree/7.x/sample",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/webapp/laravel/interactive" },
+    ],
+  }}/>
+
+  <SectionCard item={{
+    name: "Java Spring Boot",
+    subtext: "okta-spring-boot",
+    logo: "spring.svg",
+    date: "Jun 21, 2024",
+    badge: "3.0.7",
+    links: [
+      { label: "Github", url: "https://github.com/okta/okta-spring-boot/" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-spring-boot-login-samples/tree/master/mvc-login",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/webapp/java-spring-boot/interactive" },
+    ],
+  }}/>
+
+  <SectionCard item={{
+    name: "Python",
+    subtext: "auth0-python",
+    logo: "python.svg",
+    date: "Jun 6, 2024",
+    badge: "4.10.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/auth0-python" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-python-web-app/tree/master/01-Login",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/webapp/python/interactive" },
+    ],
+  }}/>
+
+  <SectionCard item={{
+    name: "PHP",
+    subtext: "auth0-php",
+    logo: "php.svg",
+    date: "May 30, 2024",
+    badge: "8.15.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/auth0-php" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-php-web-app/tree/main/app",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/webapp/php/interactive" },
+    ],
+  }}/>
+
+  <SectionCard item={{
+    name: "Ruby on Rails",
+    subtext: "omniauth-auth0",
+    logo: "rails.svg",
+    date: "Jul 25, 2023",
+    badge: "v3.1.1",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/omniauth-auth0" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-rubyonrails-sample/tree/master/sample",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/webapp/rails/interactive" },
     ],
   }}/>
 
@@ -181,102 +293,6 @@ Have a traditional web application that runs on a server? Auth0 maintains these 
     ],
   }}/>
 
-  <SectionCard item={{
-    name: "Java Spring Boot",
-    subtext: "okta-spring-boot",
-    logo: "spring.svg",
-    date: "Jun 21, 2024",
-    badge: "3.0.7",
-    links: [
-      { label: "Github", url: "https://github.com/okta/okta-spring-boot/" },
-      {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-spring-boot-login-samples/tree/master/mvc-login",
-      },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/java-spring-boot/interactive" },
-    ],
-  }}/>
-
-  <SectionCard item={{
-    name: "Laravel",
-    subtext: "laravel-auth0",
-    logo: "laravel.svg",
-    date: "May 16, 2024",
-    badge: "7.17.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/laravel-auth0" },
-      {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/laravel/tree/7.x/sample",
-      },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/laravel/interactive" },
-    ],
-  }}/>
-
-  <SectionCard item={{
-    name: "Next.js",
-    subtext: "nextjs-auth0",
-    logo: "nextjs.svg",
-    date: "Jul 1, 2024",
-    badge: "v4.8.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/nextjs-auth0/" },
-      {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-nextjs-samples/tree/main/Sample-01",
-      },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/nextjs/interactive" },
-    ],
-  }}/>
-
-  <SectionCard item={{
-    name: "PHP",
-    subtext: "auth0-php",
-    logo: "php.svg",
-    date: "May 30, 2024",
-    badge: "8.15.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-php" },
-      {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-php-web-app/tree/main/app",
-      },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/php/interactive" },
-    ],
-  }}/>
-
-  <SectionCard item={{
-    name: "Python",
-    subtext: "auth0-python",
-    logo: "python.svg",
-    date: "Jun 6, 2024",
-    badge: "4.10.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-python" },
-      {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-python-web-app/tree/master/01-Login",
-      },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/python/interactive" },
-    ],
-  }}/>
-
-  <SectionCard item={{
-    name: "Ruby on Rails",
-    subtext: "omniauth-auth0",
-    logo: "rails.svg",
-    date: "Jul 25, 2023",
-    badge: "v3.1.1",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/omniauth-auth0" },
-      {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-rubyonrails-sample/tree/master/sample",
-      },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/rails/interactive" },
-    ],
-  }}/>
-
 </Columns>
 
 ## Backend Service and API SDK Libraries
@@ -284,51 +300,6 @@ Have a traditional web application that runs on a server? Auth0 maintains these 
 Does your API or service need authentication? Auth0 has SDKs for common API and service development tools.
 
 <Columns cols={2}>
-<SectionCard item={{
-  name: "Build a Login ID screen using ACUL",
-  subtext: "universal-login",
-  logo: "auth0.svg",
-  date: "May 20, 2024",
-  badge: "v1.1.1",
-  links: [
-    { label: "Github", url: "https://github.com/auth0/go-jwt-middleware" },
-    {
-      label: "Sample App",
-      url: "https://github.com/auth0-samples/auth0-golang-api-samples/tree/master/01-Authorization-RS256",
-    },
-    { label: "Quickstart", url: "/docs/quickstart/backend/golang/interactive" },
-  ],
-}}/>
-
-<SectionCard item={{
-  name: "Go API",
-  subtext: "go-jwt-middleware",
-  logo: "golang.svg",
-  date: "Mar 5, 2024",
-  badge: "v2.3.0",
-  links: [
-    { label: "Github", url: "https://github.com/auth0/go-jwt-middleware" },
-    {
-      label: "Sample App",
-      url: "https://github.com/auth0-samples/auth0-golang-api-samples/tree/master/01-Authorization-RS256",
-    },
-    { label: "Quickstart", url: "/docs/quickstart/backend/golang/interactive" },
-  ],
-}}/>
-
-<SectionCard item={{
-  name: "Laravel API",
-  subtext: "laravel-auth0",
-  logo: "laravel.svg",
-  date: "May 16, 2024",
-  badge: "7.17.0",
-  links: [
-    { label: "Github", url: "https://github.com/auth0/laravel-auth0" },
-    { label: "Sample App", url: "https://github.com/auth0-samples/laravel/tree/7.x/sample" },
-    { label: "Quickstart", url: "/docs/quickstart/backend/laravel/interactive" },
-  ],
-}}/>
-
 <SectionCard item={{
   name: "Node (Express) API",
   subtext: "node-oauth2-jwt-bearer",
@@ -349,18 +320,63 @@ Does your API or service need authentication? Auth0 has SDKs for common API and 
 }}/>
 
 <SectionCard item={{
-  name: "PHP API",
-  subtext: "auth0-PHP",
-  logo: "php.svg",
-  date: "May 30, 2024",
-  badge: "8.15.0",
+  name: "Spring Boot API",
+  subtext: "okta-spring-boot",
+  logo: "spring.svg",
+  date: "Jun 21, 2024",
+  badge: "3.0.7",
   links: [
-    { label: "Github", url: "https://github.com/auth0/auth0-php" },
+    { label: "Github", url: "https://github.com/okta/okta-spring-boot/" },
     {
       label: "Sample App",
-      url: "https://github.com/auth0-samples/auth0-php-api-samples/tree/main/app",
+      url: "https://github.com/auth0-samples/auth0-spring-security5-api-sample/tree/master/01-Authorization-MVC",
     },
-    { label: "Quickstart", url: "/docs/quickstart/backend/php/interactive" },
+    { label: "Quickstart", url: "/docs/quickstart/backend/java-spring-security5/interactive" },
+  ],
+}}/>
+
+<SectionCard item={{
+  name: "Go API",
+  subtext: "go-jwt-middleware",
+  logo: "golang.svg",
+  date: "Mar 5, 2024",
+  badge: "v2.3.0",
+  links: [
+    { label: "Github", url: "https://github.com/auth0/go-jwt-middleware" },
+    {
+      label: "Sample App",
+      url: "https://github.com/auth0-samples/auth0-golang-api-samples/tree/master/01-Authorization-RS256",
+    },
+    { label: "Quickstart", url: "/docs/quickstart/backend/golang/interactive" },
+  ],
+}}/>
+
+<SectionCard item={{
+  name: "ASP.NET Core Web API",
+  subtext: "aspnetcore-api",
+  logo: "dotnet-platform.svg",
+  date: "Dec 18, 2025",
+  badge: "v1.0.0",
+  links: [
+    { label: "Github", url: "https://github.com/auth0/aspnetcore-api" },
+    {
+      label: "Sample App",
+      url: "https://github.com/auth0-samples/auth0-aspnetcore-webapi-samples/tree/master",
+    },
+    { label: "Quickstart", url: "/docs/quickstart/backend/aspnet-core-webapi" },
+  ],
+}}/>
+
+<SectionCard item={{
+  name: "Laravel API",
+  subtext: "laravel-auth0",
+  logo: "laravel.svg",
+  date: "May 16, 2024",
+  badge: "7.17.0",
+  links: [
+    { label: "Github", url: "https://github.com/auth0/laravel-auth0" },
+    { label: "Sample App", url: "https://github.com/auth0-samples/laravel/tree/7.x/sample" },
+    { label: "Quickstart", url: "/docs/quickstart/backend/laravel/interactive" },
   ],
 }}/>
 
@@ -381,6 +397,22 @@ Does your API or service need authentication? Auth0 has SDKs for common API and 
 }}/>
 
 <SectionCard item={{
+  name: "PHP API",
+  subtext: "auth0-PHP",
+  logo: "php.svg",
+  date: "May 30, 2024",
+  badge: "8.15.0",
+  links: [
+    { label: "Github", url: "https://github.com/auth0/auth0-php" },
+    {
+      label: "Sample App",
+      url: "https://github.com/auth0-samples/auth0-php-api-samples/tree/main/app",
+    },
+    { label: "Quickstart", url: "/docs/quickstart/backend/php/interactive" },
+  ],
+}}/>
+
+<SectionCard item={{
   name: "Ruby On Rails API",
   subtext: "omniauth-auth0",
   logo: "rails.svg",
@@ -395,22 +427,6 @@ Does your API or service need authentication? Auth0 has SDKs for common API and 
     { label: "Quickstart", url: "/docs/quickstart/backend/rails/interactive" },
   ],
 }}/>
-
-<SectionCard item={{
-  name: "Spring Boot API",
-  subtext: "okta-spring-boot",
-  logo: "spring.svg",
-  date: "Jun 21, 2024",
-  badge: "3.0.7",
-  links: [
-    { label: "Github", url: "https://github.com/okta/okta-spring-boot/" },
-    {
-      label: "Sample App",
-      url: "https://github.com/auth0-samples/auth0-spring-security5-api-sample/tree/master/01-Authorization-MVC",
-    },
-    { label: "Quickstart", url: "/docs/quickstart/backend/java-spring-security5/interactive" },
-  ],
-}}/>
 </Columns>
 
 ## Native/Mobile App
@@ -419,50 +435,18 @@ Mobile or Desktop app that runs natively on a device
 
 <Columns cols={2}>
 <SectionCard item={{
-  name: ".NET (OIDC Client)",
-  subtext: "auth0-oidc-client-net",
-  logo: "dotnet-platform.svg",
-  date: "Apr 16, 2024",
-  badge: "ios-4.3.0",
-  links: [
-    { label: "Github", url: "https://github.com/auth0/auth0-oidc-client-net" },
-    {
-      label: "Sample App",
-      url: "https://github.com/auth0-samples/auth0-xamarin-oidc-samples/tree/master/Quickstart/01-Login",
-    },
-    { label: "Quickstart", url: "/docs/quickstart/native/net-android-ios/interactive" },
-  ],
-}}/>
-
-<SectionCard item={{
-  name: "Android",
-  subtext: "Auth0.Android",
-  logo: "android.svg",
-  date: "Jun 4, 2024",
-  badge: "3.8.0",
-  links: [
-    { label: "Github", url: "https://github.com/auth0/Auth0.Android" },
-    {
-      label: "Sample App",
-      url: "https://github.com/auth0-samples/auth0-android-sample/tree/master/00-Login-Kt",
-    },
-    { label: "Quickstart", url: "/docs/quickstart/native/android/interactive" },
-  ],
-}}/>
-
-<SectionCard item={{
-  name: "Expo",
+  name: "React Native",
   subtext: "react-native-auth0",
-  logo: "expo.svg",
+  logo: "react.svg",
   date: "May 2, 2024",
   badge: "v4.6.0",
   links: [
     { label: "Github", url: "https://github.com/auth0/react-native-auth0" },
     {
       label: "Sample App",
-      url: "https://github.com/auth0-samples/auth0-react-native-sample/tree/master/00-Login-Expo",
+      url: "https://github.com/auth0-samples/auth0-react-native-sample/tree/master/00-Login-Hooks",
     },
-    { label: "Quickstart", url: "/docs/quickstart/native/react-native-expo/interactive" },
+    { label: "Quickstart", url: "/docs/quickstart/native/react-native/interactive" },
   ],
 }}/>
 
@@ -499,6 +483,54 @@ Mobile or Desktop app that runs natively on a device
 }}/>
 
 <SectionCard item={{
+  name: "Android",
+  subtext: "Auth0.Android",
+  logo: "android.svg",
+  date: "Jun 4, 2024",
+  badge: "3.8.0",
+  links: [
+    { label: "Github", url: "https://github.com/auth0/Auth0.Android" },
+    {
+      label: "Sample App",
+      url: "https://github.com/auth0-samples/auth0-android-sample/tree/master/00-Login-Kt",
+    },
+    { label: "Quickstart", url: "/docs/quickstart/native/android/interactive" },
+  ],
+}}/>
+
+<SectionCard item={{
+  name: "Expo",
+  subtext: "react-native-auth0",
+  logo: "expo.svg",
+  date: "May 2, 2024",
+  badge: "v4.6.0",
+  links: [
+    { label: "Github", url: "https://github.com/auth0/react-native-auth0" },
+    {
+      label: "Sample App",
+      url: "https://github.com/auth0-samples/auth0-react-native-sample/tree/master/00-Login-Expo",
+    },
+    { label: "Quickstart", url: "/docs/quickstart/native/react-native-expo/interactive" },
+  ],
+}}/>
+
+<SectionCard item={{
+  name: ".NET (OIDC Client)",
+  subtext: "auth0-oidc-client-net",
+  logo: "dotnet-platform.svg",
+  date: "Apr 16, 2024",
+  badge: "ios-4.3.0",
+  links: [
+    { label: "Github", url: "https://github.com/auth0/auth0-oidc-client-net" },
+    {
+      label: "Sample App",
+      url: "https://github.com/auth0-samples/auth0-xamarin-oidc-samples/tree/master/Quickstart/01-Login",
+    },
+    { label: "Quickstart", url: "/docs/quickstart/native/net-android-ios/interactive" },
+  ],
+}}/>
+
+<SectionCard item={{
   name: "MAUI",
   subtext: "auth0-oidc-client-net",
   logo: "dotnet.svg",
@@ -511,54 +543,6 @@ Mobile or Desktop app that runs natively on a device
       url: "https://github.com/auth0-samples/auth0-maui-samples/tree/master/Sample",
     },
     { label: "Quickstart", url: "/docs/quickstart/native/maui/interactive" },
-  ],
-}}/>
-
-<SectionCard item={{
-  name: "React Native",
-  subtext: "react-native-auth0",
-  logo: "react.svg",
-  date: "May 2, 2024",
-  badge: "v4.6.0",
-  links: [
-    { label: "Github", url: "https://github.com/auth0/react-native-auth0" },
-    {
-      label: "Sample App",
-      url: "https://github.com/auth0-samples/auth0-react-native-sample/tree/master/00-Login-Hooks",
-    },
-    { label: "Quickstart", url: "/docs/quickstart/native/react-native/interactive" },
-  ],
-}}/>
-
-<SectionCard item={{
-  name: "UWP",
-  subtext: "auth0-oidc-client-net",
-  logo: "windows.svg",
-  date: "Apr 16, 2024",
-  badge: "ios-4.3.0",
-  links: [
-    { label: "Github", url: "https://github.com/auth0/auth0-oidc-client-net" },
-    {
-      label: "Sample App",
-      url: "https://github.com/auth0-samples/auth0-uwp-oidc-samples/tree/master/Quickstart/00-Starter-Seed",
-    },
-    { label: "Quickstart", url: "/docs/quickstart/native/windows-uwp-csharp/interactive" },
-  ],
-}}/>
-
-<SectionCard item={{
-  name: "WPF / Winforms",
-  subtext: "auth0-oidc-client-net",
-  logo: "dotnet.svg",
-  date: "Apr 16, 2024",
-  badge: "ios-4.3.0",
-  links: [
-    { label: "Github", url: "https://github.com/auth0/auth0-oidc-client-net" },
-    {
-      label: "Sample App",
-      url: "https://github.com/auth0-samples/auth0-WinFormsWPF-oidc-samples/tree/master/Quickstart/00-Starter-Seed",
-    },
-    { label: "Quickstart", url: "/docs/quickstart/native/wpf-winforms/interactive" },
   ],
 }}/>
 
@@ -618,19 +602,29 @@ Need to programmatically perform Auth0 administrative tasks? Choose from one of 
 <Columns cols={2}>
   <SectionCard item={{
     name: ".NET",
-    subtext: "auth0-angular",
+    subtext: "auth0.net",
     logo: "dotnet-platform.svg",
-    date: "on Jan 16, 2024",
-    badge: "v2.2.3",
+    date: "Jan 16, 2024",
+    badge: "v7.28.0",
     links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-aspnet" }
+      { label: "Github", url: "https://github.com/auth0/auth0.net" }
     ],
   }}/>
   <SectionCard item={{
-    name: "Go API",
+    name: "Go",
+    subtext: "go-auth0",
+    logo: "golang.svg",
+    date: "Dec 11, 2025",
+    badge: "v2.3.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/go-auth0" }
+    ],
+  }}/>
+  <SectionCard item={{
+    name: "Go JWT Middleware",
     subtext: "go-jwt-middleware",
     logo: "golang.svg",
-    date: "on Mar 5",
+    date: "Mar 5, 2025",
     badge: "v2.3.0",
     links: [
       { label: "Github", url: "https://github.com/auth0/go-jwt-middleware" }
@@ -638,39 +632,49 @@ Need to programmatically perform Auth0 administrative tasks? Choose from one of 
   }}/>
   <SectionCard item={{
     name: "Java",
-    subtext: "auth0-java-mvc-common",
+    subtext: "auth0-java",
     logo: "java.svg",
-    date: "on Dec 19, 2023",
-    badge: "1.11.0",
+    date: "Dec 19, 2023",
+    badge: "2.12.0",
     links: [
       { label: "Github", url: "https://github.com/auth0/auth0-java" }
     ],
   }}/>
   <SectionCard item={{
-    name: "Node (Express) API",
+    name: "Node",
+    subtext: "node-auth0",
+    logo: "nodejs.svg",
+    date: "Nov 21, 2024",
+    badge: "v4.11.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/node-auth0" }
+    ],
+  }}/>
+  <SectionCard item={{
+    name: "Node JWT Bearer",
     subtext: "node-oauth2-jwt-bearer",
     logo: "nodejs.svg",
-    date: "on Mar 14",
+    date: "Mar 14, 2024",
     badge: "v1.6.1",
     links: [
       { label: "Github", url: "https://github.com/auth0/node-oauth2-jwt-bearer" }
     ],
   }}/>
   <SectionCard item={{
-    name: "PHP API",
-    subtext: "auth0-PHP",
+    name: "PHP",
+    subtext: "auth0-php",
     logo: "php.svg",
-    date: "on May 30",
+    date: "May 30, 2024",
     badge: "8.15.0",
     links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-PHP" }
+      { label: "Github", url: "https://github.com/auth0/auth0-php" }
     ],
   }}/>
   <SectionCard item={{
-    name: "Python API",
+    name: "Python",
     subtext: "auth0-python",
     logo: "python.svg",
-    date: "on Jun 6",
+    date: "Jun 6, 2024",
     badge: "4.10.0",
     links: [
       { label: "Github", url: "https://github.com/auth0/auth0-python" }
@@ -680,7 +684,7 @@ Need to programmatically perform Auth0 administrative tasks? Choose from one of 
     name: "Ruby",
     subtext: "ruby-auth0",
     logo: "ruby.svg",
-    date: "on Dec 3, 2024",
+    date: "Dec 3, 2024",
     badge: "v5.18.0",
     links: [
       { label: "Github", url: "https://github.com/auth0/ruby-auth0" }

--- a/main/docs/troubleshoot/customer-support/product-support-matrix.mdx
+++ b/main/docs/troubleshoot/customer-support/product-support-matrix.mdx
@@ -252,79 +252,151 @@ All listed operating systems are the latest versions unless otherwise indicated.
 </thead>
 <tbody>
 <tr>
-<td><a href="https://github.com/auth0/auth0-spa-js/tree/master" title="Auth0 SPA SDK v1">Auth0 SPA SDK v1</a></td>
+<td><a href="https://github.com/auth0/auth0-react" title="Auth0 React">Auth0 React</a></td>
 <td>Supported</td>
 </tr>
 <tr>
-<td><a href="https://github.com/auth0/auth0.js/tree/master" title="Auth0.js v9">Auth0.js v9</a></td>
+<td><a href="https://github.com/auth0/nextjs-auth0" title="Auth0 Next.js">Auth0 Next.js</a></td>
 <td>Supported</td>
 </tr>
 <tr>
-<td><a href="https://github.com/auth0/Auth0.Android/tree/v1" title="Auth0 Android v1">Auth0 Android v1</a></td>
+<td><a href="https://github.com/auth0/auth0-vue" title="Auth0 Vue">Auth0 Vue</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0/auth0-nuxt" title="Auth0 Nuxt">Auth0 Nuxt</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0/auth0-angular" title="Auth0 Angular">Auth0 Angular</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0/angular-lock/tree/master" title="Angular Lock">Angular Lock</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0/auth0-spa-js/tree/master" title="Auth0 SPA JS">Auth0 SPA JS</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0/auth0.js/tree/master" title="Auth0.js">Auth0.js</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0/react-native-auth0" title="Auth0 React Native">Auth0 React Native</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0/auth0-flutter" title="Auth0 Flutter">Auth0 Flutter</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0/Auth0.Android/tree/main" title="Auth0 Android">Auth0 Android</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0/Auth0.Swift/tree/master" title="Auth0 Swift">Auth0 Swift</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0/node-auth0/tree/master" title="Auth0 Node">Auth0 Node</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0/auth0-auth-js/tree/main/packages/auth0-auth-js" title="Auth0 Auth JS">Auth0 Auth JS</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0/auth0-auth-js/tree/main/packages/auth0-server-js" title="Auth0 Server JS">Auth0 Server JS</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0/auth0-auth-js/tree/main/packages/auth0-api-js" title="Auth0 API JS">Auth0 API JS</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0/express-openid-connect" title="Express OpenID Connect">Express OpenID Connect</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0/node-oauth2-jwt-bearer/tree/main/packages/express-oauth2-jwt-bearer" title="Express OAuth2 JWT Bearer">Express OAuth2 JWT Bearer</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0/auth0-python/tree/master" title="Auth0 Python">Auth0 Python</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0/auth0-server-python" title="Auth0 Server Python">Auth0 Server Python</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0/auth0-api-python" title="Auth0 API Python">Auth0 API Python</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0/Auth0.net/tree/master" title="Auth0 .NET">Auth0 .NET</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0/auth0-oidc-client-net/tree/master" title="Auth0 OIDC Client for .NET">Auth0 OIDC Client for .NET</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0/auth0-aspnetcore-authentication" title="Auth0 ASP.NET Core Authentication">Auth0 ASP.NET Core Authentication</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0/aspnetcore-api" title="Auth0 ASP.NET Core API">Auth0 ASP.NET Core API</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0/Auth0-java/tree/master" title="Auth0 Java">Auth0 Java</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0/auth0-java-mvc-common/tree/master" title="Auth0 Java MVC Common">Auth0 Java MVC Common</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0/auth0-php/tree/master" title="Auth0 PHP">Auth0 PHP</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0/laravel-auth0" title="Laravel Auth0">Laravel Auth0</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0/go-auth0" title="Go Auth0">Go Auth0</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0/go-jwt-middleware" title="Go JWT Middleware">Go JWT Middleware</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0/ruby-auth0" title="Auth0 Ruby">Auth0 Ruby</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0/omniauth-auth0" title="OmniAuth Auth0">OmniAuth Auth0</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0/jwt-auth-bundle/tree/3.x.x-dev" title="JWT Auth Bundle (v3)">JWT Auth Bundle (v3)</a></td>
 <td>Bug Fixes</td>
 </tr>
 <tr>
-<td><a href="https://github.com/auth0/Auth0.Android/tree/main" title="Auth0 Android v2">Auth0 Android v2</a></td>
+<td><a href="https://github.com/auth0/jwt-auth-bundle/tree/master" title="JWT Auth Bundle">JWT Auth Bundle</a></td>
 <td>Supported</td>
 </tr>
 <tr>
-<td><a href="https://github.com/auth0/Auth0.Swift/tree/master" title="Auth0 Swift v1">Auth0 Swift v1</a></td>
+<td><a href="https://github.com/auth0/universal-login/blob/master/packages/auth0-acul-js/README.md" title="Auth0 ACUL JS">Auth0 ACUL JS</a></td>
 <td>Supported</td>
 </tr>
 <tr>
-<td><a href="https://github.com/auth0/Auth0.net/tree/master" title="Auth0 .NET v7">Auth0 .NET v7</a></td>
-<td>Supported</td>
-</tr>
-<tr>
-<td><a href="https://github.com/auth0/Auth0-java/tree/master" title="Auth0 Java v1">Auth0 Java v1</a></td>
-<td>Supported</td>
-</tr>
-<tr>
-<td><a href="https://github.com/auth0/node-auth0/tree/master" title="Auth0 Node v2">Auth0 Node v2</a></td>
-<td>Supported</td>
-</tr>
-<tr>
-<td><a href="https://github.com/auth0/auth0-python/tree/master" title="Auth0 Python v3">Auth0 Python v3</a></td>
-<td>Supported</td>
-</tr>
-<tr>
-<td><a href="https://github.com/auth0/auth0-php/tree/master" title="Auth0 PHP v7">Auth0 PHP v7</a></td>
-<td>Supported</td>
-</tr>
-<tr>
-<td><a href="https://github.com/auth0/ruby-auth0" title="Auth0 Ruby SDK v5">Auth0 Ruby SDK v5</a></td>
-<td>Supported</td>
-</tr>
-</tbody>
-</table>
-
-### Framework and Platform Integration SDKs
-
-<table class="table"><thead>
-<tr>
-<th><strong>SDK</strong></th>
-<th><strong>Support Level</strong></th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><a href="https://github.com/auth0/angular-lock/tree/master" title="Angular Lock v3">Angular Lock v3</a></td>
-<td>Supported</td>
-</tr>
-<tr>
-<td><a href="https://github.com/auth0/auth0-java-mvc-common/tree/master" title="Auth0 Java MVC Common v1">Auth0 Java MVC Common v1</a></td>
-<td>Supported</td>
-</tr>
-<tr>
-<td><a href="https://github.com/auth0/auth0-oidc-client-net/tree/master" title="OIDC Client for .NET v3">OIDC Client for .NET v3</a></td>
-<td>Supported</td>
-</tr>
-<tr>
-<td><a href="https://github.com/auth0/jwt-auth-bundle/tree/3.x.x-dev" title="JWT Auth Bundle v3">JWT Auth Bundle v3</a></td>
-<td>Bug Fixes</td>
-</tr>
-<tr>
-<td><a href="https://github.com/auth0/jwt-auth-bundle/tree/master" title="JWT Auth Bundle v4">JWT Auth Bundle v4</a></td>
+<td><a href="https://github.com/auth0/universal-login/blob/master/packages/auth0-acul-react/README.md" title="Auth0 ACUL React">Auth0 ACUL React</a></td>
 <td>Supported</td>
 </tr>
 </tbody>
@@ -346,7 +418,7 @@ All listed operating systems are the latest versions unless otherwise indicated.
 </tbody>
 </table>
 
-## Quickstarts and samples
+## Samples
 
 ### Native and mobile apps
 
@@ -358,19 +430,11 @@ All listed operating systems are the latest versions unless otherwise indicated.
 </thead>
 <tbody>
 <tr>
+<td><a href="https://github.com/auth0-samples/auth0-ios-swift-sample/tree/master" title="iOS / macOS">iOS / macOS</a></td>
+<td>Supported</td>
+</tr>
+<tr>
 <td><a href="https://github.com/auth0-samples/auth0-android-sample/tree/master" title="Android">Android</a></td>
-<td>Supported</td>
-</tr>
-<tr>
-<td>Device Authorization Flow</td>
-<td>Supported</td>
-</tr>
-<tr>
-<td><a href="https://github.com/auth0-samples/auth0-ionic4-samples/tree/master" title="Iconic 4">Iconic 4</a></td>
-<td>Supported</td>
-</tr>
-<tr>
-<td><a href="https://github.com/auth0-samples/auth0-ios-swift-sample/tree/master" title="iOS Swift">iOS Swift</a></td>
 <td>Supported</td>
 </tr>
 <tr>
@@ -378,11 +442,39 @@ All listed operating systems are the latest versions unless otherwise indicated.
 <td>Supported</td>
 </tr>
 <tr>
-<td><a href="https://github.com/auth0-samples/auth0-uwp-oidc-samples/tree/master/Quickstart/00-Starter-Seed" title="Windows Universal App C#">Windows Universal App C#</a></td>
+<td><a href="https://github.com/auth0-samples/auth0-react-native-sample/tree/master/00-Login-Expo" title="Expo">Expo</a></td>
 <td>Supported</td>
 </tr>
 <tr>
-<td><a href="https://github.com/auth0-samples/auth0-WinFormsWPF-oidc-samples/tree/master" title="WPF/Windows">WPF/Windows</a></td>
+<td><a href="https://github.com/auth0-samples/auth0-flutter-samples/tree/main/sample" title="Flutter">Flutter</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0-samples/auth0-xamarin-oidc-samples/tree/master/Quickstart/01-Login" title=".NET Android and iOS">.NET Android and iOS</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0-samples/auth0-maui-samples/tree/master/Sample" title="MAUI">MAUI</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0-samples/auth0-ionic-samples/tree/master/angular" title="Ionic & Capacitor (Angular)">Ionic & Capacitor (Angular)</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0-samples/auth0-ionic-samples/tree/master/react" title="Ionic & Capacitor (React)">Ionic & Capacitor (React)</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0-samples/auth0-ionic-samples/tree/master/vue" title="Ionic & Capacitor (Vue)">Ionic & Capacitor (Vue)</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0-samples/auth0-uwp-oidc-samples/tree/master/Quickstart/00-Starter-Seed" title="UWP">UWP</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0-samples/auth0-WinFormsWPF-oidc-samples/tree/master" title="WPF / Winforms">WPF / Winforms</a></td>
 <td>Supported</td>
 </tr>
 <tr>
@@ -402,6 +494,10 @@ All listed operating systems are the latest versions unless otherwise indicated.
 </thead>
 <tbody>
 <tr>
+<td><a href="https://github.com/auth0-samples/auth0-react-samples/tree/master" title="React">React</a></td>
+<td>Supported</td>
+</tr>
+<tr>
 <td><a href="https://github.com/auth0-samples/auth0-angular-samples/tree/master" title="Angular">Angular</a></td>
 <td>Supported</td>
 </tr>
@@ -410,11 +506,11 @@ All listed operating systems are the latest versions unless otherwise indicated.
 <td>Supported</td>
 </tr>
 <tr>
-<td><a href="https://github.com/auth0-samples/auth0-react-samples/tree/master" title="React">React</a></td>
+<td><a href="https://github.com/auth0-samples/auth0-vue-samples/tree/master" title="Vue">Vue</a></td>
 <td>Supported</td>
 </tr>
 <tr>
-<td><a href="https://github.com/auth0-samples/auth0-vue-samples/tree/master" title="Vue.js">Vue.js</a></td>
+<td><a href="https://github.com/auth0-samples/auth0-flutter-samples/tree/main/sample" title="Flutter (Web)">Flutter (Web)</a></td>
 <td>Supported</td>
 </tr>
 </tbody>
@@ -430,15 +526,19 @@ All listed operating systems are the latest versions unless otherwise indicated.
 </thead>
 <tbody>
 <tr>
-<td><a href="https://github.com/auth0-samples/auth0-aspnet-owin-mvc-samples/tree/master" title="ASP.NET (OWIN)">ASP.NET (OWIN)</a></td>
+<td><a href="https://github.com/auth0-samples/auth0-nextjs-samples/tree/main/Sample-01" title="Next.js">Next.js</a></td>
 <td>Supported</td>
 </tr>
 <tr>
-<td><a href="https://github.com/auth0-samples/auth0-aspnetcore-mvc-samples/tree/netcore2.1" title="ASP.NET Core v2.1">ASP.NET Core v2.1</a></td>
+<td><a href="https://github.com/auth0-samples/auth0-express-webapp-sample/tree/master/01-Login" title="Express">Express</a></td>
 <td>Supported</td>
 </tr>
 <tr>
-<td><a href="https://github.com/auth0-samples/auth0-aspnetcore-mvc-samples/tree/master" title="ASP.NET Core v3.1">ASP.NET Core v3.1</a></td>
+<td><a href="https://github.com/auth0-samples/auth0-python-web-app/tree/master" title="Python">Python</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0-samples/auth0-django-web-app/tree/master" title="Django">Django</a></td>
 <td>Supported</td>
 </tr>
 <tr>
@@ -450,27 +550,35 @@ All listed operating systems are the latest versions unless otherwise indicated.
 <td>Supported</td>
 </tr>
 <tr>
-<td><a href="https://github.com/auth0-samples/auth0-spring-boot-login-samples/tree/master" title="Java Spring MVC">Java Spring MVC</a></td>
+<td><a href="https://github.com/auth0-samples/auth0-java-ee-sample/tree/master" title="Java EE">Java EE</a></td>
 <td>Supported</td>
 </tr>
 <tr>
-<td><a href="https://github.com/auth0-samples/auth0-nodejs-webapp-sample/tree/master" title="Node.js">Node.js</a></td>
+<td><a href="https://github.com/auth0-samples/auth0-spring-boot-login-samples/tree/master" title="Java Spring Boot">Java Spring Boot</a></td>
 <td>Supported</td>
 </tr>
 <tr>
-<td><a href="https://github.com/auth0-samples/auth0-php-web-app/tree/master" title="PHP">PHP</a></td>
+<td><a href="https://github.com/auth0-samples/auth0-aspnet-owin-mvc-samples/tree/master" title="ASP.NET (OWIN)">ASP.NET (OWIN)</a></td>
 <td>Supported</td>
 </tr>
 <tr>
-<td><a href="https://github.com/auth0-samples/auth0-laravel-php-web-app/tree/master" title="PHP Laravel">PHP Laravel</a></td>
+<td><a href="https://github.com/auth0-samples/auth0-aspnetcore-blazor-server-samples/tree/main/Quickstart/Sample" title="ASP.NET Core Blazor Server">ASP.NET Core Blazor Server</a></td>
 <td>Supported</td>
 </tr>
 <tr>
-<td><a href="https://github.com/auth0-samples/auth0-python-web-app/tree/master" title="Python">Python</a></td>
+<td><a href="https://github.com/auth0-samples/auth0-aspnetcore-mvc-samples/tree/master/Quickstart/Sample" title="ASP.NET Core MVC">ASP.NET Core MVC</a></td>
 <td>Supported</td>
 </tr>
 <tr>
-<td><a href="https://github.com/auth0-samples/auth0-rubyonrails-sample/tree/master" title="Ruby on Rails">Ruby on Rails</a></td>
+<td><a href="https://github.com/auth0-samples/laravel/tree/7.x/sample" title="Laravel">Laravel</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0-samples/auth0-php-web-app/tree/main/app" title="PHP">PHP</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0-samples/auth0-rubyonrails-sample/tree/master/sample" title="Ruby On Rails">Ruby On Rails</a></td>
 <td>Supported</td>
 </tr>
 </tbody>
@@ -486,6 +594,22 @@ All listed operating systems are the latest versions unless otherwise indicated.
 </thead>
 <tbody>
 <tr>
+<td><a href="https://github.com/auth0-samples/auth0-express-api-samples/tree/master/01-Authorization-RS256" title="Node.js Express">Node.js Express</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0-samples/auth0-python-api-samples/tree/master" title="Python API">Python API</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0-samples/auth0-spring-security5-api-sample/tree/master" title="Spring Boot API">Spring Boot API</a></td>
+<td>Supported</td>
+</tr>
+<tr>
+<td><a href="https://github.com/auth0-samples/auth0-golang-api-samples/tree/master" title="Go API">Go API</a></td>
+<td>Supported</td>
+</tr>
+<tr>
 <td><a href="https://github.com/auth0-samples/auth0-aspnetcore-webapi-samples/tree/master" title="ASP.NET Core Web API">ASP.NET Core Web API</a></td>
 <td>Supported</td>
 </tr>
@@ -494,31 +618,15 @@ All listed operating systems are the latest versions unless otherwise indicated.
 <td>Supported</td>
 </tr>
 <tr>
-<td><a href="https://github.com/auth0-samples/auth0-golang-api-samples/tree/master" title="Go">Go</a></td>
+<td><a href="https://github.com/auth0-samples/laravel/tree/7.x/sample" title="Laravel API">Laravel API</a></td>
 <td>Supported</td>
 </tr>
 <tr>
-<td><a href="https://github.com/auth0-samples/auth0-spring-security-api-sample/tree/master" title="Java Spring">Java Spring</a></td>
+<td><a href="https://github.com/auth0-samples/auth0-php-api-samples/tree/main/app" title="PHP API">PHP API</a></td>
 <td>Supported</td>
 </tr>
 <tr>
-<td><a href="https://github.com/auth0-samples/auth0-express-api-samples/tree/master" title="Node.js Express">Node.js Express</a></td>
-<td>Supported</td>
-</tr>
-<tr>
-<td><a href="https://github.com/auth0-samples/auth0-php-api-samples/tree/master" title="PHP">PHP</a></td>
-<td>Supported</td>
-</tr>
-<tr>
-<td><a href="https://github.com/auth0-samples/auth0-laravel-api-samples/tree/master" title="PHP Laravel">PHP Laravel</a></td>
-<td>Supported</td>
-</tr>
-<tr>
-<td><a href="https://github.com/auth0-samples/auth0-python-api-samples/tree/master" title="Python">Python</a></td>
-<td>Supported</td>
-</tr>
-<tr>
-<td><a href="https://github.com/auth0-samples/auth0-rubyonrails-api-samples/tree/master" title="Ruby on Rails">Ruby on Rails</a></td>
+<td><a href="https://github.com/auth0-samples/auth0-rubyonrails-api-samples/tree/master" title="Ruby On Rails API">Ruby On Rails API</a></td>
 <td>Supported</td>
 </tr>
 </tbody>


### PR DESCRIPTION
### Description
Product Support Matrix (product-support-matrix.mdx):
- Added 19 missing SDKs to Auth0 SDKs table
- Standardized naming: removed version suffixes (v1, v2, v3, v7, v9) and "SDK" redundancy across all entries
- Merged "Framework and Platform Integration SDKs" section into unified "Auth0 SDKs" table
- Reordered Auth0 SDKs by framework popularity (React/Next.js → Vue/Nuxt → Angular → JavaScript → Mobile → Backend)
- Removed duplicate Auth0 Android (v1) entry
- Added ACUL packages (Auth0 ACUL JS, Auth0 ACUL React)
- Added Auth0 ASP.NET Core API SDK
- Moved Nuxt from SPAs to Regular Web Applications section with corrected quickstart link
- Updated Samples section to match /quickstarts page (added Django, Ionic variants, .NET platforms)
- Fixed Ionic samples branch paths (/master/ → /main/)
- Removed 8 non-existent repository entries (Facebook Login, Cap'n Web, Svelte, Nuxt samples, NGINX Plus, Apache, Device Flow, Django API)
- Renamed "Quickstarts and samples" section to "Samples" for accuracy


Libraries Page (libraries.mdx):
- Added missing SDKs across all sections (SPA, Regular Web App, Backend/API, Native/Mobile, Management API)
- Reordered all sections by framework popularity
- Shortened "ASP.NET Core Blazor Server" to "ASP.NET Core Blazor" to fix text overlap
- Added Auth0 ASP.NET Core API SDK to Backend/API section



### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
