### PR TITLE
fix: markdown table formatting

### DIFF
--- a/main/ui/css/styles.css
+++ b/main/ui/css/styles.css
@@ -16,28 +16,15 @@ h6 {
   font-weight: 600 !important;
 }
 
-.table {
-  width: 100%;
-  table-layout: fixed;
-  border-collapse: collapse;
-}
-
-.table th,
-.table td {
+table th {
   text-align: left;
-  word-wrap: break-word;
 }
 
-.table th:first-child,
-.table td:first-child {
-  width: 30%;
-  max-width: 30%;
+/* Don't line wrap code formatting mid-word. */
+table code {
+  white-space: pre;
 }
 
-.table th:not(:first-child),
-.table td:not(:first-child) {
-  width: calc(70% / (var(--cols) - 1));
-}
 
 ol ol {
   list-style-type: decimal !important;


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

fixes wonky formatting for markdown tables (hanging too far left off the content, weird spacing). also prevents wrapping on code formatting to avoid line breaks mid-variable.

makes the manual html tables and the `.table` class unnecessary. we'll want to begin converting those tables to markdown but they're still functional for now.

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

i think this is in the docs mgmt backlog.

### Testing

look at some tables. here are a few examples:

[passkeys](https://auth0.com/docs/authenticate/database-connections/passkeys) in prod:

 <img width="402" height="329" alt="image" src="https://github.com/user-attachments/assets/14fd0599-1b8a-4491-b5a0-2c46258cdbdf" />

this branch:

<img width="402" height="329" alt="image" src="https://github.com/user-attachments/assets/f34715d2-2d7b-45e8-8239-a78bec642e9b" />

[monitor passkeys in tenant logs](http://localhost:3000/docs/authenticate/database-connections/passkeys/monitor-passkey-events-in-tenant-logs) in prod:

<img width="733" height="206" alt="image" src="https://github.com/user-attachments/assets/61fbd1ac-5c1f-4276-98d8-ca7362d2c147" />

this branch:

<img width="733" height="206" alt="image" src="https://github.com/user-attachments/assets/14ca13c8-fe29-4766-958e-5fac570daf09" />

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
