### PR TITLE
fix: duplicate scopes in API Explorer

### DIFF
--- a/main/docs/api/myorganization/config/get-configuration.mdx
+++ b/main/docs/api/myorganization/config/get-configuration.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["read:my_org:configuration","read:my_org:configuration"]} />
+<Scopes scopes={["read:my_org:configuration"]} />

--- a/main/docs/api/myorganization/config/get-identity-providers-configuration.mdx
+++ b/main/docs/api/myorganization/config/get-identity-providers-configuration.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["read:my_org:configuration","read:my_org:configuration"]} />
+<Scopes scopes={["read:my_org:configuration"]} />

--- a/main/docs/api/myorganization/idp-management/associate-domain-with-identity-provider.mdx
+++ b/main/docs/api/myorganization/idp-management/associate-domain-with-identity-provider.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["create:my_org:identity_providers_domains","create:my_org:identity_providers_domains"]} />
+<Scopes scopes={["create:my_org:identity_providers_domains"]} />

--- a/main/docs/api/myorganization/idp-management/create-identity-provider.mdx
+++ b/main/docs/api/myorganization/idp-management/create-identity-provider.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["create:my_org:identity_providers","create:my_org:identity_providers"]} />
+<Scopes scopes={["create:my_org:identity_providers"]} />

--- a/main/docs/api/myorganization/idp-management/create-provisioning-configuration.mdx
+++ b/main/docs/api/myorganization/idp-management/create-provisioning-configuration.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["create:my_org:identity_providers_provisioning","create:my_org:identity_providers_provisioning"]} />
+<Scopes scopes={["create:my_org:identity_providers_provisioning"]} />

--- a/main/docs/api/myorganization/idp-management/create-provisioning-scim-token.mdx
+++ b/main/docs/api/myorganization/idp-management/create-provisioning-scim-token.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["create:my_org:identity_providers_scim_tokens","create:my_org:identity_providers_scim_tokens"]} />
+<Scopes scopes={["create:my_org:identity_providers_scim_tokens"]} />

--- a/main/docs/api/myorganization/idp-management/delete-identity-provider.mdx
+++ b/main/docs/api/myorganization/idp-management/delete-identity-provider.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["delete:my_org:identity_providers","delete:my_org:identity_providers"]} />
+<Scopes scopes={["delete:my_org:identity_providers"]} />

--- a/main/docs/api/myorganization/idp-management/delete-provisioning-configuration.mdx
+++ b/main/docs/api/myorganization/idp-management/delete-provisioning-configuration.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["delete:my_org:identity_providers_provisioning","delete:my_org:identity_providers_provisioning"]} />
+<Scopes scopes={["delete:my_org:identity_providers_provisioning"]} />

--- a/main/docs/api/myorganization/idp-management/detach-identity-provider-from-organization.mdx
+++ b/main/docs/api/myorganization/idp-management/detach-identity-provider-from-organization.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["update:my_org:identity_providers_detach","update:my_org:identity_providers_detach"]} />
+<Scopes scopes={["update:my_org:identity_providers_detach"]} />

--- a/main/docs/api/myorganization/idp-management/get-identity-provider.mdx
+++ b/main/docs/api/myorganization/idp-management/get-identity-provider.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["read:my_org:identity_providers","read:my_org:identity_providers"]} />
+<Scopes scopes={["read:my_org:identity_providers"]} />

--- a/main/docs/api/myorganization/idp-management/get-provisioning-configuration.mdx
+++ b/main/docs/api/myorganization/idp-management/get-provisioning-configuration.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["read:my_org:identity_providers_provisioning","read:my_org:identity_providers_provisioning"]} />
+<Scopes scopes={["read:my_org:identity_providers_provisioning"]} />

--- a/main/docs/api/myorganization/idp-management/list-identity-providers.mdx
+++ b/main/docs/api/myorganization/idp-management/list-identity-providers.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["read:my_org:identity_providers","read:my_org:identity_providers"]} />
+<Scopes scopes={["read:my_org:identity_providers"]} />

