### PR TITLE
Fix: correct error code fallback in Node.js backend quickstart

### DIFF
--- a/main/docs/quickstart/backend/nodejs/interactive.mdx
+++ b/main/docs/quickstart/backend/nodejs/interactive.mdx
@@ -143,7 +143,7 @@ app.use((err, req, res, next) => {
   const message = err.message || 'Internal Server Error';
   
   res.status(status).json({
-    error: err.code || 'server_error',
+    error: err.code || 'unauthorized',
     message: status === 401 ? 'Authentication required' : message,
   });
 });


### PR DESCRIPTION
## Description

- Basic server.js error handler in the Node.js backend quickstart used `err.code || 'server_error'` as a fallback
- The SDK's base UnauthorizedError, thrown when no Bearer token is provided, has no .code property, so this fallback always fired
- This returned `server_error` to API consumers, misleading them into thinking a server fault occurred
- Fixed by changing the fallback to 'unauthorized' to match the documented expected output in the quickstart checkpoint


Error | .code | Was affected?
-- | -- | --
No token → UnauthorizedError | none | Yes — hit the fallback
Bad/expired token → InvalidTokenError | invalid_token | No
Missing scope → InsufficientScopeError | insufficient_scope | No

### Testing

- [ ] `GET /api/public` → `200` with public message
- [ ] `GET /api/private` (no token) → `401` with `{"error":"unauthorized","message":"Authentication required"}`
- [ ] `GET /api/private` (invalid token) → `401` with `{"error":"invalid_token","message":"Authentication required"}`

## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
