### PR TITLE
docs: add supported liquid variables for phone message templates

### DIFF
--- a/main/docs/customize/customize-sms-or-voice-messages.mdx
+++ b/main/docs/customize/customize-sms-or-voice-messages.mdx
@@ -1,85 +1,57 @@
 ---
-description: Learn how to customize SMS and voice messages sent by Auth0 during enrollment and verification.
 title: Customize Multi-factor Authentication SMS and Voice Messages
+description: Learn how to customize SMS and voice messages sent by Auth0 during enrollment and verification.
 ---
-You can customize SMS and voice messages sent by Auth0 during enrollment (when associating a device to Guardian) and verification (when an authentication message is sent to the device):
+
+To customize multi-factor authentication SMS and voice messages sent by Auth0:
 
 1. Go to [Dashboard > Security > Multi-factor Auth](https://manage.auth0.com/#/security/mfa), and click **Phone Message**.
-2. Customize your message templates, and click **Save**.
+2. In the **Enrollment Template** or **Verification Template** section, customize your message.
+3. Click **Save**.
 
-You can customize templates for two message types:
-
-* **Enrollment**: Message sent by Auth0 during device enrollment.
-* **Verification**: Message sent by Auth0 to verify the possession of the device.
+The **Enrollment Template** defines the message sent when a user enrolls a new device for the first time using MFA. The **Verificiation Template** defines the message sent when a user logs in after enrollment.
 
 ## Syntax
 
 [Liquid](https://github.com/Shopify/liquid/wiki/Liquid-for-Designers) syntax is the supported templating engine you use when accessing user attributes in SMS templates. The following attributes are available:
 
-<table class="table"><thead>
-<tr>
-<th>Attribute</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>message_type</code></td>
-<td>Indicates which kind of message is sent; <code>sms</code> or <code>voice</code>.</td>
-</tr>
-<tr>
-<td><code>code</code></td>
-<td>Enrollment/verification code. When sending voice messages. Variable values are separated by dots between the digits (<code>1.2.3.4.5</code>) so it can be pronounced accurately by voice messaging providers.</td>
-</tr>
-<tr>
-<td><code>locale</code></td>
-<td>For Universal Login or MFA API. Designates the language.</td>
-</tr>
-<tr>
-<td><code>requestInfo.lang</code></td>
-<td>For Classic Login localization. Browser accept-language header. For example: <code>es-AR,es;q=8.0</code>, <code>en-US,en</code>.</td>
-</tr>
-<tr>
-<td><code>tenant.friendlyName</code></td>
-<td>The <strong>Friendly Name</strong> set in <strong>Dashboard &gt; Tenant Settings</strong>.</td>
-</tr>
-</tbody>
-</table>
+| Attribute                       | Description |
+|---------------------------------|-------------|
+| `message_type`                  | Indicates which kind of message is sent: `sms` or `voice`. |
+| `code`                          | Enrollment/verification code. When sending voice messages, variable values are separated by dots between the digits (`1.2.3.4.5`) for accurate pronunciation by voice messaging providers. |
+| `locale`                        | For Universal Login or MFA API. Designates the language. |
+| `requestInfo.lang`              | For Classic Login localization. Browser accept-language header. For example: `es-AR,es;q=8.0`, `en-US,en`. |
+| `tenant.friendlyName`           | The **Friendly Name** set in **Dashboard > Tenant Settings**. |
+| `custom_domain.domain`          | The tenant's domain name. |
+| `custom_domain.domain_metadata` | The custom domain's metadata fields (as key-value pairs). |
 
-## Example
+An example of using Liquid syntax to send different messages for voice and SMS by language:
 
 ```liquid lines
 {% if message_type == "voice" %}
-  {% if locale contains "fr" %}
-  Bonjour, vous avez demandé à recevoir un code de vérification pour vous enregister avec {{tenant.friendly_name}}. Votre code est: {{pause}} {{code}}. Je répète, votre code est: {{pause}}{{code}}.
-  {% elsif locale contains "es" %}
-  Usted ha requerido un código de verificación para inscribirse con {{tenant.friendly_name}}. Su código es: {{pause}}{{code}}. Repito, su código es: {{pause}}{{code}}.
-  {% else %}
-  Hello, you requested a verification code to enroll with {{tenant.friendly_name}}. Your code is: {{pause}}{{code}}. I repeat, your code is: {{pause}}{{code}}.
-  {% endif %}
+    {% if locale contains "fr" %}
+        Bonjour, vous avez demandé à recevoir un code de vérification pour vous enregister avec {{tenant.friendly_name}}. Votre code est: {{pause}} {{code}}. Je répète, votre code est: {{pause}}{{code}}.
+    {% elsif locale contains "es" %}
+        Usted ha requerido un código de verificación para inscribirse con {{tenant.friendly_name}}. Su código es: {{pause}}{{code}}. Repito, su código es: {{pause}}{{code}}.
+    {% else %}
+        Hello, you requested a verification code to enroll with {{tenant.friendly_name}}. Your code is: {{pause}}{{code}}. I repeat, your code is: {{pause}}{{code}}.
+    {% endif %}
 {% else %}
-  {% if locale contains "fr" %}
-  {{code}} est votre code de vérification pour vous enregistrer avec {{tenant.friendly_name}}.
-  {% elsif locale contains "es" %}
-  {{code}} es su código para inscribirse con {{tenant.friendly_name}}.
-  {% else %}
-  {{code}} is your verification code to enroll with {{tenant.friendly_name}}.
-  {% endif %}
+    {% if locale contains "fr" %}
+        {{code}} est votre code de vérification pour vous enregistrer avec {{tenant.friendly_name}}.
+    {% elsif locale contains "es" %}
+        {{code}} es su código para inscribirse con {{tenant.friendly_name}}.
+    {% else %}
+        {{code}} is your verification code to enroll with {{tenant.friendly_name}}.
+    {% endif %}
 {% endif %}
 ```
 
-
-
-
-
-
 ## Localization
 
-The endpoints support the `x-request-language` header and you can use it to send the locale. See [Multi-Language Support](/docs/authenticate/passwordless/authentication-methods/sms-otp#multi-language-support) for details.
+In the Auth0 Authentication API, the [Get Code or Link endpoint](https://auth0.com/docs/api/authentication/passwordless/get-code-or-link), MFA [Challenge request endpoint](https://auth0.com/docs/api/authentication/muti-factor-authentication/request-mfa-challenge), and MFA [Add an authenticator endpoint](https://auth0.com/docs/api/authentication/muti-factor-authentication/add-an-authenticator) support the `x-request-language` header.
 
-This is also supported in the <Tooltip tip="Multi-factor authentication (MFA): User authentication process that uses a factor in addition to username and password such as a code via SMS." cta="View Glossary" href="/docs/glossary?term=MFA">MFA</Tooltip> API (`POST /mfa/associate` and `POST /mfa/challenge` endpoints). When it's sent, that locale will be available in the `locale` variable in the MFA SMS/voice template.
-
-You must also select those languages in **Tenant > Settings** (under **Supported Languages**) for this to work.
+To use it, set your supported languages in **Tenant > Settings** (under **Supported Languages**). When the `x-request-lanuage` header is sent, that locale is available in the `locale` variable in the MFA phone message templates. See [Passwordless Multi-Language Support](/docs/authenticate/passwordless/authentication-methods/sms-otp#multi-language-support) for details.
 
 ## Learn more
 


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

resolves DR-2736 by adding the two custom domain variables to the table.

also did a light edit on the article itself.

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
