### PR TITLE
chore: regenerate actions trigger docs with frontmatter comment

### DIFF
--- a/main/docs/customize/actions/explore-triggers/event-stream-triggers/event-stream-api-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/event-stream-triggers/event-stream-api-object.mdx
@@ -1,7 +1,11 @@
 ---
+#
+# THIS FILE IS AUTO-GENERATED.
+# DO NOT EDIT MANUALLY.
+#
 description: Learn about the event-stream Action trigger's API object.
 title: 'Actions Triggers: event-stream - API Object'
-validatedOn: 2026-02-25
+validatedOn: 2026-02-26
 ---
 
 The API object for the event-stream Actions trigger includes:

--- a/main/docs/customize/actions/explore-triggers/event-stream-triggers/event-stream-event-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/event-stream-triggers/event-stream-event-object.mdx
@@ -1,7 +1,11 @@
 ---
+#
+# THIS FILE IS AUTO-GENERATED.
+# DO NOT EDIT MANUALLY.
+#
 description: Learn about the event-stream Action trigger's event object, which provides contextual information about the trigger execution.
 title: 'Actions Triggers: event-stream - Event Object'
-validatedOn: 2026-02-25
+validatedOn: 2026-02-26
 ---
 
 The `event` object for the event-stream Actions trigger provides contextual information about the trigger execution.

--- a/main/docs/customize/actions/explore-triggers/machine-to-machine-trigger/credentials-exchange-api-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/machine-to-machine-trigger/credentials-exchange-api-object.mdx
@@ -1,7 +1,11 @@
 ---
+#
+# THIS FILE IS AUTO-GENERATED.
+# DO NOT EDIT MANUALLY.
+#
 description: Learn about the credentials-exchange Action trigger's API object.
 title: 'Actions Triggers: credentials-exchange - API Object'
-validatedOn: 2026-02-25
+validatedOn: 2026-02-26
 ---
 
 The API object for the credentials-exchange Actions trigger includes:

--- a/main/docs/customize/actions/explore-triggers/machine-to-machine-trigger/credentials-exchange-event-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/machine-to-machine-trigger/credentials-exchange-event-object.mdx
@@ -1,7 +1,11 @@
 ---
+#
+# THIS FILE IS AUTO-GENERATED.
+# DO NOT EDIT MANUALLY.
+#
 description: Learn about the credentials-exchange Action trigger's event object, which provides contextual information about the trigger execution.
 title: 'Actions Triggers: credentials-exchange - Event Object'
-validatedOn: 2026-02-25
+validatedOn: 2026-02-26
 ---
 
 The `event` object for the credentials-exchange Actions trigger provides contextual information about the trigger execution.

--- a/main/docs/customize/actions/explore-triggers/mfa-notifications-trigger/send-phone-message-api-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/mfa-notifications-trigger/send-phone-message-api-object.mdx
@@ -1,7 +1,11 @@
 ---
+#
+# THIS FILE IS AUTO-GENERATED.
+# DO NOT EDIT MANUALLY.
+#
 description: Learn about the send-phone-message Action trigger's API object.
 title: 'Actions Triggers: send-phone-message - API Object'
-validatedOn: 2026-02-25
+validatedOn: 2026-02-26
 ---
 
 The API object for the send-phone-message Actions trigger includes:

--- a/main/docs/customize/actions/explore-triggers/mfa-notifications-trigger/send-phone-message-event-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/mfa-notifications-trigger/send-phone-message-event-object.mdx
@@ -1,7 +1,11 @@
 ---
+#
+# THIS FILE IS AUTO-GENERATED.
+# DO NOT EDIT MANUALLY.
+#
 description: Learn about the send-phone-message Action trigger's event object, which provides contextual information about the trigger execution.
 title: 'Actions Triggers: send-phone-message - Event Object'
-validatedOn: 2026-02-25
+validatedOn: 2026-02-26
 ---
 
 The `event` object for the send-phone-message Actions trigger provides contextual information about the trigger execution.

--- a/main/docs/customize/actions/explore-triggers/password-reset-triggers/post-challenge-trigger/post-challenge-api-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/password-reset-triggers/post-challenge-trigger/post-challenge-api-object.mdx
@@ -1,7 +1,11 @@
 ---
+#
+# THIS FILE IS AUTO-GENERATED.
+# DO NOT EDIT MANUALLY.
+#
 description: Learn about the password-reset-post-challenge Action trigger's API object.
 title: 'Actions Triggers: password-reset-post-challenge - API Object'
-validatedOn: 2026-02-25
+validatedOn: 2026-02-26
 ---
 
 The API object for the password-reset-post-challenge Actions trigger includes:

--- a/main/docs/customize/actions/explore-triggers/password-reset-triggers/post-challenge-trigger/post-challenge-event-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/password-reset-triggers/post-challenge-trigger/post-challenge-event-object.mdx
@@ -1,7 +1,11 @@
 ---
+#
+# THIS FILE IS AUTO-GENERATED.
+# DO NOT EDIT MANUALLY.
+#
 description: Learn about the password-reset-post-challenge Action trigger's event object, which provides contextual information about the trigger execution.
 title: 'Actions Triggers: password-reset-post-challenge - Event Object'
