### PR TITLE
Update to change TLS 1.3 cyphers to the IANA name and advise deprecat…

### DIFF
--- a/main/docs/customize/custom-domains/self-managed-certificates/tls-ssl.mdx
+++ b/main/docs/customize/custom-domains/self-managed-certificates/tls-ssl.mdx
@@ -56,7 +56,7 @@ To learn more, read [Transport Layer Security (TLS) Parameters](https://www.iana
 ## Deprecated versions
 
 <Warning>
-Although they remain available in some environments, the following TLS 1.2 cipher suites are deprecated and **scheduled to become unsupported starting June 2026**. To learn more, read [Weak TLS 1.2 Cipher Suites](/docs/troubleshoot/product-lifecycle/deprecations-and-migrations#weak-tls-1-2-cipher-suites).
+Although they remain available in some environments, the following TLS 1.2 cipher suites are deprecated and will reach end-of-support in June 2026. To learn more, read [Weak TLS 1.2 Cipher Suites](/docs/troubleshoot/product-lifecycle/deprecations-and-migrations#weak-tls-1-2-cipher-suites).
 </Warning>
 
 TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA


### PR DESCRIPTION
…ed ciphers

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

The purpose of this PR is to:
* Update existing ciphers from the former name to the IANA names
* Advise the ciphers up for deprecation in June of 2026 with a link to the deprecation notice already in Docs

### References

https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml

### Testing


- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
