### PR TITLE
doc: updated the android quickstart with applinks configuration

### DIFF
--- a/main/docs/quickstart/native/android/index.mdx
+++ b/main/docs/quickstart/native/android/index.mdx
@@ -55,7 +55,7 @@ Your AI assistant will automatically create your Auth0 application, fetch creden
     ```kotlin app/build.gradle.kts lines
     dependencies {   
         // Auth0 SDK
-        implementation("com.auth0.android:auth0:3.11.0")
+        implementation("com.auth0.android:auth0:3.14.0")
     }
     ```
 
@@ -134,6 +134,10 @@ Your AI assistant will automatically create your Auth0 application, fetch creden
     <Warning>
       **Important**: Ensure the package name in your callback URLs matches your `applicationId` in `build.gradle.kts`. If authentication fails, verify these values are identical.
     </Warning>
+
+    <Tip>
+      When using the `https` scheme (as configured above), you must set up Android App Links so that Android routes the callback URL directly to your app instead of opening it in a browser. See the **Configure Android App Links** section under [Troubleshooting & Advanced](#troubleshooting--advanced) below.
+    </Tip>
   </Step>
 
   <Step title="Initialize the Auth0 SDK" stepNumber={4}>
@@ -347,6 +351,105 @@ Your AI assistant will automatically create your Auth0 application, fetch creden
   * Install Chrome or another modern browser on your device/emulator
   * Enable Chrome Custom Tabs for better user experience
   * Test on real device with Chrome installed
+</Accordion>
+
+<Accordion title="Configure Android App Links">
+  [Android App Links](https://developer.android.com/training/app-links) allow your app to designate itself as the default handler for Auth0 callback URLs, providing a more secure and seamless authentication experience. Without App Links, Android may show a disambiguation dialog asking the user to choose between your app and a browser.
+
+  <Note>
+    App Links use verified `https` scheme callbacks. This is more secure than custom URL schemes, which can be subject to [client impersonation attacks](https://datatracker.ietf.org/doc/html/rfc8252#section-8.6).
+  </Note>
+
+  ### Get your signing certificate fingerprint
+
+  You need the SHA256 fingerprint of your app's signing certificate. Run the following command in your terminal:
+
+  ```shellscript
+  # For debug builds
+  keytool -list -v -keystore ~/.android/debug.keystore -alias androiddebugkey -storepass android -keypass android
+
+  # For release builds
+  keytool -list -v -keystore my-release-key.keystore
+  ```
+
+  Copy the **SHA256** fingerprint value from the output.
+
+  ### Configure in the Auth0 Dashboard
+
+  1. Go to [Auth0 Dashboard > Applications > Applications](https://manage.auth0.com/#/applications), and select your application
+  2. Scroll to the bottom of the **Settings** page and select **Show Advanced Settings**
+  3. Select the **Device Settings** tab
+  4. Under **Android**, provide:
+     - **App Package Name**: Your `applicationId` (e.g., `com.auth0.samples.android`)
+     - **SHA256 Cert Fingerprints**: The fingerprint you copied above
+  5. Click **Save Changes**
+
+  ### Verify the configuration
+
+  Auth0 automatically generates the `assetlinks.json` file used by Android to verify your app. Test it by navigating to:
+
+  ```
+  https://{yourDomain}/.well-known/assetlinks.json
+  ```
+
+  You should see a JSON response containing your package name and certificate fingerprint:
+
+  ```json
+  [{
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "[YOUR_PACKAGE_NAME]",
+      "sha256_cert_fingerprints": ["YOUR_SHA256_FINGERPRINT"]
+    }
+  }]
+  ```
+
+  <Info>
+    The quickstart already uses `https` as the scheme in the manifest placeholders and `WebAuthProvider` calls, which is required for App Links. No code changes are needed if you followed the steps above.
+  </Info>
+
+  To learn more, see the [Enable Android App Links Support](/get-started/applications/enable-android-app-links-support) documentation and Android's [Verify App Links](https://developer.android.com/training/app-links/verify-site-associations) guide.
+</Accordion>
+
+<Accordion title="Use a custom URL scheme">
+  If you cannot use Android App Links (for example, when targeting Android API versions below 23), you can configure a custom URL scheme instead.
+
+  <Warning>
+    Custom URL schemes are less secure than App Links because they can be subject to [client impersonation attacks](https://datatracker.ietf.org/doc/html/rfc8252#section-8.6). Use App Links whenever possible.
+  </Warning>
+
+  1. Update the `auth0Scheme` manifest placeholder in your `app/build.gradle.kts`:
+
+  ```kotlin app/build.gradle.kts lines
+  android {
+      defaultConfig {
+          manifestPlaceholders += mapOf(
+              "auth0Domain" to "@string/com_auth0_domain",
+              "auth0Scheme" to "myapp" // Use a unique custom scheme
+          )
+      }
+  }
+  ```
+
+  2. Update the **Allowed Callback URLs** and **Allowed Logout URLs** in your [Auth0 Dashboard](https://manage.auth0.com/#/applications) application settings to use the custom scheme:
+
+  ```
+  myapp://{yourDomain}/android/PACKAGE_NAME/callback
+  ```
+
+  3. Pass the custom scheme when calling `WebAuthProvider`:
+
+  ```kotlin MainActivity.kt lines
+  WebAuthProvider.login(auth0)
+      .withScheme("myapp")
+      .withScope("openid profile email offline_access")
+      .start(this, callback)
+  ```
+
+  <Note>
+    Custom schemes [can only contain lowercase letters](https://developer.android.com/guide/topics/manifest/data-element).
+  </Note>
 </Accordion>
 
 <Accordion title="Production Deployment">


### PR DESCRIPTION


## Description

This PR improves the native Android quickstart by adding a section on how to configure App-links when using `https` scheme.

## Checklist

- [X] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [X] I've tested the site build for this change locally.
- [X] I've made appropriate docs updates for any code or config changes.
- [X] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
