### PR TITLE
Removing warning from EA for Ephemeral Sessions with Actions

### DIFF
--- a/main/docs/manage-users/sessions/manage-sessions-actions.mdx
+++ b/main/docs/manage-users/sessions/manage-sessions-actions.mdx
@@ -79,12 +79,6 @@ The `api.session.setIdleExpiresAt(idle)` method sets the session inactivity time
 
 ## Set session cookie persistence with Actions
 
-<Warning>
-
-Session cookie persistence is currently available in Early Access. By using this feature, you agree to the applicable Free Trial terms in Okta’s [Master Subscription Agreement](https://www.okta.com/legal). To learn more about Auth0's product release cycle, read [Product Release Stages](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages).
-
-</Warning>
-
 The post-login **api.session.setCookieMode(options)** method allows you to modify the session cookie persistence. You can configure whether a session cookie is persistent or non-persistent.
 
 Non-persistent (ephemeral) sessions enhance security by existing only in memory. These sessions are cleared when a browser or application is closed, which makes them ideal for sensitive workflows such as untrusted device access or step-up authentication scenarios.


### PR DESCRIPTION
### Description

This PR removes the Early Access (EA) warning from the **Session cookie persistence with Actions** documentation section.

The `api.session.setCookieMode()` method for managing session cookie persistence (ephemeral/non-persistent sessions) is transitioning from Early Access to General Availability (GA). This change updates the documentation to reflect that the feature is now generally available to all customers.

**Changes:**
- Removed the Early Access warning callout from the "Set session cookie persistence with Actions" section in `manage-sessions-actions.mdx`

### References

- Related feature: `api.session.setCookieMode()` for ephemeral sessions
- Documentation page: [Sessions with Actions](/docs/manage-users/sessions/manage-sessions-actions)

### Testing

- [x] Verified the MDX file renders correctly without the EA warning
- [x] Confirmed no broken links or formatting issues
- [ ] This change adds test coverage for new/changed/fixed functionality (N/A - documentation only)

### Checklist

- [x] I have added documentation for new/changed/fixed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch