### PR TITLE
fix: rewrite agent skills page with correct install paths

### DIFF
--- a/main/docs/quickstart/agent-skills.mdx
+++ b/main/docs/quickstart/agent-skills.mdx
@@ -1,270 +1,186 @@
 ---
 title: "Agent Skills for Auth0"
-description: "Use Auth0 agent skills to quickly integrate authentication into your applications with AI coding assistants"
+description: "Use Auth0 agent skills to integrate authentication into your applications with AI coding assistants like Claude Code, Cursor, and GitHub Copilot"
 ---
 
-Agent skills are structured instruction sets that help AI coding assistants like Claude Code, Cursor, and GitHub Copilot implement Auth0 authentication correctly in your applications. They contain best practices, code patterns, and step-by-step guidance for Auth0 integration across multiple frameworks and platforms.
+Agent skills are structured instructions that help AI coding assistants implement Auth0 authentication correctly. Install once, then ask your assistant to add login, protect routes, or secure APIs — it detects your framework and generates production-ready code using the right Auth0 SDK.
 
-## Why use agent skills?
+Works with Claude Code, Cursor, GitHub Copilot, and [40+ other agents](https://agentskills.io/clients) that support the [Agent Skills](https://agentskills.io) format.
 
-Agent skills enable you to:
+## Prerequisites
 
-* **Accelerate development** - Implement Auth0 authentication in minutes with AI-powered code generation
-* **Follow best practices** - Get production-ready code that follows Auth0's recommended patterns
-* **Support multiple frameworks** - Use the same skills across React, Vue, Angular, Next.js, and more
-* **Migrate easily** - Transition from other auth providers with guided migration workflows
-* **Implement advanced features** - Add multi-factor authentication and security features with expert guidance
+- An [Auth0 account](https://auth0.com/signup) (free tier available)
+- Your Auth0 **domain** and **client ID** from the [Auth0 Dashboard](https://manage.auth0.com)
+- An AI coding assistant (Claude Code, Cursor, or GitHub Copilot)
 
-## Supported platforms
+## Install
 
-Auth0 agent skills support a wide range of frameworks and platforms:
+<Tabs>
+<Tab title="Claude Code">
 
-* **Frontend:** React, Vue, Angular, Vanilla JS (auth0-spa-js)
-* **Backend:** Next.js, Nuxt, Express, Flask, Fastify, FastAPI, Spring Boot, Java Servlet
-* **Mobile:** React Native, Expo, iOS (Swift), Android
-* **APIs:** Express (JWT Bearer), Fastify, FastAPI, Spring Boot, ASP.NET Core
+Auth0 is on the official Claude Code plugins marketplace. Install with one command:
 
-## Installation
+```bash
+/plugin install auth0@claude-plugins-official
+```
 
-Auth0 provides a single unified skill package containing all core and SDK skills:
+Or type `/plugin` in a session, go to the **Discover** tab, and search "Auth0".
 
-### Install with Skills CLI
+You can also install from your terminal without starting a session:
 
-The easiest way to install Auth0 agent skills is using the Skills CLI:
+```bash
+claude plugin install auth0@claude-plugins-official
+```
+
+</Tab>
+
+<Tab title="Cursor">
+
+Auth0 is on the [Cursor marketplace](https://cursor.com/marketplace/auth0). Open the listing and click **Add** to install.
+
+You can also install via **Cursor Settings > Rules > Add Rule > Remote Rule (GitHub)** and enter the [Auth0 Agent Skills repository URL](https://github.com/auth0/agent-skills).
+
+</Tab>
+
+<Tab title="GitHub Copilot">
+
+Install using the [Skills CLI](https://github.com/vercel-labs/skills) targeting GitHub Copilot:
+
+```bash
+npx skills add auth0/agent-skills --agent github-copilot
+```
+
+</Tab>
+
+<Tab title="Other Agents">
+
+The [Skills CLI](https://github.com/vercel-labs/skills) works with Claude Code, Cursor, Copilot, Codex, and [40+ other agents](https://agentskills.io/clients):
 
 ```bash
 npx skills add auth0/agent-skills
 ```
 
-This command installs all Auth0 skills, making them available to your AI coding assistant.
-
-### Install in your AI coding assistant
-
-Auth0 agent skills support Claude Code, Cursor, and Codex. Choose your platform:
-
-<Tabs>
-<Tab title="Claude Code">
-Install Auth0 skills directly from the Plugins menu:
-
-<Steps>
-<Step title="Open Claude Code settings">
-Navigate to **Settings** > **Plugins** in Claude Code.
-</Step>
-
-<Step title="Search for Auth0">
-Search for "Auth0" in the available plugins list.
-</Step>
-
-<Step title="Install the plugin">
-Install the **Auth0 Agent Skills** plugin.
-</Step>
-</Steps>
-
-Or install via the CLI:
+Target specific agents with `--agent`:
 
 ```bash
-claude
-
-/plugin marketplace add auth0/agent-skills
-/plugin install auth0@auth0-agent-skills
+npx skills add auth0/agent-skills --agent claude-code cursor
 ```
-</Tab>
 
-<Tab title="Cursor">
-Auth0 agent skills are available as a Cursor plugin:
-
-<Steps>
-<Step title="Open Cursor settings">
-Navigate to **Settings** > **Plugins** in Cursor.
-</Step>
-
-<Step title="Search for Auth0">
-Search for "Auth0" in the available plugins list.
-</Step>
-
-<Step title="Install the plugin">
-Install the **Auth0 Agent Skills** plugin.
-</Step>
-</Steps>
-</Tab>
-
-<Tab title="Codex">
-Auth0 agent skills are available as a Codex plugin:
-
-<Steps>
-<Step title="Install via Codex">
-Add the Auth0 agent skills plugin from the Codex plugin directory.
-</Step>
-
-<Step title="Verify installation">
-The plugin includes all 22 Auth0 skills for authentication integration.
-</Step>
-</Steps>
 </Tab>
 </Tabs>
 
-<Tip>
-Installing skills as a plugin (recommended for enterprise users) ensures they stay up to date automatically.
-</Tip>
+## How it works
 
-### Manual installation
-
-You can also install skills manually by cloning the repository:
-
-```bash
-git clone https://github.com/auth0/agent-skills.git
-cp -r agent-skills/plugins/auth0/skills/* ~/.claude/skills/
-```
-
-## Available skills
-
-Auth0 agent skills include core capabilities and framework-specific SDK guides in a single package:
-
-### Core Skills
-
-| Skill | Description | Use Cases |
-|-------|-------------|-----------|
-| **Quickstart Router** | Framework detection and routing to appropriate Auth0 SDK guides | Starting Auth0 integration, detecting your tech stack |
-| **Migration Guide** | Step-by-step migration from other auth providers | Moving from Firebase, Cognito, Supabase, or custom auth |
-| **MFA Implementation** | Multi-factor authentication setup and configuration | Adding 2FA, step-up auth, adaptive MFA |
-
-### Frontend Skills
-
-| Skill | Description | Use Cases |
-|-------|-------------|-----------|
-| **React** | Auth0 React SDK for single-page applications | React apps with Vite or Create React App |
-| **Vue** | Auth0 Vue SDK for Vue 3 applications | Vue apps with Vite or Vue CLI |
-| **Angular** | Auth0 Angular SDK with route guards and interceptors | Enterprise Angular applications |
-| **Vanilla JS (auth0-spa-js)** | Auth0 SPA SDK for framework-free applications | Any JavaScript SPA without a framework |
-
-### Backend / Fullstack Skills
-
-| Skill | Description | Use Cases |
-|-------|-------------|-----------|
-| **Next.js** | Auth0 Next.js SDK for App Router and Pages Router | Server and client-side auth in Next.js |
-| **Nuxt** | Auth0 Nuxt SDK for Nuxt 3/4 applications | Server-side rendering with Nuxt |
-| **Express** | Auth0 Express SDK for web applications | Server-rendered apps with session management |
-| **Flask** | Auth0 Flask SDK for Python web applications | Python web apps with Flask |
-| **Fastify** | Auth0 Fastify SDK for web applications | Fastify server-rendered applications |
-| **Java Servlet** | Auth0 Java MVC Commons for servlet applications | Traditional Java web apps |
-
-### API Skills
-
-| Skill | Description | Use Cases |
-|-------|-------------|-----------|
-| **Express JWT Bearer** | Express OAuth2 JWT Bearer validation | Node.js/Express API authentication |
-| **Fastify API** | Auth0 Fastify API authentication | Fastify API endpoints |
-| **FastAPI** | Auth0 FastAPI API authentication | Python FastAPI backends |
-| **Spring Boot API** | Auth0 Spring Boot API authentication | Java/Spring Boot APIs |
-| **ASP.NET Core API** | Auth0 ASP.NET Core API authentication | .NET API endpoints |
-
-### Mobile Skills
-
-| Skill | Description | Use Cases |
-|-------|-------------|-----------|
-| **React Native** | Auth0 React Native SDK with native deep linking | React Native CLI (bare workflow) |
-| **Expo** | Auth0 React Native SDK for Expo | Expo managed workflow apps |
-| **Android** | Auth0 Android SDK for Kotlin/Java | Native Android applications |
-| **iOS/macOS (Swift)** | Auth0 Swift SDK for Apple platforms | Native iOS and macOS applications |
-
-## Using agent skills
-
-Once installed, you can use Auth0 agent skills by making natural language requests to your AI coding assistant. The assistant will automatically select and apply the appropriate skills.
-
-### Example prompts
-
-**Getting started with a new integration:**
-```
-Add Auth0 authentication to my React app
-```
-
-**Implementing specific features:**
-```
-Add multi-factor authentication with TOTP support
-```
-
-**Migrating from another provider:**
-```
-Help me migrate from Firebase Auth to Auth0
-```
-
-**Framework-specific requests:**
-```
-Set up Auth0 in my Next.js App Router project with protected routes
-```
-
-<Info>
-The quickstart router skill automatically detects your framework and routes to the appropriate SDK guide, so you don't need to specify which skill to use.
-</Info>
-
-## How agent skills work
-
-Agent skills follow a structured workflow:
+When you ask your assistant to add Auth0 authentication, the skills handle framework detection, SDK selection, and implementation guidance automatically.
 
 <Steps>
 <Step title="Framework detection">
-The AI assistant analyzes your project files to identify your framework, dependencies, and setup.
+The quickstart router skill reads your project files (`package.json`, `requirements.txt`, `build.gradle`, etc.) to identify your framework and existing dependencies.
 </Step>
 
-<Step title="Skill selection">
-Based on your request and detected framework, the assistant selects the appropriate Auth0 skill.
+<Step title="SDK selection">
+Based on your framework, the router activates the matching Auth0 skill — for example, `auth0-nextjs` for a Next.js project or `auth0-flask` for Flask.
 </Step>
 
-<Step title="Code generation">
-The skill provides step-by-step guidance and code patterns that the assistant uses to generate production-ready code.
-</Step>
-
-<Step title="Configuration">
-The assistant helps you configure Auth0 settings, environment variables, and SDK options.
+<Step title="Implementation">
+The skill guides your assistant to install the correct Auth0 SDK, create authentication routes (login, logout, callback), set up environment variables, and add route protection.
 </Step>
 
 <Step title="Verification">
-You can test the implementation and ask the assistant to make adjustments as needed.
+Test login and logout in your development environment. Ask the assistant to adjust configuration, add role-based access control, or secure additional routes.
 </Step>
 </Steps>
 
-## Best practices
+<Info>
+You don't need to specify which skill to use. The quickstart router detects your framework from your project files and selects the right skill automatically.
+</Info>
 
-When working with Auth0 agent skills:
+## Example prompts
 
-* **Start with clean state** - Skills work best in projects with clear structure and up-to-date dependencies
-* **Review generated code** - Always review the code generated by your AI assistant before deploying
-* **Follow prompts** - The assistant may ask for your Auth0 domain, client ID, and other configuration values
-* **Test thoroughly** - Verify authentication flows work correctly in your development environment
-* **Consult documentation** - Reference the full Auth0 documentation for advanced configuration and troubleshooting
+Once installed, try these with your AI coding assistant:
 
-## Limitations and considerations
+- `Add Auth0 authentication to my React app`
+- `Set up Auth0 in my Next.js App Router project with protected routes`
+- `Add multi-factor authentication with TOTP support`
+- `Help me migrate from Firebase Auth to Auth0`
+- `Secure my Express API with Auth0 JWT validation`
 
-* **AI assistant required** - Agent skills work with AI coding assistants and are not standalone tools
-* **Project context** - Skills work best when the AI assistant has access to your full project context
-* **Manual configuration** - You'll still need to configure your Auth0 tenant and create applications in the Auth0 Dashboard
-* **Framework versions** - Skills target recent stable versions of frameworks; very old or experimental versions may require manual adjustments
+<Tip>
+Provide context when prompting — mention your framework, router type, and whether you need login, API protection, or both. The more specific the prompt, the better the output.
+</Tip>
+
+## Available skills
+
+### Core
+
+| Skill | Description |
+|-------|-------------|
+| **Quickstart Router** | Detects your framework and routes to the right Auth0 SDK skill |
+| **Migration** | Step-by-step migration from Firebase, Cognito, Supabase, Clerk, or custom auth |
+| **MFA** | Multi-factor authentication: TOTP, SMS, email, push, WebAuthn |
+
+### Frontend
+
+| Skill | SDK | Description |
+|-------|-----|-------------|
+| **React** | [`@auth0/auth0-react`](https://github.com/auth0/auth0-react) | React SPAs with Vite or Create React App |
+| **Vue** | [`@auth0/auth0-vue`](https://github.com/auth0/auth0-vue) | Vue 3 applications |
+| **Angular** | [`@auth0/auth0-angular`](https://github.com/auth0/auth0-angular) | Angular 13+ with route guards and interceptors |
+| **Vanilla JS** | [`@auth0/auth0-spa-js`](https://github.com/auth0/auth0-spa-js) | Any JavaScript SPA (also works with Svelte, SolidJS) |
+
+### Backend / Fullstack
+
+| Skill | SDK | Description |
+|-------|-----|-------------|
+| **Next.js** | [`@auth0/nextjs-auth0`](https://github.com/auth0/nextjs-auth0) | Next.js 13+ with App Router and Pages Router |
+| **Nuxt** | [`@auth0/auth0-nuxt`](https://github.com/auth0/auth0-nuxt) | Nuxt 3/4 with server-side sessions |
+| **Express** | [`express-openid-connect`](https://github.com/auth0/express-openid-connect) | Express.js web applications |
+| **Flask** | [`auth0-server-python`](https://github.com/auth0/auth0-server-python) | Flask web applications |
+| **Fastify** | [`@auth0/auth0-fastify`](https://github.com/auth0/auth0-fastify) | Fastify web applications |
+| **Java Servlet** | [`mvc-auth-commons`](https://github.com/auth0/auth0-java-mvc-common) | Java Servlet web applications |
+
+### API
+
+| Skill | SDK | Description |
+|-------|-----|-------------|
+| **Express API** | [`express-oauth2-jwt-bearer`](https://github.com/auth0/node-oauth2-jwt-bearer) | Node.js/Express API authentication |
+| **Fastify API** | [`@auth0/auth0-fastify`](https://github.com/auth0/auth0-fastify) | Fastify API endpoints |
+| **FastAPI** | [`auth0-fastapi-api`](https://github.com/auth0/auth0-fastapi-api) | Python FastAPI backends |
+| **Spring Boot API** | [`auth0-springboot-api`](https://github.com/auth0/auth0-auth-java) | Java/Spring Boot APIs |
+| **ASP.NET Core API** | [`Auth0.AspNetCore.Authentication`](https://github.com/auth0/auth0-aspnetcore-authentication) | .NET API endpoints |
+
+### Mobile
+
+| Skill | SDK | Description |
+|-------|-----|-------------|
+| **React Native** | [`react-native-auth0`](https://github.com/auth0/react-native-auth0) | React Native CLI (bare workflow) |
+| **Expo** | [`react-native-auth0`](https://github.com/auth0/react-native-auth0) | Expo managed workflow |
+| **Android** | [`Auth0.Android`](https://github.com/auth0/Auth0.Android) | Native Android (Kotlin/Java) |
+| **iOS/macOS** | [`Auth0.swift`](https://github.com/auth0/Auth0.swift) | Native Swift applications |
 
 ## Learn more
 
 <CardGroup cols={2}>
   <Card title="Auth0 Agent Skills on GitHub" icon="github" href="https://github.com/auth0/agent-skills">
-    View the source code and contribution guidelines.
-  </Card>
-
-  <Card title="Agent Skills Format" icon="book" href="https://agentskills.io">
-    Learn about the open agent skills format and specification.
+    Source code, all 22 skill definitions, and issue tracker.
   </Card>
 
   <Card title="Auth0 Quickstarts" icon="rocket" href="/quickstart">
-    Follow manual quickstart guides for your framework.
+    Step-by-step guides for manual (non-AI) Auth0 integration.
   </Card>
 
   <Card title="Auth0 SDKs" icon="code" href="/sdks">
-    Explore Auth0 SDK documentation and API references.
+    SDK documentation and API references.
+  </Card>
+
+  <Card title="Agent Skills Specification" icon="book" href="https://agentskills.io">
+    The open standard behind agent skills, supported by 40+ AI coding tools.
   </Card>
 </CardGroup>
 
 ## Get help
 
-If you encounter issues with Auth0 agent skills:
-
-* **Ask your AI assistant** - Try rephrasing your request or providing more context
-* **Check the repository** - Review [example implementations](https://github.com/auth0/agent-skills) and open issues
-* **Report bugs** - Follow Auth0's [Responsible Disclosure Program](https://auth0.com/responsible-disclosure-policy) for security issues
-* **Contact support** - Reach out to Auth0 support for questions about Auth0 configuration
+* **Ask your AI assistant** — rephrase your request or provide more context about your project setup
+* **[Open an issue](https://github.com/auth0/agent-skills/issues)** — report bugs or request skills for new frameworks
+* **[Auth0 Community](https://community.auth0.com)** — get help from other Auth0 developers
+* **Security issues** — use the [Responsible Disclosure Program](https://auth0.com/responsible-disclosure-policy)

--- a/main/docs/quickstart/agent-skills.mdx
+++ b/main/docs/quickstart/agent-skills.mdx
@@ -3,7 +3,7 @@ title: "Agent Skills for Auth0"
 description: "Use Auth0 agent skills to integrate authentication into your applications with AI coding assistants like Claude Code, Cursor, and GitHub Copilot"
 ---
 
-Agent skills are structured instructions that help AI coding assistants implement Auth0 authentication correctly. Install once, then ask your assistant to add login, protect routes, or secure APIs — it detects your framework and generates production-ready code using the right Auth0 SDK.
+Agent skills are structured instructions that help AI coding assistants implement Auth0 authentication correctly. Install once, then ask your assistant to add login, protect routes, secure APIs, set up MFA, migrate from another provider, or customize your login page — it handles the rest.
 
 Works with Claude Code, Cursor, GitHub Copilot, and [40+ other agents](https://agentskills.io/clients) that support the [Agent Skills](https://agentskills.io) format.
 
@@ -69,100 +69,108 @@ npx skills add auth0/agent-skills --agent claude-code cursor
 </Tab>
 </Tabs>
 
-## How it works
+## Try it now
 
-When you ask your assistant to add Auth0 authentication, the skills handle framework detection, SDK selection, and implementation guidance automatically.
+After installing, paste any of these into your AI coding assistant:
 
-<Steps>
-<Step title="Framework detection">
-The quickstart router skill reads your project files (`package.json`, `requirements.txt`, `build.gradle`, etc.) to identify your framework and existing dependencies.
-</Step>
+```
+Add Auth0 login to my app
+```
 
-<Step title="SDK selection">
-Based on your framework, the router activates the matching Auth0 skill — for example, `auth0-nextjs` for a Next.js project or `auth0-flask` for Flask.
-</Step>
+```
+Secure my Express API with Auth0 JWT validation
+```
 
-<Step title="Implementation">
-The skill guides your assistant to install the correct Auth0 SDK, create authentication routes (login, logout, callback), set up environment variables, and add route protection.
-</Step>
-
-<Step title="Verification">
-Test login and logout in your development environment. Ask the assistant to adjust configuration, add role-based access control, or secure additional routes.
-</Step>
-</Steps>
-
-<Info>
-You don't need to specify which skill to use. The quickstart router detects your framework from your project files and selects the right skill automatically.
-</Info>
-
-## Example prompts
-
-Once installed, try these with your AI coding assistant:
-
-- `Add Auth0 authentication to my React app`
-- `Set up Auth0 in my Next.js App Router project with protected routes`
-- `Add multi-factor authentication with TOTP support`
-- `Help me migrate from Firebase Auth to Auth0`
-- `Secure my Express API with Auth0 JWT validation`
+```
+Migrate from Firebase Auth to Auth0
+```
 
 <Tip>
 Provide context when prompting — mention your framework, router type, and whether you need login, API protection, or both. The more specific the prompt, the better the output.
 </Tip>
 
+## How it works
+
+<Steps>
+<Step title="Describe what you need">
+Tell your assistant what you want — add login to your React app, secure a Spring Boot API, migrate from Cognito, add MFA, or customize your login page. You don't need to know which skill or SDK to use.
+</Step>
+
+<Step title="The right skill activates">
+The assistant reads your project files (`package.json`, `requirements.txt`, `build.gradle`, etc.), identifies your framework, and activates the matching skill from 23 available.
+</Step>
+
+<Step title="You get working code">
+The skill guides your assistant through the full implementation — installing the right SDK, creating auth routes, configuring environment variables, adding route protection, and following Auth0 best practices.
+</Step>
+</Steps>
+
+<Info>
+You don't need to pick skills manually. Framework detection handles SDK skills automatically, and you can invoke feature skills like MFA or Migration directly by describing what you need.
+</Info>
+
 ## Available skills
 
-### Core
+23 skills covering authentication setup, API protection, migration, and advanced features. Each example prompt below can be pasted directly into your AI coding assistant.
 
-| Skill | Description |
-|-------|-------------|
-| **Quickstart Router** | Detects your framework and routes to the right Auth0 SDK skill |
-| **Migration** | Step-by-step migration from Firebase, Cognito, Supabase, Clerk, or custom auth |
-| **MFA** | Multi-factor authentication: TOTP, SMS, email, push, WebAuthn |
+### Get started
+
+| Skill | What it does | Try it |
+|-------|-------------|--------|
+| **Quickstart Router** | Detects your framework and sets up Auth0 with the right SDK | `Add Auth0 authentication to my app` |
+| **Migration** | Migrate users and code from Firebase, Cognito, Supabase, Clerk, or custom auth | `Help me migrate from Firebase Auth to Auth0` |
 
 ### Frontend
 
-| Skill | SDK | Description |
-|-------|-----|-------------|
-| **React** | [`@auth0/auth0-react`](https://github.com/auth0/auth0-react) | React SPAs with Vite or Create React App |
-| **Vue** | [`@auth0/auth0-vue`](https://github.com/auth0/auth0-vue) | Vue 3 applications |
-| **Angular** | [`@auth0/auth0-angular`](https://github.com/auth0/auth0-angular) | Angular 13+ with route guards and interceptors |
-| **Vanilla JS** | [`@auth0/auth0-spa-js`](https://github.com/auth0/auth0-spa-js) | Any JavaScript SPA (also works with Svelte, SolidJS) |
+| Skill | What it does | Try it |
+|-------|-------------|--------|
+| **React** | Login, logout, user sessions, and protected routes for React SPAs | `Add Auth0 login to my React app` |
+| **Vue** | Authentication for Vue 3 applications with composables and route guards | `Set up Auth0 in my Vue 3 app` |
+| **Angular** | Auth with route guards and HTTP interceptors for Angular 13+ | `Add Auth0 authentication to my Angular app` |
+| **Vanilla JS** | Auth for any JavaScript SPA — also works with Svelte and SolidJS | `Add Auth0 login to my Svelte app` |
 
-### Backend / Fullstack
+### Backend & Fullstack
 
-| Skill | SDK | Description |
-|-------|-----|-------------|
-| **Next.js** | [`@auth0/nextjs-auth0`](https://github.com/auth0/nextjs-auth0) | Next.js 13+ with App Router and Pages Router |
-| **Nuxt** | [`@auth0/auth0-nuxt`](https://github.com/auth0/auth0-nuxt) | Nuxt 3/4 with server-side sessions |
-| **Express** | [`express-openid-connect`](https://github.com/auth0/express-openid-connect) | Express.js web applications |
-| **Flask** | [`auth0-server-python`](https://github.com/auth0/auth0-server-python) | Flask web applications |
-| **Fastify** | [`@auth0/auth0-fastify`](https://github.com/auth0/auth0-fastify) | Fastify web applications |
-| **Java Servlet** | [`mvc-auth-commons`](https://github.com/auth0/auth0-java-mvc-common) | Java Servlet web applications |
+| Skill | What it does | Try it |
+|-------|-------------|--------|
+| **Next.js** | Auth for Next.js 13+ with App Router, Pages Router, middleware, and server components | `Set up Auth0 in my Next.js app with protected routes` |
+| **Nuxt** | Server-side sessions and route protection for Nuxt 3/4 | `Add Auth0 authentication to my Nuxt app` |
+| **Express** | Session-based login, logout, and protected routes for Express.js | `Add Auth0 login to my Express app` |
+| **Flask** | Login, logout, and user profiles for Flask web applications | `Set up Auth0 in my Flask app` |
+| **Fastify** | Session-based auth for Fastify web applications | `Add Auth0 authentication to my Fastify app` |
+| **Java Servlet** | Login and callback handling for Java Servlet applications | `Add Auth0 login to my Java Servlet app` |
 
 ### API
 
-| Skill | SDK | Description |
-|-------|-----|-------------|
-| **Express API** | [`express-oauth2-jwt-bearer`](https://github.com/auth0/node-oauth2-jwt-bearer) | Node.js/Express API authentication |
-| **Fastify API** | [`@auth0/auth0-fastify`](https://github.com/auth0/auth0-fastify) | Fastify API endpoints |
-| **FastAPI** | [`auth0-fastapi-api`](https://github.com/auth0/auth0-fastapi-api) | Python FastAPI backends |
-| **Spring Boot API** | [`auth0-springboot-api`](https://github.com/auth0/auth0-auth-java) | Java/Spring Boot APIs |
-| **ASP.NET Core API** | [`Auth0.AspNetCore.Authentication`](https://github.com/auth0/auth0-aspnetcore-authentication) | .NET API endpoints |
+| Skill | What it does | Try it |
+|-------|-------------|--------|
+| **Express API** | JWT Bearer validation, scope-based access control for Node.js/Express APIs | `Secure my Express API with Auth0 JWT validation` |
+| **Fastify API** | JWT Bearer validation and scope checks for Fastify API endpoints | `Add Auth0 JWT validation to my Fastify API` |
+| **FastAPI** | Token validation and scope-based auth for Python FastAPI backends | `Secure my FastAPI endpoints with Auth0` |
+| **Spring Boot API** | JWT validation and scope-based authorization for Spring Boot APIs | `Add Auth0 authentication to my Spring Boot API` |
+| **ASP.NET Core API** | JWT Bearer auth and DPoP support for .NET API endpoints | `Secure my ASP.NET Core API with Auth0` |
 
 ### Mobile
 
-| Skill | SDK | Description |
-|-------|-----|-------------|
-| **React Native** | [`react-native-auth0`](https://github.com/auth0/react-native-auth0) | React Native CLI (bare workflow) |
-| **Expo** | [`react-native-auth0`](https://github.com/auth0/react-native-auth0) | Expo managed workflow |
-| **Android** | [`Auth0.Android`](https://github.com/auth0/Auth0.Android) | Native Android (Kotlin/Java) |
-| **iOS/macOS** | [`Auth0.swift`](https://github.com/auth0/Auth0.swift) | Native Swift applications |
+| Skill | What it does | Try it |
+|-------|-------------|--------|
+| **React Native** | Auth with biometric support and deep linking for React Native CLI apps | `Add Auth0 login to my React Native app` |
+| **Expo** | Auth with Expo Config Plugin for managed workflow mobile apps | `Set up Auth0 in my Expo app` |
+| **Android** | Web Auth, biometrics, and credential management for native Android | `Add Auth0 authentication to my Android app` |
+| **iOS / macOS** | Native Auth0.swift integration for iOS, macOS, tvOS, watchOS, and visionOS | `Add Auth0 login to my iOS app` |
+
+### Advanced
+
+| Skill | What it does | Try it |
+|-------|-------------|--------|
+| **MFA** | Multi-factor authentication — TOTP, SMS, email, push, WebAuthn | `Add TOTP-based multi-factor authentication to my app` |
+| **ACUL Screen Generator** | Generate custom-branded Universal Login screens with React or vanilla JS | `Create a branded login screen matching our design system` |
 
 ## Learn more
 
 <CardGroup cols={2}>
   <Card title="Auth0 Agent Skills on GitHub" icon="github" href="https://github.com/auth0/agent-skills">
-    Source code, all 22 skill definitions, and issue tracker.
+    Source code, all 23 skill definitions, and issue tracker.
   </Card>
 
   <Card title="Auth0 Quickstarts" icon="rocket" href="/quickstart">


### PR DESCRIPTION
## Summary

Rewrites the `docs/quickstart/agent-skills.mdx` page to fix incorrect install commands across all platforms and improve the developer experience.

### What changed

**Install tabs — all platforms had issues:**
- **Claude Code**: now shows `/plugin install auth0@claude-plugins-official` (official marketplace) + terminal CLI variant. Was showing a multi-step sideload flow with wrong commands and a fictional "Settings > Plugins" UI path.
- **Cursor**: links to `cursor.com/marketplace/auth0` (official listing) + alternative Rules path. Was citing nonexistent "Settings > Plugins" and third-party `cursor.directory`.
- **Codex tab replaced with "Other Agents"**: Codex isn't a shipping consumer product. New tab shows Skills CLI with `--agent` targeting for any of the 40+ compatible agents.
- **GitHub Copilot**: uses `--agent github-copilot` (was undocumented `-a` shorthand).

**New Prerequisites section:**
- Moved above Install. Tells developers they need an Auth0 account, domain, and client ID before starting. Was buried in a "Best practices" bullet at the bottom.

**"How it works" rewritten with concrete details:**
- Old: "The skill provides step-by-step guidance and code patterns" (says nothing).
- New: "reads your project files (package.json, requirements.txt, build.gradle)" → "activates the matching Auth0 skill" → "install the correct Auth0 SDK, create authentication routes, set up environment variables".

**Example prompts reformatted:**
- Was 5 separate code blocks (visually noisy). Now a bullet list with inline code.

**SDK links fixed:**
- Was linking to /docs/libraries/ pages that don't exist for most SDKs. All links now point to GitHub repos (consistent with README).

**Other fixes:**
- "Open Plugins" → "Agent Skills" (correct standard name per agentskills.io)
- Removed generic "Best practices" (review code, test flows)
- Added Tip callout for prompt specificity
- Improved SEO description with platform names

**Result**: 270 → 186 lines. Every install command and link verified.

## Test plan

- [ ] `mint dev` preview — verify page renders correctly with all Mintlify components
- [ ] Verify all SDK GitHub links resolve (22 links)
- [ ] Verify `cursor.com/marketplace/auth0` loads
- [ ] Verify `agentskills.io` and `agentskills.io/clients` loads
- [ ] Verify `/plugin install auth0@claude-plugins-official` is correct
- [ ] Verify Skills CLI `--agent` flag works