### PR TITLE
fix: correct Next.js SDK documentation for MCD

### DIFF
--- a/main/docs/customize/custom-domains/multiple-custom-domains/sdk-configuration.mdx
+++ b/main/docs/customize/custom-domains/multiple-custom-domains/sdk-configuration.mdx
@@ -96,85 +96,99 @@ const auth0 = await createAuth0Client({
 
 ### Next.js
 
-For Next.js applications using the [Auth0 Next.js SDK](https://github.com/auth0/nextjs-auth0):
+For Next.js applications using the [Auth0 Next.js SDK](https://github.com/auth0/nextjs-auth0) (v4+):
 
-```javascript 
-// lib/tenants.js
+<AuthCodeGroup>
+```typescript Static Configuration
+import { Auth0Client } from '@auth0/nextjs-auth0/server';
 
-export const tenantMap = {
-  customer1: {
-    issuerBaseURL: 'https://login.customer1.com',
-    clientID: process.env.AUTH0_CLIENT_ID_CUSTOMER1,
-    clientSecret: process.env.AUTH0_CLIENT_SECRET_CUSTOMER1,
-  },
-  customer2: {
-    issuerBaseURL: 'https://login.customer2.com',
-    clientID: process.env.AUTH0_CLIENT_ID_CUSTOMER2,
-    clientSecret: process.env.AUTH0_CLIENT_SECRET_CUSTOMER2,
-  },
-  default: {
-    issuerBaseURL: 'https://login.example.com',
-    clientID: process.env.AUTH0_CLIENT_ID,
-    clientSecret: process.env.AUTH0_CLIENT_SECRET,
-  },
-};
+const auth0 = new Auth0Client({
+  domain: 'login.example.com',        // Your custom domain
+  clientId: process.env.AUTH0_CLIENT_ID,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET,
+  appBaseUrl: process.env.APP_BASE_URL,
+  secret: process.env.AUTH0_SECRET
+});
+```
 
-export function getTenantFromHost(host) {
-  // customer1.yourdomain.com → customer1
+```typescript Dynamic Configuration (Multi-Brand)
+import { Auth0Client } from '@auth0/nextjs-auth0/server';
+
+const auth0 = new Auth0Client({
+  domain: ({ headers }) => {
+    // Map application hosts to Auth0 custom domains
+    const host = headers.get('host') || '';
+
+    if (host.includes('brand1.example.com')) {
+      return 'login.brand1.com';
+    } else if (host.includes('brand2.example.com')) {
+      return 'login.brand2.com';
+    }
+
+    return 'login.example.com';  // Default domain
+  },
+  clientId: process.env.AUTH0_CLIENT_ID,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET,
+  appBaseUrl: process.env.APP_BASE_URL,
+  secret: process.env.AUTH0_SECRET
+});
+```
+
+```typescript Dynamic Configuration (B2B SaaS)
+import { Auth0Client } from '@auth0/nextjs-auth0/server';
+
+// Map tenant identifiers to custom domains (from database, cache, etc.)
+async function resolveTenantDomain(host: string): Promise<string> {
+  // Extract tenant identifier from subdomain
   const subdomain = host.split('.')[0];
-  return tenantMap[subdomain] ? subdomain : 'default';
+
+  // Look up custom domain for this tenant (example: from database)
+  const tenantConfig = await getTenantConfig(subdomain);
+
+  return tenantConfig?.customDomain || 'login.example.com';
 }
 
-export function getTenantConfig(host) {
-  const tenant = getTenantFromHost(host);
-  return tenantMap[tenant] ?? tenantMap.default;
-}
+const auth0 = new Auth0Client({
+  domain: async ({ headers }) => {
+    const host = headers.get('host') || '';
+    return resolveTenantDomain(host);
+  },
+  clientId: process.env.AUTH0_CLIENT_ID,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET,
+  appBaseUrl: process.env.APP_BASE_URL,
+  secret: process.env.AUTH0_SECRET
+});
 ```
 
-```javascript Dynamic Auth0 Initializer
-
-// lib/auth0.js
-import { initAuth0 } from '@auth0/nextjs-auth0';
-import { getTenantConfig } from './tenants';
-
-export function getAuth0Client(host) {
-  const { issuerBaseURL, clientID, clientSecret } = getTenantConfig(host);
-
-  return initAuth0({
-    issuerBaseURL,
-    clientID,
-    clientSecret,
-    baseURL: `https://${host}`,
-    secret: process.env.AUTH0_SECRET,
-    authorizationParams: {
-      scope: 'openid profile email',
-    },
-    routes: {
-      callback: '/api/auth/callback',
-      postLogoutRedirect: '/',
-    },
-  });
-}
-```
-``` javascript Environment Variables
-
+```bash Environment Variables
 # .env.local
 
-# Shared
-AUTH0_SECRET='your-long-random-secret'
-
-# Default tenant
-AUTH0_CLIENT_ID=your_default_client_id
-AUTH0_CLIENT_SECRET=your_default_client_secret
-
-# Customer1 tenant
-AUTH0_CLIENT_ID_CUSTOMER1=customer1_client_id
-AUTH0_CLIENT_SECRET_CUSTOMER1=customer1_client_secret
-
-# Customer2 tenant
-AUTH0_CLIENT_ID_CUSTOMER2=customer2_client_id
-AUTH0_CLIENT_SECRET_CUSTOMER2=customer2_client_secret
+# Auth0 configuration (single tenant with multiple custom domains)
+AUTH0_DOMAIN=login.example.com           # Default or fallback custom domain
+AUTH0_CLIENT_ID=your_client_id
+AUTH0_CLIENT_SECRET=your_client_secret
+APP_BASE_URL=http://localhost:3000
+AUTH0_SECRET=your-long-random-secret
 ```
+</AuthCodeGroup>
+
+**Key concepts for MCD with Next.js:**
+
+- **Single Auth0 tenant, multiple domains**: All custom domains share the same `clientId` and `clientSecret` since they belong to the same Auth0 tenant.
+- **DomainResolver function**: The `domain` parameter accepts a function `(config: { headers: Headers; url?: URL }) => Promise<string> | string`. This allows dynamic domain resolution per request based on the incoming request headers.
+- **Instance caching**: The SDK automatically caches `Auth0Client` instances per domain using a bounded LRU cache (max 100 entries) for performance.
+- **Session isolation**: Sessions created via one custom domain are isolated to that domain and cannot be used interchangeably with sessions from another domain.
+- **URL parameter**: The `url` parameter in the resolver is `undefined` in Server Components and Server Actions; it is only available in middleware or API routes.
+- **Discovery cache tuning**: Configure OIDC metadata caching with the `discoveryCache` option:
+  ```typescript
+  const auth0 = new Auth0Client({
+    // ... other config
+    discoveryCache: {
+      ttl: 600,      // Cache for 10 minutes (default)
+      maxEntries: 100  // Max cached issuers (default: 100, LRU eviction)
+    }
+  });
+  ```
 
 ### Auth0 React SDK
 


### PR DESCRIPTION
## Summary

- Rewrites the Next.js section in `sdk-configuration.mdx` to use the correct v4 `@auth0/nextjs-auth0` API
- The existing AI-generated code samples used the v3 API (`initAuth0`, `issuerBaseURL`, `clientID`, `baseURL`) which does not exist in v4
- Cross-referenced against the actual `feat/mcd` implementation in [nextjs-auth0](https://github.com/auth0/nextjs-auth0)

## What changed

| Before (Wrong — v3 API) | After (Correct — v4 API) |
|---|---|
| `import { initAuth0 } from '@auth0/nextjs-auth0'` | `import { Auth0Client } from '@auth0/nextjs-auth0/server'` |
| `initAuth0({ issuerBaseURL, clientID, baseURL })` | `new Auth0Client({ domain, clientId, appBaseUrl })` |
| Per-request instance creation with per-tenant credentials | Single instance + `DomainResolver` function |
| `AUTH0_BASE_URL` env var | `APP_BASE_URL` |

## Key additions

- Static configuration example (single custom domain)
- Dynamic configuration with `DomainResolver` (B2C multi-brand)
- Async `DomainResolver` (B2B SaaS with database lookup)
- Correct `.env.local` showing single-tenant credentials
- Notes on session domain isolation, discovery cache tuning, URL parameter availability

## Test plan

- [ ] Verify code samples compile against `@auth0/nextjs-auth0` v4 types
- [ ] Verify env var names match SDK source (`APP_BASE_URL`, `AUTH0_DOMAIN`, etc.)
- [ ] Verify `discoveryCache` defaults match implementation (ttl: 600, maxEntries: 100)
- [ ] Site build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)