### PR TITLE
AIDX-173 - Replaces event.request.query.audience with event?.resource_server?.identifier

### DIFF
--- a/main/docs/authenticate/identity-providers/enterprise-identity-providers/okta/express-configuration.mdx
+++ b/main/docs/authenticate/identity-providers/enterprise-identity-providers/okta/express-configuration.mdx
@@ -273,7 +273,7 @@ Example values: `test.com`,`test2.com`
 
 ```javascript
 exports.onExecutePostLogin = async (event, api) => {
-if (event.request.query.audience === "urn:auth0:express-configure") {
+if (event?.resource_server?.identifier === "urn:auth0:express-configure") {
   if (event.organization && event.organization.metadata && event.organization.metadata.domains)
   {
     var domain_aliases = event.organization.metadata.domains.replace(/ /g,'').split(',');
@@ -292,7 +292,7 @@ In this example, the post-login Action makes an API call to retrieve verified do
 /**
 */
 exports.onExecutePostLogin = async (event, api) => {
- if (event.request.query.audience === "urn:auth0:express-configure") {
+ if (event?.resource_server?.identifier === "urn:auth0:express-configure") {
     const axios = require("axios");
     // configure your custom API call here 
     const domains = await axios.get("https://example.org/endpoint");

--- a/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger.mdx
+++ b/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger.mdx
@@ -259,7 +259,7 @@ When modifying the scopes associated with an <Tooltip tip="Access Token: Authori
  * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.
  */
 exports.onExecutePostLogin = async (event, api) => {
-  if (event.request.query.audience === 'https://example.com/api') {
+  if (event?.resource_server?.identifier === 'https://example.com/api') {
     api.accessToken.addScope("read:xyz");
   }
 };

--- a/main/docs/fr-ca/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger.mdx
+++ b/main/docs/fr-ca/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger.mdx
@@ -221,7 +221,7 @@ Lorsque vous modifiez les permissions associées à un jeton d’accès, assurez
  * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.
  */
 exports.onExecutePostLogin = async (event, api) => {
-  if (event.request.query.audience === 'https://example.com/api') {
+  if (event?.resource_server?.identifier === 'https://example.com/api') {
     api.accessToken.addScope("read:xyz");
   }
 };

--- a/main/docs/ja-jp/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger.mdx
+++ b/main/docs/ja-jp/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger.mdx
@@ -219,7 +219,7 @@ exports.onContinuePostLogin = async (event, api) => {
  * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.
  */
 exports.onExecutePostLogin = async (event, api) => {
-  if (event.request.query.audience === 'https://example.com/api') {
+  if (event?.resource_server?.identifier === 'https://example.com/api') {
     api.accessToken.addScope("read:xyz");
   }
 };


### PR DESCRIPTION
## Summary

  - Replaces `event.request.query.audience` with `event?.resource_server?.identifier` in Action code examples
  - Fixes 5 instances across 4 files (English, fr-ca, ja-jp locales)
  - `event.resource_server.identifier` is the canonical field - always populated for resource server requests, unlike the raw query param

  Fixes AIDX-173 (parent: AIDX-174 RFC8707 Resource Parameters - GA)

  ## Files changed

  - `main/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger.mdx`
  - `main/docs/ja-jp/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger.mdx`
  - `main/docs/fr-ca/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger.mdx`
  - `main/docs/authenticate/identity-providers/enterprise-identity-providers/okta/express-configuration.mdx` (2 instances)

  ## Out of scope

  Files using `context.request.query.audience` (Rules API, not Actions) were intentionally left unchanged.

  ## Test plan

  - [x] `grep -r "event.request.query.audience" main/docs` returns no results
  
## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
