### PR TITLE
Update to docs.json for RealTime Webtask deprecation

### DIFF
--- a/main/docs.json
+++ b/main/docs.json
@@ -1595,7 +1595,6 @@
                           },
                           "docs/customize/extensions/authentication-api-debugger-extension",
                           "docs/customize/extensions/ad-ldap-connector-health-monitor",
-                          "docs/customize/extensions/real-time-webtask-logs",
                           "docs/customize/extensions/account-link-extension",
                           "docs/customize/extensions/user-import-export-extension"
                         ]
@@ -4272,7 +4271,6 @@
                           },
                           "docs/fr-ca/customize/extensions/authentication-api-debugger-extension",
                           "docs/fr-ca/customize/extensions/ad-ldap-connector-health-monitor",
-                          "docs/fr-ca/customize/extensions/real-time-webtask-logs",
                           "docs/fr-ca/customize/extensions/account-link-extension",
                           "docs/fr-ca/customize/extensions/user-import-export-extension"
                         ]
@@ -6620,7 +6618,6 @@
                           },
                           "docs/ja-jp/customize/extensions/authentication-api-debugger-extension",
                           "docs/ja-jp/customize/extensions/ad-ldap-connector-health-monitor",
-                          "docs/ja-jp/customize/extensions/real-time-webtask-logs",
                           "docs/ja-jp/customize/extensions/account-link-extension",
                           "docs/ja-jp/customize/extensions/user-import-export-extension"
                         ]
@@ -24564,6 +24561,18 @@
     {
       "source": "/docs/secure/sender-constraining/configure-sender-constraining/configure-resource-server-for-sender-constraining",
       "destination": "/docs/secure/sender-constraining/configure-sender-constraining"
+    },
+    {
+      "source": "/docs/customize/extensions/real-time-webtask-logs",
+      "destination": "/docs/customize/actions/actions-real-time-logs"
+    },
+    {
+      "source": "/docs/ja-jp/customize/extensions/real-time-webtask-logs",
+      "destination": "/docs/ja-jp/customize/actions/actions-real-time-logs"
+    },
+    {
+      "source": "/docs/fr-ca/customize/extensions/real-time-webtask-logs",
+      "destination": "/docs/fr-ca/customize/actions/actions-real-time-logs"
     }
   ]
 }


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Real-time Webtask Logs docs are deprecated in https://github.com/auth0/docs-v2/pull/541. The `docs.json` file was throwing errors. Replaced the entries and pulled them in this PR. 


### References

Deprecation notice: https://auth0.com/docs/troubleshoot/product-lifecycle/deprecations-and-migrations#real-time-webtask-logs-extension

### Testing


- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
