### PR TITLE
fix/edit-Native-to-Web=SSO 

### DIFF
--- a/main/docs/authenticate/single-sign-on/native-to-web.mdx
+++ b/main/docs/authenticate/single-sign-on/native-to-web.mdx
@@ -1,15 +1,15 @@
 ---
-description: Learn how Auth0's Native to Web SSO works.
+description: Understand how Native to Web SSO transitions authenticated users from native to web applications.
 sidebarTitle: Overview
 title: Native to Web SSO
 validatedOn: 2026-02-24
 ---
 
-Auth0’s Native to Web <Tooltip tip="Single Sign-On (SSO): Service that, after a user logs into one applicaton, automatically logs that user in to other applications." cta="View Glossary" href="/docs/glossary?term=Single+Sign-On">Single Sign-On</Tooltip> (SSO) feature provides a seamless user experience transitioning authenticated users from your [native application](/docs/authenticate/login/native-login) to your web application.
+Native to Web <Tooltip tip="Single Sign-On (SSO): Service that, after a user logs into one application, automatically logs that user in to other applications." cta="View Glossary" href="/docs/glossary?term=Single+Sign-On">Single Sign-On</Tooltip> (SSO) gives users a continuous authenticated session as they transition from your [native application](/docs/authenticate/login/native-login) to your web application.
 
 If your web application relies on embedded WebViews or external browsers to deliver extended or advanced functionality, your users can move between native and web environments in the same authenticated session.
 
-By binding Session Transfer Tokens to the specific device through IP address or ASN, session continuity and security is maintained and ensures the authentication context remains secure throughout the transition.
+Auth0 binds each Session Transfer Token to the device's IP address or Autonomous System Number (ASN), maintaining session continuity and keeping the authentication context secure throughout the transition.
 
 ## How it works
 