--- a/main/docs/api/myorganization/idp-management/list-provisioning-scim-tokens.mdx
+++ b/main/docs/api/myorganization/idp-management/list-provisioning-scim-tokens.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["read:my_org:identity_providers_scim_tokens","read:my_org:identity_providers_scim_tokens"]} />
+<Scopes scopes={["read:my_org:identity_providers_scim_tokens"]} />

--- a/main/docs/api/myorganization/idp-management/refresh-identity-provider-attributes-mapping.mdx
+++ b/main/docs/api/myorganization/idp-management/refresh-identity-provider-attributes-mapping.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["update:my_org:identity_providers","update:my_org:identity_providers"]} />
+<Scopes scopes={["update:my_org:identity_providers"]} />

--- a/main/docs/api/myorganization/idp-management/refresh-provisioning-configuration-attributes-mapping.mdx
+++ b/main/docs/api/myorganization/idp-management/refresh-provisioning-configuration-attributes-mapping.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["update:my_org:identity_providers_provisioning","update:my_org:identity_providers_provisioning"]} />
+<Scopes scopes={["update:my_org:identity_providers_provisioning"]} />

--- a/main/docs/api/myorganization/idp-management/remove-domain-from-identity-provider.mdx
+++ b/main/docs/api/myorganization/idp-management/remove-domain-from-identity-provider.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["delete:my_org:identity_providers_domains","delete:my_org:identity_providers_domains"]} />
+<Scopes scopes={["delete:my_org:identity_providers_domains"]} />

--- a/main/docs/api/myorganization/idp-management/revoke-provisioning-scim-token.mdx
+++ b/main/docs/api/myorganization/idp-management/revoke-provisioning-scim-token.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["delete:my_org:identity_providers_scim_tokens","delete:my_org:identity_providers_scim_tokens"]} />
+<Scopes scopes={["delete:my_org:identity_providers_scim_tokens"]} />

--- a/main/docs/api/myorganization/idp-management/update-identity-provider.mdx
+++ b/main/docs/api/myorganization/idp-management/update-identity-provider.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["update:my_org:identity_providers","update:my_org:identity_providers"]} />
+<Scopes scopes={["update:my_org:identity_providers"]} />

--- a/main/docs/api/myorganization/org-details/get-organization-details.mdx
+++ b/main/docs/api/myorganization/org-details/get-organization-details.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["read:my_org:details","read:my_org:details"]} />
+<Scopes scopes={["read:my_org:details"]} />

--- a/main/docs/api/myorganization/org-details/modify-organization-details.mdx
+++ b/main/docs/api/myorganization/org-details/modify-organization-details.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["update:my_org:details","update:my_org:details"]} />
+<Scopes scopes={["update:my_org:details"]} />

--- a/main/docs/api/myorganization/org-domain-management/create-a-domain-for-an-organization.mdx
+++ b/main/docs/api/myorganization/org-domain-management/create-a-domain-for-an-organization.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["create:my_org:domains","create:my_org:domains"]} />
+<Scopes scopes={["create:my_org:domains"]} />

--- a/main/docs/api/myorganization/org-domain-management/delete-domain-from-organization.mdx
+++ b/main/docs/api/myorganization/org-domain-management/delete-domain-from-organization.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["delete:my_org:domains","delete:my_org:domains"]} />
+<Scopes scopes={["delete:my_org:domains"]} />

--- a/main/docs/api/myorganization/org-domain-management/get-identity-providers-associated-with-an-organization-domain.mdx
+++ b/main/docs/api/myorganization/org-domain-management/get-identity-providers-associated-with-an-organization-domain.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["read:my_org:domains","read:my_org:identity_providers","read:my_org:domains","read:my_org:identity_providers"]} />
+<Scopes scopes={["read:my_org:domains","read:my_org:identity_providers"]} />

--- a/main/docs/api/myorganization/org-domain-management/get-organization-domain.mdx
+++ b/main/docs/api/myorganization/org-domain-management/get-organization-domain.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["read:my_org:domains","read:my_org:domains"]} />
+<Scopes scopes={["read:my_org:domains"]} />

