### PR TITLE
fix: update agent-skills docs for single-plugin architecture

### DIFF
--- a/main/docs/quickstart/agent-skills.mdx
+++ b/main/docs/quickstart/agent-skills.mdx
@@ -19,17 +19,14 @@ Agent skills enable you to:
 
 Auth0 agent skills support a wide range of frameworks and platforms:
 
-* **Frontend:** React, Vue, Angular
-* **Backend:** Next.js, Nuxt, Express, Ruby on Rails, PHP/Laravel
-* **Mobile:** React Native, Expo, iOS, Android
-* **APIs:** Python (Flask, FastAPI), Go, Spring Boot, ASP.NET Core
+* **Frontend:** React, Vue, Angular, Vanilla JS (auth0-spa-js)
+* **Backend:** Next.js, Nuxt, Express, Flask, Fastify, FastAPI, Spring Boot, Java Servlet
+* **Mobile:** React Native, Expo, iOS (Swift), Android
+* **APIs:** Express (JWT Bearer), Fastify, FastAPI, Spring Boot, ASP.NET Core
 
 ## Installation
 
-Auth0 provides two complementary skill packages that work together:
-
-* **Auth0 Core Skills** - Essential foundational capabilities including framework detection, migrations, and MFA
-* **Auth0 SDK Skills** - Framework-specific implementation guides for each supported platform
+Auth0 provides a single unified skill package containing all core and SDK skills:
 
 ### Install with Skills CLI
 
@@ -39,11 +36,15 @@ The easiest way to install Auth0 agent skills is using the Skills CLI:
 npx skills add auth0/agent-skills
 ```
 
-This command installs both the core and SDK skill packages, making them available to your AI coding assistant.
+This command installs all Auth0 skills, making them available to your AI coding assistant.
 
-### Install in Claude Code
+### Install in your AI coding assistant
 
-If you're using Claude Code, you can install Auth0 skills directly from the Plugins menu:
+Auth0 agent skills support Claude Code, Cursor, and Codex. Choose your platform:
+
+<Tabs>
+<Tab title="Claude Code">
+Install Auth0 skills directly from the Plugins menu:
 
 <Steps>
 <Step title="Open Claude Code settings">
@@ -54,13 +55,56 @@ Navigate to **Settings** > **Plugins** in Claude Code.
 Search for "Auth0" in the available plugins list.
 </Step>
 
-<Step title="Install the skills">
-Install both **Auth0 Core Skills** and **Auth0 SDK Skills** plugins.
+<Step title="Install the plugin">
+Install the **Auth0 Agent Skills** plugin.
 </Step>
 </Steps>
 
+Or install via the CLI:
+
+```bash
+claude
+
+/plugin marketplace add auth0/agent-skills
+/plugin install auth0@auth0-agent-skills
+```
+</Tab>
+
+<Tab title="Cursor">
+Auth0 agent skills are available as a Cursor plugin:
+
+<Steps>
+<Step title="Open Cursor settings">
+Navigate to **Settings** > **Plugins** in Cursor.
+</Step>
+
+<Step title="Search for Auth0">
+Search for "Auth0" in the available plugins list.
+</Step>
+
+<Step title="Install the plugin">
+Install the **Auth0 Agent Skills** plugin.
+</Step>
+</Steps>
+</Tab>
+
+<Tab title="Codex">
+Auth0 agent skills are available as a Codex plugin:
+
+<Steps>
+<Step title="Install via Codex">
+Add the Auth0 agent skills plugin from the Codex plugin directory.
+</Step>
+
+<Step title="Verify installation">
+The plugin includes all 22 Auth0 skills for authentication integration.
+</Step>
+</Steps>
+</Tab>
+</Tabs>
+
 <Tip>
-Installing skills as plugins in Claude Code (recommended for enterprise users) ensures they stay up to date automatically.
+Installing skills as a plugin (recommended for enterprise users) ensures they stay up to date automatically.
 </Tip>
 
 ### Manual installation
@@ -69,13 +113,12 @@ You can also install skills manually by cloning the repository:
 
 ```bash
 git clone https://github.com/auth0/agent-skills.git
