### PR TITLE
fix: DOCS-5290 replace custom URI schemes with App Links and Universal Links in React Native quickstart

### DIFF
--- a/main/docs/quickstart/native/react-native/index.mdx
+++ b/main/docs/quickstart/native/react-native/index.mdx
@@ -79,37 +79,29 @@ Your AI assistant will automatically create your Auth0 application, fetch creden
   <Step title="Configure your Auth0 Application" stepNumber={3}>
     Create and configure an Auth0 application to work with your React Native app.
 
-    1. Head to the [Auth0 Dashboard](https://manage.auth0.com/dashboard/)
-    2. Click on **Applications** > **Applications** > **Create Application**
-    3. In the popup, enter a name for your app (e.g., `Auth0 React Native Sample`), select `Native` as the app type and click **Create**
-    4. Switch to the **Settings** tab on the Application Details page
-    5. Note your **Domain** and **Client ID** values
+    1. Navigate to the [Auth0 Dashboard](https://manage.auth0.com/dashboard/).
+    2. Select **Applications** > **Applications** > **Create Application**.
+    3. In the dialog, enter a name for your application (for example, `Auth0 React Native Sample`), select **Native** as the application type, and select **Create**.
+    4. Select the **Settings** tab on the Application Details page.
+    5. Note your **Domain** and **Client ID** values.
 
     **Allowed Callback URLs:**
     ```
-    org.reactjs.native.example.auth0reactnativesample.auth0://{yourDomain}/ios/org.reactjs.native.example.auth0reactnativesample/callback,
-    com.auth0reactnativesample.auth0://{yourDomain}/android/com.auth0reactnativesample/callback
+    https://YOUR_DOMAIN/ios/org.reactjs.native.example.auth0reactnativesample/callback,
+    https://YOUR_DOMAIN/android/com.auth0reactnativesample/callback
     ```
 
     **Allowed Logout URLs:**
     ```
-    org.reactjs.native.example.auth0reactnativesample.auth0://{yourDomain}/ios/org.reactjs.native.example.auth0reactnativesample/callback,
-    com.auth0reactnativesample.auth0://{yourDomain}/android/com.auth0reactnativesample/callback
+    https://YOUR_DOMAIN/ios/org.reactjs.native.example.auth0reactnativesample/callback,
+    https://YOUR_DOMAIN/android/com.auth0reactnativesample/callback
     ```
 
-    Replace `{yourDomain}` with your actual Auth0 domain (e.g., `dev-abc123.us.auth0.com`).
+    Replace `YOUR_DOMAIN` with your actual Auth0 domain (for example, `dev-abc123.us.auth0.com`).
 
     <Info>
-      **Allowed Callback URLs** are a critical security measure to ensure users are safely returned to your application after authentication. Without a matching URL, the login process will fail, and users will be blocked by an Auth0 error page instead of accessing your app.
-
-      **Allowed Logout URLs** are essential for providing a seamless user experience upon signing out. Without a matching URL, users will not be redirected back to your application after logout and will instead be left on a generic Auth0 page.
-
-      The URL scheme includes `.auth0` after your bundle identifier to ensure the callback is routed to your specific app. For this quickstart, the bundle identifier is `org.reactjs.native.example.auth0reactnativesample`.
+      These HTTPS callback URLs use App Links (Android) and Universal Links (iOS), which the operating system verifies before routing the callback to your application. This prevents other applications from intercepting the authentication response. To learn more, read [Measures Against App Impersonation](https://auth0.com/docs/secure/security-guidance/measures-against-app-impersonation).
     </Info>
-
-    <Warning>
-      **Important**: The callback URL scheme must include `.auth0` after your bundle identifier (e.g., `org.reactjs.native.example.auth0reactnativesample.auth0://`). This is required for the SDK to properly handle the authentication callback.
-    </Warning>
   </Step>
 
   <Step title="Configure Native Platforms" stepNumber={4}>
@@ -127,68 +119,36 @@ Your AI assistant will automatically create your Auth0 application, fetch creden
             
             // Add Auth0 manifest placeholders
             manifestPlaceholders = [
-                auth0Domain: "{yourDomain}",
-                auth0Scheme: "${applicationId}.auth0"
+                auth0Domain: "YOUR_DOMAIN",
+                auth0Scheme: "https"
             ]
         }
     }
     ```
 
-    Replace `{yourDomain}` with your Auth0 domain (e.g., `dev-abc123.us.auth0.com`).
+    Replace `YOUR_DOMAIN` with your Auth0 domain (for example, `dev-abc123.us.auth0.com`).
+
+    <Info>
+      Setting `auth0Scheme: "https"` enables App Links, which lets Android verify the callback URL against your domain before routing it to your application.
+    </Info>
 
     **iOS Configuration:**
 
-    <Tabs>
-      <Tab title="AppDelegate.mm (Objective-C)">
-        Open `ios/Auth0ReactNativeSample/AppDelegate.mm` and add the URL handling method:
+    To enable Universal Links, add an Associated Domain to your Xcode project.
 
-        ```objc ios/Auth0ReactNativeSample/AppDelegate.mm lines
-        #import <React/RCTLinkingManager.h>
+    1. Open your project in Xcode.
+    2. Select your target, then select the **Signing & Capabilities** tab.
+    3. Select **+ Capability** and add **Associated Domains**.
+    4. In the Associated Domains list, add the following entry:
 
-        // Add this method inside the @implementation block
-        - (BOOL)application:(UIApplication *)app
-                    openURL:(NSURL *)url
-                    options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options
-        {
-          return [RCTLinkingManager application:app openURL:url options:options];
-        }
-        ```
-      </Tab>
-
-      <Tab title="AppDelegate.swift (Swift)">
-        Open `ios/Auth0ReactNativeSample/AppDelegate.swift` and add the URL handling method:
-
-        ```swift ios/Auth0ReactNativeSample/AppDelegate.swift lines
-        import React
-
-        // Add this method inside the AppDelegate class
-        func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-          return RCTLinkingManager.application(app, open: url, options: options)
-        }
-        ```
-      </Tab>
-    </Tabs>
-
-    Open `ios/Auth0ReactNativeSample/Info.plist` and add the URL scheme. Add this before the closing `</dict>` tag:
-
-    ```xml ios/Auth0ReactNativeSample/Info.plist lines
-    <key>CFBundleURLTypes</key>
-    <array>
-      <dict>
-        <key>CFBundleTypeRole</key>
-        <string>None</string>
-        <key>CFBundleURLName</key>
-        <string>auth0</string>
-        <key>CFBundleURLSchemes</key>
-        <array>
-          <string>$(PRODUCT_BUNDLE_IDENTIFIER).auth0</string>
-        </array>
-      </dict>
-    </array>
+    ```
+    applinks:YOUR_DOMAIN
     ```
 