--- a/main/docs/api/myorganization/org-domain-management/list-organization-domains.mdx
+++ b/main/docs/api/myorganization/org-domain-management/list-organization-domains.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["read:my_org:domains","read:my_org:domains"]} />
+<Scopes scopes={["read:my_org:domains"]} />

--- a/main/docs/api/myorganization/org-domain-management/start-domain-verification.mdx
+++ b/main/docs/api/myorganization/org-domain-management/start-domain-verification.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["update:my_org:domains","update:my_org:domains"]} />
+<Scopes scopes={["update:my_org:domains"]} />

--- a/main/docs/fr-ca/api/myorganization/config/get-configuration.mdx
+++ b/main/docs/fr-ca/api/myorganization/config/get-configuration.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["read:my_org:configuration","read:my_org:configuration"]} />
+<Scopes scopes={["read:my_org:configuration"]} />

--- a/main/docs/fr-ca/api/myorganization/config/get-identity-providers-configuration.mdx
+++ b/main/docs/fr-ca/api/myorganization/config/get-identity-providers-configuration.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["read:my_org:configuration","read:my_org:configuration"]} />
+<Scopes scopes={["read:my_org:configuration"]} />

--- a/main/docs/fr-ca/api/myorganization/idp-management/associate-domain-with-identity-provider.mdx
+++ b/main/docs/fr-ca/api/myorganization/idp-management/associate-domain-with-identity-provider.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["create:my_org:identity_providers_domains","create:my_org:identity_providers_domains"]} />
+<Scopes scopes={["create:my_org:identity_providers_domains"]} />

--- a/main/docs/fr-ca/api/myorganization/idp-management/create-identity-provider.mdx
+++ b/main/docs/fr-ca/api/myorganization/idp-management/create-identity-provider.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["create:my_org:identity_providers","create:my_org:identity_providers"]} />
+<Scopes scopes={["create:my_org:identity_providers"]} />

--- a/main/docs/fr-ca/api/myorganization/idp-management/create-provisioning-configuration.mdx
+++ b/main/docs/fr-ca/api/myorganization/idp-management/create-provisioning-configuration.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["create:my_org:identity_providers_provisioning","create:my_org:identity_providers_provisioning"]} />
+<Scopes scopes={["create:my_org:identity_providers_provisioning"]} />

--- a/main/docs/fr-ca/api/myorganization/idp-management/create-provisioning-scim-token.mdx
+++ b/main/docs/fr-ca/api/myorganization/idp-management/create-provisioning-scim-token.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["create:my_org:identity_providers_scim_tokens","create:my_org:identity_providers_scim_tokens"]} />
+<Scopes scopes={["create:my_org:identity_providers_scim_tokens"]} />

--- a/main/docs/fr-ca/api/myorganization/idp-management/delete-identity-provider.mdx
+++ b/main/docs/fr-ca/api/myorganization/idp-management/delete-identity-provider.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["delete:my_org:identity_providers","delete:my_org:identity_providers"]} />
+<Scopes scopes={["delete:my_org:identity_providers"]} />

--- a/main/docs/fr-ca/api/myorganization/idp-management/delete-provisioning-configuration.mdx
+++ b/main/docs/fr-ca/api/myorganization/idp-management/delete-provisioning-configuration.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["delete:my_org:identity_providers_provisioning","delete:my_org:identity_providers_provisioning"]} />
+<Scopes scopes={["delete:my_org:identity_providers_provisioning"]} />

--- a/main/docs/fr-ca/api/myorganization/idp-management/detach-identity-provider-from-organization.mdx
+++ b/main/docs/fr-ca/api/myorganization/idp-management/detach-identity-provider-from-organization.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["update:my_org:identity_providers_detach","update:my_org:identity_providers_detach"]} />
+<Scopes scopes={["update:my_org:identity_providers_detach"]} />

--- a/main/docs/fr-ca/api/myorganization/idp-management/get-identity-provider.mdx
+++ b/main/docs/fr-ca/api/myorganization/idp-management/get-identity-provider.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["read:my_org:identity_providers","read:my_org:identity_providers"]} />
+<Scopes scopes={["read:my_org:identity_providers"]} />

