### PR TITLE
fix: Convert Express quickstart from Docusaurus to Mintlify format

### DIFF
--- a/main/docs/quickstart/webapp/express/index.mdx
+++ b/main/docs/quickstart/webapp/express/index.mdx
@@ -1,15 +1,44 @@
-# Add Login to Your Express Application
+---
+mode: wide
+description: This guide demonstrates how to integrate Auth0, add authentication, and display user profile information in an Express.js web application using the express-openid-connect SDK.
+sidebarTitle: Express
+title: Add Login to Your Express Application
+---
 
-This guide demonstrates how to integrate Auth0, add authentication, and display user profile information in an Express.js web application using the `express-openid-connect` SDK.
+import {CreateInteractiveApp} from "/snippets/recipe.jsx";
 
-:::note Prerequisites
-Before you begin, ensure you have the following installed:
+<Accordion title="Use AI to integrate Auth0" icon="microchip-ai" iconType="solid" defaultOpen>
+
+If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, you can add Auth0 authentication automatically in minutes using [agent skills](https://agentskills.io/home).
+
+**Install:**
+
+```bash
+npx skills add auth0/agent-skills
+```
+
+**Then ask your AI assistant:**
+
+```text
+Add Auth0 authentication to my Express app
+```
+
+Your AI assistant will automatically create your Auth0 application, fetch credentials, install `express-openid-connect`, configure the middleware, and set up your routes. [Full agent skills documentation →](/quickstart/agent-skills)
+
+</Accordion>
+
+<Note>
+**Prerequisites:** Before you begin, ensure you have the following installed:
 - [Node.js](https://nodejs.org/) 18 LTS or newer
 - [npm](https://www.npmjs.com/) 10+ or [yarn](https://yarnpkg.com/) 1.22+
 - [jq](https://jqlang.github.io/jq/) - Required for Auth0 CLI setup (optional)
 
 **Express Version Compatibility:** This quickstart works with Express 4.17.0 and newer.
-:::
+</Note>
+
+## Get Started
+
+This guide demonstrates how to integrate Auth0, add authentication, and display user profile information in an Express.js web application using the `express-openid-connect` SDK.
 
 ---
 
@@ -79,8 +108,8 @@ Next, you need to create a new application on your Auth0 tenant and add the envi
 
 You can choose to do this automatically by running a CLI command or manually via the Dashboard:
 
-::::tabs
-:::tab{title="CLI"}
+<Tabs>
+  <Tab title="CLI">
 
 Run the following shell command in your project's root directory to create an Auth0 application and generate your `.env` file:
 
@@ -106,16 +135,16 @@ auth0 apps create -n $appName -t regular `
   } | Out-File .env -Encoding utf8
 ```
 
-:::note
+<Note>
 If you haven't installed the Auth0 CLI yet, run:
 ```bash
 brew tap auth0/auth0-cli && brew install auth0
 ```
 Then authenticate with `auth0 login`.
-:::
+</Note>
 
-:::
-:::tab{title="Dashboard"}
+  </Tab>
+  <Tab title="Dashboard">
 
 1. Go to the [Auth0 Dashboard](https://manage.auth0.com/dashboard/)
 2. Navigate to **Applications** → **Create Application**
@@ -142,9 +171,9 @@ SECRET=use-a-long-random-string-at-least-32-characters
 BASE_URL=http://localhost:3000
 ```
 
-:::warning
+<Warning>
 Replace `YOUR_AUTH0_DOMAIN` with your Auth0 tenant domain (e.g., `dev-abc123.us.auth0.com`) and `YOUR_CLIENT_ID` with your application's Client ID from the dashboard.
-:::
+</Warning>
 
 Generate a secure secret for session encryption:
 
@@ -154,8 +183,8 @@ openssl rand -hex 32
 
 Copy the output and use it as the `SECRET` value in your `.env` file.
 
-:::
-::::
+  </Tab>
+</Tabs>
 
 ---
 
@@ -234,7 +263,7 @@ app.use(auth(config));
 // Home route - shows login/logout status
 app.get('/', (req, res) => {
   const isAuthenticated = req.oidc.isAuthenticated();
-  
+
   res.send(`
     <html>
       <head>
@@ -254,7 +283,7 @@ app.get('/', (req, res) => {
           ${isAuthenticated ? '✓ You are logged in' : '✗ You are logged out'}
         </div>
         <nav>
-          ${isAuthenticated 
+          ${isAuthenticated
             ? '<a href="/profile">Profile</a> | <a href="/logout">Logout</a>'
             : '<a href="/login">Login</a>'}
         </nav>
@@ -266,7 +295,7 @@ app.get('/', (req, res) => {
 // Protected profile route - requires authentication
 app.get('/profile', requiresAuth(), (req, res) => {
   const user = req.oidc.user;
-  
+
   res.send(`
     <html>
       <head>
@@ -319,21 +348,23 @@ npm run dev
 
 Open your browser to [http://localhost:3000](http://localhost:3000).
 
-:::checkpoint
-✓ **Checkpoint**
+<Check>
+**Checkpoint**
 
 You should now have a fully functional Auth0 login page. When you:
 1. Click "Login" - you're redirected to Auth0's Universal Login page
 2. Complete authentication - you're redirected back to your app
 3. Visit "/profile" - you see your user information
 4. Click "Logout" - you're logged out of both your app and Auth0
-:::
+</Check>
 
 ---
 
 ## Advanced Usage
 
-:::details[Protecting Specific Routes with requiresAuth()]
+<AccordionGroup>
+
+<Accordion title="Protecting Specific Routes with requiresAuth()">
 
 Use the `requiresAuth()` middleware to protect individual routes that require authentication:
 
@@ -376,9 +407,10 @@ protectedRouter.get('/settings', (req, res) => {
 app.use('/app', protectedRouter);
 // Routes: /app/dashboard, /app/settings are all protected
 ```
-:::
 
-:::details[Calling Protected APIs with Access Tokens]
+</Accordion>
+
+<Accordion title="Calling Protected APIs with Access Tokens">
 
 To call external APIs that require an access token, configure the SDK to request one:
 
@@ -414,20 +446,20 @@ Then use the access token to call your API:
 app.get('/api-data', requiresAuth(), async (req, res) => {
   try {
     let { token_type, access_token, isExpired, refresh } = req.oidc.accessToken;
-    
+
     // Refresh the token if expired
     if (isExpired()) {
       const refreshed = await refresh();
       access_token = refreshed.access_token;
     }
-    
+
     // Call your protected API
     const response = await fetch('https://your-api.example.com/data', {
       headers: {
         Authorization: `${token_type} ${access_token}`,
       },
     });
-    
+
     const data = await response.json();
     res.json(data);
   } catch (error) {
@@ -437,16 +469,16 @@ app.get('/api-data', requiresAuth(), async (req, res) => {
 });
 ```
 
-:::note
+<Note>
 To get refresh tokens, add `offline_access` to your scope:
 ```javascript
 scope: 'openid profile email offline_access read:data',
 ```
-:::
+</Note>
 
-:::
+</Accordion>
 
-:::details[Using Claim-Based Authorization]
+<Accordion title="Using Claim-Based Authorization">
 
 Protect routes based on user claims (roles, permissions, etc.):
 
@@ -473,13 +505,13 @@ app.get('/premium', claimCheck((req, claims) => {
 });
 ```
 
-:::note
+<Note>
 Claims like `role` must be added to your tokens via Auth0 Rules or Actions. [Learn more about adding custom claims](https://auth0.com/docs/customize/actions/flows-and-triggers/login-flow/add-user-roles-to-id-and-access-tokens).
-:::
+</Note>
 
-:::
+</Accordion>
 
-:::details[Custom Session Store (Redis)]
+<Accordion title="Custom Session Store (Redis)">
 
 For production environments or when running multiple server instances, use a custom session store:
 
@@ -518,9 +550,10 @@ app.use(auth(config));
 - Session data exceeds cookie size limits (~4KB)
 - Need session persistence across server restarts
 - Using back-channel logout
-:::
 
-:::details[Error Handling]
+</Accordion>
+
+<Accordion title="Error Handling">
 
 Add proper error handling for authentication errors:
 
@@ -543,7 +576,7 @@ app.use((err, req, res, next) => {
   if (err.statusCode === 401) {
     // For API requests, return JSON
     if (req.accepts('json')) {
-      return res.status(401).json({ 
+      return res.status(401).json({
         error: 'Authentication required',
         login_url: '/login',
       });
@@ -551,22 +584,27 @@ app.use((err, req, res, next) => {
     // For browser requests, redirect to login
     return res.redirect('/login');
   }
-  
+
   // Log the error (don't expose details to client)
   console.error('Application error:', err.message);
-  
-  res.status(err.statusCode || 500).json({ 
+
+  res.status(err.statusCode || 500).json({
     error: 'An unexpected error occurred',
   });
 });
 ```
-:::
+
+</Accordion>
+
+</AccordionGroup>
 
 ---
 
 ## Troubleshooting
 
-:::details[Common Issues and Solutions]
+<AccordionGroup>
+
+<Accordion title="Common Issues and Solutions">
 
 ### "Invalid state" error after login
 
@@ -609,7 +647,7 @@ session: {
 
 **Problem:** "Callback URL mismatch" error from Auth0.
 
-**Solution:** 
+**Solution:**
 1. Go to your Auth0 Dashboard → Applications → Your App → Settings
 2. Add `http://localhost:3000` (or your production URL) to **Allowed Callback URLs**
 3. The URL must match **exactly** (including trailing slashes)
@@ -631,7 +669,10 @@ console.log('Config check:', {
   issuerBaseURL: process.env.ISSUER_BASE_URL,
 });
 ```
-:::
+
+</Accordion>
+
+</AccordionGroup>
 
 ---
 


### PR DESCRIPTION
## Description

- Added YAML frontmatter (title, description, sidebarTitle)
- Converted all Docusaurus syntax to Mintlify components:
  - :::note → <Note>
  - :::warning → <Warning>
  - :::checkpoint → <Check>
  - ::::tabs/:::tab → <Tabs>/<Tab>
  - :::details → <Accordion> with <AccordionGroup>
- Added agent skills accordion for AI-assisted integration
- Fixed navigation display (was showing "index", now shows "Express")
- Fixed page rendering issue (content now loads properly)


## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
