### PR TITLE
docs: migrate Rules references to Actions in authenticate/login/auth0-universal-login/passwordless-login/webauthn-device-biometrics.mdx

### DIFF
--- a/main/docs/authenticate/login/auth0-universal-login/passwordless-login/webauthn-device-biometrics.mdx
+++ b/main/docs/authenticate/login/auth0-universal-login/passwordless-login/webauthn-device-biometrics.mdx
@@ -16,13 +16,13 @@ You must use this feature with an Auth0 database connection. Navigate to [Auth0 
 
 To enable <Tooltip tip="Passwordless: Form of authentication that does not rely on a password as the first factor." cta="View Glossary" href="/docs/glossary?term=Passwordless">Passwordless</Tooltip> with WebAuthn Device Biometrics, you need to:
 
-1. Make sure the Universal Login experience is enabled and that the HTML for the login page is not customized in [Dashboard > Universal Login](https://manage.auth0.com/#/login_settings).
+1. Make sure the Universal Login experience is enabled and that the HTML for the login page is not customized in [Dashboard > Universal Login](https://manage.auth0.com/#/login_settings).
 2. Select **Identifier First + Biometrics** in the [Dashboard > Authentication Profile](https://manage.auth0.com/#/authentication-profiles). This will automatically [enable WebAuthn with Device Biometrics](/docs/secure/multi-factor-authentication/fido-authentication-with-webauthn/configure-webauthn-device-biometrics-for-mfa) in the Multi-Factor authentication section if it is not enabled yet.
 3. If you use a [custom database connection](/docs/authenticate/database-connections/custom-db), ensure **Import Mode** is set to **On.** If it's not, you can run the [getUser script](/docs/authenticate/database-connections/custom-db/templates/get-user) to the same effect.
 
 ## How does it work
 
-Users that authenticate with username/email and password and have a device that [is capable of using WebAuthn with Device Biometrics](https://webauthn.me/browser-support), are given the option of enrolling their device:
+Users that authenticate with username/email and password and have a device that [is capable of using WebAuthn with Device Biometrics](https://webauthn.me/browser-support), are given the option of enrolling their device:
 
 <Frame>![Example of setting up a Face ID login for specific domain using WebAuthn](/docs/images/cdy7uua7fh8z/1JfsIYEo3O7xmTAxLRwNSs/2f2ba478ff32b0aa86f4f01cd6c0cf3b/2023-01-31_16-34-09.png)</Frame>
 
@@ -58,7 +58,7 @@ This has several consequences:
 The next time they log in, they can log in with password + another authentication method or with device biometrics.
 
 * When users authenticate using WebAuthn Biometrics as their only authentication method, the `amr` value in the <Tooltip tip="ID Token: Credential meant for the client itself, rather than for accessing a resource." cta="View Glossary" href="/docs/glossary?term=ID+Token">ID Token</Tooltip> will be set to `mfa`.
-* If you want to enable MFA from our extensibility platform, you’ll be able to consider how users authenticated to decide if they should be prompted for MFA or not. The rule below will only perform MFA if the user did not authenticate with the `webauthn-platform` authentication method:
+* If you want to enable MFA from our extensibility platform, you'll be able to consider how users authenticated to decide if they should be prompted for MFA or not. The rule below will only perform MFA if the user did not authenticate with the `webauthn-platform` authentication method:
 
 ```javascript javascript lines
 function (user, context, callback) {
@@ -93,7 +93,7 @@ exports.onExecutePostLogin = async (event, api) => {
 
 ## Device Recognition
 
-Auth0 will use the rules to determine if the device is already enrolled or not, and prompt the user for enrollment. To learn more, read [Device recognition](/docs/secure/multi-factor-authentication/fido-authentication-with-webauthn/configure-webauthn-device-biometrics-for-mfa#device-recognition) in the article [Configure WebAuthn with Device Biometrics for MFA](/docs/secure/multi-factor-authentication/fido-authentication-with-webauthn/configure-webauthn-device-biometrics-for-mfa).
+Auth0 will use the Actions to determine if the device is already enrolled or not, and prompt the user for enrollment. To learn more, read [Device recognition](/docs/secure/multi-factor-authentication/fido-authentication-with-webauthn/configure-webauthn-device-biometrics-for-mfa#device-recognition) in the article [Configure WebAuthn with Device Biometrics for MFA](/docs/secure/multi-factor-authentication/fido-authentication-with-webauthn/configure-webauthn-device-biometrics-for-mfa).
 
 To avoid user enumeration attacks, Auth0 will only prompt users for biometrics as the first factor if users are logging in from a known device. If not, they'll need to login with the password.
 


### PR DESCRIPTION
## Summary

Migrates Auth0 Rules references to Auth0 Actions in `authenticate/login/auth0-universal-login/passwordless-login/webauthn-device-biometrics.mdx`.

**Changes applied:** 2 of 4 suggestions

---

Generated by auth0-ia Rules Deprecation Tracker