--- a/main/docs/fr-ca/api/myorganization/idp-management/get-provisioning-configuration.mdx
+++ b/main/docs/fr-ca/api/myorganization/idp-management/get-provisioning-configuration.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["read:my_org:identity_providers_provisioning","read:my_org:identity_providers_provisioning"]} />
+<Scopes scopes={["read:my_org:identity_providers_provisioning"]} />

--- a/main/docs/fr-ca/api/myorganization/idp-management/list-identity-providers.mdx
+++ b/main/docs/fr-ca/api/myorganization/idp-management/list-identity-providers.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["read:my_org:identity_providers","read:my_org:identity_providers"]} />
+<Scopes scopes={["read:my_org:identity_providers"]} />

--- a/main/docs/fr-ca/api/myorganization/idp-management/list-provisioning-scim-tokens.mdx
+++ b/main/docs/fr-ca/api/myorganization/idp-management/list-provisioning-scim-tokens.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["read:my_org:identity_providers_scim_tokens","read:my_org:identity_providers_scim_tokens"]} />
+<Scopes scopes={["read:my_org:identity_providers_scim_tokens"]} />

--- a/main/docs/fr-ca/api/myorganization/idp-management/refresh-identity-provider-attributes-mapping.mdx
+++ b/main/docs/fr-ca/api/myorganization/idp-management/refresh-identity-provider-attributes-mapping.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["update:my_org:identity_providers","update:my_org:identity_providers"]} />
+<Scopes scopes={["update:my_org:identity_providers"]} />

--- a/main/docs/fr-ca/api/myorganization/idp-management/refresh-provisioning-configuration-attributes-mapping.mdx
+++ b/main/docs/fr-ca/api/myorganization/idp-management/refresh-provisioning-configuration-attributes-mapping.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["update:my_org:identity_providers_provisioning","update:my_org:identity_providers_provisioning"]} />
+<Scopes scopes={["update:my_org:identity_providers_provisioning"]} />

--- a/main/docs/fr-ca/api/myorganization/idp-management/remove-domain-from-identity-provider.mdx
+++ b/main/docs/fr-ca/api/myorganization/idp-management/remove-domain-from-identity-provider.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["delete:my_org:identity_providers_domains","delete:my_org:identity_providers_domains"]} />
+<Scopes scopes={["delete:my_org:identity_providers_domains"]} />

--- a/main/docs/fr-ca/api/myorganization/idp-management/revoke-provisioning-scim-token.mdx
+++ b/main/docs/fr-ca/api/myorganization/idp-management/revoke-provisioning-scim-token.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["delete:my_org:identity_providers_scim_tokens","delete:my_org:identity_providers_scim_tokens"]} />
+<Scopes scopes={["delete:my_org:identity_providers_scim_tokens"]} />

--- a/main/docs/fr-ca/api/myorganization/idp-management/update-identity-provider.mdx
+++ b/main/docs/fr-ca/api/myorganization/idp-management/update-identity-provider.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["update:my_org:identity_providers","update:my_org:identity_providers"]} />
+<Scopes scopes={["update:my_org:identity_providers"]} />

--- a/main/docs/fr-ca/api/myorganization/org-details/get-organization-details.mdx
+++ b/main/docs/fr-ca/api/myorganization/org-details/get-organization-details.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["read:my_org:details","read:my_org:details"]} />
+<Scopes scopes={["read:my_org:details"]} />

--- a/main/docs/fr-ca/api/myorganization/org-details/modify-organization-details.mdx
+++ b/main/docs/fr-ca/api/myorganization/org-details/modify-organization-details.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["update:my_org:details","update:my_org:details"]} />
+<Scopes scopes={["update:my_org:details"]} />

--- a/main/docs/fr-ca/api/myorganization/org-domain-management/create-a-domain-for-an-organization.mdx
+++ b/main/docs/fr-ca/api/myorganization/org-domain-management/create-a-domain-for-an-organization.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["create:my_org:domains","create:my_org:domains"]} />
+<Scopes scopes={["create:my_org:domains"]} />

