### PR TITLE
docs: update Hono quickstart to beta SDK API

### DIFF
--- a/main/docs/quickstart/webapp/hono/index.mdx
+++ b/main/docs/quickstart/webapp/hono/index.mdx
@@ -11,24 +11,6 @@ import {AuthCodeGroup} from "/snippets/AuthCodeGroup.jsx";
   This Quickstart is currently in **Beta**. We'd love to hear your feedback!
 </Callout>
 
-<Accordion title="Use AI to integrate Auth0" icon="microchip-ai" iconType="solid" defaultOpen>
-  If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, you can add Auth0 authentication automatically in minutes using [agent skills](https://agentskills.io/home).
-
-  **Install:**
-
-  ```bash
-  npx skills add auth0/agent-skills --skill auth0-quickstart --skill auth0-hono
-  ```
-
-  **Then ask your AI assistant:**
-
-  ```text
-  Add Auth0 authentication to my Hono app
-  ```
-
-  Your AI assistant will automatically create your Auth0 application, fetch credentials, install `@auth0/auth0-hono`, create the middleware setup, and configure environment variables. [Full agent skills documentation →](/quickstart/agent-skills)
-</Accordion>
-
 <Note>
   **Prerequisites:**
 
@@ -67,7 +49,7 @@ This quickstart shows the minimal, recommended way to secure a Hono application 
     npm install -D dotenv
     ```
 
-    Alterantively, if you prefer not to add a dependency, you can load an env file at process start using node's `--env-file` flag, which lets you omit installing and importing `dotenv`.
+    Alternatively, if you prefer not to add a dependency, you can load an env file at process start using node's `--env-file` flag, which lets you omit installing and importing `dotenv`.
 
     Modify the `start` script in `package.json` to:
 
@@ -92,7 +74,7 @@ This quickstart shows the minimal, recommended way to secure a Hono application 
           ```
 
           ```shellscript Windows
-          $AppName = "Hono Quickstart"; winget install Auth0.CLI; auth0 login --no-input; auth0 apps create -n "$AppName" -t regular -c http://localhost:3000/callback -l http://localhost:3000 -o http://localhost:3000 --reveal-secrets --json --metadata created_by="quickstart-docs-cli" | Set-Content -Path auth0-app-details.json; $ClientId = (Get-Content -Raw auth0-app-details.json | ConvertFrom-Json).client_id; $ClientSecret = (Get-Content -Raw auth0-app-details.json | ConvertFrom-Json).client_secret; $Domain = (auth0 tenants list --json | ConvertFrom-Json | Where-Object { $_.active -eq $true }).name; $Secret = [System.Convert]::ToHexString([System.Security.Cryptography.RandomNumberGenerator]::GetBytes(32)).ToLower(); Set-Content -Path .env -Value "AUTH0_DOMAIN=$Domain"; Add-Content -Path .env -Value "AUTH0_CLIENT_ID=$ClientId"; Add-Content -Path .env -Value "AUTH0_CLIENT_SECRET=$ClientSecret"; Add-Content -Path .env -Value "AUTH0_SESSION_ENCRYPTION_KEY=$Secret"; Add-Content -Path .env -Value "APP_BASE_URL=http://localhost:3000"; Remove-Item auth0-app-details.json; Write-Output ".env file created with your Auth0 details:"; Get-Content .env
+          $AppName = "Hono Quickstart"; winget install Auth0.CLI; auth0 login --no-input; auth0 apps create -n "$AppName" -t regular -c http://localhost:3000/auth/callback -l http://localhost:3000 -o http://localhost:3000 --reveal-secrets --json --metadata created_by="quickstart-docs-cli" | Set-Content -Path auth0-app-details.json; $ClientId = (Get-Content -Raw auth0-app-details.json | ConvertFrom-Json).client_id; $ClientSecret = (Get-Content -Raw auth0-app-details.json | ConvertFrom-Json).client_secret; $Domain = (auth0 tenants list --json | ConvertFrom-Json | Where-Object { $_.active -eq $true }).name; $Secret = [System.Convert]::ToHexString([System.Security.Cryptography.RandomNumberGenerator]::GetBytes(32)).ToLower(); Set-Content -Path .env -Value "AUTH0_DOMAIN=$Domain"; Add-Content -Path .env -Value "AUTH0_CLIENT_ID=$ClientId"; Add-Content -Path .env -Value "AUTH0_CLIENT_SECRET=$ClientSecret"; Add-Content -Path .env -Value "AUTH0_SESSION_ENCRYPTION_KEY=$Secret"; Add-Content -Path .env -Value "APP_BASE_URL=http://localhost:3000"; Remove-Item auth0-app-details.json; Write-Output ".env file created with your Auth0 details:"; Get-Content .env
           ```
         </AuthCodeGroup>
 

--- a/main/docs/quickstart/webapp/hono/index.mdx
+++ b/main/docs/quickstart/webapp/hono/index.mdx
@@ -11,6 +11,24 @@ import {AuthCodeGroup} from "/snippets/AuthCodeGroup.jsx";
   This Quickstart is currently in **Beta**. We'd love to hear your feedback!
 </Callout>
 
+<Accordion title="Use AI to integrate Auth0" icon="microchip-ai" iconType="solid" defaultOpen>
+  If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, you can add Auth0 authentication automatically in minutes using [agent skills](https://agentskills.io/home).
+
+  **Install:**
+
+  ```bash
+  npx skills add auth0/agent-skills --skill auth0-quickstart --skill auth0-hono
+  ```
+
+  **Then ask your AI assistant:**
+
+  ```text
+  Add Auth0 authentication to my Hono app
+  ```
+
+  Your AI assistant will automatically create your Auth0 application, fetch credentials, install `@auth0/auth0-hono`, create the middleware setup, and configure environment variables. [Full agent skills documentation →](/quickstart/agent-skills)
+</Accordion>
+
 <Note>
   **Prerequisites:**
 
@@ -22,7 +40,7 @@ import {AuthCodeGroup} from "/snippets/AuthCodeGroup.jsx";
 
 ## Get Started
 
-This quickstart shows the minimal, recommended way to secure a Hono application using `@auth0/auth0-hono`. It follows the repository's recommended patterns: environment-driven configuration, `app.use(auth(...))` middleware, and `requiresAuth()` for selective protection.
+This quickstart shows the minimal, recommended way to secure a Hono application using `@auth0/auth0-hono`. It follows the repository's recommended patterns: environment-driven configuration, `app.use(auth0(...))` middleware, and `requiresAuth()` for selective protection.
 
 <Steps>
   <Step title="Create a new Hono application" stepNumber={1}>
@@ -70,11 +88,11 @@ This quickstart shows the minimal, recommended way to secure a Hono application 
 
         <AuthCodeGroup>
           ```shellscript Mac
-          AUTH0_APP_NAME="Hono Quickstart" && brew tap auth0/auth0-cli && brew install auth0 && auth0 login --no-input && auth0 apps create -n "${AUTH0_APP_NAME}" -t regular -c http://localhost:3000/auth/callback -l http://localhost:3000 -o http://localhost:3000 --reveal-secrets --json --metadata created_by="quickstart-docs-cli" > auth0-app-details.json && CLIENT_ID=$(jq -r '.client_id' auth0-app-details.json) && CLIENT_SECRET=$(jq -r '.client_secret' auth0-app-details.json) && DOMAIN=$(auth0 tenants list --json | jq -r '.[] | select(.active == true) | .name') && SECRET=$(openssl rand -hex 32) && echo "AUTH0_DOMAIN=${DOMAIN}" > .env && echo "AUTH0_CLIENT_ID=${CLIENT_ID}" >> .env && echo "AUTH0_CLIENT_SECRET=${CLIENT_SECRET}" >> .env && echo "BASE_URL=http://localhost:3000" >> .env && echo "AUTH0_SESSION_ENCRYPTION_KEY=$(openssl rand -hex 32)" >> .env && rm auth0-app-details.json && cat .env
+          AUTH0_APP_NAME="Hono Quickstart" && brew tap auth0/auth0-cli && brew install auth0 && auth0 login --no-input && auth0 apps create -n "${AUTH0_APP_NAME}" -t regular -c http://localhost:3000/auth/callback -l http://localhost:3000 -o http://localhost:3000 --reveal-secrets --json --metadata created_by="quickstart-docs-cli" > auth0-app-details.json && CLIENT_ID=$(jq -r '.client_id' auth0-app-details.json) && CLIENT_SECRET=$(jq -r '.client_secret' auth0-app-details.json) && DOMAIN=$(auth0 tenants list --json | jq -r '.[] | select(.active == true) | .name') && SECRET=$(openssl rand -hex 32) && echo "AUTH0_DOMAIN=${DOMAIN}" > .env && echo "AUTH0_CLIENT_ID=${CLIENT_ID}" >> .env && echo "AUTH0_CLIENT_SECRET=${CLIENT_SECRET}" >> .env && echo "APP_BASE_URL=http://localhost:3000" >> .env && echo "AUTH0_SESSION_ENCRYPTION_KEY=$(openssl rand -hex 32)" >> .env && rm auth0-app-details.json && cat .env
           ```
 
           ```shellscript Windows
-          $AppName = "Hono Quickstart"; winget install Auth0.CLI; auth0 login --no-input; auth0 apps create -n "$AppName" -t regular -c http://localhost:3000/callback -l http://localhost:3000 -o http://localhost:3000 --reveal-secrets --json --metadata created_by="quickstart-docs-cli" | Set-Content -Path auth0-app-details.json; $ClientId = (Get-Content -Raw auth0-app-details.json | ConvertFrom-Json).client_id; $ClientSecret = (Get-Content -Raw auth0-app-details.json | ConvertFrom-Json).client_secret; $Domain = (auth0 tenants list --json | ConvertFrom-Json | Where-Object { $_.active -eq $true }).name; $Secret = [System.Convert]::ToHexString([System.Security.Cryptography.RandomNumberGenerator]::GetBytes(32)).ToLower(); Set-Content -Path .env -Value "AUTH0_DOMAIN=$Domain"; Add-Content -Path .env -Value "AUTH0_CLIENT_ID=$ClientId"; Add-Content -Path .env -Value "AUTH0_CLIENT_SECRET=$ClientSecret"; Add-Content -Path .env -Value "AUTH0_SECRET=$Secret"; Add-Content -Path .env -Value "BASE_URL=http://localhost:3000"; Remove-Item auth0-app-details.json; Write-Output ".env file created with your Auth0 details:"; Get-Content .env
+          $AppName = "Hono Quickstart"; winget install Auth0.CLI; auth0 login --no-input; auth0 apps create -n "$AppName" -t regular -c http://localhost:3000/callback -l http://localhost:3000 -o http://localhost:3000 --reveal-secrets --json --metadata created_by="quickstart-docs-cli" | Set-Content -Path auth0-app-details.json; $ClientId = (Get-Content -Raw auth0-app-details.json | ConvertFrom-Json).client_id; $ClientSecret = (Get-Content -Raw auth0-app-details.json | ConvertFrom-Json).client_secret; $Domain = (auth0 tenants list --json | ConvertFrom-Json | Where-Object { $_.active -eq $true }).name; $Secret = [System.Convert]::ToHexString([System.Security.Cryptography.RandomNumberGenerator]::GetBytes(32)).ToLower(); Set-Content -Path .env -Value "AUTH0_DOMAIN=$Domain"; Add-Content -Path .env -Value "AUTH0_CLIENT_ID=$ClientId"; Add-Content -Path .env -Value "AUTH0_CLIENT_SECRET=$ClientSecret"; Add-Content -Path .env -Value "AUTH0_SESSION_ENCRYPTION_KEY=$Secret"; Add-Content -Path .env -Value "APP_BASE_URL=http://localhost:3000"; Remove-Item auth0-app-details.json; Write-Output ".env file created with your Auth0 details:"; Get-Content .env
           ```
         </AuthCodeGroup>
 
@@ -104,7 +122,7 @@ This quickstart shows the minimal, recommended way to secure a Hono application 
           AUTH0_DOMAIN=YOUR_AUTH0_DOMAIN
           AUTH0_CLIENT_ID=YOUR_AUTH0_CLIENT_ID
           AUTH0_CLIENT_SECRET=YOUR_AUTH0_CLIENT_SECRET
-          BASE_URL=http://localhost:3000
+          APP_BASE_URL=http://localhost:3000
           AUTH0_SESSION_ENCRYPTION_KEY=your_32_char_min_secret
           # Optional for APIs
           AUTH0_AUDIENCE=YOUR_API_IDENTIFIER
@@ -116,48 +134,47 @@ This quickstart shows the minimal, recommended way to secure a Hono application 
   </Step>
 
   <Step title="Setup Hono web server with Auth0 middleware" stepNumber={4}>
-    Replace the initial template in `index.ts` file with the following example.
+    Replace the initial template in `index.ts` file with the following example. The code demonstrates zero-config setup where environment variables are automatically read, creating an `auth0()` middleware with public routes by default and protected routes using `requiresAuth()`.
 
-    ```typescript
-    // index.ts
-    import 'dotenv/config'; // Not required if using --env-file flag
+    ```typescript ./src/index.ts wrap lines
+    // src/index.ts
     import { serve } from '@hono/node-server';
     import { Hono } from 'hono';
-    import { auth, requiresAuth, Auth0Exception, type OIDCEnv } from '@auth0/auth0-hono';
+    import { auth0, requiresAuth, Auth0Error, type OIDCEnv } from '@auth0/auth0-hono';
 
     const app = new Hono<OIDCEnv>();
 
-    // Configure auth middleware using environment variables.
+    // Zero-config: reads AUTH0_DOMAIN, AUTH0_CLIENT_ID, AUTH0_CLIENT_SECRET,
+    // APP_BASE_URL, AUTH0_SESSION_ENCRYPTION_KEY from environment
     app.use(
-      auth({
-        domain: process.env.AUTH0_DOMAIN,
-        clientID: process.env.AUTH0_CLIENT_ID,
-        clientSecret: process.env.AUTH0_CLIENT_SECRET,
-        baseURL: process.env.BASE_URL,
-        authRequired: false, // Make routes public by default, protect specific routes below
-        session: {
-          secret: process.env.AUTH0_SESSION_ENCRYPTION_KEY,
-        },
+      auth0({
+        authRequired: false, // Public by default, protect specific routes
       })
     );
 
     // Public route
     app.get('/', (c) => c.text('Public — no login required'));
 
-    // Make most routes public, but protect /profile/*
+    // Protected routes
     app.use('/profile/*', requiresAuth());
 
-    app.get('/profile', async (c) => {
-      const session = await c.var.auth0Client?.getSession(c);
-      const user = session?.user;
+    app.get('/profile', (c) => {
+      const user = c.var.auth0.user;
       return c.json({ message: 'Protected profile', user });
+    });
+
+    // Error handling
+    app.onError((err, c) => {
+      if (err instanceof Auth0Error) {
+        return c.json({ error: err.code, error_description: err.description }, err.status);
+      }
+      return c.json({ error: 'Internal server error' }, 500);
     });
 
     const port = Number(process.env.PORT) || 3000;
     serve({ fetch: app.fetch, port }, (info) => {
-        console.log(`Server is running on http://localhost:${info.port}`);
-      }
-    );
+      console.log(`Server is running on http://localhost:${info.port}`);
+    });
     ```
   </Step>
 
@@ -181,10 +198,10 @@ This quickstart shows the minimal, recommended way to secure a Hono application 
 <Accordion title="Common issues" >
 
   <Accordion title="Callback or Redirect Mismatch" >
-    Cause: The callback URL configured in the Auth0 Dashboard does not exactly match `BASE_URL` + the callback route (e.g., `http://localhost:3000/auth/callback`).
+    Cause: The callback URL configured in the Auth0 Dashboard does not exactly match `APP_BASE_URL` + the callback route (e.g., `http://localhost:3000/auth/callback`).
 
     Fix:
-    1. Verify `.env` `BASE_URL` value.
+    1. Verify `.env` `APP_BASE_URL` value.
     2. Ensure Allowed Callback URLs in Auth0 Dashboard contain `http://localhost:3000/auth/callback`.
     3. Restart dev server after changes.
   </Accordion>
@@ -202,7 +219,7 @@ This quickstart shows the minimal, recommended way to secure a Hono application 
     Cause: Middleware not installed or placed after route registration.
 
     Fix:
-    - Ensure `app.use(auth(...))` runs before routes that depend on authentication.
+    - Ensure `app.use(auth0(...))` runs before routes that depend on authentication.
     - Confirm package installed: `npm ls @auth0/auth0-hono`.
   </Accordion>
 
@@ -218,7 +235,7 @@ This quickstart shows the minimal, recommended way to secure a Hono application 
 
 ## Advanced Usage
 
-- Selective protection: use `app.use(auth({ authRequired: false }))` to make routes public by default and `app.use('/private/*', requiresAuth())` to protect specific paths.
+- Selective protection: use `app.use(auth0({ authRequired: false }))` to make routes public by default and `app.use('/private/*', requiresAuth())` to protect specific paths.
 - Silent login: use `attemptSilentLogin()` middleware to try silent authentication for better UX.
 - Custom login flow: call `login({...})` to customize forwarded query params, `redirectAfterLogin`, or silent login options.
 - Token management: the middleware exposes access and ID tokens via the session; follow least-privilege for scopes and rotate refresh tokens safely.
@@ -229,6 +246,6 @@ This quickstart shows the minimal, recommended way to secure a Hono application 
 - Use a 32+ character `AUTH0_SESSION_ENCRYPTION_KEY`.
 - Set cookie `secure` to `true` in production and set appropriate `sameSite` policy.
 - Limit token scopes; use audience only when requesting access tokens for APIs.
-- Catch `Auth0Exception` in `app.onError` to handle auth-specific errors cleanly.
+- Catch `Auth0Error` in `app.onError` to handle auth-specific errors cleanly.
 
 ---


### PR DESCRIPTION
## Summary
- Updates the Hono webapp quickstart (`/main/docs/quickstart/webapp/hono/index.mdx`) to reflect the `@auth0/auth0-hono@1.0.0` beta SDK API
- Fixes 6 API corrections: `auth()` → `auth0()`, `Auth0Exception` → `Auth0Error`, `BASE_URL` → `APP_BASE_URL`, async `getSession()` → sync `c.var.auth0.user`/`.session`, removes explicit config in favor of zero-config pattern
- Adds AI assistant accordion with agent skills integration (matches Next.js quickstart pattern)
- Fixes Windows CLI command: `AUTH0_SECRET` → `AUTH0_SESSION_ENCRYPTION_KEY`

## Changes
- **New section:** AI accordion for agent skills integration (`auth0-hono` skill)
- **Step 4 code block:** Complete replacement with zero-config `auth0()` middleware, sync user access via `c.var.auth0.user`, and `Auth0Error` error handling
- **Environment variables:** `BASE_URL` → `APP_BASE_URL` across CLI (Mac + Windows), Dashboard `.env`, and Troubleshooting
- **Troubleshooting/Best Practices/Advanced Usage:** Updated all references to new API names

## Test plan
- [ ] Run `mint dev` in `main/` and verify Hono quickstart renders correctly
- [ ] Verify AI accordion displays with correct install command and prompt
- [ ] Verify Step 4 code block shows zero-config `auth0()` pattern
- [ ] Verify all `.env` examples use `APP_BASE_URL`
- [ ] Verify no references to old API (`auth(`, `Auth0Exception`, `BASE_URL`, `auth0Client`) remain
- [ ] Check `mint broken-links` passes