### PR TITLE
fix: clarify post_logout_redirect_uri query param requirements

### DIFF
--- a/main/docs/authenticate/login/logout/log-users-out-of-auth0.mdx
+++ b/main/docs/authenticate/login/logout/log-users-out-of-auth0.mdx
@@ -287,9 +287,15 @@ You may use an asterisk (`*`) as a wildcard for subdomains (such as `https://*.e
 
 The OIDC Logout endpoint parses query string parameters in the URL provided to the `post_logout_redirect_uri` parameter.
 
-You must include these query string parameters in your **Allowed Logout URLs**, or the logout request may be denied.
+You must include the **exact URL with query string parameters** in your **Allowed Logout URLs**, or the logout request will be denied. The URL must match exactly, including all query parameter names and values.
 
-For example, if you pass `https://example.com/logout?myParam=1234` to the `post_logout_redirect_uri` parameter (encoded as `https%3A%2F%2Fexample.com%2Flogout%3FmyParam%3D1234`), you must include `https://example.com/logout?myParam` in your **Allowed Logout URLs**.
+For example, if you pass `https://example.com/logout?myParam=1234` to the `post_logout_redirect_uri` parameter (encoded as `https%3A%2F%2Fexample.com%2Flogout%3FmyParam%3D1234`), you must include the complete URL `https://example.com/logout?myParam=1234` in your **Allowed Logout URLs**.
+
+<Warning>
+
+Dynamic query parameter values are not supported. Each unique combination of query parameter names and values must be registered as a separate entry in your **Allowed Logout URLs**.
+
+</Warning>
 
 #### ui_locales parameter
 

--- a/main/docs/fr-ca/authenticate/login/logout/log-users-out-of-auth0.mdx
+++ b/main/docs/fr-ca/authenticate/login/logout/log-users-out-of-auth0.mdx
@@ -289,9 +289,15 @@ Vous pouvez utiliser un astérisque (`*`) comme caractère générique pour les 
 
 Le point de terminaison de déconnexion OIDC analyse les paramètres de chaîne de requête dans l’URL fournie au paramètre `post_logout_redirect_uri`.
 
-Vous devez inclure ces paramètres de chaîne de requête dans vos **URL de déconnexion autorisées**, sinon la demande de déconnexion pourrait être refusée.
+Vous devez inclure **l'URL exacte avec les paramètres de chaîne de requête** dans vos **URL de déconnexion autorisées**, sinon la demande de déconnexion sera refusée. L'URL doit correspondre exactement, y compris tous les noms et valeurs des paramètres de requête.
 
-Par exemple, si vous passez `https://example.com/logout?myParam=1234` au paramètre `post_logout_redirect_uri` (encodé comme `https%3A%2F%2Fexample.com%2Flogout%3FmyParam%3D1234`), vous devez inclure `https://example.com/logout?myParam` dans vos **URL de déconnexions autorisées**.
+Par exemple, si vous passez `https://example.com/logout?myParam=1234` au paramètre `post_logout_redirect_uri` (encodé comme `https%3A%2F%2Fexample.com%2Flogout%3FmyParam%3D1234`), vous devez inclure l'URL complète `https://example.com/logout?myParam=1234` dans vos **URL de déconnexions autorisées**.
+
+<Warning>
+
+Les valeurs dynamiques des paramètres de requête ne sont pas prises en charge. Chaque combinaison unique de noms et de valeurs de paramètres de requête doit être enregistrée comme une entrée séparée dans vos **URL de déconnexion autorisées**.
+
+</Warning>
 
 #### Paramètre ui_locales
 

--- a/main/docs/ja-jp/authenticate/login/logout/log-users-out-of-auth0.mdx
+++ b/main/docs/ja-jp/authenticate/login/logout/log-users-out-of-auth0.mdx
@@ -294,9 +294,15 @@ Management APIから **［Allowed Logout URLs（許可されているログア�
 
 OIDCログアウトエンドポイントは、`post_logout_redirect_uri`パラメーターに提供されたURLのクエリ文字列パラメーターを解析します。
 
-これらのクエリ文字列パラメーターは、 **Allowed Logout URLs（許可されているログアウトURL）** に含める必要があります。含まれていない場合には、ログアウト要求が拒否される可能性があります。
+**クエリ文字列パラメーターを含む正確なURL**を**Allowed Logout URLs（許可されているログアウトURL）** に含める必要があります。含まれていない場合には、ログアウト要求が拒否されます。URLは、すべてのクエリパラメーター名と値を含め、正確に一致する必要があります。
 
-たとえば、`https://example.com/logout?myParam=1234`を`post_logout_redirect_uri`パラメーター（`https%3A%2F%2Fexample.com%2Flogout%3FmyParam%3D1234`としてエンコード）に渡す場合は、`https://example.com/logout?myParam`を **Allowed Logout URLs（許可されているログアウトURL）** に含める必要があります。
+たとえば、`https://example.com/logout?myParam=1234`を`post_logout_redirect_uri`パラメーター（`https%3A%2F%2Fexample.com%2Flogout%3FmyParam%3D1234`としてエンコード）に渡す場合は、完全なURL `https://example.com/logout?myParam=1234`を **Allowed Logout URLs（許可されているログアウトURL）** に含める必要があります。
+
+<Warning>
+
+動的なクエリパラメーター値はサポートされていません。クエリパラメーター名と値の一意の組み合わせごとに、**Allowed Logout URLs（許可されているログアウトURL）** に個別のエントリとして登録する必要があります。
+
+</Warning>
 
 #### ui_localesパラメーター
 


### PR DESCRIPTION
## Description

The documentation for the OIDC Logout endpoint incorrectly stated that users only needed to register query parameter **names** (e.g., `https://example.com/logout?myParam`) in their Allowed Logout URLs, implying that parameter values could be set dynamically.

This is incorrect. The actual behavior requires the **complete URL including query parameter values** to be registered exactly as they will be used in logout requests.

### What was changed

**Before (incorrect):**
> For example, if you pass `https://example.com/logout?myParam=1234` to the `post_logout_redirect_uri` parameter, you must include `https://example.com/logout?myParam` in your Allowed Logout URLs.

**After (correct):**
> For example, if you pass `https://example.com/logout?myParam=1234` to the `post_logout_redirect_uri` parameter, you must include the complete URL `https://example.com/logout?myParam=1234` in your Allowed Logout URLs.

### Files updated
- `main/docs/authenticate/login/logout/log-users-out-of-auth0.mdx` (English)
- `main/docs/fr-ca/authenticate/login/logout/log-users-out-of-auth0.mdx` (French-Canadian)
- `main/docs/ja-jp/authenticate/login/logout/log-users-out-of-auth0.mdx` (Japanese)

### Additional changes
- Changed "may be denied" to "will be denied" to reflect actual behavior
- Added a warning callout clarifying that dynamic query parameter values are not supported

### References

Customer-reported issue via Support escalation.

### Testing

1. Build the docs site locally
2. Navigate to `/docs/authenticate/login/logout/log-users-out-of-auth0`
3. Verify the "Add query string parameters to post_logout_redirect_uri" section reflects the updated guidance
4. Check that the Warning callout renders correctly

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.