### PR TITLE
fix: improve dpop docs to clarify expected nonce challenge as per RFC9449

### DIFF
--- a/main/docs/secure/sender-constraining/demonstrating-proof-of-possession-dpop.mdx
+++ b/main/docs/secure/sender-constraining/demonstrating-proof-of-possession-dpop.mdx
@@ -2,12 +2,6 @@
 description: Learn how to sender constraing tokens using Demonstrating Proof-of-Possession (DPoP) in Auth0.
 title: Demonstrating Proof-of-Possession (DPoP)
 ---
-<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-
-Sender constraining tokens using Demonstrating Proof-of-Possession (DPoP) is currently in Early Access. To request access to this feature, contact your Auth0 representative.
-
-</Callout>
-
 Demonstrating Proof-of-Possession (DPoP) is an [OAuth 2.0 framework extension](https://datatracker.ietf.org/doc/draft-ietf-oauth-dpop/) that binds or [sender constrains](/docs/secure/sender-constraining) <Tooltip tip="Access Token: Authorization credential, in the form of an opaque string or JWT, used to access an API." cta="View Glossary" href="/docs/glossary?term=access+tokens">access tokens</Tooltip> using asymmetric cryptography and <Tooltip tip="Access Token: Authorization credential, in the form of an opaque string or JWT, used to access an API." cta="View Glossary" href="/docs/glossary?term=JSON+Web+Tokens">JSON Web Tokens</Tooltip> (JWTs) at the application layer. DPoP ensures that only the client application that requested the access token, which possesses the private key, can use it. This prevents the misuse of stolen tokens.
 
 DPoP uses a public/private key to create a DPoP Proof as a signed JSON Web Token (JWT). The DPoP Proof contains:
@@ -298,7 +292,7 @@ console.log('Initial token request result:', result);
 
 ### Public clients
 
-If a public client, such as a single-page application (SPA) or mobile app, requests a DPoP-bound access token, you won’t have a client secret or other client authentication parameters. In this case, Auth0 requires your DPoP HTTP header to have a <Tooltip tip="Nonce: Arbitrary number issued once in an authentication protocol to detect and prevent replay attacks." cta="View Glossary" href="/docs/glossary?term=nonce">nonce</Tooltip> value to ensure the client application recently generated the DPoP Proof JWT.
+If a public client, such as a single-page application (SPA) or mobile app, requests a DPoP-bound access token, you won’t have a client secret or other client authentication parameters. In this case, and in accordance with [RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449#section-8), Auth0 requires your DPoP HTTP header to have a <Tooltip tip="Nonce: Arbitrary number issued once in an authentication protocol to detect and prevent replay attacks." cta="View Glossary" href="/docs/glossary?term=nonce">nonce</Tooltip> value to ensure the client application recently generated the DPoP Proof JWT. This is expected behavior as it allows the Authorization Server to ensure the DPoP proof is fresh and limits the window in which a proof can be used.
 
 If a public client makes a `/token` request and doesn’t include a `nonce` value in the DPoP HTTP header, Auth0 responds with an `HTTP 400` code and an error message like the following:
 
@@ -314,7 +308,7 @@ If a public client makes a `/token` request and doesn’t include a `nonce` valu
 
 
 
-Auth0 includes a `DPoP-Nonce` header in the response headers. You must use the value of the `DPoP-Nonce` header and regenerate the DPoP proof (as in [Step 2](#step-2-client-application-creates-a-dpop-proof-jwt)), include a `nonce` claim with that value, and resubmit the request to the `/token` endpoint.
+Auth0 includes a `DPoP-Nonce` header in the response headers. This follows the standard "challenge-response" flow defined in the [DPoP specification](https://datatracker.ietf.org/doc/html/rfc9449). You must use the value of the `DPoP-Nonce` header and regenerate the DPoP proof (as in [Step 2](#step-2-client-application-creates-a-dpop-proof-jwt)), include a `nonce` claim with that value, and resubmit the request to the `/token` endpoint.
 
 The following code sample shows the end-to-end flow when making and then retrying a `/token` request with a nonce claim from a public client:
 
@@ -565,6 +559,7 @@ When implementing DPoP in your client applications, consider the following:
 
 * **Private key security:** The security of your DPoP implementation depends on the security of your client's private key, so you must protect it from unauthorized access. Private keys should be generated and stored in a hardware-backed medium and marked as non-exportable.
 * **Replay protection (**`jti`** and **`dpop-nonce`**):** The `jti` claim in the DPoP Proof JWT helps prevent replay attacks for protected resources, such as the [`/userinfo`](https://auth0.com/docs/api/authentication/user-profile/get-user-info) endpoint. The Auth0 Authorization Server currently does not check `jti` reuse on the `/userinfo` endpoint. The Auth0 Authorization Server issues a `DPoP-Nonce` HTTP header in its response, which public clients must include as a `nonce` claim in subsequent DPoP Proof JWTs for enhanced replay protection.
+* **Rate Limits:** Because the DPoP challenge-response flow can sometimes require an initial request followed by a retry with the server-provided nonce, each exchange effectively counts as two requests toward your [Auth0 tenant rate limits](https://auth0.com/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy). Ensure your application's request volume accounts for this overhead.
 * **Error handling:** You are responsible for implementing logic to handle DPoP-specific errors from the Auth0 Authorization Server or resource server, such as `invalid_dpop_proof` or `use_dpop_nonce`.
 * **Client types:** Use DPoP for public clients, such as Single Page Applications (SPAs) or mobile apps that cannot securely store a client secret. For <Tooltip tip="Confidential Client: A client (application) that can hold credentials securely by using a trusted backend server. Examples include a web application with a secure backend and a machine-to-machine (M2M) application." cta="View Glossary" href="/docs/glossary?term=confidential+clients">confidential clients</Tooltip>, such as backend services with client secrets, DPoP adds a layer of security, but they already have other sender-constraining mechanisms.
 * **Performance:** Because generating and signing DPoP Proof JWTs for every API call adds a small overhead, ensure your client application’s cryptographic operations are efficient.


### PR DESCRIPTION
## Description
Updated the DPoP docs to make it clear that the nonce behaviour is recommended in the DPoP RFC. Also highlight that this can have an impact on the RPS limits.

### References
https://auth0team.atlassian.net/browse/FGI-1811

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
