### PR TITLE
chore: Update docs.json to use full URL in endpoint path

### DIFF
--- a/main/docs.json
+++ b/main/docs.json
@@ -38,6 +38,7 @@
     }
   },
   "api": {
+    "url": "full",
     "playground": {
       "proxy": false
     }


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

<!--
Added URL: Full to docs.json to display globally the full endpoint URL in API Explorers-->

### References

<!--
(https://auth0team.atlassian.net/browse/DM-534)
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
