### PR TITLE
feat: add component to render a section title

### DIFF
--- a/main/snippets/ApiSectionTitle.jsx
+++ b/main/snippets/ApiSectionTitle.jsx
@@ -1,0 +1,11 @@
+export const ApiSectionTitle = ({ title = "Section" }) => {
+  return (
+    <div>
+      <div className="api-section-heading flex flex-col gap-y-4 w-full">
+        <div className="flex items-baseline border-b pb-2.5 border-gray-100 dark:border-gray-800 w-full">
+          <h4 className="api-section-heading-title flex-1 mb-0">{title}</h4>
+        </div>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

- Adds a component to render a section title/header

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

When rendered the component looks like this.

<img width="1461" height="542" alt="image" src="https://github.com/user-attachments/assets/282aeafc-eed0-430e-9e34-afa6244c2474" />

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
