### PR TITLE
docs: remove outdated regex for email validation

### DIFF
--- a/main/docs/manage-users/user-accounts/user-profiles/user-profile-structure.mdx
+++ b/main/docs/manage-users/user-accounts/user-profiles/user-profile-structure.mdx
@@ -1,7 +1,8 @@
 ---
-description: Lists the attributes that are available on the Auth0 user profile
 title: User Profile Structure
+description: Lists the attributes that are available on the Auth0 user profile
 ---
+
 Auth0's normalized user profile consists of a few different components:
 
 * **Details**: Core User Profile object, which contains basic info, such as name, email, and timestamp of the user's latest login, in pre-defined attributes. This object may also contain info from a user's source connection. Most of the user attributes are root attributes (attributes stored at the first, or root, level of the `user` object), and some of these are editable.
@@ -51,16 +52,14 @@ To be able to edit the `name`, `nickname`, `given_name`, `family_name`, or `pict
 Auth0 accepts a specific validation schema for certain fields in the user profile. See the table below for a list of requirements when setting profile attribute values.
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-
 All characters are converted to lowercase when saved to the User Profile.
 
 This is true for all Auth0 database connections. When Auth0 DB is not the source of truth (for example, custom DB with import mode off) as well as other kinds of social enterprise connections where Auth0 is not the source of truth, the email is retained as-is and not converted to lower case.
-
 </Callout>
 
 | Field | Type | Character Limit | Validation |
 | --- | --- | --- | --- |
-| `email` | email | The maximum length is 64 characters for the user/local part and 256 characters for the domain part. | [JSON validation schema](https://json-schema.org/understanding-json-schema/reference/string#email-addresses).<br/>Regex: {"^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)\|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])\|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$"} |
+| `email` | email | The maximum length is 64 characters for the user/local part and 256 characters for the domain part. | [JSON validation schema](https://json-schema.org/understanding-json-schema/reference/type#email-addresses). |
 | `username` | string | The default allowed length for usernames is between 1 and 15 characters. Up to a maximum length of 128 characters. | The username field accepts the following characters:<br/>Alphanumeric characters (without accent marks, automatically converted to lowercase);<br/>The at sign (@) character (but email addresses are not allowed);<br/>The caret (^) character;<br/>The dollar sign ($) character;<br/>The dot (.) character;<br/>The exclamation (!) character;<br/>The grave accent (`) character;<br/>The minus (-) character;<br/>The number sign (#) character;<br/>The plus (+) character;<br/>The single quote (') character;<br/>The tilde (~) character;<br/>The underscore (_) character;<br/>No other characters/symbols are allowed, and Auth0 does not validate or sanitize custom database inputs. |
 | `phone_number` | phone | Standardized Format<br/>Phone numbers need to be in E.164 format | {"Regex: ^\+[0-9]{1,15}$"} |
 | `password` | string | The minimum password length you can set is 1 byte, while the maximum is 72 bytes. | Standard Characters: ASCII characters in the range of 33-126 are valid, including:<br/>A through Z uppercase characters,<br/>a through z lower case characters,<br/>0 through 9 numeric characters,<br/>special characters allowed. |


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

as described.

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

### References

DOCS-5251, DR-2721, ESD-55737. eng confirmed the link is the right option here.

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
