### PR TITLE
docs: update manage-refresh-tokens-actions.mdx

### DIFF
--- a/main/docs/secure/tokens/refresh-tokens/manage-refresh-tokens-actions.mdx
+++ b/main/docs/secure/tokens/refresh-tokens/manage-refresh-tokens-actions.mdx
@@ -63,13 +63,15 @@ The `api.refreshToken.setIdleExpiresAt(idle)` method sets the inactivity timeout
 
 ## Limitations
 
-Refresh tokens issued on or after 21-09-2023 (22-02-2024 for tenants in the US-3 region) contain the session ID (`session_id`) property with the appropriate value. Refresh tokens issued before this date contain this property with a `null` value.
+- Refresh tokens issued on or after 21-09-2023 (22-02-2024 for tenants in the US-3 region) contain the session ID (`session_id`) property with the appropriate value. Refresh tokens issued before this date contain this property with a `null` value.
 
-Refresh tokens issued before the release of the post-login API method `api.refreshToken.revoke(reason)` will not contain `event.refresh_token.device` information.
+- Refresh tokens issued before the release of the post-login API method `api.refreshToken.revoke(reason)` will not contain `event.refresh_token.device` information.
 
-Non-expiring refresh tokens or refresh tokens that have not been exchanged will not contain the property `event.refresh_token.last_exchanged_at`.
+- Non-expiring refresh tokens or refresh tokens that have not been exchanged will not contain the property `event.refresh_token.last_exchanged_at`.
 
-For security reasons, inactivity and absolute timeouts cannot be set above the application refresh token settings defined in the [refresh token expirations](/docs/secure/tokens/refresh-tokens/configure-refresh-token-expiration). If you attempt to set a date above the expiration settings, the API methods will update up to the [refresh token expirations](/docs/secure/tokens/refresh-tokens/configure-refresh-token-expiration) and log a warning event (`w`) in the tenant logs.
+- For security reasons, inactivity and absolute timeouts cannot be set above the application refresh token settings defined in the [refresh token expirations](/docs/secure/tokens/refresh-tokens/configure-refresh-token-expiration). If you attempt to set a date above the expiration settings, the API methods will update up to the [refresh token expirations](/docs/secure/tokens/refresh-tokens/configure-refresh-token-expiration) and log a warning event (`w`) in the tenant logs.
+
+- Both `api.refreshToken.setExpiresAt()` and `api.refreshToken.setIdleExpiresAt()` can only shorten their respective lifetimes from the current values. They cannot extend or increase the lifetime. 
 
 To learn more about refresh tokens limitations, read [Refresh Tokens limitations](/docs/secure/tokens/refresh-tokens).
 


### PR DESCRIPTION

## Description

api.refreshToken.setExpiresAt cannot increase the lifetime of the refresh token.

Per the product team:

The RT part of the API does indeed have the same limitation that tokens can only have their lifetime shortened and not increased.

Confirmed with Sessions team that `setIdleExpiresAt` has the same limitation.
 

### References

https://auth0.slack.com/archives/CMXHR8NK1/p1771530182638949

https://auth0team.atlassian.net/browse/DOCS-4603

https://auth0team.atlassian.net/browse/ESD-43736



## Checklist

- [ x] I've read and followed [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ x] I've tested the site build for this change locally.
- [ x] I've made appropriate docs updates for any code or config changes.
- [ x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
