### PR TITLE
fix: do not proxy playground api

### DIFF
--- a/main/docs.json
+++ b/main/docs.json
@@ -40,6 +40,11 @@
       "tagId": "GTM-W7FRLJ"
     }
   },
+  "api": {
+    "playground": {
+      "proxy": false
+    }
+  },
   "navigation": {
     "languages": [
       {


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

- Turns off the proxy for api playgrounds

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

- Manually validated the network requests

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
