### PR TITLE
Added more flags to the auth0 cli command for a simpler setup 

### DIFF
--- a/main/docs/quickstart/spa/react/index.mdx
+++ b/main/docs/quickstart/spa/react/index.mdx
@@ -98,7 +98,7 @@ import {CreateInteractiveApp} from "/snippets/recipe.jsx";
     brew tap auth0/auth0-cli && brew install auth0
 
     # Set up Auth0 app and generate .env file
-    auth0 quickstarts setup --type vite
+    auth0 qs setup --type vite -n "My App" -p 5173
 
   If Windows (PowerShell):
     # Install Auth0 CLI if not already installed
@@ -106,7 +106,7 @@ import {CreateInteractiveApp} from "/snippets/recipe.jsx";
     scoop install auth0
 
     # Set up Auth0 app and generate .env file
-    auth0 quickstarts setup --type vite
+    auth0 qs setup --type vite -n "My App" -p 5173
 
   This command will automatically:
   - Authenticate you with Auth0 (prompts for login if needed)
@@ -736,7 +736,7 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
           brew tap auth0/auth0-cli && brew install auth0
 
           # Set up Auth0 app and generate .env file
-          auth0 quickstarts setup --type vite
+          auth0 qs setup --type vite -n "My App" -p 5173
           ```
 
           ```powershell Windows
@@ -745,7 +745,7 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
           scoop install auth0
 
           # Set up Auth0 app and generate .env file
-          auth0 quickstarts setup --type vite
+          auth0 qs setup --type vite -n "My App" -p 5173
           ```
         </CodeGroup>
 

--- a/main/docs/quickstart/spa/svelte/index.mdx
+++ b/main/docs/quickstart/spa/svelte/index.mdx
@@ -73,7 +73,7 @@ import {CreateInteractiveApp} from "/snippets/recipe.jsx";
     brew tap auth0/auth0-cli && brew install auth0
 
     # Set up Auth0 app and generate .env file
-    auth0 quickstarts setup --type vite
+    auth0 qs setup --type vite -n "My App" -p 5173
 
   If Windows (PowerShell):
     # Install Auth0 CLI if not already installed
@@ -81,7 +81,7 @@ import {CreateInteractiveApp} from "/snippets/recipe.jsx";
     scoop install auth0
 
     # Set up Auth0 app and generate .env file
-    auth0 quickstarts setup --type vite
+    auth0 qs setup --type vite -n "My App" -p 5173
 
   This command will automatically:
   - Authenticate you with Auth0 (prompts for login if needed)
@@ -161,7 +161,7 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
           brew tap auth0/auth0-cli && brew install auth0
 
           # Set up Auth0 app and generate .env file
-          auth0 quickstarts setup --type vite
+          auth0 qs setup --type vite -n "My App" -p 5173
           ```
 
           ```powershell Windows
@@ -170,7 +170,7 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
           scoop install auth0
 
           # Set up Auth0 app and generate .env file
-          auth0 quickstarts setup --type vite
+          auth0 qs setup --type vite -n "My App" -p 5173
           ```
         </CodeGroup>
 

--- a/main/docs/quickstart/spa/vanillajs/index.mdx
+++ b/main/docs/quickstart/spa/vanillajs/index.mdx
@@ -116,7 +116,7 @@ If MacOS:
   brew tap auth0/auth0-cli && brew install auth0
 
   # Set up Auth0 app and generate .env file
-  auth0 quickstarts setup --type vite
+  auth0 qs setup --type vite -n "My App" -p 5173
 
 If Windows (PowerShell):
   # Install Auth0 CLI if not already installed
@@ -124,7 +124,7 @@ If Windows (PowerShell):
   scoop install auth0
 
   # Set up Auth0 app and generate .env file
-  auth0 quickstarts setup --type vite
+  auth0 qs setup --type vite -n "My App" -p 5173
 
 This command will automatically:
 - Authenticate you with Auth0 (prompts for login if needed)
