### PR TITLE
Remove redundant parameters from MRRT flow

### DIFF
--- a/main/docs/secure/call-apis-on-users-behalf/token-vault/connected-accounts-for-token-vault.mdx
+++ b/main/docs/secure/call-apis-on-users-behalf/token-vault/connected-accounts-for-token-vault.mdx
@@ -222,10 +222,8 @@ curl -s --request POST \
 {
   "grant_type": "authorization_code",
   "code": "<CONNECT_CODE>",
-  "scope": "openid profile offline_access",
   "client_id": "<CLIENT_ID>",
   "client_secret": "<CLIENT_SECRET>",
-  "audience": "https://{yourDomain}/me/",
   "redirect_uri": "<REDIRECT_URI>"
 }
 EOF


### PR DESCRIPTION
## Description
The example request to `/oauth/token` can be confusing because the audience is set to `https://{yourDomain}/me/`. So essentially what we are doing if we follow the example is:
- Get an authorization code
- Exchange that authorization code for an access token & refresh token for my account
- Exchange that refresh token for a my account access token account with some additional scopes

That flow can be confusing to a customer because it would never work this way in reality. 

More importantly, the `/oauth/token` endpoint doesn't support the parameters `audience` and `scope`, these are both defined in the `/authorize` endpoint. So it's simpler to just remove the redundant properties in the request body.

### References
No JIRA ticket

### Testing


## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
