### PR TITLE
docs(auth4genai): Update CTE profile creation instruction to use auth0-cli

### DIFF
--- a/auth4genai/snippets/mcp/get-started/create-custom-token-exchange-profile.mdx
+++ b/auth4genai/snippets/mcp/get-started/create-custom-token-exchange-profile.mdx
@@ -1,31 +1,7 @@
 To enable Custom Token Exchange, you need to create a Token Exchange Profile that links your Custom Token Exchange Action to a unique subject token type identifier.
 
 <AccordionGroup>
-  <Accordion title="1. Get a Management API Token from the Dashboard">
-    To create a token exchange profile, you need a Management API access token with the appropriate scopes.
-
-    The quickest way to get a token for testing is from the Auth0 Dashboard:
-
-    1. Navigate to **Applications > APIs** in your Auth0 Dashboard
-    2. Select **Auth0 Management API**
-    3. Click on the **API Explorer** tab
-    4. Copy the displayed token
-
-    <Frame>
-      <img
-        src="/img/mcp/management_dashboard_api_token.png"
-        alt="Management API Token in Dashboard"
-      />
-    </Frame>
-
-    <Info>
-    The token includes all the scopes granted to the API Explorer Application. For production environments, we recommend using the [Client Credentials flow](https://auth0.com/docs/get-started/authentication-and-authorization-flow/client-credentials-flow) to acquire tokens with only the necessary scopes.
-    </Info>
-
-    Save this token - you'll use it in step 3.
-  </Accordion>
-
-  <Accordion title="2. Get Your Action ID">
+  <Accordion title="1. Get Your Action ID">
     You need the ID of the Custom Token Exchange Action you deployed earlier.
 
     Run the following command to list all actions in your tenant:
@@ -45,29 +21,23 @@ To enable Custom Token Exchange, you need to create a Token Exchange Profile tha
     Save this Action ID - you'll use it in the next step.
   </Accordion>
 
-  <Accordion title="3. Create the Token Exchange Profile">
-    Now use the Management API to create your Custom Token Exchange Profile.
+  <Accordion title="2. Create the Token Exchange Profile">
+    Now use the Auth0 CLI to create your Custom Token Exchange Profile.
 
     Replace the placeholder values in the command below:
-    - `YOUR_TENANT` - Your Auth0 tenant domain (e.g., `dev-abc123.us.auth0.com`)
-    - `YOUR_MANAGEMENT_API_TOKEN` - The token from Step 1
-    - `YOUR_PROFILE_NAME` - A descriptive name for your profile (e.g., `"MCP Custom Token Exchange"`)
-    - `<your-action-id>` - The Action ID from Step 2
+    - `<your-action-id>` - The Action ID from Step 1
+    - `<YOUR_PROFILE_NAME>` - A descriptive name for your profile (e.g., `MCP Custom Token Exchange`)
 
     ```shell wrap lines
-    curl --location 'https://YOUR_TENANT/api/v2/token-exchange-profiles' \
-    --header 'Content-Type: application/json' \
-    --header 'Authorization: Bearer YOUR_MANAGEMENT_API_TOKEN' \
-    --data '{
-        "name": "YOUR_PROFILE_NAME",
-        "subject_token_type": "urn:fastmcp:mcp",
-        "action_id": "<your-action-id>",
-        "type": "custom_authentication"
-    }'
+    auth0 token-exchange create \
+      --name "<YOUR_PROFILE_NAME>" \
+      --subject-token-type "urn:fastmcp:mcp" \
+      --action-id "<your-action-id>" \
+      --type "custom_authentication"
     ```
 
     <Info>
-    The `subject_token_type` must be a unique URI identifier. In this example, we use `urn:fastmcp:mcp` which is specific to FastMCP implementations. You cannot use reserved namespaces like `urn:auth0`.
+    The `subject_token_type` must be a unique URI identifier. In this example, we use `urn:fastmcp:mcp` which is specific to FastMCP implementations. You cannot use reserved namespaces like `urn:auth0`, `urn:okta`, or `urn:ietf`.
     </Info>
 
     A successful response will return the profile details including the profile ID and creation timestamp.


### PR DESCRIPTION
### Description
Update CTE profile creation instruction to use auth0-cli https://auth0.com/ai/docs/mcp/get-started/call-your-apis-on-users-behalf#set-up-the-token-exchange-profile

### References
- https://github.com/auth0/auth0-cli/releases/tag/v1.25.0

### Testing
<img width="1069" height="919" alt="image" src="https://github.com/user-attachments/assets/a3079883-96c1-44f2-9868-b373c791fd0e" />

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
