### PR TITLE
docs: remove manual duplication of action trigger props

### DIFF
--- a/main/docs/secure/multi-factor-authentication/adaptive-mfa/customize-adaptive-mfa.mdx
+++ b/main/docs/secure/multi-factor-authentication/adaptive-mfa/customize-adaptive-mfa.mdx
@@ -54,7 +54,7 @@ The following table describes low-risk scenarios that result in a `high` confide
 
 If you want to implement your own method for evaluating the overall confidence score of different scenarios, you can use the data available in the the `riskAssessment` object, which contains the overall confidence score, versioning information, and details of the individual assessments.
 
-You can view the full description, properties, and values of the `riskAssessment` object in the [post-login Actions trigger `riskAssessment` reference](/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-event-object#param-risk-assessmj).
+You can view the full description, properties, and values of the `riskAssessment` object in the [post-login Actions trigger `riskAssessment` reference](/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-event-object#param-risk-assessment).
 
 ## Action result outcomes
 


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

removes the manual documentation for the post-login action trigger from the adaptive MFA page and instead links to the automatically-generated post-login action trigger reference doc.

also tidies up some of the length of the rest of the doc with a tactical accordion.

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

### References

partially addresses DR-2739

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