+    Replace `YOUR_DOMAIN` with your Auth0 domain (for example, `dev-abc123.us.auth0.com`).
+
     <Info>
-      The URL scheme uses your bundle identifier with `.auth0` appended. This ensures the callback is routed to your specific app after authentication completes in the browser.
+      Universal Links are verified by iOS against a file hosted at your Auth0 domain before routing callbacks to your application. This prevents other applications from intercepting the authentication response.
     </Info>
   </Step>
 
@@ -208,8 +168,8 @@ Your AI assistant will automatically create your Auth0 application, fetch creden
         const App = () => {
           return (
             <Auth0Provider
-              domain="{yourDomain}"
-              clientId="{yourClientId}">
+              domain="YOUR_DOMAIN"
+              clientId="YOUR_CLIENT_ID">
               <SafeAreaView style={styles.container}>
                 <MainScreen />
               </SafeAreaView>
@@ -227,7 +187,7 @@ Your AI assistant will automatically create your Auth0 application, fetch creden
         export default App;
         ```
 
-        Replace `{yourDomain}` with your Auth0 domain and `{yourClientId}` with your Client ID from the Auth0 Dashboard.
+        Replace `YOUR_DOMAIN` with your Auth0 domain and `YOUR_CLIENT_ID` with your Client ID from the Auth0 Dashboard settings.
 
         <Tip>
           The `Auth0Provider` initializes the SDK and provides authentication context to all child components via the `useAuth0` hook.
@@ -268,7 +228,7 @@ Your AI assistant will automatically create your Auth0 application, fetch creden
   </Step>
 
   <Step title="Implement Login and Logout" stepNumber={6}>
-    Create a screen component that handles login and logout. You can choose between a hooks-based approach (recommended) or a class-based approach.
+    Create a screen component that handles login and logout. Choose between a hooks-based approach (recommended) or a class-based approach.
 
     <Tabs>
       <Tab title="Hooks-based (Recommended)">
@@ -416,8 +376,8 @@ Your AI assistant will automatically create your Auth0 application, fetch creden
         import Auth0, {Credentials} from 'react-native-auth0';
 
         const auth0 = new Auth0({
-          domain: '{yourDomain}',
-          clientId: '{yourClientId}',
+          domain: 'YOUR_DOMAIN',
+          clientId: 'YOUR_CLIENT_ID',
         });
 
         interface User {
@@ -582,7 +542,7 @@ Your AI assistant will automatically create your Auth0 application, fetch creden
         export default MainScreen;
         ```
 
-        Replace `{yourDomain}` with your Auth0 domain and `{yourClientId}` with your Client ID from the Auth0 Dashboard.
+        Replace `YOUR_DOMAIN` with your Auth0 domain and `YOUR_CLIENT_ID` with your Client ID from the Auth0 Dashboard settings.
       </Tab>
     </Tabs>
 
@@ -621,7 +581,7 @@ Your AI assistant will automatically create your Auth0 application, fetch creden
 <Check>
   **Checkpoint**
 
-  You should now have a fully functional Auth0 login experience running on your device or emulator. The app uses secure browser authentication and automatically manages credentials.
+  You now have a fully functional Auth0 login experience running on your device or emulator. The app uses secure browser authentication and automatically manages credentials.
 </Check>
 
 ***
@@ -633,25 +593,25 @@ Your AI assistant will automatically create your Auth0 application, fetch creden
 
   **Solution:**
 
-  1. Verify the exact URL (including `.auth0` suffix) is in **Allowed Callback URLs** in your Auth0 Dashboard
-  2. Ensure both iOS and Android URLs are added
-  3. Check that `{yourDomain}` is replaced with your actual Auth0 domain
+  1. Verify the HTTPS callback URL is in **Allowed Callback URLs** in the Auth0 Dashboard.
+  2. Ensure both iOS and Android URLs are added.
+  3. Confirm `YOUR_DOMAIN` is replaced with your actual Auth0 domain.
 
   ### App doesn't return after login (iOS)
 
   **Fix:**
 
-  1. Check `Info.plist` has the `CFBundleURLSchemes` entry with `$(PRODUCT_BUNDLE_IDENTIFIER).auth0`
-  2. Verify `AppDelegate.mm` includes the URL handling method
-  3. Ensure the URL scheme matches your bundle identifier
+  1. Confirm the Associated Domain `applinks:YOUR_DOMAIN` is added in Xcode under **Signing & Capabilities**.
+  2. Verify the HTTPS callback URL in the Auth0 Dashboard matches your bundle identifier and domain.
+  3. Ensure your Apple Developer team has an active membership, as Associated Domains requires a valid team ID.
 
   ### Android build fails
 
   **Fix:**
 
-  1. Add `auth0Domain` and `auth0Scheme` manifest placeholders to `build.gradle`
-  2. Sync project with Gradle files
-  3. Clean build: `./gradlew clean`
+  1. Add `auth0Domain` and `auth0Scheme` manifest placeholders to `android/app/build.gradle`. Set `auth0Scheme: "https"` to enable App Links.
+  2. Sync the project with Gradle files.
+  3. Clean the build: `./gradlew clean`
 
   ### "PKCE not allowed" error
 
@@ -756,28 +716,22 @@ Your AI assistant will automatically create your Auth0 application, fetch creden
 <Accordion title="Production Deployment">
   ### Before deploying to production
 
-  **Use HTTPS callback URLs** for enhanced security:
-  ```text
-  https://{yourDomain}/ios/{bundleId}/callback
-  https://{yourDomain}/android/{packageName}/callback
-  ```
+  **Verify Android App Links** in the Auth0 Dashboard:
+  * Navigate to **Settings** > **Advanced Settings** > **Device Settings**.
+  * Add your application's SHA-256 certificate fingerprint so Android can verify your domain.
 
-  **Configure Android App Links** in Auth0 Dashboard:
-  * Settings → Advanced Settings → Device Settings
-  * Add your app's SHA-256 fingerprint
+  **Verify iOS Universal Links:**
+  * Confirm `applinks:YOUR_DOMAIN` is present in **Signing & Capabilities** > **Associated Domains** in Xcode.
+  * Confirm the callback URL registered in the Auth0 Dashboard matches the format `https://YOUR_DOMAIN/ios/{bundleId}/callback`.
 
-  **Configure iOS Universal Links:**
-  * Add Associated Domains capability in Xcode
-  * Add `webcredentials:{yourDomain}` to Associated Domains
+  **Enable biometric authentication** for sensitive applications using `localAuthenticationOptions` in `Auth0Provider`.
 
-  **Enable biometric authentication** for sensitive apps using `localAuthenticationOptions` in `Auth0Provider`
-
-  **Review security settings** in Auth0 Dashboard:
-  * Enable **OIDC Conformant** in Advanced Settings
-  * Configure **Token Expiration** appropriately
-  * Set up **Brute Force Protection**
-  * Test on multiple devices and OS versions
-  * Implement proper error handling for network failures
+  **Review security settings** in the Auth0 Dashboard:
+  * Enable **OIDC Conformant** in **Advanced Settings**.
+  * Configure **Token Expiration** appropriately.
+  * Set up **Brute Force Protection**.
+  * Test on multiple devices and OS versions.
+  * Implement proper error handling for network failures.
 </Accordion>
 
 - [Sample Application](https://github.com/auth0-samples/auth0-react-native-sample)


### PR DESCRIPTION
## Summary

- **Step 3 (Configure Auth0 Application):** Updated callback and logout URLs from custom URI schemes (`com.example.auth0://`) to HTTPS format (`https://YOUR_DOMAIN/android/.../callback` and `https://YOUR_DOMAIN/ios/.../callback`); replaced dual Info/Warning callouts with a single Info callout explaining App Links and Universal Links verification.
- **Step 4 (Android):** Changed `auth0Scheme` from `"${applicationId}.auth0"` to `"https"` in the `build.gradle` manifest placeholders snippet; added Info callout explaining that `auth0Scheme: "https"` enables App Links.
- **Step 4 (iOS):** Removed `CFBundleURLSchemes`/`CFBundleURLTypes` in `Info.plist` and `AppDelegate.mm`/`AppDelegate.swift` URL handler blocks; replaced with Associated Domains (`applinks:YOUR_DOMAIN`) Xcode configuration steps and an Info callout explaining Universal Links verification.
- **Troubleshooting accordions:** Updated "Callback URL mismatch", "App doesn't return after login (iOS)", and "Android build fails" to reference HTTPS URLs, App Links, and Universal Links rather than custom URI schemes.
- **Production Deployment accordion:** Removed redundant "Use HTTPS callback URLs" block; updated Android and iOS verification steps; removed incorrect `webcredentials:` reference.
- **Style guide fixes:** `{yourDomain}` → `YOUR_DOMAIN`, `{yourClientId}` → `YOUR_CLIENT_ID` (ALL_CAPS placeholder format throughout); "click" → "select"; "app" → "application"; `e.g.` → "for example"; removed passive voice in steps.

## Test plan

- [ ] Verify all callback URL examples render correctly in Mintlify preview
- [ ] Confirm `build.gradle` code block displays `auth0Scheme: "https"` with correct syntax highlighting
- [ ] Confirm iOS section shows Associated Domains steps (no `Info.plist` or `AppDelegate` content)
- [ ] Confirm no remaining `{yourDomain}`, `{yourClientId}`, or `.auth0` custom scheme references in the file
- [ ] Verify troubleshooting and production accordions open and render correctly

Closes DOCS-5290

🤖 Generated with [Claude Code](https://claude.com/claude-code)