--- a/main/docs/fr-ca/api/myorganization/org-domain-management/delete-domain-from-organization.mdx
+++ b/main/docs/fr-ca/api/myorganization/org-domain-management/delete-domain-from-organization.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["delete:my_org:domains","delete:my_org:domains"]} />
+<Scopes scopes={["delete:my_org:domains"]} />

--- a/main/docs/fr-ca/api/myorganization/org-domain-management/get-identity-providers-associated-with-an-organization-domain.mdx
+++ b/main/docs/fr-ca/api/myorganization/org-domain-management/get-identity-providers-associated-with-an-organization-domain.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["read:my_org:domains","read:my_org:identity_providers","read:my_org:domains","read:my_org:identity_providers"]} />
+<Scopes scopes={["read:my_org:domains","read:my_org:identity_providers"]} />

--- a/main/docs/fr-ca/api/myorganization/org-domain-management/get-organization-domain.mdx
+++ b/main/docs/fr-ca/api/myorganization/org-domain-management/get-organization-domain.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["read:my_org:domains","read:my_org:domains"]} />
+<Scopes scopes={["read:my_org:domains"]} />

--- a/main/docs/fr-ca/api/myorganization/org-domain-management/list-organization-domains.mdx
+++ b/main/docs/fr-ca/api/myorganization/org-domain-management/list-organization-domains.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["read:my_org:domains","read:my_org:domains"]} />
+<Scopes scopes={["read:my_org:domains"]} />

--- a/main/docs/fr-ca/api/myorganization/org-domain-management/start-domain-verification.mdx
+++ b/main/docs/fr-ca/api/myorganization/org-domain-management/start-domain-verification.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["update:my_org:domains","update:my_org:domains"]} />
+<Scopes scopes={["update:my_org:domains"]} />

--- a/main/docs/ja-jp/api/myorganization/config/get-configuration.mdx
+++ b/main/docs/ja-jp/api/myorganization/config/get-configuration.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["read:my_org:configuration","read:my_org:configuration"]} />
+<Scopes scopes={["read:my_org:configuration"]} />

--- a/main/docs/ja-jp/api/myorganization/config/get-identity-providers-configuration.mdx
+++ b/main/docs/ja-jp/api/myorganization/config/get-identity-providers-configuration.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["read:my_org:configuration","read:my_org:configuration"]} />
+<Scopes scopes={["read:my_org:configuration"]} />

--- a/main/docs/ja-jp/api/myorganization/idp-management/associate-domain-with-identity-provider.mdx
+++ b/main/docs/ja-jp/api/myorganization/idp-management/associate-domain-with-identity-provider.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["create:my_org:identity_providers_domains","create:my_org:identity_providers_domains"]} />
+<Scopes scopes={["create:my_org:identity_providers_domains"]} />

--- a/main/docs/ja-jp/api/myorganization/idp-management/create-identity-provider.mdx
+++ b/main/docs/ja-jp/api/myorganization/idp-management/create-identity-provider.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["create:my_org:identity_providers","create:my_org:identity_providers"]} />
+<Scopes scopes={["create:my_org:identity_providers"]} />

--- a/main/docs/ja-jp/api/myorganization/idp-management/create-provisioning-configuration.mdx
+++ b/main/docs/ja-jp/api/myorganization/idp-management/create-provisioning-configuration.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["create:my_org:identity_providers_provisioning","create:my_org:identity_providers_provisioning"]} />
+<Scopes scopes={["create:my_org:identity_providers_provisioning"]} />

--- a/main/docs/ja-jp/api/myorganization/idp-management/create-provisioning-scim-token.mdx
+++ b/main/docs/ja-jp/api/myorganization/idp-management/create-provisioning-scim-token.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["create:my_org:identity_providers_scim_tokens","create:my_org:identity_providers_scim_tokens"]} />
+<Scopes scopes={["create:my_org:identity_providers_scim_tokens"]} />

--- a/main/docs/ja-jp/api/myorganization/idp-management/delete-identity-provider.mdx
+++ b/main/docs/ja-jp/api/myorganization/idp-management/delete-identity-provider.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["delete:my_org:identity_providers","delete:my_org:identity_providers"]} />
+<Scopes scopes={["delete:my_org:identity_providers"]} />