+cp -r agent-skills/plugins/auth0/skills/* ~/.claude/skills/
 ```
-
-Then copy the skill directories to your AI assistant's skills folder according to its documentation.
 
 ## Available skills
 
-Auth0 agent skills are organized into two packages with complementary capabilities:
+Auth0 agent skills include core capabilities and framework-specific SDK guides in a single package:
 
 ### Core Skills
 
@@ -85,17 +128,44 @@ Auth0 agent skills are organized into two packages with complementary capabiliti
 | **Migration Guide** | Step-by-step migration from other auth providers | Moving from Firebase, Cognito, Supabase, or custom auth |
 | **MFA Implementation** | Multi-factor authentication setup and configuration | Adding 2FA, step-up auth, adaptive MFA |
 
-### SDK Skills
+### Frontend Skills
 
 | Skill | Description | Use Cases |
 |-------|-------------|-----------|
-| **React Integration** | Auth0 React SDK setup for single-page applications | Building React apps with Vite or Create React App |
-| **Next.js Integration** | Auth0 Next.js SDK for App Router and Pages Router | Server and client-side auth in Next.js applications |
-| **Vue Integration** | Auth0 Vue SDK setup for Vue 3 applications | Building Vue apps with Vite or Vue CLI |
-| **Angular Integration** | Auth0 Angular SDK with route guards and interceptors | Enterprise Angular applications |
-| **React Native Integration** | Auth0 React Native SDK with native deep linking | iOS and Android mobile apps with Expo or React Native CLI |
-| **Nuxt Integration** | Auth0 Nuxt SDK for Nuxt 3/4 applications | Server-side rendering and hybrid apps with Nuxt |
-| **Express Integration** | Auth0 Express SDK for traditional web apps | Server-rendered applications with session management |
+| **React** | Auth0 React SDK for single-page applications | React apps with Vite or Create React App |
+| **Vue** | Auth0 Vue SDK for Vue 3 applications | Vue apps with Vite or Vue CLI |
+| **Angular** | Auth0 Angular SDK with route guards and interceptors | Enterprise Angular applications |
+| **Vanilla JS (auth0-spa-js)** | Auth0 SPA SDK for framework-free applications | Any JavaScript SPA without a framework |
+
+### Backend / Fullstack Skills
+
+| Skill | Description | Use Cases |
+|-------|-------------|-----------|
+| **Next.js** | Auth0 Next.js SDK for App Router and Pages Router | Server and client-side auth in Next.js |
+| **Nuxt** | Auth0 Nuxt SDK for Nuxt 3/4 applications | Server-side rendering with Nuxt |
+| **Express** | Auth0 Express SDK for web applications | Server-rendered apps with session management |
+| **Flask** | Auth0 Flask SDK for Python web applications | Python web apps with Flask |
+| **Fastify** | Auth0 Fastify SDK for web applications | Fastify server-rendered applications |
+| **Java Servlet** | Auth0 Java MVC Commons for servlet applications | Traditional Java web apps |
+
+### API Skills
+
+| Skill | Description | Use Cases |
+|-------|-------------|-----------|
+| **Express JWT Bearer** | Express OAuth2 JWT Bearer validation | Node.js/Express API authentication |
+| **Fastify API** | Auth0 Fastify API authentication | Fastify API endpoints |
+| **FastAPI** | Auth0 FastAPI API authentication | Python FastAPI backends |
+| **Spring Boot API** | Auth0 Spring Boot API authentication | Java/Spring Boot APIs |
+| **ASP.NET Core API** | Auth0 ASP.NET Core API authentication | .NET API endpoints |
+
+### Mobile Skills
+
+| Skill | Description | Use Cases |
+|-------|-------------|-----------|
+| **React Native** | Auth0 React Native SDK with native deep linking | React Native CLI (bare workflow) |
+| **Expo** | Auth0 React Native SDK for Expo | Expo managed workflow apps |
+| **Android** | Auth0 Android SDK for Kotlin/Java | Native Android applications |
+| **iOS/macOS (Swift)** | Auth0 Swift SDK for Apple platforms | Native iOS and macOS applications |
 
 ## Using agent skills
 


### PR DESCRIPTION
## Summary

- Updates `agent-skills.mdx` to reflect the single unified plugin after [auth0/agent-skills#50](https://github.com/auth0/agent-skills/pull/50) merged `auth0-sdks` into `auth0`
- Removes stale "two complementary packages" language
- Adds all 22 skills to the Available Skills tables (was only listing 7 SDK skills)
- Adds Cursor and Codex installation tabs alongside Claude Code
- Organizes skills into Core, Frontend, Backend/API, and Mobile categories

## Additional fix needed (separate PR)

The `sync-agent-skills.yml` workflow has been failing since Apr 13 because `git sparse-checkout set` no longer accepts glob patterns in git 2.53. The fix is to use a full shallow clone instead. This requires a token with `workflow` scope to push — will submit separately or request someone with that permission to push.

The broken sync is why `auth0.com/docs/.well-known/skills/index.json` is missing 8 of the 22 skills.

## Test plan

- [ ] Preview the page locally with `mint dev`
- [ ] Verify the three platform tabs (Claude Code, Cursor, Codex) render correctly
- [ ] Verify all 22 skills are listed in the tables