### PR TITLE
Fix for claude code command to add docs MCP server

### DIFF
--- a/auth4genai/build-with-ai/using-ai-tools.mdx
+++ b/auth4genai/build-with-ai/using-ai-tools.mdx
@@ -93,7 +93,7 @@ Or follow these steps to connect the MCP server:
   </Step>
 </Steps>
 
-To learn more, read [Installing MCP servers](https://docs.cursor.com/en/context/mcp#installing-mcp-servers).
+To learn more, read [Installing MCP servers](https://cursor.com/docs/context/mcp#installing-mcp-servers).
 </Tab>
 
 <Tab title="Claude Code">


### PR DESCRIPTION
Error when using command with Claude Code to add MCP server: Invalid name Auth0 for AI Agents. Names can only contain letters, numbers, hyphens, and underscores.

Updated name to valid string

<img width="868" height="98" alt="image" src="https://github.com/user-attachments/assets/32b50e7b-2c0a-4fdf-b7e3-10fc3c548cc3" />
