### PR TITLE
fix: Updated Contributor guidelines link in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,7 +25,7 @@
 
 ## Checklist
 
-- [ ] I've read and followed [`CONTRIBUTING.md`](CONTRIBUTING.md).
+- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
 - [ ] I've tested the site build for this change locally.
 - [ ] I've made appropriate docs updates for any code or config changes.
 - [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

Link to our contributor's guide was not working in our PR template. 

<img width="577" height="148" alt="Screenshot 2026-02-26 at 9 43 00 AM" src="https://github.com/user-attachments/assets/f0322eae-0aed-457d-b5de-12f093bdd336" />

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
