### PR TITLE
feat: add mgmt-api redirects

### DIFF
--- a/main/docs.json
+++ b/main/docs.json
@@ -8630,7 +8630,7 @@
     },
     {
       "source": "/docs/api/management/v2/guardian/put-factor-duo-settings",
-      "destination": "/docs/api/management/v2/guardian/update-the-duo-configuration"
+      "destination": "/docs/api/management/v2/guardian/set-the-duo-configuration"
     },
     {
       "source": "/docs/api/management/v2/guardian/get-message-types",
@@ -8682,7 +8682,7 @@
     },
     {
       "source": "/docs/api/management/v2/guardian/put-fcm",
-      "destination": "/docs/api/management/v2/guardian/updates-fcm-configuration"
+      "destination": "/docs/api/management/v2/guardian/overwrite-fcm-configuration"
     },
     {
       "source": "/docs/api/management/v2/guardian/patch-fcmv-1",
@@ -8690,7 +8690,7 @@
     },
     {
       "source": "/docs/api/management/v2/guardian/put-fcmv-1",
-      "destination": "/docs/api/management/v2/guardian/updates-fcmv-1-configuration"
+      "destination": "/docs/api/management/v2/guardian/overwrite-fcmv-1-configuration"
     },
     {
       "source": "/docs/api/management/v2/guardian/get-sns",
@@ -8702,7 +8702,7 @@
     },
     {
       "source": "/docs/api/management/v2/guardian/put-sns",
-      "destination": "/docs/api/management/v2/guardian/update-aws-sns-configuration"
+      "destination": "/docs/api/management/v2/guardian/configure-aws-sns-configuration"
     },
     {
       "source": "/docs/api/management/v2/guardian/get-pn-providers",


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

This PR adds `redirects` for the Management API Explorer for transitioning from `v1` to `v2`.
### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

```
cd main
mint dev
```

Confirmed that navigating to the `source` URL redirects to the `destination` URL.

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
