### PR TITLE
docs: clarify back-channel logout uses async queue

### DIFF
--- a/main/docs/authenticate/login/logout/back-channel-logout.mdx
+++ b/main/docs/authenticate/login/logout/back-channel-logout.mdx
@@ -62,11 +62,9 @@ The sample use case demonstrates how Back-Channel Logout works with more than on
 10. Application A validates the Logout Token and terminates the session.
 11. Auth0 calls Application B’s Back-Channel Logout URI and posts the Logout Token.
 12. Application B validates the Logout Token and terminates the session.
-<Callout icon="circle-info" color="#0EA5E9" iconType="regular">
 
-Back-channel logout requests are placed into an asynchronous queue and processed as quickly as possible. During high load situations, there may be a slight delay before the logout request is executed. Applications should be designed to handle this eventual consistency.
+Back-channel logout requests are placed into an asynchronous queue and processed as quickly as possible. During high load situations, there may be a slight delay before the logout request is executed, so design your applications to handle this eventual consistency.
 
-</Callout>
 #### Sample token
 
 Your application must be able to parse and validate <Tooltip tip="JSON Web Token (JWT): Standard ID Token format (and often Access Token format) used to represent claims securely between two parties." cta="View Glossary" href="/docs/glossary?term=JWTs">JWTs</Tooltip> to use as Logout Tokens with Auth0. To learn more, read [Validate JSON Web Tokens](/docs/secure/tokens/json-web-tokens/validate-json-web-tokens).


### PR DESCRIPTION
Adds a callout explaining that back-channel logout requests are placed into an asynchronous queue and processed as quickly as possible. During high load situations, there may be a slight delay before the logout request is executed.

This helps set proper expectations for implementers regarding the eventual consistency nature of back-channel logout.