-validatedOn: 2026-02-25
+validatedOn: 2026-02-26
 ---
 
 The `event` object for the password-reset-post-challenge Actions trigger provides contextual information about the trigger execution.

--- a/main/docs/customize/actions/explore-triggers/password-reset-triggers/post-change-password-trigger/post-change-password-api-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/password-reset-triggers/post-change-password-trigger/post-change-password-api-object.mdx
@@ -1,7 +1,11 @@
 ---
+#
+# THIS FILE IS AUTO-GENERATED.
+# DO NOT EDIT MANUALLY.
+#
 description: Learn about the post-change-password Action trigger's API object.
 title: 'Actions Triggers: post-change-password - API Object'
-validatedOn: 2026-02-25
+validatedOn: 2026-02-26
 ---
 
 The API object for the post-change-password Actions trigger includes:

--- a/main/docs/customize/actions/explore-triggers/password-reset-triggers/post-change-password-trigger/post-change-password-event-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/password-reset-triggers/post-change-password-trigger/post-change-password-event-object.mdx
@@ -1,7 +1,11 @@
 ---
+#
+# THIS FILE IS AUTO-GENERATED.
+# DO NOT EDIT MANUALLY.
+#
 description: Learn about the post-change-password Action trigger's event object, which provides contextual information about the trigger execution.
 title: 'Actions Triggers: post-change-password - Event Object'
-validatedOn: 2026-02-25
+validatedOn: 2026-02-26
 ---
 
 The `event` object for the post-change-password Actions trigger provides contextual information about the trigger execution.

--- a/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/custom-token-exchange-trigger/custom-token-exchange-api-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/custom-token-exchange-trigger/custom-token-exchange-api-object.mdx
@@ -1,7 +1,11 @@
 ---
+#
+# THIS FILE IS AUTO-GENERATED.
+# DO NOT EDIT MANUALLY.
+#
 description: Learn about the custom-token-exchange Action trigger's API object.
 title: 'Actions Triggers: custom-token-exchange - API Object'
-validatedOn: 2026-02-25
+validatedOn: 2026-02-26
 ---
 
 The API object for the custom-token-exchange Actions trigger includes:

--- a/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/custom-token-exchange-trigger/custom-token-exchange-event-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/custom-token-exchange-trigger/custom-token-exchange-event-object.mdx
@@ -1,7 +1,11 @@
 ---
+#
+# THIS FILE IS AUTO-GENERATED.
+# DO NOT EDIT MANUALLY.
+#
 description: Learn about the custom-token-exchange Action trigger's event object, which provides contextual information about the trigger execution.
 title: 'Actions Triggers: custom-token-exchange - Event Object'
-validatedOn: 2026-02-25
+validatedOn: 2026-02-26
 ---
 
 The `event` object for the custom-token-exchange Actions trigger provides contextual information about the trigger execution.

--- a/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-api-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-api-object.mdx
@@ -1,7 +1,11 @@
 ---
+#
+# THIS FILE IS AUTO-GENERATED.
+# DO NOT EDIT MANUALLY.
+#
 description: Learn about the post-login Action trigger's API object.
 title: 'Actions Triggers: post-login - API Object'
-validatedOn: 2026-02-25
+validatedOn: 2026-02-26
 ---
 
 The API object for the post-login Actions trigger includes:

--- a/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-event-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-event-object.mdx
@@ -1,7 +1,11 @@
 ---
+#
+# THIS FILE IS AUTO-GENERATED.
+# DO NOT EDIT MANUALLY.
+#
 description: Learn about the post-login Action trigger's event object, which provides contextual information about the trigger execution.
 title: 'Actions Triggers: post-login - Event Object'
-validatedOn: 2026-02-25
+validatedOn: 2026-02-26
 ---
 
 The `event` object for the post-login Actions trigger provides contextual information about the trigger execution.
@@ -750,7 +754,7 @@ The `event` object for the post-login Actions trigger provides contextual inform
       Correlation ID can be provided in the initial authentication request when the application redirects to Universal Login. You can use value to correlate logs and requests from your Action code with the user flow.
     </ResponseField>
     <ResponseField name="metadata" type="dictionary">
-      [Limited Early Access] An object containing shared data across custom Actions for the duration of a transaction.
+      An object containing shared data across custom Actions for the duration of a transaction.
     </ResponseField>
   </Expandable>
 </ResponseField>

--- a/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/post-user-registration-trigger/post-user-registration-api-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/post-user-registration-trigger/post-user-registration-api-object.mdx
@@ -1,7 +1,11 @@
 ---
+#
+# THIS FILE IS AUTO-GENERATED.
+# DO NOT EDIT MANUALLY.
+#
 description: Learn about the post-user-registration Action trigger's API object.
 title: 'Actions Triggers: post-user-registration - API Object'
-validatedOn: 2026-02-25
+validatedOn: 2026-02-26
 ---
 
 The API object for the post-user-registration Actions trigger includes:

