### PR TITLE
fix: update Custom Token Exchange limitations

### DIFF
--- a/main/docs/authenticate/custom-token-exchange.mdx
+++ b/main/docs/authenticate/custom-token-exchange.mdx
@@ -52,4 +52,4 @@ Custom Token Exchange in Early Access does not support the following:
 * Custom DB Connections with import mode `ON` are not supported for `setUserByConnection()` operations
 * Specific delegation support (e.g. `actor_token` and `actor` claim)
 * Third-party and non-OIDC conformant clients
-* The target API must have **Allow Skipping User Consent** enabled, since consent cannot be collected in a non-interactive flow.
+* The target API must have **Allow Skipping User Consent** enabled since consent cannot be collected in a non-interactive flow.


### PR DESCRIPTION
 ## Description

  Updates the Custom Token Exchange (CTE) limitations section on the overview page (main/docs/authenticate/custom-token-exchange.mdx):

  - Removed the Organization + MFA limitation (api.multifactor.enable() and MFA policies not supported when associated with an Organization), which is no longer accurate.
  - Added a missing limitation about consent: the target API must have Allow Skipping User Consent enabled, since consent cannot be collected in a non-interactive flow. This was already documented in the French-Canadian and Japanese translations but missing from the English source page.

 ## References

  - Server-side enforcement: CustomTokenExchangeProfile.js — #consentRequired() method rejects requests when the resource server does not allow skipping consent for first-party clients.

 ## Testing

  - Run mint dev from the main/ directory and navigate to the /docs/authenticate/custom-token-exchange to verify the updated limitations list renders correctly.

## Checklist
- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
