### PR TITLE
docs: add write org endpoint rate limits

### DIFF
--- a/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/enterprise-public.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/enterprise-public.mdx
@@ -15,7 +15,7 @@ Rate limits for the Authentication API and API endpoints in the Enterprise subsc
 | Production (4x Public Performance Burst) | 400/second for 48/hrs per month | 100/second |
 | Non-production | 100/second | 100/second |
 
-These limits are constrained to 48 hours per month. After 48 hours, these limits revert to product limits. For more information, see [Public Performance Burst](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy#public-performance).
+These limits are constrained to 48 hours per month. After 48 hours, these limits revert to product limits. For more information, read [Public Performance Burst](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy#public-performance).
 
 | [Endpoint](https://auth0.com/docs/api/authentication#introduction) | Method | [Burst Request Limit](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy#rate-limit-algorithm) | [Sustained Request Limit](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy#rate-limit-algorithm) | Limit Type |
 |--|--|--|--|--|
@@ -33,7 +33,7 @@ These limits are constrained to 48 hours per month. After 48 hours, these limits
 | MFA OOB token exchange | `POST` | 12 | 12/minute | To a unique session |
 | [Custom Token Exchange](/docs/authenticate/custom-token-exchange) | `POST` | 15 | 15/second | Any request |
 
-Represents the default limit. You can configure the Signup endpoint limit in Auth0 Dashboard. To learn more, read Suspicious IP Throttling.
+Represents the default limit. You can configure the Signup endpoint limit in Auth0 Dashboard. To learn more, read [Suspicious IP Throttling](/docs/secure/attack-protection/suspicious-ip-throttling#suspicious-ip-throttling).
 
 ## Management API
 


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

adds write org endpoint rate limits.

also converts the HTML on the page to markdown. commits are descriptive.

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

### References

DR-2720

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