@@ -897,7 +897,7 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
           brew tap auth0/auth0-cli && brew install auth0
 
           # Set up Auth0 app and generate .env file
-          auth0 quickstarts setup --type vite
+          auth0 qs setup --type vite -n "My App" -p 5173
           ```
 
           ```powershell Windows
@@ -906,7 +906,7 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
           scoop install auth0
 
           # Set up Auth0 app and generate .env file
-          auth0 quickstarts setup --type vite
+          auth0 qs setup --type vite -n "My App" -p 5173
           ```
         </CodeGroup>
 

--- a/main/docs/quickstart/spa/vuejs/index.mdx
+++ b/main/docs/quickstart/spa/vuejs/index.mdx
@@ -98,14 +98,14 @@ If MacOS:
   brew tap auth0/auth0-cli && brew install auth0
 
   # Set up Auth0 app and generate .env file
-  auth0 quickstarts setup --type vite
+  auth0 qs setup --type vite -n "My App" -p 5173
 
 If Windows:
   # Install Auth0 CLI if not already installed
   winget install Auth0.CLI
 
   # Set up Auth0 app and generate .env file
-  auth0 quickstarts setup --type vite
+  auth0 qs setup --type vite -n "My App" -p 5173
 
 This command will automatically:
 - Authenticate you with Auth0 (prompts for login if needed)
@@ -777,7 +777,7 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
           brew tap auth0/auth0-cli && brew install auth0
 
           # Set up Auth0 app and generate .env file
-          auth0 quickstarts setup --type vite
+          auth0 qs setup --type vite -n "My App" -p 5173
           ```
 
           ```powershell Windows
@@ -786,7 +786,7 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
           scoop install auth0
 
           # Set up Auth0 app and generate .env file
-          auth0 quickstarts setup --type vite
+          auth0 qs setup --type vite -n "My App" -p 5173
           ```
         </CodeGroup>
 

--- a/main/docs/quickstart/webapp/nextjs/index.mdx
+++ b/main/docs/quickstart/webapp/nextjs/index.mdx
@@ -118,7 +118,7 @@ import {CreateInteractiveApp} from "/snippets/recipe.jsx";
     brew tap auth0/auth0-cli && brew install auth0
 
     # Set up Auth0 app and generate .env.local file
-    auth0 quickstarts setup --type nextjs
+    auth0 qs setup --type nextjs -n "My App" -p 3000
 
   If Windows (PowerShell):
     # Install Auth0 CLI if not already installed
@@ -126,7 +126,7 @@ import {CreateInteractiveApp} from "/snippets/recipe.jsx";
     scoop install auth0
 
     # Set up Auth0 app and generate .env.local file
-    auth0 quickstarts setup --type nextjs
+    auth0 qs setup --type nextjs -n "My App" -p 3000
 
   This command will automatically:
   - Authenticate you with Auth0 (prompts for login if needed)
@@ -776,7 +776,7 @@ APP_BASE_URL=http://localhost:3000`;
           brew tap auth0/auth0-cli && brew install auth0
 
           # Set up Auth0 app and generate .env.local file
-          auth0 quickstarts setup --type nextjs
+          auth0 qs setup --type nextjs -n "My App" -p 3000
           ```
 
           ```powershell Windows
@@ -785,7 +785,7 @@ APP_BASE_URL=http://localhost:3000`;
           scoop install auth0
 
           # Set up Auth0 app and generate .env.local file
-          auth0 quickstarts setup --type nextjs
+          auth0 qs setup --type nextjs -n "My App" -p 3000
           ```
         </CodeGroup>
 


### PR DESCRIPTION
## Description
For Vite-based projects (React, Vue.js, Vanilla JS, Svelte):
  - Before: auth0 quickstarts setup --type vite
  - After: auth0 qs setup --type vite -n "My App" -p 5173

  For Next.js:
  - Before: auth0 quickstarts setup --type nextjs
  - After: auth0 qs setup --type nextjs -n "My App" -p 3000

## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