--- a/main/docs/ja-jp/api/myorganization/idp-management/delete-provisioning-configuration.mdx
+++ b/main/docs/ja-jp/api/myorganization/idp-management/delete-provisioning-configuration.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["delete:my_org:identity_providers_provisioning","delete:my_org:identity_providers_provisioning"]} />
+<Scopes scopes={["delete:my_org:identity_providers_provisioning"]} />

--- a/main/docs/ja-jp/api/myorganization/idp-management/detach-identity-provider-from-organization.mdx
+++ b/main/docs/ja-jp/api/myorganization/idp-management/detach-identity-provider-from-organization.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["update:my_org:identity_providers_detach","update:my_org:identity_providers_detach"]} />
+<Scopes scopes={["update:my_org:identity_providers_detach"]} />

--- a/main/docs/ja-jp/api/myorganization/idp-management/get-identity-provider.mdx
+++ b/main/docs/ja-jp/api/myorganization/idp-management/get-identity-provider.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["read:my_org:identity_providers","read:my_org:identity_providers"]} />
+<Scopes scopes={["read:my_org:identity_providers"]} />

--- a/main/docs/ja-jp/api/myorganization/idp-management/get-provisioning-configuration.mdx
+++ b/main/docs/ja-jp/api/myorganization/idp-management/get-provisioning-configuration.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["read:my_org:identity_providers_provisioning","read:my_org:identity_providers_provisioning"]} />
+<Scopes scopes={["read:my_org:identity_providers_provisioning"]} />

--- a/main/docs/ja-jp/api/myorganization/idp-management/list-identity-providers.mdx
+++ b/main/docs/ja-jp/api/myorganization/idp-management/list-identity-providers.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["read:my_org:identity_providers","read:my_org:identity_providers"]} />
+<Scopes scopes={["read:my_org:identity_providers"]} />

--- a/main/docs/ja-jp/api/myorganization/idp-management/list-provisioning-scim-tokens.mdx
+++ b/main/docs/ja-jp/api/myorganization/idp-management/list-provisioning-scim-tokens.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["read:my_org:identity_providers_scim_tokens","read:my_org:identity_providers_scim_tokens"]} />
+<Scopes scopes={["read:my_org:identity_providers_scim_tokens"]} />

--- a/main/docs/ja-jp/api/myorganization/idp-management/refresh-identity-provider-attributes-mapping.mdx
+++ b/main/docs/ja-jp/api/myorganization/idp-management/refresh-identity-provider-attributes-mapping.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["update:my_org:identity_providers","update:my_org:identity_providers"]} />
+<Scopes scopes={["update:my_org:identity_providers"]} />

--- a/main/docs/ja-jp/api/myorganization/idp-management/refresh-provisioning-configuration-attributes-mapping.mdx
+++ b/main/docs/ja-jp/api/myorganization/idp-management/refresh-provisioning-configuration-attributes-mapping.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["update:my_org:identity_providers_provisioning","update:my_org:identity_providers_provisioning"]} />
+<Scopes scopes={["update:my_org:identity_providers_provisioning"]} />

--- a/main/docs/ja-jp/api/myorganization/idp-management/remove-domain-from-identity-provider.mdx
+++ b/main/docs/ja-jp/api/myorganization/idp-management/remove-domain-from-identity-provider.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["delete:my_org:identity_providers_domains","delete:my_org:identity_providers_domains"]} />
+<Scopes scopes={["delete:my_org:identity_providers_domains"]} />

--- a/main/docs/ja-jp/api/myorganization/idp-management/revoke-provisioning-scim-token.mdx
+++ b/main/docs/ja-jp/api/myorganization/idp-management/revoke-provisioning-scim-token.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["delete:my_org:identity_providers_scim_tokens","delete:my_org:identity_providers_scim_tokens"]} />
+<Scopes scopes={["delete:my_org:identity_providers_scim_tokens"]} />

