### PR TITLE
docs: migrate Rules references to Actions in authenticate/login/auth0-universal-login/passwordless-login/webauthn-device-biometrics.mdx

### DIFF
--- a/main/docs/authenticate/login/auth0-universal-login/passwordless-login/webauthn-device-biometrics.mdx
+++ b/main/docs/authenticate/login/auth0-universal-login/passwordless-login/webauthn-device-biometrics.mdx
@@ -93,7 +93,7 @@ exports.onExecutePostLogin = async (event, api) => {
 
 ## Device Recognition
 
-Auth0 will use the rules to determine if the device is already enrolled or not, and prompt the user for enrollment. To learn more, read [Device recognition](/docs/secure/multi-factor-authentication/fido-authentication-with-webauthn/configure-webauthn-device-biometrics-for-mfa#device-recognition) in the article [Configure WebAuthn with Device Biometrics for MFA](/docs/secure/multi-factor-authentication/fido-authentication-with-webauthn/configure-webauthn-device-biometrics-for-mfa).
+Auth0 will use Actions to determine if the device is already enrolled or not, and prompt the user for enrollment. To learn more, read [Device recognition](/docs/secure/multi-factor-authentication/fido-authentication-with-webauthn/configure-webauthn-device-biometrics-for-mfa#device-recognition) in the article [Configure WebAuthn with Device Biometrics for MFA](/docs/secure/multi-factor-authentication/fido-authentication-with-webauthn/configure-webauthn-device-biometrics-for-mfa).
 
 To avoid user enumeration attacks, Auth0 will only prompt users for biometrics as the first factor if users are logging in from a known device. If not, they'll need to login with the password.
 


### PR DESCRIPTION
## Summary

Migrates Auth0 Rules references to Auth0 Actions in `authenticate/login/auth0-universal-login/passwordless-login/webauthn-device-biometrics.mdx`.

**Changes applied:** 1 of 3 suggestions

## Requested changes

1. ````js function (user, context, callback) {   const completedMfa = !!(     contex...`
2. `Auth0 will use the rules to determine if the device is already enrolled or not, ...`
3. `To learn more, read [Device recognition using rules](/secure/multi-factor-authen...`

---

Generated by auth0-ia Rules Deprecation Tracker (AI-applied to MDX source)