### PR TITLE
docs: regenerate post-login docs to include ea tags

### DIFF
--- a/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-api-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-api-object.mdx
@@ -5,7 +5,7 @@
 #
 description: Learn about the post-login Action trigger's API object.
 title: 'Actions Triggers: post-login - API Object'
-validatedOn: 2026-02-26
+validatedOn: 2026-02-27
 ---
 
 The API object for the post-login Actions trigger includes:
@@ -897,7 +897,7 @@ When called multiple times, the earliest expiration time will be used.
 
 ### `api.session.setCookieMode(mode)`
 
-[Enterprise Customers] Sets the cookie mode for the current session, allowing it to be either 'persistent' or 'non-persistent' (ephemeral).
+[Enterprise Customers] [Early Access] Sets the cookie mode for the current session, allowing it to be either 'persistent' or 'non-persistent' (ephemeral).
 This determines how the session cookie is handled in the browser:
 - 'persistent': The cookie will be stored until it expires or is deleted by the user.
 - 'non-persistent' (ephemeral): The cookie will be deleted when the browser is closed.
@@ -915,7 +915,7 @@ or the session is revoked through our available APIs. For more information on co
 
 ### `api.session.setMetadata(key, value)`
 
-[Enterprise Customers] Sets a key value pair in the metadata object of the current session.
+[Enterprise Customers] [Limited Early Access] Sets a key value pair in the metadata object of the current session.
 
 <ResponseField name="key" type="string">
   Required, the key to set in the metadata object.
@@ -926,7 +926,7 @@ or the session is revoked through our available APIs. For more information on co
 
 ### `api.session.deleteMetadata(key)`
 
-[Enterprise Customers] Deletes a key in the metadata object of the current session.
+[Enterprise Customers] [Limited Early Access] Deletes a key in the metadata object of the current session.
 
 <ResponseField name="key" type="string">
   Required, the key to delete from the metadata object.
@@ -934,7 +934,7 @@ or the session is revoked through our available APIs. For more information on co
 
 ### `api.session.evictMetadata()`
 
-[Enterprise Customers] Deletes all keys from the metadata object of the current session.
+[Enterprise Customers] [Limited Early Access] Deletes all keys from the metadata object of the current session.
 
 ## `api.transaction`
 

--- a/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-event-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-event-object.mdx
@@ -5,7 +5,7 @@
 #
 description: Learn about the post-login Action trigger's event object, which provides contextual information about the trigger execution.
 title: 'Actions Triggers: post-login - Event Object'
-validatedOn: 2026-02-26
+validatedOn: 2026-02-27
 ---
 
 The `event` object for the post-login Actions trigger provides contextual information about the trigger execution.
@@ -154,6 +154,7 @@ The `event` object for the post-login Actions trigger provides contextual inform
           Allowed values: `low`, `medium`, `high`, `neutral`
         </ResponseField>
         <ResponseField name="supplemental" type="dictionary" post={["optional"]}>
+          [Limited Early Access] Supplemental risk assessment.
           <Expandable title="supplemental properties">
             <ResponseField name="akamai" type="dictionary" post={["optional"]}>
               [Limited Early Access] Supplemental risk assessment.
@@ -575,10 +576,10 @@ The `event` object for the post-login Actions trigger provides contextual inform
       [Enterprise Customers] The date and time when the session was last successfully interacted with.
     </ResponseField>
     <ResponseField name="metadata" type="dictionary" post={["optional"]}>
-      [Enterprise Customers] Session Metadata
+      [Enterprise Customers] [Limited Early Access] Session Metadata
     </ResponseField>
     <ResponseField name="session_transfer" type="dictionary" post={["optional"]}>
-      [Enterprise Customers] This object is defined when the session is created from a session transfer token (Native to Web SSO), undefined otherwise.
+      [Enterprise Customers] [Limited Early Access] This object is defined when the session is created from a session transfer token (Native to Web SSO), undefined otherwise.
       <Expandable title="session_transfer properties" defaultOpen>
         <ResponseField name="parent_refresh_token" type="dictionary" post={["optional"]}>
           [Enterprise Customers] This object is defined when the refresh token is created from a session initiated as a result of session transfer (Native to Web SSO), undefined otherwise.


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

Regenerate post-login trigger docs to include missing EA tags.

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
