### PR TITLE
remove grafana cloud references

### DIFF
--- a/main/docs/deploy-monitor/metric-streams.mdx
+++ b/main/docs/deploy-monitor/metric-streams.mdx
@@ -1,5 +1,5 @@
 ---
-description: Stream Auth0 metrics to monitoring platforms like Datadog, New Relic, Grafana, and Splunk for real-time observability.
+description: Stream Auth0 metrics to monitoring platforms like Datadog, New Relic, and Splunk for real-time observability.
 title: Metric Streams
 ---
 
@@ -9,7 +9,7 @@ title: Metric Streams
 Metric Streams is currently available in Beta. To use this feature, you must have an Enterprise plan. By using this feature, you agree to the applicable Free Trial terms in Okta’s [Master Subscription Agreement](https://www.okta.com/legal). To learn more about Auth0's product release cycle, read [Product Release Stages](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages).
 </Warning>
 
-Stream real-time Auth0 metrics to your monitoring platform to track API performance, identify rate limit issues, and troubleshoot errors faster. Metric Streams support both native Datadog integration and OpenTelemetry Protocol (OTLP) for platforms like New Relic, Grafana Cloud, and Splunk.
+Stream real-time Auth0 metrics to your monitoring platform to track API performance, identify rate limit issues, and troubleshoot errors faster. Metric Streams support both native Datadog integration and OpenTelemetry Protocol (OTLP) for platforms like New Relic and Splunk.
 
 ## What you can monitor
 
@@ -104,10 +104,6 @@ Metric Streams support the following monitoring platforms:
 <CardGroup cols={2}>
 <Card title="Datadog" icon="chart-line" href="#set-up-datadog">
 Native integration with Datadog's metrics API
-</Card>
-
-<Card title="Grafana Cloud" icon="chart-area" href="#set-up-grafana-cloud">
-Stream via OpenTelemetry Protocol (OTLP)
 </Card>
 
 <Card title="New Relic" icon="chart-mixed" href="#set-up-new-relic">
@@ -239,87 +235,6 @@ auth0 api patch /api/v2/metric-streams/YOUR_STREAM_ID \
 ```bash
 auth0 api patch /api/v2/metric-streams/YOUR_STREAM_ID \
   --data '{"status":"enabled"}'
-```
-</Tab>
-</Tabs>
-
-## Set up Grafana Cloud
-
-Stream Auth0 metrics to Grafana Cloud using OpenTelemetry Protocol (OTLP).
-
-### Get Grafana Cloud credentials
-
-<Steps>
-<Step title="Navigate to OpenTelemetry configuration">
-1. Log in to your Grafana Cloud Dashboard.
-2. Select **Connections** > **Add new connection**.
-3. Select **OpenTelemetry** from Featured connections.
-4. Select **OpenTelemetry SDK** > **Language Other** > **Next**.
-5. Select **Other** for infrastructure > **Next**.
-6. Select **OpenTelemetry Collector** > **Next**.
-</Step>
-
-<Step title="Create access token">
-In the **Instrumentation Instructions** section:
-1. Select **Create token**.
-2. Enter a descriptive name (e.g., `auth0-metrics`).
-3. Select **Create token**.
-4. Copy the token value as you need it for the stream configuration steps.
-</Step>
-
-<Step title="Copy endpoint URL">
-Copy the value from the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable in the generated configuration block.
-</Step>
-
-<Step title="Extract authentication token">
-From the `OTEL_EXPORTER_OTLP_HEADERS` value, copy only the token portion after `Authorization=Basic%20`.
-
-Example:
-```
-OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic%20abc123xyz456
-```
-Copy: `abc123xyz456`
-</Step>
-</Steps>
-
-### Create metric stream
-
-<Tabs>
-<Tab title="Dashboard">
-**Navigate to Metric Streams:**
-1. Go to [Auth0 Dashboard](https://manage.auth0.com) > **Monitoring** > **Metric Streams**.
-2. Select **+Create Metric Stream**.
-3. Select **OpenTelemetry**.
-
-**Configure stream:**
-1. **Name**: Enter a descriptive name (e.g., `grafana-production`).
-2. **Protocol**: Select **HTTP** from the dropdown.
-3. **OTLP Endpoint**: Paste your Grafana Cloud OTLP endpoint (from the setup steps above).
-4. **Authentication Method**: Select **Basic** from the dropdown.
-5. **Username**: Leave blank or enter if required by your Grafana setup.
-6. **Password**: Paste your Grafana token (from Step 4 above).
-7. Select **Save**.
-
-This creates and automatically enables your Metric Stream.
-</Tab>
-
-<Tab title="CLI">
-```bash
-auth0 api post metric-streams \
-  --data '{
-    "name": "grafana-production",
-    "subscriptions": [{ "metric_type": "metrics_bridge.api_request" }],
-    "destination": {
-      "type": "otlp",
-      "configuration": {
-        "endpoint": "YOUR_GRAFANA_OTLP_ENDPOINT",
-        "protocol": "http",
-        "auth_type": "api_key",
-        "api_key": "Basic YOUR_GRAFANA_TOKEN",
-        "auth_header_name": "Authorization"
-      }
-    }
-  }'
 ```
 </Tab>
 </Tabs>


### PR DESCRIPTION


## Description

remove grafana cloud references from metric streams docs. 

### References

https://auth0.slack.com/archives/C07MDVD825A/p1772642854587199

### Testing


## Checklist

- [ x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ x] I've tested the site build for this change locally.
- [ x] I've made appropriate docs updates for any code or config changes.
- [ x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
