### PR TITLE
docs: add username to session-clearing attributes list

### DIFF
--- a/main/docs/manage-users/sessions/session-layers.mdx
+++ b/main/docs/manage-users/sessions/session-layers.mdx
@@ -19,7 +19,7 @@ Auth0 provides tools to help you give users the ability to log out; this include
 
   <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 
-  Generally, you clear an Auth0 session by diverting users to the `/logout` endpoint. However, if you call the [Update a User](https://auth0.com/docs/api/management/v2/#!/Users/patch_users_by_id) endpoint to reset user attributes (passing values `email`, `email_verified`, `phone_number`, and `password`), `auth0.checkSession` does not renew the session, and the user must re-login.
+  Generally, you clear an Auth0 session by diverting users to the `/logout` endpoint. However, if you call the [Update a User](https://auth0.com/docs/api/management/v2/#!/Users/patch_users_by_id) endpoint to reset user attributes (passing values `email`, `email_verified`, `phone_number`, `password`, and `username`), `auth0.checkSession` does not renew the session, and the user must re-login.
 
   </Callout>
 * **Identity Provider Session Layer Logout**: It is not necessary to log the users out of this session layer, but you can use Auth0 to force the logout if required.


### PR DESCRIPTION
Adds username to the list of user attributes that, when updated via the Management API, will clear the Auth0 session and require the user to re-login.