### PR TITLE
fix: migrate-dedicated-connection-endpoints.mdx

### DIFF
--- a/main/docs/troubleshoot/product-lifecycle/deprecations-and-migrations/migrate-dedicated-connection-endpoints.mdx
+++ b/main/docs/troubleshoot/product-lifecycle/deprecations-and-migrations/migrate-dedicated-connection-endpoints.mdx
@@ -1,13 +1,7 @@
 ---
 description: Learn how to update your Auth0 connection configuration from using the `enabled_clients` field to dedicated connection endpoints.
-'og:image': https://cdn2.auth0.com/docs/1.14553.0/img/share-image.png
-'og:title': Migrate Enabled Client Management to Dedicated Connection Endpoints
-'og:url': https://auth0.com/docs/
-permalink: migrate-dedicated-connection-endpoints
 title: Migrate Enabled Client Management to Dedicated Connection Endpoints
-'twitter:description': Learn how to update your Auth0 connection configuration from using the `enabled_clients` field to dedicated connection endpoints.
-'twitter:title': Migrate Enabled Client Management to Dedicated Connection Endpoints
-validatedOn: 2026-03-02
+validatedOn: 2026-04-20
 ---
 
 Auth0 is deprecating the `enabled_clients` field from Management API’s [Get All Connections](/docs/api/management/v2/connections/get-connections), [Get Connections](/docs/api/management/v2/connections/get-connections-by-id), and [Update a Connection](/docs/api/management/v2/connections/patch-connections-by-id). Auth0 customers can retrieve enabled clients on a connection by using the [Get enabled clients for a connection](https://auth0.com/docs/api/management/v2/connections/get-connection-clients) endpoint. To update clients already established on a connection, use the [Update enabled clients for a connection](https://auth0.com/docs/api/management/v2/connections/patch-clients).
@@ -56,16 +50,14 @@ In addition, the presence of a deprecation notice for a specific client applicat
 ## Review extensions usage
 
 The following extensions can trigger deprecation notices in tenant logs:
-* [User Import/Export](/docs/customize/extensions/user-import-export-extension#user-import-export-extension): This extension does not use the deprecated endpoints. These are false positive deprecation notices because the extension retrieves connection information.
-* [Custom Social Connections](https://github.com/auth0/custom-social-connections): This extension uses the deprecated endpoints and will experience issues and trigger deprecation notices.
-* [Delegated Administration Dashboard](/docs/customize/extensions/delegated-administration-extension/install-delegated-admin-extension): This extension uses the deprecated endpoints and will experience issues and trigger deprecation notices.
+* [User Import/Export](/docs/customize/extensions/user-import-export-extension#user-import-export-extension): This extension does not depend on the deprecated functionality. The notices are false positives that trigger when the extension obtains connection info. 
+* [Custom Social Connections](https://github.com/auth0/custom-social-connections): This extension depends on the deprecated functionality and experiences issues.
+* [Delegated Administration Dashboard](/docs/customize/extensions/delegated-administration-extension/install-delegated-admin-extension): Older versions of this extension may depend on the deprecated functionality and experience issues. Update to version 4.8 or later via the Auth0 Dashboard.
 
 The first two extensions are superseded by Auth0 Dashboard functionality that addresses their use cases and no longer receive updates. 
 
 * Use the [Bulk User Import / Export](/docs/manage-users/user-migration/bulk-user-import-export) Dashboard feature to replace the User Import/Export extension. 
 * Use the [Social Identity Providers](/docs/authenticate/identity-providers/social-identity-providers#auth0-dashboard) Dashboard feature to replace the Custom Social Connections extension.
-
-For the Delegated Administration Dashboard extension, Auth0 is working to address the incompatibility in the current 4.7 version and will release a new version for this extension. Tenants using this extension should hold off on finalizing the migration until a new version is available.
 
 
 ## Update your integrations


### PR DESCRIPTION
## Description

The Review extensions usage section of the migration guide ([Enabled Client Management to Dedicated Connection Endpoints)](https://auth0.com/docs/troubleshoot/product-lifecycle/deprecations-and-migrations/migrate-dedicated-connection-endpoints) requires some updates, most importantly, to contains instructions for customers to update the Delegated Admin extension among some other minor rewording.

### References

https://auth0team.atlassian.net/jira/servicedesk/projects/DR/queues/custom/98/DR-2770


## Checklist

- [ x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ x] I've tested the site build for this change locally.
- [ x] I've made appropriate docs updates for any code or config changes.
- [ x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
