### PR TITLE
feat: adding generation script

### DIFF
--- a/scripts/artifact-generation.js
+++ b/scripts/artifact-generation.js
@@ -115,7 +115,7 @@ function convertPathToName(path) {
 // creates the base snippet
 function formatSnippet(oas, path, method) {
     return `---
-openapi: ${oas.destination}/${prefix}${oas.file} ${method} ${path}
+openapi: ${prefix}${oas.file} ${method} ${path}
 ---
 `;
 }


### PR DESCRIPTION
### Description

This PR adds a generation script for creating assets within docs based on API specs. The aim is to run this script on a regular basis (or perhaps on changes), and automatically regenerate .mdx files, .json specs, and alter the docs.json navigation file on every run.

#### Spec Generation
- Take existing .json specs for a variety of APIs and add supported code snippets into them.
- .json specs before processing should live in `/main`, and after processing, the generated files will be in `/main/oas`
- Only the management API is supported for the time being, but it should be easy to enable other APIs.
- Only typescript code snippets are being inserted for the time being.

#### MDX File Generation
- Takes a spec and creates all the files and folders needed to render the full API documentation.
- If there are nested folders in the final output structure, the script will recursively create them.
- .mdx pages are created with an `openapi` header containing the .json spec file, method, and path for the endpoint.
- The pages also have a release lifecycle component and a scopes component that are populated with information from the spec.

#### Docs.json Alteration
- Looks through the docs.json for a tab in the navigation called "API References", within that, it looks for the specific friendly name of the API it's working on (friendly name stored in the config at the top of the script)
- It either replaces or creates the section for the API, but with the most up to date page listings.
- Only English supported for now.

### References

DM-72

### Testing

Testing can be performed by making sure the correct .json specs are in `/main`, and their names and other information matches what is specified in the config at the top of the script.

From the `main` folder:

`node scripts/artifact-generation`

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not the default branch
