### PR TITLE
Correct SMS MFA security details

### DIFF
--- a/main/docs/secure/multi-factor-authentication/multi-factor-authentication-factors/configure-sms-voice-notifications-mfa.mdx
+++ b/main/docs/secure/multi-factor-authentication/multi-factor-authentication-factors/configure-sms-voice-notifications-mfa.mdx
@@ -307,8 +307,8 @@ When using any phone messaging provider, be aware that attackers abusing the sig
 
 Auth0 limits a single user to send up to 10 SMS or voice messages per hour, and OTP flows via email or authenticators are limited to five requests every five minutes. (The burst rate is 10 but only 1 voice message per hour will be sent for new requests.) To further protect your account, consider:
 
-* Enabling [Brute Force Protection](/docs/secure/attack-protection/brute-force-protection). Auth0 will block an IP if it attempts to do more than 50 signup requests per minute.
-* Enabling [Log Streaming](/docs/customize/log-streams) and creating alerts using your favorite monitoring tool when you see spikes in the number of `gd_send_voice` or `gd_send_voice_failure` [log events](/docs/deploy-monitor/logs/log-event-type-codes).
+* Enabling [Suspicious IP Throttling](/docs/secure/attack-protection/suspicious-ip-throttling#signup-attempts). Auth0 will block an IP if it attempts to do more than 50 signup requests per minute.
+* Enabling [Log Streaming](/docs/customize/log-streams) and creating alerts using your favorite monitoring tool when you see spikes in the number of `gd_send_voice`, `gd_send_voice_failure`, `gd_send_sms`, or `gd_send_sms_failure` [log events](/docs/deploy-monitor/logs/log-event-type-codes).
 
 Phone Messaging providers have additional protections. If you are using Twilio, read the [Twilio's Anti-Fraud Developer Guide](https://www.twilio.com/docs/usage/anti-fraud-developer-guide). Consider the following options:
 


### PR DESCRIPTION
update the log events to include SMS (not just voice) and link to the right product for blocking sign-up attempts.