--- a/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/post-user-registration-trigger/post-user-registration-event-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/post-user-registration-trigger/post-user-registration-event-object.mdx
@@ -1,7 +1,11 @@
 ---
+#
+# THIS FILE IS AUTO-GENERATED.
+# DO NOT EDIT MANUALLY.
+#
 description: Learn about the post-user-registration Action trigger's event object, which provides contextual information about the trigger execution.
 title: 'Actions Triggers: post-user-registration - Event Object'
-validatedOn: 2026-02-25
+validatedOn: 2026-02-26
 ---
 
 The `event` object for the post-user-registration Actions trigger provides contextual information about the trigger execution.

--- a/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/pre-user-registration-trigger/pre-user-registration-api-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/pre-user-registration-trigger/pre-user-registration-api-object.mdx
@@ -1,7 +1,11 @@
 ---
+#
+# THIS FILE IS AUTO-GENERATED.
+# DO NOT EDIT MANUALLY.
+#
 description: Learn about the pre-user-registration Action trigger's API object.
 title: 'Actions Triggers: pre-user-registration - API Object'
-validatedOn: 2026-02-25
+validatedOn: 2026-02-26
 ---
 
 The API object for the pre-user-registration Actions trigger includes:

--- a/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/pre-user-registration-trigger/pre-user-registration-event-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/pre-user-registration-trigger/pre-user-registration-event-object.mdx
@@ -1,7 +1,11 @@
 ---
+#
+# THIS FILE IS AUTO-GENERATED.
+# DO NOT EDIT MANUALLY.
+#
 description: Learn about the pre-user-registration Action trigger's event object, which provides contextual information about the trigger execution.
 title: 'Actions Triggers: pre-user-registration - Event Object'
-validatedOn: 2026-02-25
+validatedOn: 2026-02-26
 ---
 
 The `event` object for the pre-user-registration Actions trigger provides contextual information about the trigger execution.

--- a/main/docs/customize/email/smtp-email-providers/custom/action-triggers-custom-email-provider-api-object.mdx
+++ b/main/docs/customize/email/smtp-email-providers/custom/action-triggers-custom-email-provider-api-object.mdx
@@ -1,7 +1,11 @@
 ---
+#
+# THIS FILE IS AUTO-GENERATED.
+# DO NOT EDIT MANUALLY.
+#
 description: Learn about the custom-email-provider Action trigger's API object.
 title: 'Actions Triggers: custom-email-provider - API Object'
-validatedOn: 2026-02-25
+validatedOn: 2026-02-26
 ---
 
 The API object for the custom-email-provider Actions trigger includes:

--- a/main/docs/customize/email/smtp-email-providers/custom/action-triggers-custom-email-provider-event-object.mdx
+++ b/main/docs/customize/email/smtp-email-providers/custom/action-triggers-custom-email-provider-event-object.mdx
@@ -1,7 +1,11 @@
 ---
+#
+# THIS FILE IS AUTO-GENERATED.
+# DO NOT EDIT MANUALLY.
+#
 description: Learn about the custom-email-provider Action trigger's event object, which provides contextual information about the trigger execution.
 title: 'Actions Triggers: custom-email-provider - Event Object'
-validatedOn: 2026-02-25
+validatedOn: 2026-02-26
 ---
 
 The `event` object for the custom-email-provider Actions trigger provides contextual information about the trigger execution.

--- a/main/docs/customize/phone-messages/configure-phone-messaging-providers/configure-a-custom-phone-provider/action-triggers-custom-phone-provider-api-object.mdx
+++ b/main/docs/customize/phone-messages/configure-phone-messaging-providers/configure-a-custom-phone-provider/action-triggers-custom-phone-provider-api-object.mdx
@@ -1,7 +1,11 @@
 ---
+#
+# THIS FILE IS AUTO-GENERATED.
+# DO NOT EDIT MANUALLY.
+#
 description: Learn about the custom-phone-provider Action trigger's API object.
 title: 'Actions Triggers: custom-phone-provider - API Object'
-validatedOn: 2026-02-25
+validatedOn: 2026-02-26
 ---
 
 The API object for the custom-phone-provider Actions trigger includes:

--- a/main/docs/customize/phone-messages/configure-phone-messaging-providers/configure-a-custom-phone-provider/actions-triggers-custom-phone-provider-event-object.mdx
+++ b/main/docs/customize/phone-messages/configure-phone-messaging-providers/configure-a-custom-phone-provider/actions-triggers-custom-phone-provider-event-object.mdx
@@ -1,7 +1,11 @@
 ---
+#
+# THIS FILE IS AUTO-GENERATED.
+# DO NOT EDIT MANUALLY.
+#
 description: Learn about the custom-phone-provider Action trigger's event object, which provides contextual information about the trigger execution.
 title: 'Actions Triggers: custom-phone-provider - Event Object'
-validatedOn: 2026-02-25
+validatedOn: 2026-02-26
 ---
 
 The `event` object for the custom-phone-provider Actions trigger provides contextual information about the trigger execution.


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

Regenerated our Actions trigger documentation with the new YAML comment indicating the docs are automatically generated and should not be manually edited.

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](../CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
