### PR TITLE
Fixing double bullets on AI SDKs JS page

### DIFF
--- a/auth4genai/sdks/javascript-sdk.mdx
+++ b/auth4genai/sdks/javascript-sdk.mdx
@@ -98,7 +98,7 @@ Checkout our sample applications for JavaScript/TypeScript built with frameworks
     (Gmail, Google Calendar, etc) securely using Token Vault, Human-in-the-loop
     interactions using Asynchronous Authorization, and using Auth0 FGA for
     securing RAG tools.
-    <ul className="list-disc list-inside pl-4">
+    <ul>
       <li>
         [LangGraph
         version](https://github.com/auth0-samples/auth0-assistant0/tree/main/ts-langchain)


### PR DESCRIPTION
Fixing display of double bullets on the first sample card
<img width="1023" height="757" alt="image" src="https://github.com/user-attachments/assets/32b20e96-8107-48ef-838f-8a4e772a0c5a" />

Fix:
<img width="472" height="575" alt="image" src="https://github.com/user-attachments/assets/ee99067a-b1c5-4e35-8508-4832c1dad9a8" />

