### PR TITLE
fix: CODEOWNERS for docs.json

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,10 +2,9 @@
 * @auth0/project-docs-writers-codeowner
 
 # Docs Management ownership for code, config, and related docs
-**/snippets          @auth0/project-docs-management-codeowner
-**/ui                @auth0/project-docs-management-codeowner
-**/scripts           @auth0/project-docs-management-codeowner
-**/css               @auth0/project-docs-management-codeowner
+snippets             @auth0/project-docs-management-codeowner
+ui                   @auth0/project-docs-management-codeowner
+scripts              @auth0/project-docs-management-codeowner
 **/package.json      @auth0/project-docs-management-codeowner
 **/package-lock.json @auth0/project-docs-management-codeowner
 **/CLAUDE.md         @auth0/project-docs-management-codeowner


### PR DESCRIPTION
small update to `CODEOWNERS` to give shared ownership for `docs.json` so writers can update the menu and redirects as part of normal content work. naturally, docs mgmt should still review any more substantial config changes.

based on the top-level structure of `main/`, these changes should preserve the existing ownership structure (aside from now sharing `docs.json`).