### PR TITLE
docs: migrate Rules to Actions in authenticate/passwordless/sample-use-cases-rules.mdx

### DIFF
--- a/main/docs/authenticate/passwordless/sample-use-cases-rules.mdx
+++ b/main/docs/authenticate/passwordless/sample-use-cases-rules.mdx
@@ -1,6 +1,7 @@
 ---
-description: Explore examples using rules with passwordless connections.
-title: Sample Use Cases - Rules with Passwordless Authentication
+description: Explore examples using Actions with passwordless connections.
+title: Sample Use Cases - Actions with Passwordless Authentication
+validatedOn: 2026-04-10
 ---
 <Warning>
 
@@ -14,29 +15,29 @@ To read more about the Rules and Hooks deprecation, read our blog post: [Prepari
 
 </Warning>
 
-With [rules](/docs/customize/rules), you can handle more complicated cases than is possible with [passwordless connections](/docs/authenticate/passwordless) alone. For instance, you can add extra precautions to further ensure possession of an email address or device.
+With [Actions](/docs/customize/actions), you can handle more complicated cases than is possible with [passwordless connections](/docs/authenticate/passwordless) alone. For instance, you can add extra precautions to further ensure possession of an email address or device.
 
 ## Require Multi-factor Authentication for users who are outside the corporate network
 
 Let's say you want to require [multi-factor authentication (MFA)](/docs/secure/multi-factor-authentication) for any users who are accessing the application using a <Tooltip tip="Passwordless: Form of authentication that does not rely on a password as the first factor." cta="View Glossary" href="/docs/glossary?term=passwordless">passwordless</Tooltip> connection from outside your corporate network.
 
-Using a rule, you can check whether a user is authenticating using a passwordless method (`sms`, `email`) and if their session IP falls outside of the designated corporate network, prompt them for a second authentication factor.
+Using an Action, you can check whether a user is authenticating using a passwordless method (`sms`, `email`) and if their session IP falls outside of the designated corporate network, prompt them for a second authentication factor.
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 
-You could also trigger this rule based on other criteria, such as whether the current IP matches the user's IP allowlist or whether geolocating the user reveals they are in a different country from the one listed in their user profile.
+You could also trigger this Action based on other criteria, such as whether the current IP matches the user's IP allowlist or whether geolocating the user reveals they are in a different country from the one listed in their user profile.
 
 </Callout>
 
-To do this, you would [create the following rule](/docs/customize/rules/create-rules):
+To do this, you would [create the following Action](/docs/customize/actions/write-your-first-action):
 
 ```javascript lines
-function(user, context, callback) {
+exports.onExecutePostLogin = async (event, api) => {
   const ipaddr = require('ipaddr.js');
   const corp_network = "192.168.1.134/26";
-  const current_ip = ipaddr.parse(context.request.ip);
+  const current_ip = ipaddr.parse(event.request.ip);
   // is auth method passwordless and IP outside corp network?
-  const passwordlessOutside = context.authentication.methods.find(
+  const passwordlessOutside = event.authentication.methods.find(
     (method) => (
       ((method.name === 'sms') || (method.name === 'email')) && 
       (!current_ip.match(ipaddr.parseCIDR(corp_network)))
@@ -45,13 +46,11 @@ function(user, context, callback) {
 
   // if yes, then require MFA
   if (passwordlessOutside) {
-    context.multifactor = {
-      provider: 'any',
+    api.multifactor.enable('any', {
       allowRememberBrowser: false
-    };
+    });
   }
-  callback(null, user, context);
-}
+};
 ```
 
 


### PR DESCRIPTION
## Summary

Migrates Auth0 Rules references to Auth0 Actions in `authenticate/passwordless/sample-use-cases-rules.mdx`.

---

Generated by auth0-ia Rules Deprecation Tracker