### PR TITLE
fix/added-Native-to-Web-SSO-limitation

### DIFF
--- a/main/docs/authenticate/single-sign-on/native-to-web.mdx
+++ b/main/docs/authenticate/single-sign-on/native-to-web.mdx
@@ -29,4 +29,4 @@ Learn how to [Configure and Implement Native to Web SSO](/docs/authenticate/sing
 
 * Once Native to Web SSO is enabled in an application, the `session_transfer_token` parameter only works for Native to Web SSO.
 * <Tooltip tip="Refresh Token: Token used to obtain a renewed Access Token without forcing users to log in again." cta="View Glossary" href="/docs/glossary?term=Refresh+Tokens">Refresh Tokens</Tooltip> originated from a previous Session Transfer Token transaction do not generate new Session Transfer Tokens.
-* Refresh Tokens obtained from a web session created using the `session_transfer_token` parameter cannot request new Session Transfer Tokens.
+* Refresh Tokens originated from a web session created using the `session_transfer_token` parameter can not request new [Session Transfer Tokens](https://auth0.com/docs/authenticate/single-sign-on/native-to-web/native-to-web-sso-and-sessions#sessions-and-refresh-token-revocation).

--- a/main/docs/authenticate/single-sign-on/native-to-web.mdx
+++ b/main/docs/authenticate/single-sign-on/native-to-web.mdx
@@ -29,4 +29,4 @@ Learn how to [Configure and Implement Native to Web SSO](/docs/authenticate/sing
 
 * Once Native to Web SSO is enabled in an application, the `session_transfer_token` parameter only works for Native to Web SSO.
 * <Tooltip tip="Refresh Token: Token used to obtain a renewed Access Token without forcing users to log in again." cta="View Glossary" href="/docs/glossary?term=Refresh+Tokens">Refresh Tokens</Tooltip> originated from a previous Session Transfer Token transaction do not generate new Session Transfer Tokens.
-* Refresh tokens obtained from a web session established using a Session Transfer Token cannot be used to request new Session Transfer Tokens.
+* Refresh Tokens obtained from a web session created using the `session_transfer_token` parameter cannot request new Session Transfer Tokens.

--- a/main/docs/authenticate/single-sign-on/native-to-web.mdx
+++ b/main/docs/authenticate/single-sign-on/native-to-web.mdx
@@ -29,3 +29,4 @@ Learn how to [Configure and Implement Native to Web SSO](/docs/authenticate/sing
 
 * Once Native to Web SSO is enabled in an application, the `session_transfer_token` parameter only works for Native to Web SSO.
 * <Tooltip tip="Refresh Token: Token used to obtain a renewed Access Token without forcing users to log in again." cta="View Glossary" href="/docs/glossary?term=Refresh+Tokens">Refresh Tokens</Tooltip> originated from a previous Session Transfer Token transaction do not generate new Session Transfer Tokens.
+* Refresh tokens obtained from a web session established using a Session Transfer Token cannot be used to request new Session Transfer Tokens.


### PR DESCRIPTION
## Summary

- Adds a third bullet to the `## Limitations` section of `native-to-web.mdx`
- Clarifies that refresh tokens obtained from a web session established via a Session Transfer Token cannot be used to request new Session Transfer Tokens (nested N2W SSO is not supported)
- Closes DOCS-5283

## Test plan

- [ ] Verify the new bullet renders correctly in the Mintlify preview
- [ ] Confirm the limitation accurately reflects the nested N2W SSO restriction described in DOCS-5283

🤖 Generated with [Claude Code](https://claude.com/claude-code)