### PR TITLE
fix: update mgmt api payload

### DIFF
--- a/main/docs/manage-users/organizations/organizations-for-m2m-applications/configure-your-application-for-m2m-access.mdx
+++ b/main/docs/manage-users/organizations/organizations-for-m2m-applications/configure-your-application-for-m2m-access.mdx
@@ -34,9 +34,11 @@ export const codeExample3 = `curl -X PATCH --location "https://{yourDomain}/api/
   --header 'authorization: Bearer MGMT_API_ACCESS_TOKEN' \\
   --header 'content-type: application/json' \\
   --data '{
-    "default_organization": "ORGANIZATION_ID",
+    "default_organization": {
+    "organization_id": "ORGANIZATION_ID",
     "flows": ["client_credentials"]
-  }'
+    }
+}'
 `;
 
 After creating the application, configure it for machine-to-machine access by following these steps:


### PR DESCRIPTION


## Description

The management API request for setting a Default Organization for M2M access has the wrong payload and produces an error when actually trying it. 

### References

(https://auth0team.atlassian.net/browse/DOCS-5448)

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
