### PR TITLE
Update entity-limit-policy.mdx

### DIFF
--- a/main/docs/troubleshoot/customer-support/operational-policies/entity-limit-policy.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/entity-limit-policy.mdx
@@ -76,9 +76,9 @@ These limits can be increased to 2,000,000 Organizations per tenant and 2,000,00
 | Dependencies (NPM Modules) per Action Module | 10    |
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-  Actions and Actions Modules limits include both deployed and undeployed entities. When you delete them, they no longer count toward the specific limit.
+  Actions and Actions Modules limits only apply to Actions that are bound and deployed. When you delete them, they no longer count toward the specific limit. Draft Actions do not count toward quota utilization.
 
-  Action Versions and Action Module Versions limits include both draft and active. Once you reach the limit, adding every additional version results in Auth0 deleting the oldest unused version.
+Once you reach the limit, every additional version results in Auth0 deleting the oldest unused version.
 </Callout>
 
 ### Forms


### PR DESCRIPTION
## Description

Describe the issue: In the Public documentation it is mentioned that both deployed and undeployed entities (actions) are counted towards the limit. Action Versions and Action Module Versions limits include both draft and active
Definition of Done: The document is updated with the correct Actions Quota count information
Actions should be only counted towards Quota Utilization only if they are bound and deployed. Draft actions should not be counted towards Quota as they are not active. 


### References

Additional links: Verified with Product Team https://auth0.slack.com/archives/C0EDTEVL4/p1774023782313379Connect your Slack account 

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