@@ -23,9 +23,9 @@ By binding Session Transfer Tokens to the specific device through IP address or 
 6. The web application exchanges the authorization code for access or refresh tokens at the [`/token`](https://auth0.com/docs/api/authentication/authorization-code-flow/get-token) endpoint.
 7. The web application initializes a session for the user.
 
-Learn how to [Configure and Implement Native to Web SSO](/docs/authenticate/single-sign-on/native-to-web/configure-implement-native-to-web)
+To configure and implement Native to Web SSO, read [Configure and Implement Native to Web SSO](/docs/authenticate/single-sign-on/native-to-web/configure-implement-native-to-web).
 
 ## Limitations
 
-* Once Native to Web SSO is enabled in a client, the `session_transfer_token` parameter only works for Native to Web SSO
-* <Tooltip tip="Refresh Token: Token used to obtain a renewed Access Token without forcing users to log in again." cta="View Glossary" href="/docs/glossary?term=Refresh+Tokens">Refresh Tokens</Tooltip> originated from a previous Session Transfer Token transaction will not generate new Session Transfer Tokens.
+* Once Native to Web SSO is enabled in an application, the `session_transfer_token` parameter only works for Native to Web SSO.
+* <Tooltip tip="Refresh Token: Token used to obtain a renewed Access Token without forcing users to log in again." cta="View Glossary" href="/docs/glossary?term=Refresh+Tokens">Refresh tokens</Tooltip> originated from a previous Session Transfer Token transaction do not generate new Session Transfer Tokens.

--- a/main/docs/authenticate/single-sign-on/native-to-web.mdx
+++ b/main/docs/authenticate/single-sign-on/native-to-web.mdx
@@ -5,7 +5,7 @@ title: Native to Web SSO
 validatedOn: 2026-02-24
 ---
 
-Native to Web <Tooltip tip="Single Sign-On (SSO): Service that, after a user logs into one application, automatically logs that user in to other applications." cta="View Glossary" href="/docs/glossary?term=Single+Sign-On">Single Sign-On</Tooltip> (SSO) feature provides a seamless user experience transitioning authenticated users from your [native application](/docs/authenticate/login/native-login) to your web application.
+Auth0’s Native to Web <Tooltip tip="Single Sign-On (SSO): Service that, after a user logs into one application, automatically logs that user in to other applications." cta="View Glossary" href="/docs/glossary?term=Single+Sign-On">Single Sign-On</Tooltip> (SSO) feature provides a seamless user experience transitioning authenticated users from your [native application](/docs/authenticate/login/native-login) to your web application.
 
 If your web application relies on embedded WebViews or external browsers to deliver extended or advanced functionality, your users can move between native and web environments in the same authenticated session.
 

--- a/main/docs/authenticate/single-sign-on/native-to-web.mdx
+++ b/main/docs/authenticate/single-sign-on/native-to-web.mdx
@@ -9,7 +9,7 @@ Auth0’s Native to Web <Tooltip tip="Single Sign-On (SSO): Service that, after 
 
 If your web application relies on embedded WebViews or external browsers to deliver extended or advanced functionality, your users can move between native and web environments in the same authenticated session.
 
-Auth0 binds each Session Transfer Token to the device's IP address or Autonomous System Number (ASN), maintaining session continuity and keeping the authentication context secure throughout the transition.
+By binding Session Transfer Tokens to the specific device through IP address or ASN, session continuity and security is maintained and ensures the authentication context remains secure throughout the transition.
 
 ## How it works
 
@@ -23,7 +23,7 @@ Auth0 binds each Session Transfer Token to the device's IP address or Autonomous
 6. The web application exchanges the authorization code for access or refresh tokens at the [`/token`](https://auth0.com/docs/api/authentication/authorization-code-flow/get-token) endpoint.
 7. The web application initializes a session for the user.
 
-Learn how to [Configure and Implement Native to Web SSO](/docs/authenticate/single-sign-on/native-to-web/configure-implement-native-to-web).
+Learn how to [Configure and Implement Native to Web SSO](/docs/authenticate/single-sign-on/native-to-web/configure-implement-native-to-web)
 
 ## Limitations
 

--- a/main/docs/authenticate/single-sign-on/native-to-web.mdx
+++ b/main/docs/authenticate/single-sign-on/native-to-web.mdx
@@ -5,7 +5,7 @@ title: Native to Web SSO
 validatedOn: 2026-02-24
 ---
 
-Native to Web <Tooltip tip="Single Sign-On (SSO): Service that, after a user logs into one application, automatically logs that user in to other applications." cta="View Glossary" href="/docs/glossary?term=Single+Sign-On">Single Sign-On</Tooltip> (SSO) gives users a continuous authenticated session as they transition from your [native application](/docs/authenticate/login/native-login) to your web application.
+Native to Web <Tooltip tip="Single Sign-On (SSO): Service that, after a user logs into one application, automatically logs that user in to other applications." cta="View Glossary" href="/docs/glossary?term=Single+Sign-On">Single Sign-On</Tooltip> (SSO) feature provides a seamless user experience transitioning authenticated users from your [native application](/docs/authenticate/login/native-login) to your web application.
 
 If your web application relies on embedded WebViews or external browsers to deliver extended or advanced functionality, your users can move between native and web environments in the same authenticated session.
 

--- a/main/docs/authenticate/single-sign-on/native-to-web.mdx
+++ b/main/docs/authenticate/single-sign-on/native-to-web.mdx
@@ -23,7 +23,7 @@ Auth0 binds each Session Transfer Token to the device's IP address or Autonomous
 6. The web application exchanges the authorization code for access or refresh tokens at the [`/token`](https://auth0.com/docs/api/authentication/authorization-code-flow/get-token) endpoint.
 7. The web application initializes a session for the user.
 
-To configure and implement Native to Web SSO, read [Configure and Implement Native to Web SSO](/docs/authenticate/single-sign-on/native-to-web/configure-implement-native-to-web).
+Learn how to [Configure and Implement Native to Web SSO](/docs/authenticate/single-sign-on/native-to-web/configure-implement-native-to-web).
 
 ## Limitations
 

--- a/main/docs/authenticate/single-sign-on/native-to-web.mdx
+++ b/main/docs/authenticate/single-sign-on/native-to-web.mdx
@@ -28,4 +28,4 @@ To configure and implement Native to Web SSO, read [Configure and Implement Nati
 ## Limitations
 
 * Once Native to Web SSO is enabled in an application, the `session_transfer_token` parameter only works for Native to Web SSO.
-* <Tooltip tip="Refresh Token: Token used to obtain a renewed Access Token without forcing users to log in again." cta="View Glossary" href="/docs/glossary?term=Refresh+Tokens">Refresh tokens</Tooltip> originated from a previous Session Transfer Token transaction do not generate new Session Transfer Tokens.
+* <Tooltip tip="Refresh Token: Token used to obtain a renewed Access Token without forcing users to log in again." cta="View Glossary" href="/docs/glossary?term=Refresh+Tokens">Refresh Tokens</Tooltip> originated from a previous Session Transfer Token transaction do not generate new Session Transfer Tokens.


### PR DESCRIPTION
## Summary

Style guide corrections to `docs/authenticate/single-sign-on/native-to-web.mdx`:

- **Tooltip typo:** `applicaton` → `application`
- **Frontmatter description:** Removed "Learn how…" phrasing; rewritten to describe what the page covers
- **Intro sentence:** Removed "Auth0's X feature provides" anti-pattern; rewritten to lead with user benefit
- **Passive voice:** Rewrote "session continuity and security is maintained" as active voice; fixed subject-verb agreement
- **ASN:** Spelled out on first use as "Autonomous System Number (ASN)"
- **Cross-reference link:** Updated to baseline format "To X, read [Y]."
- **Limitations — bullet 1:** `client` → `application`; added missing period
- **Limitations — bullet 2:** `Refresh Tokens` → `refresh tokens` (per word list); `will not` → `do not` (present tense default)

## Test plan

- [ ] Verify Mintlify preview renders correctly
- [ ] Confirm tooltip text reads correctly with typo fix
- [ ] Confirm no remaining style guide violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)