### PR TITLE
fix: Add missing comma to node jwt example

### DIFF
--- a/main/docs/get-started/authentication-and-authorization-flow/authorization-code-flow/authorization-code-flow-with-jar.mdx
+++ b/main/docs/get-started/authentication-and-authorization-flow/authorization-code-flow/authorization-code-flow-with-jar.mdx
@@ -72,7 +72,7 @@ const requestObject = jwt.sign(
   client_id,
   response_type: "code",
   scope: "openid profile",
-  redirect_uri : "https://myapp.com/callback" // your app's callback URL
+  redirect_uri : "https://myapp.com/callback", // your app's callback URL
   nonce
 },
 privateKey,


### PR DESCRIPTION
## Description
The documentation page for the authorization flow with JAR has some example code to build and sign a JWT with node. This PR adds a missing comma that is necessary for the example code to run properly.

### References
No JIRA ticket since this is a very small change.

### Testing
Checked the output running `mint dev`

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
