### PR TITLE
fix: update Angular quickstart for Angular 20+ compatibility

### DIFF
--- a/main/docs/quickstart/spa/angular/index.mdx
+++ b/main/docs/quickstart/spa/angular/index.mdx
@@ -147,7 +147,7 @@ export const localEnvSnippet = `export const environment = {
     </Tabs>
   </Step>
   <Step title="Configure the Auth0 module" stepNumber={4}>
-    The CLI script has already created your environment file. Now configure the Auth0 module in your app:
+    With your environment file in place from the previous step, configure the Auth0 module in your app:
 
     ```typescript src/main.ts {3,4,5,9-15} lines
     import { bootstrapApplication } from '@angular/platform-browser';
@@ -155,7 +155,7 @@ export const localEnvSnippet = `export const environment = {
     import { provideAuth0 } from '@auth0/auth0-angular';
     import { mergeApplicationConfig } from '@angular/core';
     import { environment } from './environments/environment';
-    import { AppComponent } from './app/app.component';
+    import { App } from './app/app';
 
     const auth0Config = mergeApplicationConfig(appConfig, {
       providers: [
@@ -169,13 +169,20 @@ export const localEnvSnippet = `export const environment = {
       ]
     });
 
-    bootstrapApplication(AppComponent, auth0Config).catch((err) =>
+    bootstrapApplication(App, auth0Config).catch((err) =>
       console.error(err)
     );
     ```
 
     <Note>
       If you set up your Auth0 app manually via the dashboard, create `src/environments/environment.ts` with your domain and client ID from the dashboard.
+
+      If you're using **Angular 18 or 19**, the CLI generates `app.component.ts` and exports `AppComponent` instead of `App`. Change lines 6 and 20 to match:
+      ```typescript
+      import { AppComponent } from './app/app.component';
+      // ...
+      bootstrapApplication(AppComponent, auth0Config).catch((err) => console.error(err));
+      ```
     </Note>
   </Step>
   <Step title="Create Login, Logout and Profile Components" stepNumber={5}>
@@ -319,7 +326,7 @@ export const localEnvSnippet = `export const environment = {
 
     <Tabs>
       <Tab title="App Component">
-        Replace the contents of `src/app/app.component.ts`:
+        Replace the contents of `src/app/app.ts`:
 
         ```typescript src/app/app.ts expandable lines
         import { Component, inject } from '@angular/core';
@@ -384,7 +391,7 @@ export const localEnvSnippet = `export const environment = {
           `,
           styles: []
         })
-        export class AppComponent {
+        export class App {
           protected auth = inject(AuthService);
         }
         ```
@@ -675,19 +682,27 @@ export const localEnvSnippet = `export const environment = {
 ## Advanced Usage
 
 <Accordion title="Using Traditional NgModule Approach">
-  If you prefer using NgModules instead of standalone components, here's how to configure the SDK:
+  If you created your project with `--standalone=false` or prefer using NgModules instead of standalone components, here's how to configure the SDK with Angular 20+ CLI-generated projects:
 
-  ```typescript src/app/app.module.ts
-  import { NgModule } from '@angular/core';
+  ```typescript src/main.ts
+  import { platformBrowser } from '@angular/platform-browser';
+  import { AppModule } from './app/app-module';
+
+  platformBrowser().bootstrapModule(AppModule)
+    .catch((err) => console.error(err));
+  ```
+
+  ```typescript src/app/app-module.ts
+  import { NgModule, provideBrowserGlobalErrorListeners } from '@angular/core';
   import { BrowserModule } from '@angular/platform-browser';
   import { AuthModule } from '@auth0/auth0-angular';
   import { environment } from '../environments/environment';
 
-  import { AppRoutingModule } from './app-routing.module';
-  import { AppComponent } from './app';
+  import { AppRoutingModule } from './app-routing-module';
+  import { App } from './app';
 
   @NgModule({
-    declarations: [AppComponent],
+    declarations: [App],
     imports: [
       BrowserModule,
       AppRoutingModule,
@@ -699,11 +714,17 @@ export const localEnvSnippet = `export const environment = {
         }
       })
     ],
-    providers: [],
-    bootstrap: [AppComponent]
+    providers: [provideBrowserGlobalErrorListeners()],
+    bootstrap: [App]
   })
   export class AppModule { }
   ```
+
+  <Note>
+    If you're using Angular 18 or 19, your generated files are typically `app.component.ts`, `app.module.ts`, and `app-routing.module.ts`, and `main.ts` typically uses `platformBrowserDynamic` instead.
+
+    In all cases, NgModule projects bootstrap via `bootstrapModule()` rather than the `bootstrapApplication()` approach shown in the main quickstart.
+  </Note>
 </Accordion>
 
 <Accordion title="Protecting Routes with AuthGuard">


### PR DESCRIPTION
Related: https://github.com/auth0/auth0-angular/issues/889

Angular 20+ CLI generates `src/app/app.ts` (class `App`) instead of `src/app/app.component.ts` (`AppComponent`). Updated the quickstart code to match, added a backward-compat note for Angular 18/19, and fixed the NgModule accordion to use `platformBrowserDynamic` bootstrapping.