### PR TITLE
feat: add DCR enablement step to MCP prerequisites

### DIFF
--- a/auth4genai/snippets/mcp/get-started/pre-reqs/prerequisites.mdx
+++ b/auth4genai/snippets/mcp/get-started/pre-reqs/prerequisites.mdx
@@ -14,10 +14,23 @@ Auth for MCP is currently available in Early Access. To join the Early Access pr
   <Accordion title="2. Enable your tenant to use the Resource Parameter Compatibility Profile">
   <MCPGetStartedEnableResourceParamStep />
   </Accordion>
-  <Accordion title="3. Install the Auth0 CLI">
+  <Accordion title="3. Enable Dynamic Client Registration (DCR)">
+    <Warning>
+      Auth0 supports **Open Dynamic Registration**, which means that if you enable this feature, **anyone** will be able to create applications in your tenant without a token.
+    </Warning>
+
+    The quickest way to enable it is through the [Auth0 Dashboard](https://manage.auth0.com/dashboard/):
+
+    1. Navigate to **Settings** on the left sidebar.
+    2. Click on [**Advanced**](https://manage.auth0.com/dashboard/#/tenant/advanced) in the top right corner.
+    3. Scroll down to the Settings section, find and enable the **Dynamic Client Registration** toggle.
+
+    To learn more about securing DCR for your MCP server, read [Register Your MCP Client Application](/mcp/guides/registering-your-mcp-client-application).
+  </Accordion>
+  <Accordion title="4. Install the Auth0 CLI">
     <MCPGetStartedAuth0CLIStep />
   </Accordion>
-  <Accordion title="4. Install jq">
+  <Accordion title="5. Install jq">
     To simplify the process of interacting with the Auth0 CLI, we recommend installing [jq](https://jqlang.org/download/). This will allow you to easily parse JSON responses from the CLI.
 
     <Tabs>


### PR DESCRIPTION
Add a new prerequisite step for enabling Dynamic Client Registration via the Auth0 Dashboard, following the same pattern as the Resource Parameter step. Includes Open DCR warning and link to the securing DCR guide.

  ---
  Description

  Adds a missing prerequisite step for enabling Dynamic Client Registration (DCR) to the MCP get-started prerequisites snippet (auth4genai/snippets/mcp/get-started/pre-reqs/prerequisites.mdx).

  The new step (inserted as step 3) follows the same structure as the existing Resource Parameter Compatibility Profile step:
  - Brief intro explaining the feature
  - Numbered Dashboard navigation steps (Settings → Advanced → enable toggle)
  - A <Warning> callout about Open DCR — anyone can create applications in the tenant without a token when this is enabled
  - A reference link to the /mcp/guides/registering-your-mcp-client-application guide for securing DCR

  Existing steps were renumbered: Install Auth0 CLI moved from step 3 → 4, Install jq moved from step 4 → 5.

  ---
  References

  - Related guide: auth4genai/mcp/guides/registering-your-mcp-client-application.mdx
  - Source DCR docs: main/docs/get-started/applications/dynamic-client-registration.mdx

  ---
  Testing

  1. Run mint dev from the auth4genai/ directory
  2. Navigate to any page that renders the prerequisites snippet
  3. Confirm the new DCR accordion (step 3) renders correctly with the warning, numbered steps, and reference link
  4. Confirm steps 4 (Auth0 CLI) and 5 (jq) are correctly renumbered

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
