### PR TITLE
docs: add GitHub and Google social connection documentation

### DIFF
--- a/main/docs.json
+++ b/main/docs.json
@@ -738,6 +738,8 @@
                             "group": "Social Identity Providers",
                             "pages": [
                               "docs/authenticate/identity-providers/social-identity-providers",
+                              "docs/authenticate/identity-providers/social-identity-providers/github",
+                              "docs/authenticate/identity-providers/social-identity-providers/google",
                               "docs/authenticate/identity-providers/social-identity-providers/oauth2",
                               "docs/authenticate/identity-providers/social-identity-providers/apple-native",
                               "docs/authenticate/identity-providers/social-identity-providers/facebook-native",

--- a/main/docs/authenticate/identity-providers/social-identity-providers.mdx
+++ b/main/docs/authenticate/identity-providers/social-identity-providers.mdx
@@ -35,6 +35,11 @@ You can also access the Auth0 Marketplace through the Auth0 Dashboard. Navigate 
 
 </Tab></Tabs>
 
+Auth0 also provides detailed setup guides for the following web-based social providers:
+
+* [GitHub](/docs/authenticate/identity-providers/social-identity-providers/github)
+* [Google](/docs/authenticate/identity-providers/social-identity-providers/google)
+
 ## Native applications
 
 Auth0 supports social login with select providers for native applications. To learn more, review the resources below:

--- a/main/docs/authenticate/identity-providers/social-identity-providers.mdx
+++ b/main/docs/authenticate/identity-providers/social-identity-providers.mdx
@@ -35,7 +35,7 @@ You can also access the Auth0 Marketplace through the Auth0 Dashboard. Navigate 
 
 </Tab></Tabs>
 
-Auth0 also provides detailed setup guides for the following web-based social providers:
+Auth0 also provides detailed setup guides for the following social providers:
 
 * [GitHub](/docs/authenticate/identity-providers/social-identity-providers/github)
 * [Google](/docs/authenticate/identity-providers/social-identity-providers/google)

--- a/main/docs/authenticate/identity-providers/social-identity-providers/github.mdx
+++ b/main/docs/authenticate/identity-providers/social-identity-providers/github.mdx
@@ -1,0 +1,98 @@
+---
+title: Add GitHub Login to Your App
+description: "Learn how to add Sign In with GitHub to your application using Auth0. Configure a GitHub social connection with OAuth to let users authenticate with their GitHub accounts."
+sidebarTitle: Add GitHub Login to Your App
+---
+
+Auth0 supports sign in with GitHub, allowing your users to authenticate with their GitHub accounts through <Tooltip tip="OAuth 2.0: Authorization framework that defines authorization protocols and workflows." cta="View Glossary" href="/docs/glossary?term=OAuth+2.0">OAuth 2.0</Tooltip>. Adding GitHub as a social login option provides a fast, familiar sign-in experience for developers and technical users.
+
+To set up this connection, you register an OAuth application in GitHub, then configure the connection in the Auth0 Dashboard using the credentials GitHub provides.
+
+<Card title="Before you start">
+
+Before you configure GitHub as a social connection, you need:
+
+1. An [Auth0 account](https://auth0.com/signup). If you do not have one, you can sign up for free.
+2. A [GitHub account](https://github.com/signup).
+3. An application registered in the [Auth0 Dashboard](https://manage.auth0.com/#/applications).
+
+</Card>
+
+## Configure GitHub
+
+Create an OAuth application in GitHub to generate the credentials Auth0 needs to establish the connection.
+
+<Steps>
+  <Step title="Open GitHub Developer Settings">
+    Log in to your GitHub account. Select your profile photo in the upper-right corner, then select **Settings**. In the left sidebar, select **Developer settings**, then select **OAuth Apps**.
+  </Step>
+
+  <Step title="Register a new OAuth application">
+    Select **New OAuth App**. If you have not created any applications before, select **Register a new application**.
+
+    Complete the following fields:
+
+    | **Field** | **Value** |
+    |---|---|
+    | **Application name** | A name your users will recognize and trust, for example `My App (Auth0)` |
+    | **Homepage URL** | The full URL to your application homepage, for example `https://myapp.example.com` |
+    | **Application description** | (Optional) A description displayed to all users of your application |
+    | **Authorization callback URL** | `https://YOUR_AUTH0_DOMAIN/login/callback` |
+
+    Replace `YOUR_AUTH0_DOMAIN` with your Auth0 tenant domain. You can find this value in [Auth0 Dashboard > Applications > Applications](https://manage.auth0.com/#/applications) under the **Settings** tab.
+
+    You can leave **Enable Device Flow** unchecked unless your application requires device-based authorization.
+
+    Select **Register application**.
+  </Step>
+
+  <Step title="Copy the Client ID and Client Secret">
+    After registration, GitHub displays the application details page. Copy the **Client ID** value.
+
+    Select **Generate a new client secret** to create a secret. Copy the generated value immediately.
+
+    <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+    GitHub displays the Client Secret only once. Store it securely before navigating away from the page. If you lose it, you must generate a new one.
+    </Callout>
+  </Step>
+</Steps>
+
+## Configure Auth0
+
+Add the GitHub connection to your Auth0 tenant and enter the credentials from the previous section.
+
+<Steps>
+  <Step title="Create a GitHub connection">
+    Navigate to [Auth0 Dashboard > Authentication > Social](https://manage.auth0.com/#/social) and select **Create Connection**. Select **GitHub** from the list of providers.
+  </Step>
+
+  <Step title="Enter your GitHub credentials">
+    In the connection settings, enter the **Client ID** and **Client Secret** you copied from GitHub.
+  </Step>
+
+  <Step title="Select permissions">
+    Under **Permissions**, select the scopes your application requires. Most applications need **read:user** for profile information and **user:email** for email addresses.
+  </Step>
+
+  <Step title="Save and enable the connection">
+    Select **Create** to save the connection.
+
+    Select the **Applications** tab and enable the connection for the applications that should offer GitHub login.
+  </Step>
+</Steps>
+
+## Test the connection
+
+Verify that the GitHub connection works before deploying to production.
+
+1. Navigate to [Auth0 Dashboard > Authentication > Social](https://manage.auth0.com/#/social).
+2. Select the GitHub connection from the list.
+3. Select **Try Connection**.
+4. Authenticate with your GitHub account when prompted.
+5. Confirm that Auth0 returns user profile data, including the user's GitHub username and email address.
+
+## Keep reading
+
+* [Test Social Connections Using Auth0 Developer Keys](/docs/authenticate/identity-providers/social-identity-providers/devkeys)
+* [Add Sign In with Google to Native Android Apps](/docs/authenticate/identity-providers/social-identity-providers/google-native)
+* [Create Custom Social Connections](/docs/authenticate/identity-providers/social-identity-providers/oauth2)

--- a/main/docs/authenticate/identity-providers/social-identity-providers/github.mdx
+++ b/main/docs/authenticate/identity-providers/social-identity-providers/github.mdx
@@ -1,6 +1,6 @@
 ---
 title: Add GitHub Login to Your App
-description: "Learn how to add Sign In with GitHub to your application using Auth0. Configure a GitHub social connection with OAuth to let users authenticate with their GitHub accounts."
+description: "Learn how to add Sign In with GitHub to your application using Auth0. Configure a GitHub social connection with OAuth 2.0 to let users authenticate with their GitHub accounts."
 sidebarTitle: Add GitHub Login to Your App
 ---
 
@@ -66,12 +66,16 @@ Add the GitHub connection to your Auth0 tenant and enter the credentials from th
     Navigate to [Auth0 Dashboard > Authentication > Social](https://manage.auth0.com/#/social) and select **Create Connection**. Select **GitHub** from the list of providers.
   </Step>
 
+  <Step title="Select the connection purpose">
+    Under **Purpose**, specify how this connection will be used: for login, connected accounts, or both.
+  </Step>
+
   <Step title="Enter your GitHub credentials">
-    In the connection settings, enter the **Client ID** and **Client Secret** you copied from GitHub.
+    In **General**, enter the **Client ID** and **Client Secret** you copied from GitHub.
   </Step>
 
   <Step title="Select permissions">
-    Under **Permissions**, select the scopes your application requires. Most applications need **read:user** for profile information and **user:email** for email addresses.
+    Under **Permissions**, select the permissions your application requires. Most applications need **Email address** for the user's email and **Read user** for profile information.
   </Step>
 
   <Step title="Save and enable the connection">
@@ -93,6 +97,6 @@ Verify that the GitHub connection works before deploying to production.
 
 ## Keep reading
 
+* [Add Google Login to Your App](/docs/authenticate/identity-providers/social-identity-providers/google)
 * [Test Social Connections Using Auth0 Developer Keys](/docs/authenticate/identity-providers/social-identity-providers/devkeys)
-* [Add Sign In with Google to Native Android Apps](/docs/authenticate/identity-providers/social-identity-providers/google-native)
 * [Create Custom Social Connections](/docs/authenticate/identity-providers/social-identity-providers/oauth2)

--- a/main/docs/authenticate/identity-providers/social-identity-providers/google.mdx
+++ b/main/docs/authenticate/identity-providers/social-identity-providers/google.mdx
@@ -1,0 +1,140 @@
+---
+title: Add Google Login to Your App
+description: "Learn how to add Sign In with Google to your application using Auth0. Configure a Google social connection with OAuth 2.0 to let users authenticate with their Google accounts."
+sidebarTitle: Add Google Login to Your App
+---
+
+Auth0 supports sign in with Google, allowing your users to authenticate with their Google accounts through <Tooltip tip="OAuth 2.0: Authorization framework that defines authorization protocols and workflows." cta="View Glossary" href="/docs/glossary?term=OAuth+2.0">OAuth 2.0</Tooltip>. Adding Google as a social login option provides a fast, familiar sign-in experience that most users already trust.
+
+To set up a Google social connection, you must:
+
+1. Create Google OAuth credentials with the Google Auth Platform.
+2. Configure and test a Google social connection with the Auth0 Dashboard.
+
+<Card title="Before you start">
+
+Before you configure Google as a social connection, you need:
+
+1. An [Auth0 account](https://auth0.com/signup). If you do not have one, you can sign up for free.
+2. A [Google Developer account](https://console.cloud.google.com/).
+3. A [Google Project](https://developers.google.com/workspace/guides/create-project).
+4. An application registered in the [Auth0 Dashboard](https://manage.auth0.com/#/applications).
+
+</Card>
+
+## Google Auth Platform
+
+The Google Auth Platform is a section within the [Google Cloud Console](https://console.cloud.google.com/) that helps you manage your applications and OAuth credentials for logging in and calling Google APIs. To learn more, read [Get started with the Google Auth Platform](https://developers.google.com/identity/protocols/oauth2) on Google's documentation.
+
+Use the Google Auth Platform to:
+
+1. Configure the Google consent screen.
+2. Create a Google OAuth 2.0 Client.
+
+### Configure the Google consent screen
+
+Before creating an OAuth client ID, you must configure the OAuth consent screen with information about your application. When you use OAuth 2.0 for authorization, your application requests one or more scopes of access from a Google Account. Google displays a consent screen to the user, including a summary of your project, its policies, and the requested access scopes.
+
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+If your application requests sensitive OAuth scopes or uses a custom image, [Google limits it to 100 logins until the OAuth consent screen is verified](https://support.google.com/cloud/answer/10311615). Consent screen verification may take up to several days.
+</Callout>
+
+In the Google Cloud Console, [configure your Google OAuth consent screen](https://support.google.com/cloud/answer/10311615):
+
+<Steps>
+  <Step title="Configure branding">
+    Navigate to **Google Auth Platform > Branding**. For **Authorized domains**, enter `auth0.com`. If you are using a custom domain, enter your custom domain instead.
+  </Step>
+
+  <Step title="Configure audience">
+    Navigate to **Google Auth Platform > Audience**. For **User type**, select **Make External**. In **Test Users**, you can add the email addresses you want to use for testing.
+  </Step>
+
+  <Step title="Configure data access">
+    Navigate to **Google Auth Platform > Data Access** to add or remove scopes. To learn more, read [OAuth 2.0 Scopes for Google APIs](https://developers.google.com/identity/protocols/oauth2/scopes) on Google's documentation.
+  </Step>
+
+  <Step title="Save your changes">
+    Follow the rest of the instructions to finish configuring your Google OAuth consent screen. Select **Save Changes**.
+  </Step>
+</Steps>
+
+### Create a Google OAuth 2.0 Client
+
+To create a Google OAuth 2.0 Client, you need your Auth0 domain, which you can find in the Auth0 Dashboard.
+
+Navigate to [Auth0 Dashboard > Settings > Custom Domains](https://manage.auth0.com/#/custom_domains) to find your domain:
+
+* If you have not configured a custom domain, your Auth0 domain name is `YOUR_TENANT_NAME.YOUR_REGIONAL_SUBDOMAIN.auth0.com`. Your redirect URI is `https://YOUR_TENANT_NAME.YOUR_REGIONAL_SUBDOMAIN.auth0.com/login/callback`.
+* If you have configured a custom domain, use your custom domain instead. Your redirect URI is `https://YOUR_CUSTOM_DOMAIN/login/callback`.
+
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+If you created your US tenant before June 2020, your Auth0 domain name does not include the regional subdomain: `YOUR_TENANT_NAME.auth0.com`.
+</Callout>
+
+In the Google Cloud Console, create a new OAuth 2.0 Client:
+
+<Steps>
+  <Step title="Create a new client">
+    Navigate to **Google Auth Platform > Clients**. Select **New Client**.
+  </Step>
+
+  <Step title="Select the application type">
+    For the **Application type**, select **Web application**.
+  </Step>
+
+  <Step title="Enter your client details">
+    Enter the following information for your OAuth 2.0 Client:
+
+    | **Field** | **Value** |
+    |---|---|
+    | **Name** | The name of your OAuth 2.0 Client |
+    | **Authorized Javascript origins** | `https://YOUR_DOMAIN` |
+    | **Authorized redirect URIs** | `https://YOUR_DOMAIN/login/callback` |
+
+    Replace `YOUR_DOMAIN` with the Auth0 domain you found in the previous step.
+  </Step>
+
+  <Step title="Create the client">
+    Select **Create**. Copy the **Client ID** and **Client Secret** that Google displays.
+  </Step>
+</Steps>
+
+## Configure Auth0
+
+Use the Auth0 Dashboard to create and configure a Google social connection with the OAuth credentials you created.
+
+<Steps>
+  <Step title="Create a Google social connection">
+    Navigate to [Auth0 Dashboard > Authentication > Social](https://manage.auth0.com/#/social). Select **Create Connection** and then **Google/Gmail**.
+  </Step>
+
+  <Step title="Enter your Google credentials">
+    In **General**, enter the client credentials from the Google OAuth 2.0 Client you created:
+
+    * **Client ID**: The unique identifier for your application.
+    * **Client Secret**: The secret used by the application to authenticate with Auth0.
+  </Step>
+
+  <Step title="Select permissions and save">
+    Select any permissions you want to enable for the connection. Most applications need **email** for the user's email address and **profile** for basic profile information.
+
+    Select **Save Changes**.
+  </Step>
+</Steps>
+
+## Test the connection
+
+Once you have created your Google social connection, verify that it works before deploying to production.
+
+1. Navigate to [Auth0 Dashboard > Authentication > Social](https://manage.auth0.com/#/social).
+2. Select the Google connection from the list.
+3. Select **Try Connection**.
+4. Authenticate with your Google account when prompted.
+5. Confirm that Auth0 returns user profile data, including the user's name and email address.
+
+## Keep reading
+
+* [Add Sign In with Google to Native Android Apps](/docs/authenticate/identity-providers/social-identity-providers/google-native)
+* [Test Social Connections Using Auth0 Developer Keys](/docs/authenticate/identity-providers/social-identity-providers/devkeys)
+* [Create Custom Social Connections](/docs/authenticate/identity-providers/social-identity-providers/oauth2)

--- a/main/docs/authenticate/identity-providers/social-identity-providers/google.mdx
+++ b/main/docs/authenticate/identity-providers/social-identity-providers/google.mdx
@@ -89,7 +89,7 @@ In the Google Cloud Console, create a new OAuth 2.0 Client:
     | **Field** | **Value** |
     |---|---|
     | **Name** | The name of your OAuth 2.0 Client |
-    | **Authorized Javascript origins** | `https://YOUR_DOMAIN` |
+    | **Authorized JavaScript origins** | `https://YOUR_DOMAIN` |
     | **Authorized redirect URIs** | `https://YOUR_DOMAIN/login/callback` |
 
     Replace `YOUR_DOMAIN` with the Auth0 domain you found in the previous step.
@@ -109,15 +109,15 @@ Use the Auth0 Dashboard to create and configure a Google social connection with 
     Navigate to [Auth0 Dashboard > Authentication > Social](https://manage.auth0.com/#/social). Select **Create Connection** and then **Google/Gmail**.
   </Step>
 
-  <Step title="Enter your Google credentials">
-    In **General**, enter the client credentials from the Google OAuth 2.0 Client you created:
+  <Step title="Enter a name and your Google credentials">
+    In **General**, enter a **Name** for the connection and the client credentials from the Google OAuth 2.0 Client you created:
 
     * **Client ID**: The unique identifier for your application.
-    * **Client Secret**: The secret used by the application to authenticate with Auth0.
+    * **Client Secret**: The secret used by Auth0 to authenticate with Google on behalf of your application.
   </Step>
 
   <Step title="Select permissions and save">
-    Select any permissions you want to enable for the connection. Most applications need **email** for the user's email address and **profile** for basic profile information.
+    Select any permissions you want to enable for the connection. Most applications need **Basic Profile** for the user's email and verified email flag, and **Extended Profile** for name, photo, and other profile details.
 
     Select **Save Changes**.
   </Step>


### PR DESCRIPTION
## Summary

- Add standalone setup guide for GitHub social connection (`github.mdx`)
- Add standalone setup guide for Google social connection (`google.mdx`)
- Add both pages to English social identity providers navigation in `docs.json`

## Motivation

Auth0's digital team found that Clerk wins on GEO for the prompt "Add sign in with Google and GitHub to my app." The root cause is that Auth0's social connection setup guides only exist on marketplace.auth0.com (a JS-rendered SPA that's uncrawlable by search engines and AI models). These docs bring that content into auth0.com/docs where it's indexable and AI-parseable.

## Test plan

- [ ] `mint dev` renders both pages without errors
- [ ] Sidebar navigation shows both pages under Social Identity Providers
- [ ] All internal and external links resolve
- [ ] Content matches the marketplace installation instructions