### PR TITLE
docs: add response_mode documentation to silent authentication page

### DIFF
--- a/main/docs/authenticate/login/configure-silent-authentication.mdx
+++ b/main/docs/authenticate/login/configure-silent-authentication.mdx
@@ -46,37 +46,101 @@ Any applicable [rules](/docs/customize/rules) will be executed as part of the si
 
 </Callout>
 
+### Response modes
+
+The `response_mode` parameter determines how Auth0 delivers the authorization response to your application. For silent authentication, you can use:
+
+| Mode | Delivery Method | Use Case |
+|------|----------------|----------|
+| `query` | Query string (`?code=...`) | Authorization Code flow with server-side handling |
+| `fragment` | URL fragment (`#access_token=...`) | Implicit flow (legacy) |
+| `web_message` | `postMessage()` API | **Recommended for SPAs** - no page navigation required |
+
+When using `web_message`, Auth0 renders an HTML page inside a hidden iframe that uses the [HTML5 Web Messaging API](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) to communicate the result back to your application. This allows silent authentication without any visible page redirects or state loss.
+
+<Note>
+
+To use `response_mode=web_message`, you must add your application's URL to the **Allowed Web Origins** field in your [application settings](https://manage.auth0.com/#/applications). For more details on all response modes, see [OAuth 2.0 Authorization Framework](/docs/authenticate/protocols/oauth#authorization-endpoint).
+
+</Note>
+
 ### Successful authentication responses
 
-If the user was already logged in to Auth0 and no other interactive prompts are required, Auth0 will respond exactly as if the user had authenticated manually through the login page.
+If the user was already logged in to Auth0 and no other interactive prompts are required, Auth0 will respond exactly as if the user had authenticated manually through the login page. The format of the response depends on the `response_mode` used:
 
-For example, when using the Implicit Flow, (`response_type=id_token token`, used for single-page applications), Auth0 will respond with the requested tokens:
+<Tabs>
+<Tab title="web_message">
 
-```bash cURL lines
-GET {https://yourApp/callback}
-    #id_token=...&
-    access_token=...&
-    state=...&
-    expires_in=...
+When using `response_mode=web_message` with Authorization Code Flow with PKCE (`response_type=code`), Auth0 returns an HTML page that posts the authorization code to your application:
+
+```html
+<script>
+  window.parent.postMessage({
+    type: 'authorization_response',
+    response: {
+      code: 'SplX...GT',
+      state: 'your_state_value'
+    }
+  }, 'https://yourApp.com');
+</script>
 ```
 
+Your application (or SDK) listens for this message and exchanges the code for tokens. If the user has no valid session, Auth0 posts an error instead:
 
+```html
+<script>
+  window.parent.postMessage({
+    type: 'authorization_response',
+    response: {
+      error: 'login_required',
+      error_description: 'Login required',
+      state: 'your_state_value'
+    }
+  }, 'https://yourApp.com');
+</script>
+```
 
+</Tab>
+<Tab title="fragment">
 
+When using `response_mode=fragment` (default for Implicit Flow with `response_type=id_token token`), Auth0 redirects with tokens in the URL fragment:
 
+```text
+GET https://yourApp.com/callback
+    #id_token=eyJhbG...&
+    access_token=eyJhbG...&
+    state=your_state_value&
+    expires_in=86400
+```
 
-This response is indistinguishable from a login performed directly without the `prompt=none` parameter.
+</Tab>
+<Tab title="query">
+
+When using `response_mode=query` (default for Authorization Code Flow with `response_type=code`), Auth0 redirects with the code in the query string:
+
+```text
+GET https://yourApp.com/callback
+    ?code=SplX...GT&
+    state=your_state_value
+```
+
+</Tab>
+</Tabs>
+
+These responses are identical in format to a login performed directly without the `prompt=none` parameter. The only difference is that with `prompt=none`, the response is immediate without any user interaction.
 
 ### Error responses
 
-If the user was not logged in via <Tooltip tip="Single Sign-On (SSO): Service that, after a user logs into one applicaton, automatically logs that user in to other applications." cta="View Glossary" href="/docs/glossary?term=Single+Sign-on">Single Sign-on</Tooltip> (SSO) or their SSO session had expired, Auth0 will redirect to the specified `redirect_uri` (callback URL) with an error:
+If the user was not logged in via <Tooltip tip="Single Sign-On (SSO): Service that, after a user logs into one applicaton, automatically logs that user in to other applications." cta="View Glossary" href="/docs/glossary?term=Single+Sign-on">Single Sign-on</Tooltip> (SSO) or their SSO session had expired, Auth0 returns an error using the same `response_mode`. For redirect-based modes (`fragment` or `query`):
 
-```json lines
+```text
 GET https://your_callback_url/
     #error=ERROR_CODE&
     error_description=ERROR_DESCRIPTION&
     state=...
 ```
+
+For `web_message` mode, the error is posted via `postMessage()` as shown in the example above.
 
 
 


### PR DESCRIPTION
A customer inquiry revealed that the Silent Authentication documentation page doesn't clearly explain how response_mode options work, particularly the web_message mode commonly used by Auth0 SDKs (auth0-react, auth0-spa-js).

  This PR improves the documentation by adding:

  1. New "Response modes" section with a comparison table explaining:
    - query - Authorization Code flow with server-side handling
    - fragment - Implicit flow (legacy)
    - web_message - Recommended for SPAs, uses postMessage API
  2. Detailed explanation of how web_message works - describes the hidden iframe + HTML5 Web Messaging mechanism that allows silent authentication without page redirects
  3. Tabbed response examples showing the actual response format for each mode:
    - web_message: postMessage JavaScript code (success and error cases)
    - fragment: URL redirect with hash parameters
    - query: URL redirect with query string parameters
  4. Cross-reference to OAuth documentation - links to /docs/authenticate/protocols/oauth#authorization-endpoint where all response modes are documented in detail
  5. Updated error responses section - clarifies that errors are returned using the same response_mode format

  References

  - Related OAuth 2.0 documentation: /docs/authenticate/protocols/oauth
  - Sessions documentation: /docs/manage-users/sessions
  - https://tools.ietf.org/html/draft-sakimura-oauth-wmrm-00

  Testing

  1. Run mint dev from the /main directory
  2. Navigate to http://localhost:3000/docs/authenticate/login/configure-silent-authentication
  3. Verify:
    - Response modes table renders correctly
    - Tabs (web_message, fragment, query) switch properly
    - Code examples display with correct syntax highlighting
    - Cross-reference links work

  Checklist

  - I've read and followed https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md.
  - I've tested the site build for this change locally.
  - I've made appropriate docs updates for any code or config changes.
  - I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.