### PR TITLE
feat: migrate events catalog overview to docs-v2

### DIFF
--- a/main/docs.json
+++ b/main/docs.json
@@ -3745,7 +3745,7 @@
           {
             "tab": "Events Catalog",
             "pages": [
-              "docs/events/index",
+              "docs/events",
               {
                 "group": " ",
                 "pages": [
@@ -7028,7 +7028,7 @@
           {
             "tab": "Events Catalog",
             "pages": [
-              "docs/fr-ca/events/index",
+              "docs/fr-ca/events",
               {
                 "group": " ",
                 "pages": [
@@ -10311,7 +10311,7 @@
           {
             "tab": "Events Catalog",
             "pages": [
-              "docs/ja-jp/events/index",
+              "docs/ja-jp/events",
               {
                 "group": " ",
                 "pages": [

--- a/main/docs.json
+++ b/main/docs.json
@@ -3745,7 +3745,7 @@
           {
             "tab": "Events Catalog",
             "pages": [
-              "docs/events",
+              "docs/events/index",
               {
                 "group": " ",
                 "pages": [
@@ -7028,7 +7028,7 @@
           {
             "tab": "Events Catalog",
             "pages": [
-              "docs/fr-ca/events",
+              "docs/fr-ca/events/index",
               {
                 "group": " ",
                 "pages": [
@@ -10311,7 +10311,7 @@
           {
             "tab": "Events Catalog",
             "pages": [
-              "docs/ja-jp/events",
+              "docs/ja-jp/events/index",
               {
                 "group": " ",
                 "pages": [

--- a/main/docs/events/index.mdx
+++ b/main/docs/events/index.mdx
@@ -1,10 +1,8 @@
 ---
-title: Events
-description: Overview page for Events Explorer
+title: Events Catalog Overview
+description: Events provide an API-based method of synchronizing, correlating, or orchestrating changes that occur within Auth0 or third-party identity providers to external apps or third-party services.
 sidebarTitle: Overview
 ---
-
-Events offer Auth0 customers an API-based method of synchronizing, correlating, or orchestrating changes that occur within Auth0 or 3rd-party <Tooltip tip="Identity Provider (IdP): Service that stores and manages digital identities." cta="View Glossary" href="/docs/glossary?term=identity+providers">identity providers</Tooltip> (IdPs) to external apps or 3rd-party services.
 
 ## Use cases
 

--- a/main/docs/events/index.mdx
+++ b/main/docs/events/index.mdx
@@ -1,4 +1,22 @@
 ---
-title: "Events Catalog"
-description: "Reference documentation for Auth0 event schemas delivered via Event Streams."
+title: Events
+description: Overview page for Events Explorer
+sidebarTitle: Overview
 ---
+
+Events offer Auth0 customers an API-based method of synchronizing, correlating, or orchestrating changes that occur within Auth0 or 3rd-party <Tooltip tip="Identity Provider (IdP): Service that stores and manages digital identities." cta="View Glossary" href="/docs/glossary?term=identity+providers">identity providers</Tooltip> (IdPs) to external apps or 3rd-party services.
+
+## Use cases
+
+Events are real-time notifications about specific actions – initially changes to a user and organizations, but eventually others – that have occurred within your Auth0 tenant. You can create event streams that listen for these events to orchestrate asynchronous changes (i.e., changes to an entity or flow that have been completed) in Auth0 and forward them to one of many destinations for external processing. Events support a variety of use cases, including:
+
+* Sending emails to new customers to welcome them or ask them to verify their email address.
+* Monitoring user lifecycle changes so that you can update CRM (customer relationship management) or billing systems.
+
+## Resources
+
+| Read... | To learn... |
+| :---- | :---- |
+| [Create an Event Stream](/docs/customize/events/create-an-event-stream) | How to get started with an Event Stream. |
+| [Event Testing, Observability, and Failure Recovery](/docs/customize/events/event-testing-observability-and-failure-recovery) | How to test and manage your active event streams. |
+| [Events Best Practices](/docs/customize/events/events-best-practices) | Best practices for working with events. |


### PR DESCRIPTION
Adds main/docs/events/index.mdx and updates docs.json to point the Events Catalog tab to the local page instead of the external URL. I have also updated the SUS/TUS/PROD instances to remove the trialling slash.


<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing
local testing: `/events` and `/events/index` result in the same thing

<img width="1827" height="978" alt="Screenshot 2026-04-13 at 12 15 58 PM" src="https://github.com/user-attachments/assets/4019e91c-2d22-45f8-8419-580ea04fa8c6" />
<img width="1846" height="1036" alt="Screenshot 2026-04-13 at 12 15 21 PM" src="https://github.com/user-attachments/assets/a82852bc-41b6-49fb-88b8-c1f7202d1e1d" />

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
