### PR TITLE
Quickstart Auth0 CLI Command Optimizations

### DIFF
--- a/main/docs/quickstart/spa/angular/index.mdx
+++ b/main/docs/quickstart/spa/angular/index.mdx
@@ -746,6 +746,8 @@ SECURITY BEST PRACTICES FOR ANGULAR
   - **[npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)** 10+ or **[yarn](https://classic.yarnpkg.com/lang/en/docs/install/)** 1.22+ or **[pnpm](https://pnpm.io/installation)** 8+
   - **[jq](https://jqlang.org/)** - Required for Auth0 CLI setup
 
+  Verify installation: `node --version && npm --version`
+
   **Angular Version Compatibility:** This quickstart works with **Angular 18.x** and newer using the Angular CLI. For older versions of Angular, use the Auth0 Angular SDK v2.
 </Note>
 
@@ -888,9 +890,18 @@ export const localEnvSnippet = `export const environment = {
   <Step title="Create Login, Logout and Profile Components" stepNumber={5}>
     Create the component files manually for better control
 
-    ```shellscript
-    mkdir -p src/app/components && touch src/app/components/login-button.component.ts && touch src/app/components/logout-button.component.ts && touch src/app/components/profile.component.ts
-    ```
+    <CodeGroup>
+      ```shellscript Mac/Linux
+      mkdir -p src/app/components && touch src/app/components/login-button.component.ts && touch src/app/components/logout-button.component.ts && touch src/app/components/profile.component.ts
+      ```
+
+      ```powershell Windows
+      New-Item -ItemType Directory -Force -Path src/app/components
+      New-Item -ItemType File -Path src/app/components/login-button.component.ts
+      New-Item -ItemType File -Path src/app/components/logout-button.component.ts
+      New-Item -ItemType File -Path src/app/components/profile.component.ts
+      ```
+    </CodeGroup>
 
     Add the following code to each component:
 
@@ -1355,6 +1366,10 @@ export const localEnvSnippet = `export const environment = {
     ```shellscript
     ng serve
     ```
+
+    <Info>
+      If port 4200 is in use, run: `ng serve --port 4201` and update your Auth0 app's callback URLs to `http://localhost:4201`
+    </Info>
   </Step>
 </Steps>
 

--- a/main/docs/quickstart/spa/react/index.mdx
+++ b/main/docs/quickstart/spa/react/index.mdx
@@ -91,11 +91,27 @@ import {CreateInteractiveApp} from "/snippets/recipe.jsx";
   
   This will help you understand if you're in the main directory or a subdirectory, and whether the project was created in the current directory or a new subdirectory.
   
-  If MacOS, execute the following command:
-  AUTH0_APP_NAME="My App" && brew tap auth0/auth0-cli && brew install auth0 && auth0 login --no-input && auth0 apps create -n "${AUTH0_APP_NAME}" -t spa -c http://localhost:5173 -l http://localhost:5173 -o http://localhost:5173 --json --metadata created_by="quickstart-docs-ai-prompt" > auth0-app-details.json && CLIENT_ID=$(jq -r '.client_id' auth0-app-details.json) && DOMAIN=$(auth0 tenants list --json | jq -r '.[] | select(.active == true) | .name') && echo "VITE_AUTH0_DOMAIN=${DOMAIN}" > .env && echo "VITE_AUTH0_CLIENT_ID=${CLIENT_ID}" >> .env && rm auth0-app-details.json && echo ".env file created with your Auth0 details:" && cat .env
-  
-  If Windows, execute the following command:
-  $AppName = "My App"; winget install Auth0.CLI; auth0 login --no-input; auth0 apps create -n "$AppName" -t spa -c http://localhost:5173 -l http://localhost:5173 -o http://localhost:5173 --json --metadata created_by="quickstart-docs-ai-prompt" | Set-Content -Path auth0-app-details.json; $ClientId = (Get-Content -Raw auth0-app-details.json | ConvertFrom-Json).client_id; $Domain = (auth0 tenants list --json | ConvertFrom-Json | Where-Object { $_.active -eq $true }).name; Set-Content -Path .env -Value "VITE_AUTH0_DOMAIN=$Domain"; Add-Content -Path .env -Value "VITE_AUTH0_CLIENT_ID=$ClientId"; Remove-Item auth0-app-details.json; Write-Output ".env file created with your Auth0 details:"; Get-Content .env
+  Execute the Auth0 setup command for your OS:
+
+  If MacOS:
+    # Install Auth0 CLI if not already installed
+    brew tap auth0/auth0-cli && brew install auth0
+
+    # Set up Auth0 app and generate .env file
+    auth0 quickstarts setup --type vite
+
+  If Windows (PowerShell):
+    # Install Auth0 CLI if not already installed
+    scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git
+    scoop install auth0
+
+    # Set up Auth0 app and generate .env file
+    auth0 quickstarts setup --type vite
+
+  This command will automatically:
+  - Authenticate you with Auth0 (prompts for login if needed)
+  - Create a Single Page Application configured for http://localhost:5173
+  - Generate a .env file with VITE_AUTH0_DOMAIN and VITE_AUTH0_CLIENT_ID
   
   
   Step 2.1b: Create manual .env template (if automatic setup fails)
@@ -666,7 +682,8 @@ import {CreateInteractiveApp} from "/snippets/recipe.jsx";
 
   - **[Node.js](https://nodejs.org/en/download)** 20 LTS or newer
   - **[npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)** 10+ or **[yarn](https://classic.yarnpkg.com/lang/en/docs/install/)** 1.22+ or **[pnpm](https://pnpm.io/installation)** 8+
-  - **[jq](https://jqlang.org/)** - Required for Auth0 CLI setup
+
+  Verify installation: `node --version && npm --version`
 
   **React Version Compatibility:** This quickstart works with **React 18.x** and newer.
 </Note>
@@ -711,17 +728,33 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
       </Tab>
       
       <Tab title="CLI">
-        Run the following shell command on your project's root directory to create an Auth0 app and generate a `.env` file:
+        Run the following command in your project's root directory to create an Auth0 app and generate a `.env` file:
 
-        <AuthCodeGroup>
+        <CodeGroup>
           ```shellscript Mac
-          AUTH0_APP_NAME="My App" && brew tap auth0/auth0-cli && brew install auth0 && auth0 login --no-input && auth0 apps create -n "${AUTH0_APP_NAME}" -t spa -c http://localhost:5173 -l http://localhost:5173 -o http://localhost:5173 --json --metadata created_by="quickstart-docs-manual" > auth0-app-details.json && CLIENT_ID=$(jq -r '.client_id' auth0-app-details.json) && DOMAIN=$(auth0 tenants list --json | jq -r '.[] | select(.active == true) | .name') && echo "VITE_AUTH0_DOMAIN=${DOMAIN}" > .env && echo "VITE_AUTH0_CLIENT_ID=${CLIENT_ID}" >> .env && rm auth0-app-details.json && echo ".env file created with your Auth0 details:" && cat .env
+          # Install Auth0 CLI (if not already installed)
+          brew tap auth0/auth0-cli && brew install auth0
+
+          # Set up Auth0 app and generate .env file
+          auth0 quickstarts setup --type vite
           ```
 
-          ```shellscript Windows
-          $AppName = "My App"; winget install Auth0.CLI; auth0 login --no-input; auth0 apps create -n "$AppName" -t spa -c http://localhost:5173 -l http://localhost:5173 -o http://localhost:5173 --json --metadata created_by="quickstart-docs-manual" | Set-Content -Path auth0-app-details.json; $ClientId = (Get-Content -Raw auth0-app-details.json | ConvertFrom-Json).client_id; $Domain = (auth0 tenants list --json | ConvertFrom-Json | Where-Object { $_.active -eq $true }).name; Set-Content -Path .env -Value "VITE_AUTH0_DOMAIN=$Domain"; Add-Content -Path .env -Value "VITE_AUTH0_CLIENT_ID=$ClientId"; Remove-Item auth0-app-details.json; Write-Output ".env file created with your Auth0 details:"; Get-Content .env
+          ```powershell Windows
+          # Install Auth0 CLI (if not already installed)
+          scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git
+          scoop install auth0
+
+          # Set up Auth0 app and generate .env file
+          auth0 quickstarts setup --type vite
           ```
-        </AuthCodeGroup>
+        </CodeGroup>
+
+        <Note>
+          This command will:
+          1. Check if you're authenticated (and prompt for login if needed)
+          2. Create an Auth0 Single Page Application configured for `http://localhost:5173`
+          3. Generate a `.env` file with `VITE_AUTH0_DOMAIN` and `VITE_AUTH0_CLIENT_ID`
+        </Note>
       </Tab>
 
       <Tab title="Dashboard">
@@ -764,6 +797,10 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
         </Info>
       </Tab>
     </Tabs>
+
+    <Tip>
+      Verify your `.env` file exists: `cat .env` (Mac/Linux) or `type .env` (Windows)
+    </Tip>
   </Step>
   <Step title="Add the provider" stepNumber={4}>
     ```javascript src/main.tsx {5,9,10,11,12,13,14,15,17} lines
@@ -791,9 +828,17 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
   <Step title="Create Login, Logout and Profile Components" stepNumber={5}>
     Create files
 
-    ```shellscript
-    touch src/LoginButton.tsx && touch src/LogoutButton.tsx && touch src/Profile.tsx
-    ```
+    <CodeGroup>
+      ```shellscript Mac/Linux
+      touch src/LoginButton.tsx && touch src/LogoutButton.tsx && touch src/Profile.tsx
+      ```
+
+      ```powershell Windows
+      New-Item -ItemType File -Path src/LoginButton.tsx
+      New-Item -ItemType File -Path src/LogoutButton.tsx
+      New-Item -ItemType File -Path src/Profile.tsx
+      ```
+    </CodeGroup>
 
     And add the following code snippets
 
@@ -1216,6 +1261,10 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
     ```shellscript
     npm run dev
     ```
+
+    <Info>
+      If port 5173 is in use, run: `npm run dev -- --port 5174` and update your Auth0 app's callback URLs to `http://localhost:5174`
+    </Info>
   </Step>
 </Steps>
 

--- a/main/docs/quickstart/spa/svelte/index.mdx
+++ b/main/docs/quickstart/spa/svelte/index.mdx
@@ -66,11 +66,27 @@ import {CreateInteractiveApp} from "/snippets/recipe.jsx";
   
   Execute the environment setup command for your OS:
   
-  If MacOS, execute the following command:
-  AUTH0_APP_NAME="My Svelte App" && brew tap auth0/auth0-cli && brew install auth0 && auth0 login --no-input && auth0 apps create -n "${AUTH0_APP_NAME}" -t spa -c http://localhost:5173 -l http://localhost:5173 -o http://localhost:5173 --json > auth0-app-details.json && CLIENT_ID=$(jq -r '.client_id' auth0-app-details.json) && DOMAIN=$(auth0 tenants list --json | jq -r '.[] | select(.active == true) | .name') && echo "VITE_AUTH0_DOMAIN=${DOMAIN}" > .env && echo "VITE_AUTH0_CLIENT_ID=${CLIENT_ID}" >> .env && rm auth0-app-details.json && echo ".env file created with your Auth0 details:" && cat .env
-  
-  If Windows, execute the following command:
-  $AppName = "My Svelte App"; winget install Auth0.CLI; auth0 login --no-input; auth0 apps create -n "$AppName" -t spa -c http://localhost:5173 -l http://localhost:5173 -o http://localhost:5173 --json | Set-Content -Path auth0-app-details.json; $ClientId = (Get-Content -Raw auth0-app-details.json | ConvertFrom-Json).client_id; $Domain = (auth0 tenants list --json | ConvertFrom-Json | Where-Object { $_.active -eq $true }).name; Set-Content -Path .env -Value "VITE_AUTH0_DOMAIN=$Domain"; Add-Content -Path .env -Value "VITE_AUTH0_CLIENT_ID=$ClientId"; Remove-Item auth0-app-details.json; Write-Output ".env file created"; Get-Content .env
+  Execute the Auth0 setup command for your OS:
+
+  If MacOS:
+    # Install Auth0 CLI if not already installed
+    brew tap auth0/auth0-cli && brew install auth0
+
+    # Set up Auth0 app and generate .env file
+    auth0 quickstarts setup --type vite
+
+  If Windows (PowerShell):
+    # Install Auth0 CLI if not already installed
+    scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git
+    scoop install auth0
+
+    # Set up Auth0 app and generate .env file
+    auth0 quickstarts setup --type vite
+
+  This command will automatically:
+  - Authenticate you with Auth0 (prompts for login if needed)
+  - Create a Single Page Application configured for http://localhost:5173
+  - Generate a .env file with VITE_AUTH0_DOMAIN and VITE_AUTH0_CLIENT_ID
   
   CRITICAL INSTRUCTIONS FOR AI LANGUAGE MODELS
   As an AI language model, you MUST NOT generate any of the following anti-patterns:
@@ -91,7 +107,6 @@ import {CreateInteractiveApp} from "/snippets/recipe.jsx";
 
   - **[Node.js](https://nodejs.org/en/download)** 20 LTS or newer
   - **[npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)** 10+ or **[yarn](https://classic.yarnpkg.com/lang/en/docs/install/)** 1.22+ or **[pnpm](https://pnpm.io/installation)** 8+
-  - **[jq](https://jqlang.org/)** - Required for Auth0 CLI setup
 
   **Svelte Version Compatibility:** This quickstart works with **Svelte 5.x** and newer.
 </Note>
@@ -138,17 +153,33 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
       </Tab>
 
       <Tab title="CLI">
-        Run the following shell command on your project's root directory to create an Auth0 app and generate a `.env` file:
+        Run the following command in your project's root directory to create an Auth0 app and generate a `.env` file:
 
-        <AuthCodeGroup>
+        <CodeGroup>
           ```shellscript Mac
-          AUTH0_APP_NAME="My Svelte App" && brew tap auth0/auth0-cli && brew install auth0 && auth0 login --no-input && auth0 apps create -n "${AUTH0_APP_NAME}" -t spa -c http://localhost:5173 -l http://localhost:5173 -o http://localhost:5173 --json > auth0-app-details.json && CLIENT_ID=$(jq -r '.client_id' auth0-app-details.json) && DOMAIN=$(auth0 tenants list --json | jq -r '.[] | select(.active == true) | .name') && echo "VITE_AUTH0_DOMAIN=${DOMAIN}" > .env && echo "VITE_AUTH0_CLIENT_ID=${CLIENT_ID}" >> .env && rm auth0-app-details.json && echo ".env file created with your Auth0 details:" && cat .env
+          # Install Auth0 CLI (if not already installed)
+          brew tap auth0/auth0-cli && brew install auth0
+
+          # Set up Auth0 app and generate .env file
+          auth0 quickstarts setup --type vite
           ```
 
-          ```shellscript Windows
-          $AppName = "My Svelte App"; winget install Auth0.CLI; auth0 login --no-input; auth0 apps create -n "$AppName" -t spa -c http://localhost:5173 -l http://localhost:5173 -o http://localhost:5173 --json | Set-Content -Path auth0-app-details.json; $ClientId = (Get-Content -Raw auth0-app-details.json | ConvertFrom-Json).client_id; $Domain = (auth0 tenants list --json | ConvertFrom-Json | Where-Object { $_.active -eq $true }).name; Set-Content -Path .env -Value "VITE_AUTH0_DOMAIN=$Domain"; Add-Content -Path .env -Value "VITE_AUTH0_CLIENT_ID=$ClientId"; Remove-Item auth0-app-details.json; Write-Output ".env file created with your Auth0 details:"; Get-Content .env
+          ```powershell Windows
+          # Install Auth0 CLI (if not already installed)
+          scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git
+          scoop install auth0
+
+          # Set up Auth0 app and generate .env file
+          auth0 quickstarts setup --type vite
           ```
-        </AuthCodeGroup>
+        </CodeGroup>
+
+        <Note>
+          This command will:
+          1. Check if you're authenticated (and prompt for login if needed)
+          2. Create an Auth0 Single Page Application configured for `http://localhost:5173`
+          3. Generate a `.env` file with `VITE_AUTH0_DOMAIN` and `VITE_AUTH0_CLIENT_ID`
+        </Note>
       </Tab>
 
       <Tab title="Dashboard">
@@ -196,9 +227,16 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
   <Step title="Create the Auth0 store" stepNumber={4}>
     Create the store file
 
-    ```shellscript
-    mkdir -p src/lib/stores && touch src/lib/stores/auth.ts
-    ```
+    <CodeGroup>
+      ```shellscript Mac/Linux
+      mkdir -p src/lib/stores && touch src/lib/stores/auth.ts
+      ```
+
+      ```powershell Windows
+      New-Item -ItemType Directory -Force -Path src/lib/stores
+      New-Item -ItemType File -Path src/lib/stores/auth.ts
+      ```
+    </CodeGroup>
 
     Add the following code to manage authentication state
 
@@ -296,9 +334,18 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
   <Step title="Create Login, Logout and Profile Components" stepNumber={5}>
     Create component files
 
-    ```shellscript
-    mkdir -p src/lib/components && touch src/lib/components/LoginButton.svelte && touch src/lib/components/LogoutButton.svelte && touch src/lib/components/Profile.svelte
-    ```
+    <CodeGroup>
+      ```shellscript Mac/Linux
+      mkdir -p src/lib/components && touch src/lib/components/LoginButton.svelte && touch src/lib/components/LogoutButton.svelte && touch src/lib/components/Profile.svelte
+      ```
+
+      ```powershell Windows
+      New-Item -ItemType Directory -Force -Path src/lib/components
+      New-Item -ItemType File -Path src/lib/components/LoginButton.svelte
+      New-Item -ItemType File -Path src/lib/components/LogoutButton.svelte
+      New-Item -ItemType File -Path src/lib/components/Profile.svelte
+      ```
+    </CodeGroup>
 
     And add the following code snippets
 

--- a/main/docs/quickstart/spa/vanillajs/index.mdx
+++ b/main/docs/quickstart/spa/vanillajs/index.mdx
@@ -72,7 +72,11 @@ Otherwise, create a new project and install the SDK:
 
 ⚠️ IMPORTANT: The project creation may create the project files in the CURRENT directory instead of a subdirectory. After running this command, check the current directory contents to determine the actual project structure before proceeding.
 
+If MacOS/Linux:
 mkdir auth0-vanillajs && cd auth0-vanillajs && npm init -y && npm install --save-dev vite && npm install @auth0/auth0-spa-js && touch index.html app.js style.css
+
+If Windows (PowerShell):
+mkdir auth0-vanillajs; cd auth0-vanillajs; npm init -y; npm install --save-dev vite; npm install @auth0/auth0-spa-js; New-Item -ItemType File -Path index.html, app.js, style.css
 
 
 Step 2: Modify & Create Files
@@ -105,11 +109,27 @@ BEFORE executing the Auth0 CLI setup command, you MUST run:
 
 This will help you understand if you're in the main directory or a subdirectory, and whether the project was created in the current directory or a new subdirectory.
 
-If MacOS, execute the following command:
-AUTH0_APP_NAME="My Vanilla JS App" && brew tap auth0/auth0-cli && brew install auth0 && auth0 login --no-input && auth0 apps create -n "${AUTH0_APP_NAME}" -t spa -c http://localhost:5173 -l http://localhost:5173 -o http://localhost:5173 --json --metadata created_by="quickstart-docs-ai-prompt" > auth0-app-details.json && CLIENT_ID=$(jq -r '.client_id' auth0-app-details.json) && DOMAIN=$(auth0 tenants list --json | jq -r '.[] | select(.active == true) | .name') && echo "VITE_AUTH0_DOMAIN=${DOMAIN}" > .env.local && echo "VITE_AUTH0_CLIENT_ID=${CLIENT_ID}" >> .env.local && rm auth0-app-details.json && echo ".env.local file created with your Auth0 details:" && cat .env.local
+Execute the Auth0 setup command for your OS:
 
-If Windows, execute the following command:
-$AppName = "My Vanilla JS App"; winget install Auth0.CLI; auth0 login --no-input; auth0 apps create -n "$AppName" -t spa -c http://localhost:5173 -l http://localhost:5173 -o http://localhost:5173 --json --metadata created_by="quickstart-docs-ai-prompt" | Set-Content -Path auth0-app-details.json; $ClientId = (Get-Content -Raw auth0-app-details.json | ConvertFrom-Json).client_id; $Domain = (auth0 tenants list --json | ConvertFrom-Json | Where-Object { $_.active -eq $true }).name; Set-Content -Path .env.local -Value "VITE_AUTH0_DOMAIN=$Domain"; Add-Content -Path .env.local -Value "VITE_AUTH0_CLIENT_ID=$ClientId"; Remove-Item auth0-app-details.json; Write-Output ".env.local file created with your Auth0 details:"; Get-Content .env.local
+If MacOS:
+  # Install Auth0 CLI if not already installed
+  brew tap auth0/auth0-cli && brew install auth0
+
+  # Set up Auth0 app and generate .env file
+  auth0 quickstarts setup --type vite
+
+If Windows (PowerShell):
+  # Install Auth0 CLI if not already installed
+  scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git
+  scoop install auth0
+
+  # Set up Auth0 app and generate .env file
+  auth0 quickstarts setup --type vite
+
+This command will automatically:
+- Authenticate you with Auth0 (prompts for login if needed)
+- Create a Single Page Application configured for http://localhost:5173
+- Generate a .env file with VITE_AUTH0_DOMAIN and VITE_AUTH0_CLIENT_ID
 
 
 Step 2.1b: Create manual .env.local template (if automatic setup fails)
@@ -811,7 +831,8 @@ If you're using Auth0 Organizations:
 
   - **[Node.js](https://nodejs.org/en/download)** 20 LTS or newer
   - **[npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)** 10+ or **[yarn](https://classic.yarnpkg.com/lang/en/docs/install/)** 1.22+ or **[pnpm](https://pnpm.io/installation)** 8+
-  - **[jq](https://jqlang.org/)** - Required for Auth0 CLI setup
+
+  Verify installation: `node --version && npm --version`
 
   **Build Tool:** This quickstart uses **Vite** for development. You can also use the SDK via CDN for a build-tool-free setup.
 </Note>
@@ -840,9 +861,15 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
 
     Create the basic project structure
 
-    ```shellscript
-    touch index.html app.js style.css
-    ```
+    <CodeGroup>
+      ```shellscript Mac/Linux
+      touch index.html app.js style.css
+      ```
+
+      ```powershell Windows
+      New-Item -ItemType File -Path index.html, app.js, style.css
+      ```
+    </CodeGroup>
   </Step>
   <Step title="Install the Auth0 SPA JS SDK" stepNumber={2}>
     ```shellscript
@@ -862,17 +889,33 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
       </Tab>
 
       <Tab title="CLI">
-        Run the following shell command on your project's root directory to create an Auth0 app and generate a `.env.local` file:
+        Run the following command in your project's root directory to create an Auth0 app and generate a `.env` file:
 
-        <AuthCodeGroup>
+        <CodeGroup>
           ```shellscript Mac
-          AUTH0_APP_NAME="My Vanilla JS App" && brew tap auth0/auth0-cli && brew install auth0 && auth0 login --no-input && auth0 apps create -n "${AUTH0_APP_NAME}" -t spa -c http://localhost:5173 -l http://localhost:5173 -o http://localhost:5173 --json --metadata created_by="quickstart-docs-manual" > auth0-app-details.json && CLIENT_ID=$(jq -r '.client_id' auth0-app-details.json) && DOMAIN=$(auth0 tenants list --json | jq -r '.[] | select(.active == true) | .name') && echo "VITE_AUTH0_DOMAIN=${DOMAIN}" > .env.local && echo "VITE_AUTH0_CLIENT_ID=${CLIENT_ID}" >> .env.local && rm auth0-app-details.json && echo ".env.local file created with your Auth0 details:" && cat .env.local
+          # Install Auth0 CLI (if not already installed)
+          brew tap auth0/auth0-cli && brew install auth0
+
+          # Set up Auth0 app and generate .env file
+          auth0 quickstarts setup --type vite
           ```
 
-          ```shellscript Windows
-          $AppName = "My Vanilla JS App"; winget install Auth0.CLI; auth0 login --no-input; auth0 apps create -n "$AppName" -t spa -c http://localhost:5173 -l http://localhost:5173 -o http://localhost:5173 --json --metadata created_by="quickstart-docs-manual" | Set-Content -Path auth0-app-details.json; $ClientId = (Get-Content -Raw auth0-app-details.json | ConvertFrom-Json).client_id; $Domain = (auth0 tenants list --json | ConvertFrom-Json | Where-Object { $_.active -eq $true }).name; Set-Content -Path .env.local -Value "VITE_AUTH0_DOMAIN=$Domain"; Add-Content -Path .env.local -Value "VITE_AUTH0_CLIENT_ID=$ClientId"; Remove-Item auth0-app-details.json; Write-Output ".env.local file created with your Auth0 details:"; Get-Content .env.local
+          ```powershell Windows
+          # Install Auth0 CLI (if not already installed)
+          scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git
+          scoop install auth0
+
+          # Set up Auth0 app and generate .env file
+          auth0 quickstarts setup --type vite
           ```
-        </AuthCodeGroup>
+        </CodeGroup>
+
+        <Note>
+          This command will:
+          1. Check if you're authenticated (and prompt for login if needed)
+          2. Create an Auth0 Single Page Application configured for `http://localhost:5173`
+          3. Generate a `.env` file with `VITE_AUTH0_DOMAIN` and `VITE_AUTH0_CLIENT_ID`
+        </Note>
       </Tab>
 
       <Tab title="Dashboard">
@@ -1391,6 +1434,10 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
     ```shellscript
     npm run dev
     ```
+
+    <Info>
+      If port 5173 is in use, run: `npm run dev -- --port 5174` and update your Auth0 app's callback URLs to `http://localhost:5174`
+    </Info>
   </Step>
 </Steps>
 

--- a/main/docs/quickstart/spa/vuejs/index.mdx
+++ b/main/docs/quickstart/spa/vuejs/index.mdx
@@ -91,11 +91,26 @@ BEFORE executing the Auth0 CLI setup command, you MUST run:
 
 This will help you understand if you're in the main directory or a subdirectory, and whether the project was created in the current directory or a new subdirectory.
 
-If MacOS, execute the following command:
-AUTH0_APP_NAME="My Vue App" && brew tap auth0/auth0-cli && brew install auth0 && auth0 login --no-input && auth0 apps create -n "${AUTH0_APP_NAME}" -t spa -c http://localhost:5173 -l http://localhost:5173 -o http://localhost:5173 --json > auth0-app-details.json && CLIENT_ID=$(jq -r '.client_id' auth0-app-details.json) && DOMAIN=$(auth0 tenants list --json | jq -r '.[] | select(.active == true) | .name') && echo "VITE_AUTH0_DOMAIN=${DOMAIN}" > .env && echo "VITE_AUTH0_CLIENT_ID=${CLIENT_ID}" >> .env && rm auth0-app-details.json && echo ".env file created with your Auth0 details:" && cat .env
+Execute the Auth0 setup command for your OS:
 
-If Windows, execute the following command:
-$AppName = "My Vue App"; winget install Auth0.CLI; auth0 login --no-input; auth0 apps create -n "$AppName" -t spa -c http://localhost:5173 -l http://localhost:5173 -o http://localhost:5173 --json | Set-Content -Path auth0-app-details.json; $ClientId = (Get-Content -Raw auth0-app-details.json | ConvertFrom-Json).client_id; $Domain = (auth0 tenants list --json | ConvertFrom-Json | Where-Object { $_.active -eq $true }).name; Set-Content -Path .env -Value "VITE_AUTH0_DOMAIN=$Domain"; Add-Content -Path .env -Value "VITE_AUTH0_CLIENT_ID=$ClientId"; Remove-Item auth0-app-details.json; Write-Output ".env file created with your Auth0 details:"; Get-Content .env
+If MacOS:
+  # Install Auth0 CLI if not already installed
+  brew tap auth0/auth0-cli && brew install auth0
+
+  # Set up Auth0 app and generate .env file
+  auth0 quickstarts setup --type vite
+
+If Windows:
+  # Install Auth0 CLI if not already installed
+  winget install Auth0.CLI
+
+  # Set up Auth0 app and generate .env file
+  auth0 quickstarts setup --type vite
+
+This command will automatically:
+- Authenticate you with Auth0 (prompts for login if needed)
+- Create a Single Page Application configured for http://localhost:5173
+- Generate a .env file with VITE_AUTH0_DOMAIN and VITE_AUTH0_CLIENT_ID
 
 
 Step 2.1b: Create manual .env template (if automatic setup fails)
@@ -163,7 +178,13 @@ Replace the entire contents of src/main.ts (or create it if it doesn't exist):
 2.3: Create authentication components
 Create the component files first:
 
+If MacOS/Linux:
   touch src/components/LoginButton.vue && touch src/components/LogoutButton.vue && touch src/components/UserProfile.vue
+
+If Windows (PowerShell):
+  New-Item -ItemType File -Path src/components/LoginButton.vue
+  New-Item -ItemType File -Path src/components/LogoutButton.vue
+  New-Item -ItemType File -Path src/components/UserProfile.vue
 
 2.4: Create LoginButton component
 Create src/components/LoginButton.vue with this code:
@@ -702,7 +723,8 @@ Solution: Vue 3 with Vite uses import.meta.env.VITE_* for environment variables,
 
   - **[Node.js](https://nodejs.org/en/download)** 20 LTS or newer
   - **[npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)** 10+ or **[yarn](https://classic.yarnpkg.com/lang/en/docs/install/)** 1.22+ or **[pnpm](https://pnpm.io/installation)** 8+
-  - **[jq](https://jqlang.org/)** - Required for Auth0 CLI setup
+
+  Verify installation: `node --version && npm --version`
 
   **Vue Version Compatibility:** This quickstart works with **Vue 3.x** and newer.
 </Note>
@@ -747,17 +769,33 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
       </Tab>
 
       <Tab title="CLI">
-        Run the following shell command on your project's root directory to create an Auth0 app and generate a `.env` file:
+        Run the following command in your project's root directory to create an Auth0 app and generate a `.env` file:
 
-        <AuthCodeGroup>
+        <CodeGroup>
           ```shellscript Mac
-          AUTH0_APP_NAME="My Vue App" && brew tap auth0/auth0-cli && brew install auth0 && auth0 login --no-input && auth0 apps create -n "${AUTH0_APP_NAME}" -t spa -c http://localhost:5173 -l http://localhost:5173 -o http://localhost:5173 --json > auth0-app-details.json && CLIENT_ID=$(jq -r '.client_id' auth0-app-details.json) && DOMAIN=$(auth0 tenants list --json | jq -r '.[] | select(.active == true) | .name') && echo "VITE_AUTH0_DOMAIN=${DOMAIN}" > .env && echo "VITE_AUTH0_CLIENT_ID=${CLIENT_ID}" >> .env && rm auth0-app-details.json && echo ".env file created with your Auth0 details:" && cat .env
+          # Install Auth0 CLI (if not already installed)
+          brew tap auth0/auth0-cli && brew install auth0
+
+          # Set up Auth0 app and generate .env file
+          auth0 quickstarts setup --type vite
           ```
 
-          ```shellscript Windows
-          $AppName = "My Vue App"; winget install Auth0.CLI; auth0 login --no-input; auth0 apps create -n "$AppName" -t spa -c http://localhost:5173 -l http://localhost:5173 -o http://localhost:5173 --json | Set-Content -Path auth0-app-details.json; $ClientId = (Get-Content -Raw auth0-app-details.json | ConvertFrom-Json).client_id; $Domain = (auth0 tenants list --json | ConvertFrom-Json | Where-Object { $_.active -eq $true }).name; Set-Content -Path .env -Value "VITE_AUTH0_DOMAIN=$Domain"; Add-Content -Path .env -Value "VITE_AUTH0_CLIENT_ID=$ClientId"; Remove-Item auth0-app-details.json; Write-Output ".env file created with your Auth0 details:"; Get-Content .env
+          ```powershell Windows
+          # Install Auth0 CLI (if not already installed)
+          scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git
+          scoop install auth0
+
+          # Set up Auth0 app and generate .env file
+          auth0 quickstarts setup --type vite
           ```
-        </AuthCodeGroup>
+        </CodeGroup>
+
+        <Note>
+          This command will:
+          1. Check if you're authenticated (and prompt for login if needed)
+          2. Create an Auth0 Single Page Application configured for `http://localhost:5173`
+          3. Generate a `.env` file with `VITE_AUTH0_DOMAIN` and `VITE_AUTH0_CLIENT_ID`
+        </Note>
       </Tab>
 
       <Tab title="Dashboard">
@@ -800,6 +838,10 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
         </Info>
       </Tab>
     </Tabs>
+
+    <Tip>
+      Verify your `.env` file exists: `cat .env` (Mac/Linux) or `type .env` (Windows)
+    </Tip>
   </Step>
   <Step title="Configure the Auth0 Plugin" stepNumber={4}>
     ```typescript src/main.ts {6,11,12,13,14,15,16,17} lines
@@ -831,9 +873,17 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
   <Step title="Create Authentication Components" stepNumber={5}>
     Create component files
 
-    ```shellscript
-    touch src/components/LoginButton.vue && touch src/components/LogoutButton.vue && touch src/components/UserProfile.vue
-    ```
+    <CodeGroup>
+      ```shellscript Mac/Linux
+      touch src/components/LoginButton.vue && touch src/components/LogoutButton.vue && touch src/components/UserProfile.vue
+      ```
+
+      ```powershell Windows
+      New-Item -ItemType File -Path src/components/LoginButton.vue
+      New-Item -ItemType File -Path src/components/LogoutButton.vue
+      New-Item -ItemType File -Path src/components/UserProfile.vue
+      ```
+    </CodeGroup>
 
     And add the following code snippets
 
@@ -1275,6 +1325,10 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
     ```shellscript
     npm run dev
     ```
+
+    <Info>
+      If port 5173 is in use, run: `npm run dev -- --port 5174` and update your Auth0 app's callback URLs to `http://localhost:5174`
+    </Info>
   </Step>
 </Steps>
 

--- a/main/docs/quickstart/webapp/nextjs/index.mdx
+++ b/main/docs/quickstart/webapp/nextjs/index.mdx
@@ -72,8 +72,13 @@ import {CreateInteractiveApp} from "/snippets/recipe.jsx";
   
   Step 1b: Create project files
   After installing the SDK, create all necessary directories and files:
-  
+
+  If MacOS/Linux:
     mkdir -p src/lib src/components && touch src/lib/auth0.ts src/middleware.ts src/components/LoginButton.tsx src/components/LogoutButton.tsx src/components/Profile.tsx
+
+  If Windows (PowerShell):
+    New-Item -ItemType Directory -Force -Path src/lib, src/components
+    New-Item -ItemType File -Path src/lib/auth0.ts, src/middleware.ts, src/components/LoginButton.tsx, src/components/LogoutButton.tsx, src/components/Profile.tsx
   
   
   Step 2: Modify & Create Files
@@ -106,11 +111,27 @@ import {CreateInteractiveApp} from "/snippets/recipe.jsx";
   
   This will help you understand if you're in the main directory or a subdirectory, and whether the project was created in the current directory or a new subdirectory.
   
-  If MacOS, execute the following command:
-  AUTH0_APP_NAME="My App" && brew tap auth0/auth0-cli && brew install auth0 && auth0 login --no-input && auth0 apps create -n "${AUTH0_APP_NAME}" -t regular -c http://localhost:3000/auth/callback -l http://localhost:3000 -o http://localhost:3000 --reveal-secrets --json --metadata created_by="quickstart-docs-ai-prompt" > auth0-app-details.json && CLIENT_ID=$(jq -r '.client_id' auth0-app-details.json) && CLIENT_SECRET=$(jq -r '.client_secret' auth0-app-details.json) && DOMAIN=$(auth0 tenants list --json | jq -r '.[] | select(.active == true) | .name') && SECRET=$(openssl rand -hex 32) && echo "AUTH0_DOMAIN=${DOMAIN}" > .env.local && echo "AUTH0_CLIENT_ID=${CLIENT_ID}" >> .env.local && echo "AUTH0_CLIENT_SECRET=${CLIENT_SECRET}" >> .env.local && echo "AUTH0_SECRET=${SECRET}" >> .env.local && echo "APP_BASE_URL=http://localhost:3000" >> .env.local && rm auth0-app-details.json && echo ".env.local file created with your Auth0 details:" && cat .env.local
-  
-  If Windows, execute the following command:
-  $AppName = "My App"; winget install Auth0.CLI; auth0 login --no-input; auth0 apps create -n "$AppName" -t regular -c http://localhost:3000/auth/callback -l http://localhost:3000 -o http://localhost:3000 --reveal-secrets --json --metadata created_by="quickstart-docs-ai-prompt" | Set-Content -Path auth0-app-details.json; $ClientId = (Get-Content -Raw auth0-app-details.json | ConvertFrom-Json).client_id; $ClientSecret = (Get-Content -Raw auth0-app-details.json | ConvertFrom-Json).client_secret; $Domain = (auth0 tenants list --json | ConvertFrom-Json | Where-Object { $_.active -eq $true }).name; $Secret = [System.Convert]::ToHexString([System.Security.Cryptography.RandomNumberGenerator]::GetBytes(32)).ToLower(); Set-Content -Path .env.local -Value "AUTH0_DOMAIN=$Domain"; Add-Content -Path .env.local -Value "AUTH0_CLIENT_ID=$ClientId"; Add-Content -Path .env.local -Value "AUTH0_CLIENT_SECRET=$ClientSecret"; Add-Content -Path .env.local -Value "AUTH0_SECRET=$Secret"; Add-Content -Path .env.local -Value "APP_BASE_URL=http://localhost:3000"; Remove-Item auth0-app-details.json; Write-Output ".env.local file created with your Auth0 details:"; Get-Content .env.local
+  Execute the Auth0 setup command for your OS:
+
+  If MacOS:
+    # Install Auth0 CLI if not already installed
+    brew tap auth0/auth0-cli && brew install auth0
+
+    # Set up Auth0 app and generate .env.local file
+    auth0 quickstarts setup --type nextjs
+
+  If Windows (PowerShell):
+    # Install Auth0 CLI if not already installed
+    scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git
+    scoop install auth0
+
+    # Set up Auth0 app and generate .env.local file
+    auth0 quickstarts setup --type nextjs
+
+  This command will automatically:
+  - Authenticate you with Auth0 (prompts for login if needed)
+  - Create a Regular Web Application configured for http://localhost:3000
+  - Generate a .env.local file with AUTH0_DOMAIN, AUTH0_CLIENT_ID, AUTH0_CLIENT_SECRET, AUTH0_SECRET, and APP_BASE_URL
   
   
   Step 2.1b: Create manual .env.local template (if automatic setup fails)
@@ -666,7 +687,8 @@ import {CreateInteractiveApp} from "/snippets/recipe.jsx";
 
   - **[Node.js](https://nodejs.org/en/download)** 20 LTS or newer
   - **[npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)** 10+ or **[yarn](https://classic.yarnpkg.com/lang/en/docs/install/)** 1.22+ or **[pnpm](https://pnpm.io/installation)** 8+
-  - **[jq](https://jqlang.org/)** - Required for Auth0 CLI setup
+
+  Verify installation: `node --version && npm --version`
 
   **Next.js Version Compatibility:** This quickstart uses **Next.js 15** which is fully supported by the Auth0 SDK. Next.js 16 is also compatible but requires the `--legacy-peer-deps` flag during installation (see Step 2 for details).
 </Note>
@@ -722,9 +744,16 @@ APP_BASE_URL=http://localhost:3000`;
   <Step title="Create project files" stepNumber={3}>
     Create all necessary directories and files for Auth0 integration:
 
-    ```shellscript
-    mkdir -p src/lib src/components && touch src/lib/auth0.ts src/middleware.ts src/components/LoginButton.tsx src/components/LogoutButton.tsx src/components/Profile.tsx
-    ```
+    <CodeGroup>
+      ```shellscript Mac/Linux
+      mkdir -p src/lib src/components && touch src/lib/auth0.ts src/middleware.ts src/components/LoginButton.tsx src/components/LogoutButton.tsx src/components/Profile.tsx
+      ```
+
+      ```powershell Windows
+      New-Item -ItemType Directory -Force -Path src/lib, src/components
+      New-Item -ItemType File -Path src/lib/auth0.ts, src/middleware.ts, src/components/LoginButton.tsx, src/components/LogoutButton.tsx, src/components/Profile.tsx
+      ```
+    </CodeGroup>
   </Step>
   <Step title="Setup your Auth0 App" stepNumber={4}>
     Next up, you need to create a new app on your Auth0 tenant and add the environment variables to your project.
@@ -739,17 +768,33 @@ APP_BASE_URL=http://localhost:3000`;
       </Tab>
 
       <Tab title="CLI">
-        Run the following shell command on your project's root directory to create an Auth0 app and generate a `.env.local` file:
+        Run the following command in your project's root directory to create an Auth0 app and generate a `.env.local` file:
 
-        <AuthCodeGroup>
+        <CodeGroup>
           ```shellscript Mac
-          AUTH0_APP_NAME="My App" && brew tap auth0/auth0-cli && brew install auth0 && auth0 login --no-input && auth0 apps create -n "${AUTH0_APP_NAME}" -t regular -c http://localhost:3000/auth/callback -l http://localhost:3000 -o http://localhost:3000 --reveal-secrets --json --metadata created_by="quickstart-docs-manual" > auth0-app-details.json && CLIENT_ID=$(jq -r '.client_id' auth0-app-details.json) && CLIENT_SECRET=$(jq -r '.client_secret' auth0-app-details.json) && DOMAIN=$(auth0 tenants list --json | jq -r '.[] | select(.active == true) | .name') && SECRET=$(openssl rand -hex 32) && echo "AUTH0_DOMAIN=${DOMAIN}" > .env.local && echo "AUTH0_CLIENT_ID=${CLIENT_ID}" >> .env.local && echo "AUTH0_CLIENT_SECRET=${CLIENT_SECRET}" >> .env.local && echo "AUTH0_SECRET=${SECRET}" >> .env.local && echo "APP_BASE_URL=http://localhost:3000" >> .env.local && rm auth0-app-details.json && echo ".env.local file created with your Auth0 details:" && cat .env.local
+          # Install Auth0 CLI (if not already installed)
+          brew tap auth0/auth0-cli && brew install auth0
+
+          # Set up Auth0 app and generate .env.local file
+          auth0 quickstarts setup --type nextjs
           ```
 
-          ```shellscript Windows
-          $AppName = "My App"; winget install Auth0.CLI; auth0 login --no-input; auth0 apps create -n "$AppName" -t regular -c http://localhost:3000/auth/callback -l http://localhost:3000 -o http://localhost:3000 --reveal-secrets --json --metadata created_by="quickstart-docs-manual" | Set-Content -Path auth0-app-details.json; $ClientId = (Get-Content -Raw auth0-app-details.json | ConvertFrom-Json).client_id; $ClientSecret = (Get-Content -Raw auth0-app-details.json | ConvertFrom-Json).client_secret; $Domain = (auth0 tenants list --json | ConvertFrom-Json | Where-Object { $_.active -eq $true }).name; $Secret = [System.Convert]::ToHexString([System.Security.Cryptography.RandomNumberGenerator]::GetBytes(32)).ToLower(); Set-Content -Path .env.local -Value "AUTH0_DOMAIN=$Domain"; Add-Content -Path .env.local -Value "AUTH0_CLIENT_ID=$ClientId"; Add-Content -Path .env.local -Value "AUTH0_CLIENT_SECRET=$ClientSecret"; Add-Content -Path .env.local -Value "AUTH0_SECRET=$Secret"; Add-Content -Path .env.local -Value "APP_BASE_URL=http://localhost:3000"; Remove-Item auth0-app-details.json; Write-Output ".env.local file created with your Auth0 details:"; Get-Content .env.local
+          ```powershell Windows
+          # Install Auth0 CLI (if not already installed)
+          scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git
+          scoop install auth0
+
+          # Set up Auth0 app and generate .env.local file
+          auth0 quickstarts setup --type nextjs
           ```
-        </AuthCodeGroup>
+        </CodeGroup>
+
+        <Note>
+          This command will:
+          1. Check if you're authenticated (and prompt for login if needed)
+          2. Create an Auth0 Regular Web Application configured for `http://localhost:3000`
+          3. Generate a `.env.local` file with `AUTH0_DOMAIN`, `AUTH0_CLIENT_ID`, `AUTH0_CLIENT_SECRET`, `AUTH0_SECRET`, and `APP_BASE_URL`
+        </Note>
       </Tab>
 
       <Tab title="Dashboard">
@@ -1250,6 +1295,8 @@ APP_BASE_URL=http://localhost:3000`;
 
     <Info>
       Your app will be available at http://localhost:3000. The Auth0 SDK v4 automatically mounts authentication routes at `/auth/*` (not `/api/auth/*` like in v3).
+
+      If port 3000 is in use, run: `npm run dev -- --port 3001` and update your Auth0 app's callback URLs to `http://localhost:3001`
     </Info>
   </Step>
 </Steps>


### PR DESCRIPTION
## Description
Auth0 CLI now supports a nifty [setup command ](https://github.com/auth0/auth0-cli/pull/1428) that removes the need to add an obscure and verbose shell command to setup an auth0 app via the CLI on quickstarts. 

This PR replaces the long shell command with the new `auth0 setup` command for better readability and ergonomics. Also addresses some gaps in windows v/s maclinux shell command to improve success rate.


### References
https://auth0team.atlassian.net/browse/DXCDT-1253

### Testing
Tested

## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
