### PR TITLE
Add agent skills documentation to Quickstarts

### DIFF
--- a/main/docs.json
+++ b/main/docs.json
@@ -2384,7 +2384,10 @@
             "groups": [
               {
                 "group": " ",
-                "pages": ["docs/quickstarts"]
+                "pages": [
+                  "docs/quickstarts",
+                  "docs/quickstart/agent-skills"
+                ]
               },
               {
                 "group": "Single Page App",

--- a/main/docs/quickstart/agent-skills.mdx
+++ b/main/docs/quickstart/agent-skills.mdx
@@ -1,0 +1,200 @@
+---
+title: "Agent Skills for Auth0"
+description: "Use Auth0 agent skills to quickly integrate authentication into your applications with AI coding assistants"
+---
+
+Agent skills are structured instruction sets that help AI coding assistants like Claude Code, Cursor, and GitHub Copilot implement Auth0 authentication correctly in your applications. They contain best practices, code patterns, and step-by-step guidance for Auth0 integration across multiple frameworks and platforms.
+
+## Why use agent skills?
+
+Agent skills enable you to:
+
+* **Accelerate development** - Implement Auth0 authentication in minutes with AI-powered code generation
+* **Follow best practices** - Get production-ready code that follows Auth0's recommended patterns
+* **Support multiple frameworks** - Use the same skills across React, Vue, Angular, Next.js, and more
+* **Migrate easily** - Transition from other auth providers with guided migration workflows
+* **Implement advanced features** - Add multi-factor authentication and security features with expert guidance
+
+## Supported platforms
+
+Auth0 agent skills support a wide range of frameworks and platforms:
+
+* **Frontend:** React, Vue, Angular
+* **Backend:** Next.js, Nuxt, Express, Ruby on Rails, PHP/Laravel
+* **Mobile:** React Native, Expo, iOS, Android
+* **APIs:** Python (Flask, FastAPI), Go, Spring Boot, ASP.NET Core
+
+## Installation
+
+Auth0 provides two complementary skill packages that work together:
+
+* **Auth0 Core Skills** - Essential foundational capabilities including framework detection, migrations, and MFA
+* **Auth0 SDK Skills** - Framework-specific implementation guides for each supported platform
+
+### Install with Skills CLI
+
+The easiest way to install Auth0 agent skills is using the Skills CLI:
+
+```bash
+npx skills add auth0/agent-skills
+```
+
+This command installs both the core and SDK skill packages, making them available to your AI coding assistant.
+
+### Install in Claude Code
+
+If you're using Claude Code, you can install Auth0 skills directly from the Plugins menu:
+
+<Steps>
+<Step title="Open Claude Code settings">
+Navigate to **Settings** > **Plugins** in Claude Code.
+</Step>
+
+<Step title="Search for Auth0">
+Search for "Auth0" in the available plugins list.
+</Step>
+
+<Step title="Install the skills">
+Install both **Auth0 Core Skills** and **Auth0 SDK Skills** plugins.
+</Step>
+</Steps>
+
+<Tip>
+Installing skills as plugins in Claude Code (recommended for enterprise users) ensures they stay up to date automatically.
+</Tip>
+
+### Manual installation
+
+You can also install skills manually by cloning the repository:
+
+```bash
+git clone https://github.com/auth0/agent-skills.git
+```
+
+Then copy the skill directories to your AI assistant's skills folder according to its documentation.
+
+## Available skills
+
+Auth0 agent skills are organized into two packages with complementary capabilities:
+
+### Core Skills
+
+| Skill | Description | Use Cases |
+|-------|-------------|-----------|
+| **Quickstart Router** | Framework detection and routing to appropriate Auth0 SDK guides | Starting Auth0 integration, detecting your tech stack |
+| **Migration Guide** | Step-by-step migration from other auth providers | Moving from Firebase, Cognito, Supabase, or custom auth |
+| **MFA Implementation** | Multi-factor authentication setup and configuration | Adding 2FA, step-up auth, adaptive MFA |
+
+### SDK Skills
+
+| Skill | Description | Use Cases |
+|-------|-------------|-----------|
+| **React Integration** | Auth0 React SDK setup for single-page applications | Building React apps with Vite or Create React App |
+| **Next.js Integration** | Auth0 Next.js SDK for App Router and Pages Router | Server and client-side auth in Next.js applications |
+| **Vue Integration** | Auth0 Vue SDK setup for Vue 3 applications | Building Vue apps with Vite or Vue CLI |
+| **Angular Integration** | Auth0 Angular SDK with route guards and interceptors | Enterprise Angular applications |
+| **React Native Integration** | Auth0 React Native SDK with native deep linking | iOS and Android mobile apps with Expo or React Native CLI |
+| **Nuxt Integration** | Auth0 Nuxt SDK for Nuxt 3/4 applications | Server-side rendering and hybrid apps with Nuxt |
+| **Express Integration** | Auth0 Express SDK for traditional web apps | Server-rendered applications with session management |
+
+## Using agent skills
+
+Once installed, you can use Auth0 agent skills by making natural language requests to your AI coding assistant. The assistant will automatically select and apply the appropriate skills.
+
+### Example prompts
+
+**Getting started with a new integration:**
+```
+Add Auth0 authentication to my React app
+```
+
+**Implementing specific features:**
+```
+Add multi-factor authentication with TOTP support
+```
+
+**Migrating from another provider:**
+```
+Help me migrate from Firebase Auth to Auth0
+```
+
+**Framework-specific requests:**
+```
+Set up Auth0 in my Next.js App Router project with protected routes
+```
+
+<Info>
+The quickstart router skill automatically detects your framework and routes to the appropriate SDK guide, so you don't need to specify which skill to use.
+</Info>
+
+## How agent skills work
+
+Agent skills follow a structured workflow:
+
+<Steps>
+<Step title="Framework detection">
+The AI assistant analyzes your project files to identify your framework, dependencies, and setup.
+</Step>
+
+<Step title="Skill selection">
+Based on your request and detected framework, the assistant selects the appropriate Auth0 skill.
+</Step>
+
+<Step title="Code generation">
+The skill provides step-by-step guidance and code patterns that the assistant uses to generate production-ready code.
+</Step>
+
+<Step title="Configuration">
+The assistant helps you configure Auth0 settings, environment variables, and SDK options.
+</Step>
+
+<Step title="Verification">
+You can test the implementation and ask the assistant to make adjustments as needed.
+</Step>
+</Steps>
+
+## Best practices
+
+When working with Auth0 agent skills:
+
+* **Start with clean state** - Skills work best in projects with clear structure and up-to-date dependencies
+* **Review generated code** - Always review the code generated by your AI assistant before deploying
+* **Follow prompts** - The assistant may ask for your Auth0 domain, client ID, and other configuration values
+* **Test thoroughly** - Verify authentication flows work correctly in your development environment
+* **Consult documentation** - Reference the full Auth0 documentation for advanced configuration and troubleshooting
+
+## Limitations and considerations
+
+* **AI assistant required** - Agent skills work with AI coding assistants and are not standalone tools
+* **Project context** - Skills work best when the AI assistant has access to your full project context
+* **Manual configuration** - You'll still need to configure your Auth0 tenant and create applications in the Auth0 Dashboard
+* **Framework versions** - Skills target recent stable versions of frameworks; very old or experimental versions may require manual adjustments
+
+## Learn more
+
+<CardGroup cols={2}>
+  <Card title="Auth0 Agent Skills on GitHub" icon="github" href="https://github.com/auth0/agent-skills">
+    View the source code and contribution guidelines.
+  </Card>
+
+  <Card title="Agent Skills Format" icon="book" href="https://agentskills.io">
+    Learn about the open agent skills format and specification.
+  </Card>
+
+  <Card title="Auth0 Quickstarts" icon="rocket" href="/quickstart">
+    Follow manual quickstart guides for your framework.
+  </Card>
+
+  <Card title="Auth0 SDKs" icon="code" href="/sdks">
+    Explore Auth0 SDK documentation and API references.
+  </Card>
+</CardGroup>
+
+## Get help
+
+If you encounter issues with Auth0 agent skills:
+
+* **Ask your AI assistant** - Try rephrasing your request or providing more context
+* **Check the repository** - Review [example implementations](https://github.com/auth0/agent-skills) and open issues
+* **Report bugs** - Follow Auth0's [Responsible Disclosure Program](https://auth0.com/responsible-disclosure-policy) for security issues
+* **Contact support** - Reach out to Auth0 support for questions about Auth0 configuration


### PR DESCRIPTION
### Description
- Add new documentation page for Auth0 agent skills at /quickstarts/agent-skills
- Include installation methods (Skills CLI, Claude Code, manual)
- Document available core and SDK skills with use cases
- Add example prompts and workflow steps
- Place in Quickstarts tab for easy developer discovery

### References
https://github.com/auth0/agent-skills/

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