--- a/main/docs/ja-jp/api/myorganization/idp-management/update-identity-provider.mdx
+++ b/main/docs/ja-jp/api/myorganization/idp-management/update-identity-provider.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["update:my_org:identity_providers","update:my_org:identity_providers"]} />
+<Scopes scopes={["update:my_org:identity_providers"]} />

--- a/main/docs/ja-jp/api/myorganization/org-details/get-organization-details.mdx
+++ b/main/docs/ja-jp/api/myorganization/org-details/get-organization-details.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["read:my_org:details","read:my_org:details"]} />
+<Scopes scopes={["read:my_org:details"]} />

--- a/main/docs/ja-jp/api/myorganization/org-details/modify-organization-details.mdx
+++ b/main/docs/ja-jp/api/myorganization/org-details/modify-organization-details.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["update:my_org:details","update:my_org:details"]} />
+<Scopes scopes={["update:my_org:details"]} />

--- a/main/docs/ja-jp/api/myorganization/org-domain-management/create-a-domain-for-an-organization.mdx
+++ b/main/docs/ja-jp/api/myorganization/org-domain-management/create-a-domain-for-an-organization.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["create:my_org:domains","create:my_org:domains"]} />
+<Scopes scopes={["create:my_org:domains"]} />

--- a/main/docs/ja-jp/api/myorganization/org-domain-management/delete-domain-from-organization.mdx
+++ b/main/docs/ja-jp/api/myorganization/org-domain-management/delete-domain-from-organization.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["delete:my_org:domains","delete:my_org:domains"]} />
+<Scopes scopes={["delete:my_org:domains"]} />

--- a/main/docs/ja-jp/api/myorganization/org-domain-management/get-identity-providers-associated-with-an-organization-domain.mdx
+++ b/main/docs/ja-jp/api/myorganization/org-domain-management/get-identity-providers-associated-with-an-organization-domain.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["read:my_org:domains","read:my_org:identity_providers","read:my_org:domains","read:my_org:identity_providers"]} />
+<Scopes scopes={["read:my_org:domains","read:my_org:identity_providers"]} />

--- a/main/docs/ja-jp/api/myorganization/org-domain-management/get-organization-domain.mdx
+++ b/main/docs/ja-jp/api/myorganization/org-domain-management/get-organization-domain.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["read:my_org:domains","read:my_org:domains"]} />
+<Scopes scopes={["read:my_org:domains"]} />

--- a/main/docs/ja-jp/api/myorganization/org-domain-management/list-organization-domains.mdx
+++ b/main/docs/ja-jp/api/myorganization/org-domain-management/list-organization-domains.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["read:my_org:domains","read:my_org:domains"]} />
+<Scopes scopes={["read:my_org:domains"]} />

--- a/main/docs/ja-jp/api/myorganization/org-domain-management/start-domain-verification.mdx
+++ b/main/docs/ja-jp/api/myorganization/org-domain-management/start-domain-verification.mdx
@@ -7,4 +7,4 @@ import { ApiReleaseLifecycle } from "/snippets/ApiReleaseLifecycle.jsx";
 import { Scopes } from "/snippets/ApiScopes.jsx";
 
 <ApiReleaseLifecycle releaseLifecycle="beta" />
-<Scopes scopes={["update:my_org:domains","update:my_org:domains"]} />
+<Scopes scopes={["update:my_org:domains"]} />

--- a/scripts/artifact-generation.js
+++ b/scripts/artifact-generation.js
@@ -4,6 +4,7 @@ const {
   kebabCase,
   startCase,
   flattenDeep,
+  uniq,
   chain,
   initial,
   last,
@@ -109,7 +110,7 @@ function getEndpointScopes(spec) {
     const scopeList = Object.values(securityScheme);
     return [...acc, ...scopeList];
   }, []);
-  return flattenDeep(scopes);
+  return uniq(flattenDeep(scopes));
 }
 
 async function writeMdxContent(config) {


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

This PR removes duplicate scopes from the output of `getEndpointScopes`.

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

Tested locally 

<img width="579" height="903" alt="image" src="https://github.com/user-attachments/assets/824bd4bc-9610-4f6f-857d-9c2aa3324028" />

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
