### PR TITLE
Add 9 missing skills to .well-known/skills/ discovery endpoint

### DIFF
--- a/main/.mintlify/skills/acul-screen-generator/SKILL.md
+++ b/main/.mintlify/skills/acul-screen-generator/SKILL.md
@@ -1,0 +1,377 @@
+---
+name: acul-screen-generator
+description: Generates complete, branded Auth0 Advanced Custom Universal Login (ACUL) screen implementations using the React or Vanilla JS SDK. Use when a developer asks to create, add, or modify ACUL login screens with custom branding, social login, theming, or specific authentication flows. Triggers on requests like "generate a custom login screen", "add a signup screen to my ACUL project", "customize my Auth0 Universal Login with our brand colors", "apply our theme to all ACUL screens", or any task involving Auth0 Universal Login customization with @auth0/auth0-acul-react or @auth0/auth0-acul-js.
+license: Apache-2.0
+metadata:
+  author: Auth0 <support@auth0.com>
+---
+
+# ACUL Screen Generator
+
+Generates production-ready, fully themed Auth0 ACUL screen components. Follows a strict 8-phase workflow (Phases 0–7): CLI authentication → intent detection → project setup → screen requirements → tech stack and design → theme extraction → structured code generation → dev mode wiring.
+
+## Reference Hierarchy
+
+Always resolve the correct reference for a screen using this priority order:
+
+```
+1. auth0-acul-samples  (31 React screens, 3 React-JS screens)
+   → Complete modular implementation: index.tsx + components/ + hooks/ + locales/
+   → React:    https://github.com/auth0-samples/auth0-acul-samples/tree/main/react/src/screens/<screen-name>
+   → React-JS: https://github.com/auth0-samples/auth0-acul-samples/tree/main/react-js/src/screens/<screen-name>
+
+2. SDK examples  (68 React, 71 JS — all screens)
+   → Code snippets showing SDK imports, hooks, and action functions
+   → React: https://github.com/auth0/universal-login/blob/master/packages/auth0-acul-react/examples/<screen-name>.md
+   → JS:    https://github.com/auth0/universal-login/blob/master/packages/auth0-acul-js/examples/<screen-name>.md
+
+3. assets/react-templates/ or assets/js-templates/
+   → Structural component pattern only — never use their hooks/actions for other screens
+```
+
+For which screens are in auth0-acul-samples → read `references/screen-catalog.md`.
+
+---
+
+## auth0-acul-samples Architecture
+
+When a screen is available in auth0-acul-samples, generate code using this modular pattern — not a monolithic component.
+
+**Directory structure per screen:**
+```
+<screen-name>/
+├── index.tsx                        thin entry: wires manager hook + applies theme + renders layout
+├── components/
+│   ├── Header.tsx                   logo, title, subtitle from screen.texts
+│   ├── <ScreenName>Form.tsx         form fields, submit, captcha, passkey button
+│   ├── Footer.tsx                   signup link, forgot password, back link
+│   └── AlternativeLogins.tsx        social login buttons (if screen has social)
+├── hooks/
+│   └── use<ScreenName>Manager.ts    wraps SDK hooks, exposes clean handlers + feature flags
+└── locales/
+    └── en.json                      fallback text strings
+```
+
+**index.tsx pattern:**
+```tsx
+import { ULThemeCard, ULThemePageLayout } from '@/components'
+import { applyAuth0Theme } from '@/utils/theme/themeEngine'
+import Header from './components/Header'
+import <ScreenName>Form from './components/<ScreenName>Form'
+import Footer from './components/Footer'
+import { use<ScreenName>Manager } from './hooks/use<ScreenName>Manager'
+
+export const <ScreenName>Screen = () => {
+  const { sdkInstance, texts, locales } = use<ScreenName>Manager()
+  applyAuth0Theme(sdkInstance)
+  document.title = texts?.pageTitle ?? locales.pageTitle
+
+  return (
+    <ULThemePageLayout>
+      <ULThemeCard>
+        <Header texts={texts} />
+        <AlternativeLogins alignment="top" />    {/* conditional */}
+        <<ScreenName>Form />
+        <Footer texts={texts} links={links} />
+        <AlternativeLogins alignment="bottom" />  {/* conditional */}
+      </ULThemeCard>
+    </ULThemePageLayout>
+  )
+}
+```
+
+**hooks/use\<ScreenName\>Manager.ts pattern:**
+```ts
+import { useLoginId, useScreen, useTransaction } from '@auth0/auth0-acul-react/<screen-name>'
+import { executeSafely } from '@/utils/helpers/executeSafely'
+import locales from '../locales/en.json'
+
+export const use<ScreenName>Manager = () => {
+  const sdkInstance = useLoginId()       // screen-specific SDK hook
+  const screen = useScreen()
+  const { alternateConnections } = useTransaction()
+
+  const handleSubmit = async (data) => executeSafely(() => login(data))
+  const handleFederatedLogin = async (conn) => executeSafely(() => federatedLogin({ connection: conn }))
+
+  return {
+    sdkInstance,
+    texts: screen.texts,
+    locales,
+    alternateConnections,
+    handleSubmit,
+    handleFederatedLogin,
+    isPasskeyEnabled: screen.isPasskeyEnabled,
+    isCaptchaAvailable: screen.isCaptchaAvailable,
+  }
+}
+```
+
+When a screen is **not** in auth0-acul-samples, fall back to a single-file component based on the SDK example.
+
+## Prerequisites
+
+- Auth0 CLI installed: `brew install auth0`
+- Custom domain configured on the Auth0 tenant (hard ACUL requirement)
+- Node.js 18+
+
+---
+
+## Phase 0: CLI Authentication & Tenant Check
+
+```bash
+auth0 login
+auth0 acul config list --rendering-mode advanced
+```
+
+If `auth0 acul config list` returns an error about custom domain: stop and inform the customer they must configure a custom domain on their tenant before ACUL is available.
+
+For full CLI flag reference → read `references/cli-commands.md`.
+
+---
+
+## Phase 1: Intent Detection
+
+Ask the customer which mode they need:
+
+- **A) Build from scratch** — new project, select screens, full setup
+- **B) Add a screen** — existing project, add one or more new screens
+- **C) Modify a screen** — existing project, change an existing screen's code or styling
+
+This choice gates Phases 2A / 2B / 2C.
+
+---
+
+## Phase 2A: Scratch — Project Init
+
+Gather: app name, framework (`react` or `js`), initial screen list.
+
+```bash
+auth0 acul init <app_name> -t react -s login-id,login-password,signup
+auth0 acul config generate <screen-name>    # repeat per screen
+```
+
+Verify `acul_config.json` is created in the project directory. Proceed to Phase 3.
+
+---
+
+## Phase 2B: Add Screen — CLI + Reference Fetch
+
+1. Verify `acul_config.json` exists in the project directory.
+   - If missing → stop. Instruct customer to run `auth0 acul init` first.
+
+2. Run:
+   ```bash
+   auth0 acul screen add <screen-name> -d <project-dir>
+   ```
+   If CLI errors or screen is not recognised → continue to step 3.
+
+3. **Always resolve the reference using the hierarchy** (regardless of CLI success or failure):
+
+   **Step 3a — Check auth0-acul-samples first:**
+   - Read `references/screen-catalog.md` to check if the screen has a `✅` in the Samples column
+   - If yes → fetch the screen directory from:
+     - React: `https://github.com/auth0-samples/auth0-acul-samples/tree/main/react/src/screens/<screen-name>`
+     - React-JS: `https://github.com/auth0-samples/auth0-acul-samples/tree/main/react-js/src/screens/<screen-name>`
+   - Fetch `index.tsx` and the `hooks/use<ScreenName>Manager.ts` file to understand the full implementation
+   - Use the samples architecture (modular: index + components + hooks + locales)
+
+   **Step 3b — If not in samples, fetch SDK example:**
+   - React: `https://github.com/auth0/universal-login/blob/master/packages/auth0-acul-react/examples/<screen-name>.md`
+   - JS: `https://github.com/auth0/universal-login/blob/master/packages/auth0-acul-js/examples/<screen-name>.md`
+   - Parse for: exact import path, hook pattern (generic vs screen-specific), action functions and payload shapes
+   - Use a single-file component (no modular split needed)
+
+   This step is mandatory. The 68+ ACUL screens use fundamentally different hook patterns — wrong pattern = broken code.
+
+   For all screen names and which are in samples → read `references/screen-catalog.md`.
+
+---
+
+## Phase 2C: Modify Screen — Fetch Current State
+
+1. Verify `acul_config.json` exists.
+
+2. Fetch current rendering configuration:
+   ```bash
+   auth0 acul config get <screen-name> -f <screen-name>.json
+   auth0 acul config list --rendering-mode advanced
+   ```
+
+3. Read the existing screen file from the customer's codebase.
+
+4. **Always resolve the reference using the same hierarchy as Phase 2B** (samples first, SDK example second). Even when modifying an existing file, the reference confirms whether the current code uses the correct hook pattern, action functions, and component structure before making changes.
+
+---
+
+## Phase 3: Screen Requirements
+
+Gather from the customer:
+
+- **Screen type** — for full list of available screens → read `references/screen-catalog.md`
+- **Components needed:**
+  - Social providers: Google, GitHub, Apple, Microsoft, Facebook
+  - Form fields: email, username, phone, password, confirm-password
+  - MFA type (if applicable): OTP, SMS, push, WebAuthn
+  - Optional extras: captcha, passkey button, remember-me, terms checkbox
+- **For modify mode:** what specifically to change (layout, colors, add/remove a component)
+
+---
+
+## Phase 4: Tech Stack Detection
+
+Confirm or detect:
+
+- **Framework:** React (`@auth0/auth0-acul-react`) or JS (`@auth0/auth0-acul-js`)
+- **Styling library:** Tailwind CSS / CSS Modules / styled-components / plain CSS
+- **Existing theme file?** Check for `tailwind.config.ts`, `styles/tokens.css`, `theme/index.ts`
+
+Load the appropriate SDK reference:
+- React → read `references/acul-react-sdk.md`
+- JS → read `references/acul-js-sdk.md`
+
+For social button implementation → read `references/social-providers.md`.
+
+---
+
+## Phase 5: Theme Extraction & Scope
+
+### Design input — detect which the customer has provided:
+
+**Option A — Image or mockup (jpeg / png / screenshot):**
+Analyze the image and extract:
+- Primary, secondary, accent colors (as hex)
+- Background and card/surface colors
+- Font family and weights
+- Border radius style (sharp / slight / rounded / pill)
+- Spacing rhythm (compact / normal / spacious)
+- Layout type: centered card / full-bleed / split-panel / floating card
+
+**Option B — Brand colors only (no image):**
+Derive the full token set from the provided hex values:
+```
+primary        → button bg, links, focus ring
+primary-hover  → primary darkened ~10%
+primary-text   → white if primary is dark, else #111827
+background     → page background
+surface        → card/panel background
+text-primary   → headings (#111827 light / #F1F5F9 dark)
+text-secondary → labels, placeholders
+border         → input borders
+error          → #EF4444 (unless specified)
+success        → #22C55E (unless specified)
+```
+
+### Theme scope — ask the customer:
+
+- **Single screen:** apply tokens inline to just this component's styles
+- **All screens:** generate a shared theme file first, then apply consistently across every screen
+
+For theme file patterns per styling library → read `references/theming-patterns.md`.
+
+**Theme file to generate per styling library (all-screens scope):**
+
+| Styling library | Template to use | Output file |
+|----------------|-----------------|-------------|
+| Tailwind | `assets/theme-templates/tailwind.config.ts` | `tailwind.config.ts` |
+| CSS Modules | `assets/theme-templates/tokens.css` | `styles/tokens.css` |
+| styled-components | `assets/theme-templates/theme-provider.ts` | `theme/index.ts` |
+| Plain CSS | `assets/theme-templates/globals.css` | `styles/globals.css` |
+
+Replace all `{{TOKEN}}` placeholders with extracted token values.
+
+---
+
+## Phase 6: Structured Code Generation
+
+Generation approach depends on whether the screen is in auth0-acul-samples.
+
+### Path A — Screen is in auth0-acul-samples (modular architecture)
+
+Generate the full directory structure using the samples pattern (see "auth0-acul-samples Architecture" above):
+
+```
+<screen-name>/
+├── index.tsx
+├── components/
+│   ├── Header.tsx
+│   ├── <ScreenName>Form.tsx
+│   ├── Footer.tsx
+│   └── AlternativeLogins.tsx       (only if screen has social login)
+├── hooks/
+│   └── use<ScreenName>Manager.ts
+└── locales/
+    └── en.json
+```
+
+- `index.tsx` — thin: calls `use<ScreenName>Manager()`, calls `applyAuth0Theme()`, renders `ULThemePageLayout` → `ULThemeCard` → sub-components
+- `use<ScreenName>Manager.ts` — wraps SDK hooks from the samples reference, exposes typed handlers and feature flags
+- Form component — uses react-hook-form, reads from manager hook, no direct SDK calls
+- Header/Footer — stateless, receive texts as props
+- `en.json` — fallback strings matching keys used in `screen.texts.*`
+
+Apply design tokens from Phase 5 to the layout components and form component styling.
+
+### Path B — Screen is NOT in auth0-acul-samples (single-file component)
+
+Generate a single `<screen-name>.tsx` (React) or `<screen-name>.js` (JS) using the structure from `assets/react-templates/` or `assets/js-templates/` as a pattern, with hooks and actions sourced entirely from the SDK example fetched in Phase 2.
+
+JSX structure order:
+```
+Outer layout wrapper → Card/panel → Logo slot → Title (screen.texts) →
+Error banner (conditional) → Form fields → Captcha (conditional) →
+Submit button → Passkey button (conditional) → Social divider + buttons
+(conditional on alternateConnections) → Footer links
+```
+
+### Validation before outputting any code
+
+- SDK import path exactly matches the screen name (e.g., `@auth0/auth0-acul-react/mfa-otp-challenge`)
+- Hook pattern (generic `useScreen()` vs screen-specific hook) sourced from the reference, not assumed
+- Action function names and payload shapes sourced from the reference
+- Error state uses SDK source (`hasErrors` / `getErrors()`) — never local-only error state
+- No hardcoded UI strings — use `screen.texts.*` with locale fallback
+- `applyAuth0Theme()` called in index.tsx for Path A screens
+
+**All-screens scope:** repeat Path A or Path B (whichever applies per screen) for every screen in the project, all importing from the shared theme file. Consistent component structure within each path.
+
+---
+
+## Phase 7: Dev Mode Wiring
+
+Provide the customer with ready-to-run commands:
+
+```bash
+# Local preview — no tenant connection needed
+auth0 acul dev -p 3000 -d <project-dir>
+
+# Connected mode — syncs assets to tenant (stage/dev only)
+auth0 acul dev --connected -s <screen-name> -d <project-dir>
+```
+
+⚠️ Always include this warning when connected mode is suggested:
+> Connected mode updates your Auth0 tenant in real time. Only use this on a stage or development tenant — never on production.
+
+---
+
+## Reference Files
+
+| File | Load when |
+|------|-----------|
+| `references/acul-react-sdk.md` | Framework is React |
+| `references/acul-js-sdk.md` | Framework is JS / Vanilla |
+| `references/screen-catalog.md` | Selecting screen type or triggering CLI fallback |
+| `references/social-providers.md` | Social login buttons are needed |
+| `references/theming-patterns.md` | Generating or applying a shared theme file |
+| `references/cli-commands.md` | Need full CLI flag details |
+
+## Asset Templates
+
+| File | Use when |
+|------|----------|
+| `assets/theme-templates/tailwind.config.ts` | Tailwind, all-screens scope |
+| `assets/theme-templates/tokens.css` | CSS Modules, all-screens scope |
+| `assets/theme-templates/theme-provider.ts` | styled-components |
+| `assets/theme-templates/globals.css` | Plain CSS, all-screens scope |
+| `assets/react-templates/<screen>.tsx` | React component boilerplate base |
+| `assets/js-templates/<screen>.js` | JS component boilerplate base |

--- a/main/.mintlify/skills/auth0-expo/SKILL.md
+++ b/main/.mintlify/skills/auth0-expo/SKILL.md
@@ -1,0 +1,270 @@
+---
+name: auth0-expo
+description: Use when adding authentication to Expo (React Native) mobile apps — login, logout, user sessions, protected routes, biometrics, or token management. Integrates react-native-auth0 SDK with Expo Config Plugin for native iOS/Android builds. Trigger for any Expo project needing Auth0, including app.json plugin config, custom scheme setup, or credential management. Do NOT use for bare React Native CLI projects (use auth0-react-native), React web apps (use auth0-react), Next.js (use auth0-nextjs), or backend APIs.
+license: Proprietary
+metadata:
+  author: Auth0 <support@auth0.com>
+---
+
+# Auth0 Expo Integration
+
+Add authentication to Expo (React Native) applications using `react-native-auth0` with the Expo Config Plugin.
+
+> **Agent instruction:** Before providing SDK setup instructions, fetch the latest release version by running:
+> ```bash
+> gh api repos/auth0/react-native-auth0/releases/latest --jq '.tag_name'
+> ```
+> Use the returned version in all dependency lines instead of any hardcoded version below. If the command fails, fall back to checking https://github.com/auth0/react-native-auth0/releases.
+
+## Prerequisites
+
+- Expo SDK 53 or higher (react-native-auth0 v5.x requires Expo 53+)
+- React 19 and React Native 0.78.0 or higher
+- Node.js 20+ (for bootstrap script automation)
+- Auth0 account with a **Native** application configured
+- If Auth0 is not set up yet, use the `auth0-quickstart` skill first
+- **Not compatible with Expo Go** — requires custom development client or EAS Build
+
+## When NOT to Use
+
+| Use Case | Recommended Skill |
+|----------|------------------|
+| Bare React Native CLI project (no Expo) | `auth0-react-native` |
+| React web SPA (Vite/CRA) | `auth0-react` |
+| Next.js application | `auth0-nextjs` |
+| Vue.js SPA | `auth0-vue` |
+| Angular SPA | `auth0-angular` |
+| Express.js backend | `auth0-express` |
+| Native Android (Kotlin/Java) | `auth0-android` |
+| Backend API (JWT validation) | `auth0-fastify-api` or `auth0-express` |
+
+## Quick Start Workflow
+
+> **Agent instruction:** First, check whether the user's prompt already includes both Auth0 **Client ID** and **Domain**.
+> - If both are provided, skip the setup-choice question and proceed directly to **Step 2 (Verify Expo Dev Client)** using those values.
+> - If either value is missing, ask the user using `AskUserQuestion`: _"How would you like to configure Auth0 for this Expo project?"_
+>   - **Automatic setup (Recommended)** — runs a bootstrap script that creates the Auth0 app, database connection, callback URLs, and writes the plugin config to app.json
+>   - **Manual setup** — the user provides their Auth0 Client ID and Domain
+>
+> Follow the matching section below based on their choice.
+
+### 1. Configure Auth0
+
+#### Automatic Setup
+
+> **Agent instruction:** Run these quick checks before the bootstrap script. Do NOT run `auth0 login` from the agent — it is interactive and will hang.
+>
+> 1. **Check Node.js**: `node --version`. If missing or below 20, ask user: install (`brew install node`) or switch to manual setup.
+> 2. **Check Auth0 CLI**: `command -v auth0`. If missing, ask user: install (`brew install auth0/auth0-cli/auth0`) or switch to manual setup.
+> 3. **Check Auth0 login**: `auth0 tenants list --csv --no-input 2>&1`. If it fails or returns empty:
+>    - Tell the user: _"Please run `auth0 login` in your terminal and let me know when done."_
+>    - Wait for the user to confirm, then re-run the check to verify.
+> 4. **Confirm active tenant**: Parse the `→` line from the CSV output to identify the active tenant domain. Tell the user: _"Your active Auth0 tenant is: `<domain>`. Is this the correct tenant?"_
+>    - If yes, proceed.
+>    - If no, ask the user to run `auth0 tenants use <tenant-domain>` in their terminal, then re-run step 3 to confirm the new active tenant.
+>
+> Once confirmed, run the bootstrap script:
+> ```bash
+> cd <path-to-skill>/auth0-expo/scripts
+> npm install
+> node bootstrap.mjs <path-to-expo-project>
+> ```
+>
+> The script validates the Expo project, creates a Native Auth0 application, sets up a database connection, and writes the plugin config to app.json. The agent should NOT handle client_id or domain manually.
+>
+> If the script fails due to session expiry, ask the user to run `auth0 login` again, then re-run the script. For other failures, fall back to **Manual Setup** below.
+>
+> After the script completes, proceed to **Step 2 (Verify Expo Dev Client)**.
+
+#### Manual Setup (User-Provided Credentials)
+
+> **Agent instruction:** Ask the user for their Auth0 credentials using `AskUserQuestion`:
+>
+> "I need your Auth0 credentials to set up authentication. Please provide:
+>
+> 1. **Auth0 Domain** (e.g., `your-tenant.us.auth0.com`)
+> 2. **Client ID** (a 32-character alphanumeric string)
+>
+> You can find both in the [Auth0 Dashboard](https://manage.auth0.com/) under **Applications > Applications > your app > Settings**. If you don't have an Auth0 app yet, create one with type **Native** and copy the domain and client ID from the settings page."
+>
+> Then write the configuration to app.json and proceed to **Step 2**.
+
+### 2. Verify Expo Dev Client
+
+> **Agent instruction:** Before installing the Auth0 SDK, check if the project has `expo-dev-client` installed. Read the project's `package.json` and look for `expo-dev-client` in `dependencies` or `devDependencies`.
+>
+> - **If `expo-dev-client` is found:** Proceed to step 3.
+> - **If `expo-dev-client` is NOT found:** Use `AskUserQuestion` with the following message:
+>
+>   "The `react-native-auth0` SDK requires a custom Expo development client — it does **not** work with Expo Go. Your project does not have `expo-dev-client` installed.
+>
+>   How would you like to proceed?
+>   1. **Install it for me** — I'll run `npx expo install expo-dev-client` and continue setup
+>   2. **I'll set it up myself** — skip this step and continue to Auth0 SDK installation"
+>
+>   If the user picks option 1, run:
+>   ```bash
+>   npx expo install expo-dev-client
+>   ```
+>   Then proceed to step 3. If option 2, proceed to step 3 directly.
+
+### 3. Install SDK
+
+```bash
+npx expo install react-native-auth0
+```
+
+### 4. Configure Expo Config Plugin
+
+Add the react-native-auth0 plugin to `app.json` (or `app.config.js`) with your Auth0 domain and a custom scheme. Also ensure `bundleIdentifier` (iOS) and `package` (Android) are set:
+
+```json
+{
+  "expo": {
+    "ios": { "bundleIdentifier": "com.yourcompany.yourapp" },
+    "android": { "package": "com.yourcompany.yourapp" },
+    "plugins": [
+      ["react-native-auth0", {
+        "domain": "YOUR_AUTH0_DOMAIN",
+        "customScheme": "YOUR_CUSTOM_SCHEME"
+      }]
+    ]
+  }
+}
+```
+
+The `customScheme` must be all lowercase with no special characters (e.g., `auth0sample`). See [**Setup Guide**](./references/setup.md) for HTTPS callbacks, multiple domains, EAS Build, and secret management.
+
+> **Agent instruction:** If you used automatic setup (Step 1), the bootstrap script already wrote the plugin config to app.json — verify it's correct but do not overwrite it. If you used manual setup, write the config now using the user-provided domain and a custom scheme.
+
+### 5. Configure Callback URLs
+
+Add to **Allowed Callback URLs** and **Allowed Logout URLs** in the [Auth0 Dashboard](https://manage.auth0.com/):
+
+```text
+YOUR_CUSTOM_SCHEME://YOUR_AUTH0_DOMAIN/ios/YOUR_BUNDLE_ID/callback,
+YOUR_CUSTOM_SCHEME://YOUR_AUTH0_DOMAIN/android/YOUR_PACKAGE/callback
+```
+
+All values must be **lowercase** with **no trailing slash**. For HTTPS callback URLs (App Links / Universal Links), see [Setup Guide](./references/setup.md#using-https-callback-urls-android-app-links).
+
+### 6. Add Authentication with Auth0Provider
+
+Wrap your app with `Auth0Provider` and use the `useAuth0` hook:
+
+> **Agent instruction:** Before adding new UI elements, search the project for existing click handlers for login, logout, sign-in, or sign-out buttons. If existing handlers are found, hook the Auth0 code into them. Only create new buttons if no existing handlers are found.
+
+```typescript
+import React from 'react';
+import { Auth0Provider, useAuth0 } from 'react-native-auth0';
+import { View, Button, Text, ActivityIndicator } from 'react-native';
+
+function HomeScreen() {
+  const { authorize, clearSession, user, isLoading, error } = useAuth0();
+
+  const login = async () => {
+    try {
+      await authorize(
+        { scope: 'openid profile email' },
+        { customScheme: 'YOUR_CUSTOM_SCHEME' }
+      );
+    } catch (e) {
+      console.error('Login error:', e);
+    }
+  };
+
+  const logout = async () => {
+    try {
+      await clearSession({ customScheme: 'YOUR_CUSTOM_SCHEME' });
+    } catch (e) {
+      console.error('Logout error:', e);
+    }
+  };
+
+  if (isLoading) {
+    return <ActivityIndicator size="large" />;
+  }
+
+  return (
+    <View>
+      {user ? (
+        <>
+          <Text>Welcome, {user.name}!</Text>
+          <Text>{user.email}</Text>
+          <Button title="Log Out" onPress={logout} />
+        </>
+      ) : (
+        <Button title="Log In" onPress={login} />
+      )}
+      {error && <Text>{error.message}</Text>}
+    </View>
+  );
+}
+
+export default function App() {
+  return (
+    <Auth0Provider
+      domain="YOUR_AUTH0_DOMAIN"
+      clientId="YOUR_AUTH0_CLIENT_ID"
+    >
+      <HomeScreen />
+    </Auth0Provider>
+  );
+}
+```
+
+### 7. Build & Verify
+
+> **Agent instruction:** After completing the integration, build the project to verify it compiles:
+> ```bash
+> npx expo prebuild --clean
+> npx expo run:ios
+> # or
+> npx expo run:android
+> ```
+> If the build fails, analyze the error output. Common integration build failures include:
+> - **"Invariant Violation: Native module cannot be null"**: Using Expo Go instead of a development build — run `npx expo run:ios` or `npx expo run:android` instead of `npx expo start`
+> - **Plugin not applied**: Missing `react-native-auth0` in app.json plugins array — verify the plugin configuration
+> - **Pod install fails (iOS)**: Run `npx expo prebuild --clean` to regenerate native projects
+> - **Manifest merge failure (Android)**: Conflicting auth0Domain placeholder — ensure only the config plugin sets the domain
+>
+> Re-run the build after each fix. Track the number of build-fix iterations.
+>
+> **Failcheck:** If the build still fails after 5–6 fix attempts, stop and ask the user using `AskUserQuestion`:
+> _"The build is still failing after several fix attempts. How would you like to proceed?"_
+> - **Let the skill continue fixing iteratively**
+> - **Fix it manually** — show the remaining errors
+> - **Skip build verification** — proceed without a successful build
+
+## Detailed Documentation
+
+- **[Setup Guide](./references/setup.md)** — Dev client requirement, automated setup, Expo config plugin, callback URLs, EAS Build, secret management
+- **[Integration Patterns](./references/integration.md)** — Login/logout, credential management, biometric auth, token refresh, organizations, DPoP, error handling
+- **[API Reference & Testing](./references/api.md)** — Configuration options, useAuth0 hook API, testing checklist, common issues, security
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Using Expo Go instead of development build | react-native-auth0 requires native code. Use `npx expo run:ios` / `npx expo run:android` or create a development build with EAS. |
+| Missing `customScheme` in authorize/clearSession calls | Pass `{ customScheme: 'your-scheme' }` as the second argument to `authorize()` and `clearSession()`. Must match the value in app.json plugin config. |
+| Callback URL mismatch | Ensure callback URL is all lowercase, no trailing slash, and matches Auth0 Dashboard exactly: `{customScheme}://{domain}/ios/{bundleId}/callback` |
+| App type not set to Native | The Auth0 application must be type **Native** in the Dashboard, not SPA or Regular Web. |
+| Missing bundleIdentifier or package in app.json | Both `expo.ios.bundleIdentifier` and `expo.android.package` must be set in app.json for callback URLs to work. |
+| Forgot to wrap app with Auth0Provider | All components using `useAuth0()` must be children of `Auth0Provider`. |
+| Using react-native-auth0 v5.x with Expo < 53 | Version 5.x requires Expo 53+. Use v4.x for older Expo versions. |
+| Not testing on physical device | Biometric authentication (Face ID, fingerprint) only works on a physical device, not simulators. Always test the full auth flow on a real device before release. |
+
+## Related Skills
+
+- [auth0-quickstart](/auth0-quickstart) — Set up an Auth0 account and application
+- [auth0-react-native](/auth0-react-native) — Bare React Native CLI projects
+- [auth0-mfa](/auth0-mfa) — Configure multi-factor authentication
+
+## References
+
+- [Auth0 Expo Quickstart](https://auth0.com/docs/quickstart/native/react-native-expo/interactive)
+- [react-native-auth0 GitHub Repository](https://github.com/auth0/react-native-auth0)
+- [react-native-auth0 API Documentation](https://auth0.github.io/react-native-auth0/)
+- [Expo Sample App](https://github.com/auth0-samples/auth0-react-native-sample/tree/master/00-Login-Expo)
+- [EXAMPLES.md](https://github.com/auth0/react-native-auth0/blob/master/EXAMPLES.md)

--- a/main/.mintlify/skills/auth0-fastapi-api/SKILL.md
+++ b/main/.mintlify/skills/auth0-fastapi-api/SKILL.md
@@ -1,0 +1,268 @@
+---
+name: auth0-fastapi-api
+description: "Use when securing FastAPI API endpoints with JWT Bearer token validation, scope/permission checks, or stateless auth - integrates auth0-fastapi-api for REST APIs receiving access tokens from SPAs, mobile apps, or other clients. Also handles DPoP proof-of-possession token binding. Triggers on: Auth0FastAPI, FastAPI API auth, JWT validation, require_auth, DPoP."
+license: Apache-2.0
+metadata:
+  author: Auth0 <support@auth0.com>
+---
+
+# Auth0 FastAPI API Integration
+
+Protect FastAPI API endpoints with JWT access token validation using `auth0-fastapi-api`.
+
+> **Note:** This SDK is currently in beta. The API surface may change before the stable 1.0 release. Check [PyPI](https://pypi.org/project/auth0-fastapi-api/) for the latest version. Requires Python >= 3.9 and FastAPI >= 0.115.11.
+
+---
+
+## Prerequisites
+
+- FastAPI application (Python 3.9+)
+- Auth0 API resource configured (not an Application — must be an API)
+- If you don't have Auth0 set up yet, use the `auth0-quickstart` skill first
+
+## When NOT to Use
+
+- **Server-rendered web applications** — Use a session-based login/logout flow instead
+- **Single Page Applications** — Use `auth0-react`, `auth0-vue`, or `auth0-angular` for client-side auth
+- **Mobile applications** — Use `auth0-react-native` or `auth0-android`
+- **Issuing tokens** — This skill is for *validating* access tokens, not issuing them
+
+---
+
+## Quick Start Workflow
+
+### 1. Install SDK
+
+```bash
+pip install auth0-fastapi-api python-dotenv
+```
+
+### 2. Create Auth0 API
+
+You need an **API** (not Application) in Auth0.
+
+> **STOP — ask the user before proceeding.**
+>
+> Ask exactly this question and wait for their answer before doing anything else:
+>
+> > "How would you like to create the Auth0 API resource?
+> > 1. **Automated** — I'll run Auth0 CLI scripts that create the resource and write the exact values to your `.env` automatically.
+> > 2. **Manual** — You create the API yourself in the Auth0 Dashboard (or via `auth0 apis create`) and provide me the Domain and Audience.
+> >
+> > Which do you prefer? (1 = Automated / 2 = Manual)"
+>
+> Do NOT proceed to any setup steps until the user has answered. Do NOT default to manual.
+
+**If the user chose Automated**, follow the [Setup Guide](references/setup.md) for complete CLI scripts. The automated path writes `.env` for you — skip Step 3 below and proceed directly to Step 4.
+
+**If the user chose Manual**, follow the [Setup Guide](references/setup.md) (Manual Setup section) for full instructions. Then continue with Step 3 below.
+
+Quick reference for manual API creation:
+
+```bash
+# Using Auth0 CLI
+auth0 apis create \
+  --name "My FastAPI API" \
+  --identifier https://my-api.example.com
+```
+
+Or create manually in Auth0 Dashboard → Applications → APIs
+
+### 3. Configure Environment
+
+Create `.env`:
+
+```bash
+AUTH0_DOMAIN=your-tenant.us.auth0.com
+AUTH0_AUDIENCE=https://your-api.example.com
+```
+
+`AUTH0_DOMAIN` is your Auth0 tenant domain (without `https://`). `AUTH0_AUDIENCE` is the API identifier you set when creating the API resource in Auth0.
+
+### 4. Initialize Auth0
+
+```python
+import os
+from fastapi import FastAPI, Depends
+from auth0_fastapi_api import Auth0FastAPI
+from dotenv import load_dotenv
+
+load_dotenv()
+
+app = FastAPI()
+
+auth0 = Auth0FastAPI(
+    domain=os.getenv("AUTH0_DOMAIN"),
+    audience=os.getenv("AUTH0_AUDIENCE"),
+)
+```
+
+Create one `Auth0FastAPI` instance per application and reuse it across routes. Never hardcode the domain or audience — always use environment variables.
+
+### 5. Protect Routes
+
+```python
+# Require any valid access token
+@app.get("/api/private")
+async def private(claims: dict = Depends(auth0.require_auth())):
+    return {"user": claims["sub"]}
+
+# No authentication required
+@app.get("/api/public")
+async def public():
+    return {"message": "Public endpoint"}
+```
+
+The `require_auth()` dependency validates the Bearer token, verifies the issuer and audience, and returns the decoded JWT claims.
+
+Error responses:
+- **400** `invalid_request` — Missing or malformed Authorization header
+- **401** `invalid_token` — Expired token, invalid signature, wrong issuer/audience
+- **403** `insufficient_scope` — Valid token but missing required scopes
+- **500** `internal_server_error` — Unexpected errors
+
+Response body format: `{"detail": {"error": "...", "error_description": "..."}}`
+
+### 6. Protect Routes with Scope Checks
+
+```python
+# Requires the read:messages scope
+@app.get("/api/messages")
+async def get_messages(claims: dict = Depends(auth0.require_auth(scopes="read:messages"))):
+    return {"messages": []}
+
+# Requires both read:data and write:data scopes
+@app.post("/api/data")
+async def write_data(claims: dict = Depends(auth0.require_auth(scopes=["read:data", "write:data"]))):
+    return {"created": True}
+```
+
+`require_auth(scopes=...)` checks the `scope` claim in the JWT. All specified scopes must be present (AND logic). Missing scopes return **403**.
+
+### 7. Access Token Claims
+
+The decoded JWT claims are returned directly from the dependency:
+
+```python
+@app.get("/api/profile")
+async def profile(claims: dict = Depends(auth0.require_auth())):
+    return {
+        "sub": claims["sub"],       # user ID
+        "scope": claims.get("scope"),  # granted scopes
+    }
+```
+
+Key claims:
+- `claims["sub"]` — user/client ID
+- `claims["scope"]` — space-separated granted scopes
+- `claims["iss"]` — issuer (your Auth0 domain URL)
+- `claims["aud"]` — audience
+- `claims["exp"]` — expiration timestamp
+- `claims["iat"]` — issued-at timestamp
+
+### 8. Protect Routes Without Needing Claims
+
+```python
+@app.get("/api/protected", dependencies=[Depends(auth0.require_auth())])
+async def protected():
+    return {"message": "You need a valid access token to see this."}
+```
+
+### 9. Test the API
+
+```bash
+# No token — expect 401
+curl http://localhost:8000/api/private
+
+# With a valid access token
+curl http://localhost:8000/api/private \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
+Get a test token via Client Credentials flow or Auth0 Dashboard → APIs → Test tab.
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Hardcoding `domain` or `audience` in source | Always read from environment variables — never embed credentials in code |
+| Using `python-jose` or `PyJWT` directly | Not needed; `auth0-fastapi-api` handles all validation via JWKS |
+| Manually parsing `Authorization` header | The SDK extracts and validates the token automatically |
+| Calling `jwt.decode()` manually | The SDK verifies tokens against the JWKS endpoint — do not verify yourself |
+| Using `fastapi-users` for Auth0 JWT validation | That package is for user management, not Auth0 JWT verification |
+| Created an Application instead of an API in Auth0 | Must create an **API** resource (Applications → APIs) — an Application doesn't issue access tokens with the right audience |
+| Passing `domain` as full URL with `https://` | `domain` should be the bare domain, e.g. `my-tenant.us.auth0.com`, not `https://my-tenant.us.auth0.com` |
+| Using an ID token instead of an access token | Must use the **access token** for API auth — ID tokens are for the client app, not for API authorization |
+| Not configuring CORS for SPA clients | Add `CORSMiddleware` to allow requests from your frontend origin |
+| `os.getenv()` returns `None` silently | Ensure `python-dotenv` is installed and `load_dotenv()` is called before `Auth0FastAPI()` initialization — or use `os.environ[]` to fail fast |
+
+---
+
+## DPoP Support
+
+Built-in proof-of-possession token binding per RFC 9449. DPoP is enabled by default in mixed mode (accepts both Bearer and DPoP tokens). See [Integration Guide](references/integration.md#dpop-support) for configuration.
+
+---
+
+## Related Skills
+
+- `auth0-quickstart` - Basic Auth0 setup and framework detection
+- `auth0-mfa` - Add Multi-Factor Authentication
+
+---
+
+## Quick Reference
+
+**Auth0FastAPI configuration:**
+```python
+auth0 = Auth0FastAPI(
+    domain=os.getenv("AUTH0_DOMAIN"),       # required (or use domains)
+    audience=os.getenv("AUTH0_AUDIENCE"),    # required
+    dpop_enabled=True,                       # default; set False for Bearer-only
+    dpop_required=False,                     # default; set True to reject Bearer tokens
+)
+```
+
+**Route protection:**
+```python
+Depends(auth0.require_auth())                    # any valid token
+Depends(auth0.require_auth(scopes="read:res"))   # single scope
+Depends(auth0.require_auth(scopes=["r", "w"]))   # all scopes required
+```
+
+**Accessing claims:**
+```python
+claims["sub"]           # user/client ID
+claims["scope"]         # space-separated scopes
+```
+
+**Environment variables:**
+- `AUTH0_DOMAIN` — your Auth0 tenant domain (e.g. `tenant.us.auth0.com`)
+- `AUTH0_AUDIENCE` — your API identifier (e.g. `https://api.example.com`)
+
+**Common Use Cases:**
+- Protect routes → `Depends(auth0.require_auth())` (see Step 5)
+- Scope enforcement → `Depends(auth0.require_auth(scopes="..."))` (see Step 6)
+- DPoP token binding → [Integration Guide](references/integration.md#dpop-support)
+- Reverse proxy setup → [Integration Guide](references/integration.md#reverse-proxy-support)
+- Advanced configuration → [API Reference](references/api.md)
+
+---
+
+## Detailed Documentation
+
+- **[Setup Guide](references/setup.md)** — Auth0 CLI setup, environment configuration, getting test tokens
+- **[Integration Guide](references/integration.md)** — DPoP, scopes, error handling, reverse proxy, testing
+- **[API Reference](references/api.md)** — Complete constructor options, method signatures, error codes
+
+---
+
+## References
+
+- [auth0-fastapi-api GitHub](https://github.com/auth0/auth0-fastapi-api)
+- [auth0-fastapi-api on PyPI](https://pypi.org/project/auth0-fastapi-api/)
+- [Auth0 FastAPI API Quickstart](https://auth0.com/docs/quickstart/backend/fastapi)
+- [FastAPI Dependency Injection](https://fastapi.tiangolo.com/tutorial/dependencies/)
+- [Access Tokens Guide](https://auth0.com/docs/secure/tokens/access-tokens)

--- a/main/.mintlify/skills/auth0-flask/SKILL.md
+++ b/main/.mintlify/skills/auth0-flask/SKILL.md
@@ -1,0 +1,377 @@
+---
+name: auth0-flask
+description: Use when adding login, logout, and user profile to a Flask web application using session-based authentication - integrates auth0-server-python for server-rendered apps with login/callback/profile/logout flows.
+license: Apache-2.0
+metadata:
+  author: Auth0 <support@auth0.com>
+---
+
+# Auth0 Flask Web App Integration
+
+Add login, logout, and user profile to a Flask web application using `auth0-server-python`.
+
+---
+
+## Prerequisites
+
+- Flask application
+- Auth0 Regular Web Application configured (not an API — must be an Application)
+- If you don't have Auth0 set up yet, use the `auth0-quickstart` skill first
+
+## When NOT to Use
+
+- **Python APIs with JWT Bearer validation** — Use `auth0-fastapi-api` for FastAPI, or see the [Django REST Framework quickstart](https://auth0.com/docs/quickstart/backend/django)
+- **FastAPI web app with login/logout UI** — No dedicated skill yet; see the [FastAPI quickstart](https://auth0.com/docs/quickstart/webapp/python)
+- **Single Page Applications** — Use `auth0-react`, `auth0-vue`, or `auth0-angular` for client-side auth
+- **Next.js applications** — Use `auth0-nextjs` which handles both client and server
+- **Node.js web apps** — Use `auth0-express` or `auth0-fastify` for session-based auth
+
+---
+
+## Quick Start Workflow
+
+### 1. Install SDK
+
+```bash
+pip install auth0-server-python "flask[async]" python-dotenv
+```
+
+**Critical:** You must install `flask[async]` (not just `flask`). The `[async]` extra installs `asgiref` which is required for Flask 2.0+ to support `async def` route handlers. Without it, async routes will not work. In `requirements.txt`, use `flask[async]>=2.0.0`.
+
+### 2. Configure Environment
+
+Create `.env`:
+
+```bash
+AUTH0_DOMAIN=your-tenant.us.auth0.com
+AUTH0_CLIENT_ID=your_client_id
+AUTH0_CLIENT_SECRET=your_client_secret
+AUTH0_SECRET=your_generated_app_secret
+AUTH0_REDIRECT_URI=http://localhost:5000/callback
+```
+
+`AUTH0_DOMAIN` is your Auth0 tenant domain (without `https://`). `AUTH0_CLIENT_ID` and `AUTH0_CLIENT_SECRET` come from your Auth0 Application settings. `AUTH0_SECRET` is used for encrypting session data — generate with `openssl rand -hex 64`.
+
+### 3. Configure Auth0 Dashboard
+
+In your Auth0 Application settings:
+- **Allowed Callback URLs**: `http://localhost:5000/callback`
+- **Allowed Logout URLs**: `http://localhost:5000`
+
+### 4. Create Auth Module
+
+Create `auth.py` to initialize the `ServerClient` with Flask session-based stores. The stores use Flask's built-in `session` (cookie-based by default) for a **stateless** setup — no external database needed:
+
+```python
+import os
+from flask import session as flask_session
+from auth0_server_python.auth_server.server_client import ServerClient
+from auth0_server_python.auth_types import StateData, TransactionData
+from auth0_server_python.store import StateStore, TransactionStore
+from dotenv import load_dotenv
+
+load_dotenv()  # Uses .env by default; pass load_dotenv(".env.local") if credentials are in .env.local
+
+
+class FlaskSessionStateStore(StateStore):
+    """State store that uses Flask's session for persistence."""
+
+    def __init__(self, secret: str):
+        super().__init__({"secret": secret})
+
+    async def set(self, identifier, state, remove_if_expires=False, options=None):
+        data = state.dict() if hasattr(state, "dict") else state
+        flask_session[identifier] = self.encrypt(identifier, data)
+
+    async def get(self, identifier, options=None):
+        data = flask_session.get(identifier)
+        if data is None:
+            return None
+        decrypted = self.decrypt(identifier, data)
+        # Ensure to not return a dict, as the underlying SDK expects a StateData instance, not a dict
+        return StateData(**decrypted) if isinstance(decrypted, dict) else decrypted
+
+    async def delete(self, identifier, options=None):
+        flask_session.pop(identifier, None)
+
+    async def delete_by_logout_token(self, claims, options=None):
+        pass
+
+
+class FlaskSessionTransactionStore(TransactionStore):
+    """Transaction store that uses Flask's session for persistence."""
+
+    def __init__(self, secret: str):
+        super().__init__({"secret": secret})
+
+    async def set(self, identifier, state, remove_if_expires=False, options=None):
+        data = state.dict() if hasattr(state, "dict") else state
+        flask_session[identifier] = self.encrypt(identifier, data)
+
+    async def get(self, identifier, options=None):
+        data = flask_session.get(identifier)
+        if data is None:
+            return None
+        decrypted = self.decrypt(identifier, data)
+        # Ensure to not return a dict, as the underlying SDK expects a TransactionData instance, not a dict
+        return TransactionData(**decrypted) if isinstance(decrypted, dict) else decrypted
+
+    async def delete(self, identifier, options=None):
+        flask_session.pop(identifier, None)
+
+
+secret = os.getenv("AUTH0_SECRET")
+
+auth0 = ServerClient(
+    domain=os.getenv("AUTH0_DOMAIN"),
+    client_id=os.getenv("AUTH0_CLIENT_ID"),
+    client_secret=os.getenv("AUTH0_CLIENT_SECRET"),
+    secret=secret,
+    redirect_uri=os.getenv("AUTH0_REDIRECT_URI"),
+    state_store=FlaskSessionStateStore(secret=secret),
+    transaction_store=FlaskSessionTransactionStore(secret=secret),
+    authorization_params={"scope": "openid profile email"},
+)
+```
+
+Create one `ServerClient` instance and reuse it. Never hardcode credentials — always use environment variables.
+
+**How this works:** Flask's default session is cookie-based (stateless). The SDK encrypts session data (tokens, user profile) with JWE before storing it in the session, so data is both signed and encrypted in the cookie. No server-side database is required.
+
+**No `store_options` or `before_request` needed:** The SDK supports passing `store_options` (e.g. request/response objects) to store methods. Since these stores use `flask.session` — which is globally available during a request — they don't need anything from `store_options`, so you can call SDK methods without passing it. If you implement a custom store that manages cookies directly (instead of using `flask.session`), you would need to reintroduce `store_options` with `{"request": request, "response": response}`.
+
+**Cookie size note:** Stateless sessions store all data in a cookie (~4KB limit). For most apps this is sufficient. If you store large amounts of session data or hit cookie size limits, switch to [stateful setup](#stateful-setup-with-redis).
+
+### 5. Configure Flask App
+
+In `app.py`, set up Flask with the secret key and session configuration:
+
+```python
+import os
+from flask import Flask, redirect, request
+from auth import auth0
+from dotenv import load_dotenv
+
+load_dotenv()
+
+app = Flask(__name__)
+app.secret_key = os.getenv("AUTH0_SECRET")
+app.config.update(
+    SESSION_COOKIE_SECURE=False,  # Set to True in production (requires HTTPS)
+    SESSION_COOKIE_HTTPONLY=True,
+    SESSION_COOKIE_SAMESITE="Lax",
+)
+```
+
+**Critical:** `app.secret_key` must be set for Flask session management. Without it, sessions won't work.
+
+**For production:** Set `SESSION_COOKIE_SECURE=True` when deploying with HTTPS. Leaving it as `False` in production allows session cookies to be sent over unencrypted connections.
+
+### 6. Add Home Route
+
+```python
+@app.route("/")
+async def home():
+    user = await auth0.get_user()
+    if user:
+        return f"Hello, {user['name']}! <a href='/profile'>Profile</a> | <a href='/logout'>Logout</a>"
+    return "Welcome! <a href='/login'>Login</a>"
+```
+
+### 7. Add Login Route
+
+```python
+@app.route("/login")
+async def login():
+    authorization_url = await auth0.start_interactive_login()
+    return redirect(authorization_url)
+```
+
+`start_interactive_login()` returns a URL string pointing to Auth0's Universal Login page. You must wrap it in `redirect()`. Authorization params (scope, redirect_uri) are already configured on the `ServerClient`.
+
+### 8. Add Callback Route
+
+```python
+@app.route("/callback")
+async def callback():
+    try:
+        await auth0.complete_interactive_login(str(request.url))
+        return redirect("/")
+    except Exception as e:
+        return f"Authentication error: {str(e)}", 400
+```
+
+Pass `str(request.url)` as the first argument — this is the full callback URL including the authorization code query parameters. Always wrap in try/except since the token exchange can fail (e.g. expired code, CSRF mismatch).
+
+### 9. Add Profile Route (Protected)
+
+```python
+@app.route("/profile")
+async def profile():
+    user = await auth0.get_user()
+    if user is None:
+        return redirect("/login")
+    return (
+        f"<h1>{user['name']}</h1>"
+        f"<p>Email: {user['email']}</p>"
+        f"<img src='{user['picture']}' alt='{user['name']}' width='100' />"
+        f"<p><a href='/logout'>Logout</a></p>"
+    )
+```
+
+`get_user()` returns the user's profile from the session, or `None` if not logged in.
+
+### 10. Add Logout Route
+
+```python
+@app.route("/logout")
+async def logout():
+    url = await auth0.logout()
+    return redirect(url)
+```
+
+`logout()` returns the Auth0 logout URL. Redirect the user to it.
+
+### 11. Test the App
+
+```bash
+flask run
+```
+
+Visit `http://localhost:5000/login` to start the login flow.
+
+---
+
+## Stateful Setup with Redis
+
+For production apps or when session data exceeds cookie size limits, use **Flask-Session** with Redis to store sessions server-side. Only a session ID is stored in the cookie.
+
+### 1. Install Dependencies
+
+```bash
+pip install flask-session redis
+```
+
+### 2. Configure Flask-Session
+
+Update `app.py` to use Redis-backed sessions:
+
+```python
+import os
+from flask import Flask, redirect, request
+from flask_session import Session
+from auth import auth0
+from dotenv import load_dotenv
+
+load_dotenv()
+
+app = Flask(__name__)
+app.secret_key = os.getenv("AUTH0_SECRET")
+app.config.update(
+    SESSION_TYPE="redis",
+    SESSION_PERMANENT=True,
+    SESSION_KEY_PREFIX="auth0:",
+    SESSION_COOKIE_SECURE=False,
+    SESSION_COOKIE_HTTPONLY=True,
+    SESSION_COOKIE_SAMESITE="Lax",
+)
+Session(app)
+```
+
+### 3. No Store Changes Needed
+
+The same `FlaskSessionStateStore` and `FlaskSessionTransactionStore` from `auth.py` work without modification. Flask-Session transparently switches the `flask.session` backend from cookies to Redis — the stores continue to use `flask.session` as before.
+
+**Routes are identical** to the stateless setup — no code changes needed.
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Hardcoding `domain`, `client_id`, or `client_secret` in source | Always read from environment variables — never embed credentials in code |
+| Using `Authlib` or `python-jose` directly | Not needed; `auth0-server-python` handles all OAuth/OIDC flows |
+| Using `Flask-Login` or `Flask-Dance` | Not needed; the SDK manages sessions and authentication |
+| Manually parsing JWTs with `jwt.decode()` | The SDK handles token validation internally |
+| Installing `flask` without `[async]` extra | Must use `flask[async]>=2.0.0` in requirements.txt — without it, async route handlers silently fail |
+| Using synchronous route handlers | All routes calling SDK methods must be `async def` and use `await` |
+| Forgetting `app.secret_key` | Required for Flask session management — without it, sessions silently fail |
+| Using `auth0-fastapi-api` in Flask | That package is for FastAPI APIs — use `auth0-server-python` for Flask |
+| Passing `domain` as full URL with `https://` | `domain` should be the bare domain, e.g. `my-tenant.us.auth0.com`, not `https://my-tenant.us.auth0.com` |
+| Not configuring callback URL in Auth0 Dashboard | Must add `http://localhost:5000/callback` to Allowed Callback URLs |
+| Returning `start_interactive_login()` directly | It returns a URL string, not a response — must wrap in `redirect()` |
+| Not handling errors in `/callback` | `complete_interactive_login()` can fail — always wrap in try/except |
+| Calling SDK methods without `await` | All SDK methods are async — forgetting `await` returns a coroutine instead of the result |
+| Passing options positionally to `logout()` | Use `logout(store_options=...)` — the first positional parameter is `LogoutOptions`, not store options |
+| Expecting backchannel logout to work | Not supported with cookie-based sessions — `delete_by_logout_token` is a no-op. Use standard `/logout` route |
+| Deploying with `SESSION_COOKIE_SECURE=False` | Must set to `True` in production — cookies are sent over HTTP otherwise |
+
+---
+
+## Key SDK Methods
+
+All methods are async:
+
+| Method | Signature | Purpose |
+|--------|-----------|---------|
+| `start_interactive_login` | `await auth0.start_interactive_login()` | Returns authorization URL string — wrap in `redirect()` |
+| `complete_interactive_login` | `await auth0.complete_interactive_login(str(request.url))` | Processes the callback URL, exchanges code for tokens |
+| `get_user` | `await auth0.get_user()` | Returns current session user dict or `None` |
+| `get_access_token` | `await auth0.get_access_token()` | Returns the access token for calling external APIs |
+| `logout` | `await auth0.logout()` | Returns Auth0 logout URL string |
+
+---
+
+## Related Skills
+
+- `auth0-express` — For server-rendered Express web apps with login/logout sessions
+- `auth0-fastify` — For Fastify web applications with session-based auth
+
+---
+
+## Quick Reference
+
+**ServerClient configuration:**
+```python
+auth0 = ServerClient(
+    domain=os.getenv("AUTH0_DOMAIN"),                    # required
+    client_id=os.getenv("AUTH0_CLIENT_ID"),              # required
+    client_secret=os.getenv("AUTH0_CLIENT_SECRET"),      # required
+    secret=os.getenv("AUTH0_SECRET"),                    # required (encryption secret)
+    redirect_uri=os.getenv("AUTH0_REDIRECT_URI"),        # required
+    state_store=FlaskSessionStateStore(secret=secret),   # required
+    transaction_store=FlaskSessionTransactionStore(secret=secret),  # required
+    authorization_params={"scope": "openid profile email"},  # recommended
+)
+```
+
+**Route protection pattern:**
+```python
+user = await auth0.get_user()
+if user is None:
+    return redirect("/login")
+```
+
+**Environment variables:**
+- `AUTH0_DOMAIN` — your Auth0 tenant domain (e.g. `tenant.us.auth0.com`)
+- `AUTH0_CLIENT_ID` — your Application's client ID
+- `AUTH0_CLIENT_SECRET` — your Application's client secret
+- `AUTH0_SECRET` — encryption and session secret key
+- `AUTH0_REDIRECT_URI` — callback URL (e.g. `http://localhost:5000/callback`)
+
+---
+
+## Detailed Documentation
+
+- **[Setup Guide](references/setup.md)** - Automated setup scripts, environment configuration, Auth0 CLI usage
+- **[Integration Guide](references/integration.md)** - Protected routes, calling APIs, session management, error handling
+- **[API Reference](references/api.md)** - Complete ServerClient API, configuration options, store implementation, security
+
+---
+
+## References
+
+- [auth0-server-python on PyPI](https://pypi.org/project/auth0-server-python/)
+- [Auth0 Flask Quickstart](https://auth0.com/docs/quickstart/webapp/python)
+- [Flask Documentation](https://flask.palletsprojects.com/)

--- a/main/.mintlify/skills/auth0-java-mvc-common/SKILL.md
+++ b/main/.mintlify/skills/auth0-java-mvc-common/SKILL.md
@@ -1,0 +1,348 @@
+---
+name: auth0-java-mvc-common
+description: Use when adding Auth0 login, logout, and callback handling to Java Servlet web applications - integrates com.auth0:mvc-auth-commons SDK for server-side Java apps using javax.servlet with session-based authentication. Triggers on AuthenticationController, AuthorizeUrl, Tokens, IdentityVerificationException, Java MVC auth.
+license: MIT
+metadata:
+  author: Auth0 <support@auth0.com>
+---
+
+# Auth0 Java MVC Common Integration
+
+Add Auth0 authentication to Java Servlet web applications using `com.auth0:mvc-auth-commons`. Provides `AuthenticationController` for building authorize URLs and handling callbacks, with session-based authentication and support for Organizations and Multiple Custom Domains.
+
+---
+
+> **Agent instruction:** Before providing SDK setup instructions, fetch the latest release version by running:
+> ```bash
+> gh api repos/auth0/auth0-java-mvc-common/releases/latest --jq '.tag_name'
+> ```
+> Use the returned version in all dependency lines instead of any hardcoded version below. If the API call fails, use `1.12.0`.
+
+## Prerequisites
+
+- Java 8+ (Java 17+ recommended)
+- Servlet container (Tomcat, Jetty, etc.) with javax.servlet 3+
+- Maven 3.6+ or Gradle 7+
+- Auth0 Regular Web Application configured
+- If you don't have Auth0 set up yet, use the `auth0-quickstart` skill first
+
+## When NOT to Use
+
+| Use Case | Recommended Skill |
+|----------|-------------------|
+| Spring Boot web applications with auto-configuration | Use Spring Boot + Okta starter for auto-configured Spring Boot login |
+| Spring Boot REST APIs (stateless JWT) | Use `auth0-springboot-api` for JWT Bearer token validation |
+| Single Page Applications | Use `auth0-react`, `auth0-vue`, or `auth0-angular` for client-side auth |
+| Mobile applications | Use `auth0-android` or `auth0-swift` for native mobile |
+| Machine-to-machine API calls | Use Auth0 Management API SDK for server-to-server |
+
+---
+
+## Quick Start Workflow
+
+> **Agent instruction:** If the user's prompt already provides Auth0 credentials (domain, client ID, client secret), use them directly — skip the bootstrap script and credential questions. Only offer setup options when credentials are missing.
+
+### 1. Install SDK
+
+**Gradle (build.gradle):**
+
+```groovy
+implementation 'com.auth0:mvc-auth-commons:1.12.0'
+```
+
+**Maven (pom.xml):**
+
+```xml
+<dependency>
+    <groupId>com.auth0</groupId>
+    <artifactId>mvc-auth-commons</artifactId>
+    <version>1.12.0</version>
+</dependency>
+```
+
+### 2. Create Auth0 Application
+
+You need a **Regular Web Application** (not SPA or Native) in Auth0.
+
+> **STOP — ask the user before proceeding.**
+>
+> Ask exactly this question and wait for their answer before doing anything else:
+>
+> > "How would you like to create the Auth0 application?
+> > 1. **Automated** — I'll run Auth0 CLI scripts that create the application and write the values to your config automatically.
+> > 2. **Manual** — You create the application yourself in the Auth0 Dashboard (or via `auth0 apps create`) and provide me the Domain, Client ID, and Client Secret.
+> >
+> > Which do you prefer? (1 = Automated / 2 = Manual)"
+>
+> Do NOT proceed to any setup steps until the user has answered. Do NOT default to manual.
+
+**If the user chose Automated**, follow the [Setup Guide](references/setup.md) for complete CLI scripts. The automated path writes configuration for you — skip Step 3 below and proceed directly to Step 4.
+
+**If the user chose Manual**, follow the [Setup Guide](references/setup.md) (Manual Setup section). Then continue with Step 3.
+
+Quick reference for manual application creation:
+
+```bash
+# Using Auth0 CLI
+auth0 apps create \
+  --name "My Java Web App" \
+  --type regular \
+  --callbacks http://localhost:3000/callback \
+  --logout-urls http://localhost:3000
+```
+
+Or create manually in Auth0 Dashboard → Applications → Applications → Create Application → Regular Web Applications
+
+### 3. Configure Credentials
+
+Store credentials as environment variables (never hardcode in source):
+
+```bash
+export AUTH0_DOMAIN="your-tenant.auth0.com"
+export AUTH0_CLIENT_ID="your-client-id"
+export AUTH0_CLIENT_SECRET="your-client-secret"
+```
+
+Or use a `.env` file (add to `.gitignore`):
+
+```properties
+AUTH0_DOMAIN=your-tenant.auth0.com
+AUTH0_CLIENT_ID=your-client-id
+AUTH0_CLIENT_SECRET=your-client-secret
+```
+
+> **Agent instruction:** Java does not auto-load `.env` files. `System.getenv()` only reads OS-level environment variables. If you generate a `.env` file, you must also either: (1) add [dotenv-java](https://github.com/cdimascio/dotenv-java) as a dependency and use `Dotenv.load().get("AUTH0_DOMAIN")` instead of `System.getenv()`, or (2) instruct the user to run `source .env` before starting the server. Do not generate code that uses both a `.env` file and `System.getenv()` without a loading mechanism — the values will be `null`.
+
+**Important:** Domain must NOT include `https://`. The library constructs the issuer URL automatically.
+
+### 4. Initialize AuthenticationController
+
+Create a singleton `AuthenticationController` instance:
+
+```java
+import com.auth0.AuthenticationController;
+import com.auth0.jwk.JwkProviderBuilder;
+import com.auth0.jwk.JwkProvider;
+
+public class Auth0Config {
+
+    private static final AuthenticationController controller = createController();
+
+    private static AuthenticationController createController() {
+        String domain = System.getenv("AUTH0_DOMAIN");
+        String clientId = System.getenv("AUTH0_CLIENT_ID");
+        String clientSecret = System.getenv("AUTH0_CLIENT_SECRET");
+
+        JwkProvider jwkProvider = new JwkProviderBuilder(domain).build();
+
+        return AuthenticationController.newBuilder(domain, clientId, clientSecret)
+            .withJwkProvider(jwkProvider)
+            .build();
+    }
+
+    public static AuthenticationController getAuthController() {
+        return controller;
+    }
+}
+```
+
+### 5. Create Login Servlet
+
+```java
+import com.auth0.AuthenticationController;
+import com.auth0.AuthorizeUrl;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@WebServlet(urlPatterns = {"/login"})
+public class LoginServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        AuthenticationController controller = Auth0Config.getAuthController();
+
+        // Build callback URL — omit port for standard ports (80/443) to avoid
+        // mismatch with the URL registered in Auth0 Dashboard, especially behind proxies.
+        String scheme = request.getScheme();
+        int port = request.getServerPort();
+        String redirectUrl = scheme + "://" + request.getServerName()
+            + ((port == 80 || port == 443) ? "" : ":" + port) + "/callback";
+
+        AuthorizeUrl authorizeUrl = controller.buildAuthorizeUrl(request, response, redirectUrl)
+            .withScope("openid profile email");
+
+        response.sendRedirect(authorizeUrl.build());
+    }
+}
+```
+
+### 6. Create Callback Servlet
+
+```java
+import com.auth0.AuthenticationController;
+import com.auth0.IdentityVerificationException;
+import com.auth0.Tokens;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@WebServlet(urlPatterns = {"/callback"})
+public class CallbackServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        AuthenticationController controller = Auth0Config.getAuthController();
+
+        try {
+            Tokens tokens = controller.handle(request, response);
+
+            request.getSession().setAttribute("accessToken", tokens.getAccessToken());
+            request.getSession().setAttribute("idToken", tokens.getIdToken());
+
+            response.sendRedirect("/dashboard");
+        } catch (IdentityVerificationException e) {
+            response.sendRedirect("/login?error=" + e.getCode());
+        }
+    }
+}
+```
+
+### 7. Protect Routes with Authentication Middleware (Servlet Filter)
+
+```java
+import javax.servlet.*;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.io.IOException;
+
+@WebFilter(urlPatterns = {"/dashboard/*", "/api/private/*"})
+public class AuthenticationFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain)
+            throws IOException, ServletException {
+        HttpServletRequest request = (HttpServletRequest) req;
+        HttpServletResponse response = (HttpServletResponse) res;
+        HttpSession session = request.getSession(false);
+
+        if (session == null || session.getAttribute("idToken") == null) {
+            response.sendRedirect("/login");
+            return;
+        }
+
+        chain.doFilter(req, res);
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) {}
+
+    @Override
+    public void destroy() {}
+}
+```
+
+### 8. Test Application
+
+> **Agent instruction:** After writing all code, verify the build succeeds:
+> ```bash
+> ./gradlew build
+> ```
+> or `mvn package`. If build fails, diagnose and fix. After 5-6 failed attempts, use `AskUserQuestion` to get help.
+
+1. Start the application and navigate to `http://localhost:3000/login`
+2. You should be redirected to the Auth0 Universal Login page
+3. After login, the callback servlet handles the response and redirects to `/dashboard`
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Domain includes `https://` | Use `your-tenant.auth0.com` format only — no scheme prefix |
+| Client secret hardcoded in source | Use environment variables or `.env` file, add to `.gitignore` |
+| Created SPA or Native app instead of Regular Web | Must create **Regular Web Application** in Auth0 Dashboard |
+| Callback URL mismatch | Callback URL in code must exactly match what's registered in Auth0 Dashboard |
+| Missing `openid` scope | Always include `openid` in the scope — required for ID token |
+| Not handling `IdentityVerificationException` | Always catch this in the callback handler to show login errors |
+| Using `response_type=token` | Regular web apps must use `code` flow (the default) — never implicit |
+| Session not invalidated on logout | Call `request.getSession().invalidate()` before redirecting to Auth0 logout |
+
+---
+
+## Scope and Audience Configuration
+
+See [Integration Guide](references/integration.md) for requesting custom scopes, audience for API access tokens, and Organizations support.
+
+---
+
+## Multiple Custom Domains (MCD)
+
+Built-in support for routing users to the correct Auth0 domain via `DomainResolver`. See [Integration Guide](references/integration.md) for configuration.
+
+---
+
+## Related Skills
+
+- `auth0-quickstart` — Basic Auth0 setup and account creation
+- `auth0-springboot-api` — Spring Boot REST APIs with JWT Bearer token validation
+
+---
+
+## Quick Reference
+
+**Core Classes:**
+- `AuthenticationController` — Main entry point, builds authorize URLs and handles callbacks
+- `AuthenticationController.Builder` — Configures the controller via `newBuilder(domain, clientId, clientSecret)`
+- `AuthorizeUrl` — Fluent builder for `/authorize` URL parameters
+- `Tokens` — Access token, ID token, refresh token from callback
+- `IdentityVerificationException` — Authentication error with error code
+- `DomainResolver` — Interface for Multiple Custom Domain support
+
+**Builder Methods (`AuthorizeUrl`):**
+- `.withScope("openid profile email")` — Set requested scopes
+- `.withAudience("https://my-api")` — Request API access token
+- `.withOrganization("org_xxx")` — Lock to specific Organization
+- `.withInvitation("invite_xxx")` — Accept Organization invitation
+- `.withConnection("google-oauth2")` — Skip to specific connection
+- `.withParameter("key", "value")` — Add custom authorize parameter
+
+**Token Access (`Tokens`):**
+- `tokens.getAccessToken()` — Access token string
+- `tokens.getIdToken()` — ID token (JWT) string
+- `tokens.getRefreshToken()` — Refresh token (if `offline_access` scope requested)
+- `tokens.getExpiresIn()` — Token expiration in seconds
+- `tokens.getType()` — Token type (usually "Bearer")
+- `tokens.getDomain()` — Auth0 domain that issued the tokens
+- `tokens.getIssuer()` — Token issuer URL
+
+---
+
+## Detailed Documentation
+
+- **[Setup Guide](references/setup.md)** — Auth0 CLI automation, environment configuration, secret management
+- **[Integration Guide](references/integration.md)** — Organizations, MCD, custom scopes, logout, error handling, advanced patterns
+- **[API Reference](references/api.md)** — Complete configuration options, builder methods, claims reference, testing checklist
+
+---
+
+## References
+
+- [Auth0 Java Web App Quickstart](https://auth0.com/docs/quickstart/webapp/java)
+- [SDK GitHub Repository](https://github.com/auth0/auth0-java-mvc-common)
+- [Auth0 Universal Login](https://auth0.com/docs/authenticate/login/auth0-universal-login)
+- [Authorization Code Flow](https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow)
+- [Auth0 Organizations](https://auth0.com/docs/manage-users/organizations)

--- a/main/.mintlify/skills/auth0-spa-js/SKILL.md
+++ b/main/.mintlify/skills/auth0-spa-js/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: auth0-spa-js
+description: Use when adding authentication to Vanilla JS, Svelte, or any framework-agnostic single-page applications - integrates @auth0/auth0-spa-js SDK for SPAs without framework-specific wrappers
+license: Proprietary
+metadata:
+  author: Auth0 <support@auth0.com>
+---
+
+# Auth0 SPA JS Integration
+
+Add authentication to any browser-based single-page application using `@auth0/auth0-spa-js` — the low-level Auth0 SDK for Vanilla JS, Svelte, SolidJS, and any SPA not using React, Angular, or Vue.
+
+> **Agent instruction:** Before providing SDK setup instructions, fetch the latest release version by running:
+> ```
+> gh api repos/auth0/auth0-spa-js/releases/latest --jq '.tag_name'
+> ```
+> Use the returned version in all dependency lines instead of any hardcoded version below. If the command fails, fall back to checking https://github.com/auth0/auth0-spa-js/releases.
+
+## Prerequisites
+
+- Modern browser with ES2017+ support
+- npm or yarn (or use CDN for no-bundler apps)
+- Auth0 account with a Single Page Application configured
+- If you don't have Auth0 set up, see [auth0-quickstart](/auth0-quickstart)
+
+## When NOT to Use
+
+- **React SPAs** (hooks, Auth0Provider): Use [auth0-react](/auth0-react)
+- **Angular SPAs** (AuthModule, AuthGuard): Use [auth0-angular](/auth0-angular)
+- **Vue 3 SPAs** (createAuth0, useAuth0): Use [auth0-vue](/auth0-vue)
+- **Next.js** (server-side sessions, App Router): Use [auth0-nextjs](/auth0-nextjs)
+- **Nuxt** (server-side SSR): Use [auth0-nuxt](/auth0-nuxt)
+- **Express server-side web apps**: Use [auth0-express](/auth0-express)
+- **React Native / Expo mobile apps**: Use [auth0-react-native](/auth0-react-native)
+
+## Quick Start Workflow
+
+### 1. Install SDK
+
+```bash
+npm install @auth0/auth0-spa-js
+```
+
+Or via CDN (no bundler). Run this to get the latest version, then use it in your HTML:
+```bash
+VERSION=$(npm view @auth0/auth0-spa-js version)
+```
+```html
+<script src="https://cdn.auth0.com/js/auth0-spa-js/$VERSION/auth0-spa-js.production.js"></script>
+```
+
+### 2. Configure Auth0
+
+**For automated setup with Auth0 CLI**, see [Setup Guide](references/setup.md) for complete scripts.
+
+**For manual setup**, create `.env` (Vite):
+
+```bash
+VITE_AUTH0_DOMAIN=your-tenant.auth0.com
+VITE_AUTH0_CLIENT_ID=your-client-id
+```
+
+In Auth0 Dashboard, set for your **Single Page Application**:
+- **Allowed Callback URLs**: `http://localhost:5173`
+- **Allowed Logout URLs**: `http://localhost:5173`
+- **Allowed Web Origins**: `http://localhost:5173`
+
+### 3. Initialize Auth0 Client
+
+```js
+import { createAuth0Client } from '@auth0/auth0-spa-js';
+
+const auth0 = await createAuth0Client({
+  domain: import.meta.env.VITE_AUTH0_DOMAIN,
+  clientId: import.meta.env.VITE_AUTH0_CLIENT_ID,
+  authorizationParams: {
+    redirect_uri: window.location.origin
+  }
+});
+
+// Handle redirect callback after login
+const query = new URLSearchParams(window.location.search);
+if ((query.has('code') || query.has('error')) && query.has('state')) {
+  await auth0.handleRedirectCallback();
+  window.history.replaceState({}, document.title, window.location.pathname);
+}
+```
+
+### 4. Add Login / Logout
+
+> **Agent instruction:** Before adding new UI elements, search the project for existing click handlers for login, logout, sign-in, or sign-out buttons. If existing handlers are found, hook the Auth0 code into them without modifying the existing UI. Only create new buttons if no existing handlers are found.
+
+```js
+// Login
+document.getElementById('login-btn').addEventListener('click', async () => {
+  await auth0.loginWithRedirect();
+});
+
+// Logout
+document.getElementById('logout-btn').addEventListener('click', () => {
+  auth0.logout({
+    logoutParams: { returnTo: window.location.origin }
+  });
+});
+
+// Update UI based on auth state
+const isAuthenticated = await auth0.isAuthenticated();
+if (isAuthenticated) {
+  const user = await auth0.getUser();
+  console.log(user.name, user.email);
+}
+```
+
+### 5. Get Access Tokens for API Calls
+
+```js
+const accessToken = await auth0.getTokenSilently();
+
+const response = await fetch('https://your-api.example.com/data', {
+  headers: { Authorization: `Bearer ${accessToken}` }
+});
+```
+
+### 6. Build & Verify
+
+> **Agent instruction:** After completing the integration, build the project to verify it compiles successfully:
+> ```bash
+> npm run build
+> ```
+> If the build fails, analyze the error output and fix the issues. Common integration build failures include:
+> - **Module not found**: Missing `npm install @auth0/auth0-spa-js` — run the install command
+> - **Cannot find name 'import.meta'**: TypeScript target too low — set `"target": "ES2020"` or higher in `tsconfig.json`
+> - **`createAuth0Client` is not a function**: Wrong import path or CDN usage without bundle step
+> - **Env vars undefined at runtime**: Vite requires `VITE_` prefix; webpack/CRA requires `REACT_APP_` prefix
+>
+> Re-run the build after each fix. Track the number of build-fix iterations.
+>
+> **Failcheck:** If the build still fails after 5–6 fix attempts, stop and ask the user using `AskUserQuestion`:
+> _"The build is still failing after several fix attempts. How would you like to proceed?"_
+> - **Let the skill continue fixing iteratively** — continue the build-fix loop for another 5–6 attempts
+> - **Fix it manually** — show the remaining errors and let the user resolve them
+> - **Skip build verification** — proceed without a successful build
+
+## Detailed Documentation
+
+- [**Setup Guide**](references/setup.md) — Automated setup scripts (Bash/PowerShell), Auth0 CLI commands, `.env` configuration, callback URL setup
+- [**Integration Patterns**](references/integration.md) — Token management, calling APIs, refresh tokens, organizations, MFA, DPoP, error handling, advanced patterns
+- [**Testing & Reference**](references/api.md) — Configuration options, claims reference, testing checklist, common issues, security considerations
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Callback URL port mismatch (e.g., `localhost:3001` vs `localhost:5173`) | Match Allowed Callback URLs exactly to your dev server port in Auth0 Dashboard |
+| `client_secret` in SPA code | SPAs must never have a client secret — remove it. Auth0 sets auth method to `None` for SPA apps |
+| Tokens stored in `localStorage` | Use in-memory storage (default) or `sessionStorage`. Never `localStorage` — XSS risk |
+| `getTokenSilently()` throws `login_required` on page refresh | Add your app origin to **Allowed Web Origins** in Auth0 Dashboard |
+| `handleRedirectCallback()` not called after redirect | Must call after login redirect to exchange the auth code; without this the URL params persist and re-trigger |
+| Domain includes `https://` prefix | Auth0 domain should be hostname only: `your-tenant.auth0.com`, not `https://your-tenant.auth0.com` |
+| `loginWithPopup()` called from async init code | Popups must be triggered directly from a user gesture (click handler). Never call from init or page load code |
+| Using `Auth0Provider` from `@auth0/auth0-react` in Vanilla JS | For Vanilla JS, use `createAuth0Client()` directly — no provider component needed |
+
+## Related Skills
+
+- [auth0-quickstart](/auth0-quickstart) — Set up an Auth0 account and application
+- [auth0-react](/auth0-react) — Auth0 for React SPAs with hooks
+- [auth0-angular](/auth0-angular) — Auth0 for Angular SPAs
+- [auth0-vue](/auth0-vue) — Auth0 for Vue 3 SPAs
+- [auth0-mfa](/auth0-mfa) — Add Multi-Factor Authentication
+
+## Quick Reference
+
+### Core Methods
+
+| Method | Description |
+|--------|-------------|
+| `createAuth0Client(options)` | Create and initialize client (calls `checkSession` internally) |
+| `new Auth0Client(options)` | Instantiate without auto session check |
+| `auth0.loginWithRedirect(options?)` | Redirect to Auth0 Universal Login |
+| `auth0.loginWithPopup(options?)` | Open Auth0 login in a popup |
+| `auth0.logout(options?)` | Clear session and redirect |
+| `auth0.handleRedirectCallback(url?)` | Process redirect result after login |
+| `auth0.isAuthenticated()` | `Promise<boolean>` |
+| `auth0.getUser()` | `Promise<User \| undefined>` |
+| `auth0.getTokenSilently(options?)` | `Promise<string>` — access token |
+| `auth0.checkSession()` | Attempt silent re-authentication |
+
+### Common Use Cases
+
+- Login/Logout → See Step 4 above
+- Protecting content → [Integration Guide](references/integration.md#protecting-content)
+- API calls with tokens → [Integration Guide](references/integration.md#calling-protected-apis)
+- Refresh tokens → [Integration Guide](references/integration.md#refresh-token-rotation)
+- Organizations → [Integration Guide](references/integration.md#organizations)
+- MFA handling → [Integration Guide](references/integration.md#mfa-handling)
+- Error handling → [Integration Guide](references/integration.md#error-handling)
+
+## References
+
+- [Auth0 SPA JS SDK Documentation](https://auth0.com/docs/libraries/auth0-spa-js)
+- [Auth0 Vanilla JS Quickstart](https://auth0.com/docs/quickstart/spa/vanillajs)
+- [SDK GitHub Repository](https://github.com/auth0/auth0-spa-js)
+- [EXAMPLES.md — Advanced patterns](https://github.com/auth0/auth0-spa-js/blob/main/EXAMPLES.md)
+- [API Documentation](https://auth0.github.io/auth0-spa-js/)

--- a/main/.mintlify/skills/auth0-springboot-api/SKILL.md
+++ b/main/.mintlify/skills/auth0-springboot-api/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: auth0-springboot-api
+description: Use when securing Spring Boot API endpoints with JWT Bearer token validation, scope-based authorization, or DPoP proof-of-possession - integrates com.auth0:auth0-springboot-api SDK for REST APIs receiving access tokens from frontends or mobile apps. Triggers on Auth0AuthenticationFilter, Spring Boot API auth, JWT validation, SecurityFilterChain, hasAuthority SCOPE.
+license: Apache-2.0
+metadata:
+  author: Auth0 <support@auth0.com>
+---
+
+# Auth0 Spring Boot API Integration
+
+Protect Spring Boot API endpoints with JWT access token validation using `com.auth0:auth0-springboot-api`. Features auto-configuration, scope-based authorization, and built-in DPoP (RFC 9449) support.
+
+---
+
+> **Agent instruction:** Before providing SDK setup instructions, fetch the latest release version by running:
+> ```bash
+> gh api repos/auth0/auth0-auth-java/releases/latest --jq '.tag_name'
+> ```
+> Use the returned version in all dependency lines instead of any hardcoded version below. If the API call fails (e.g., no releases yet), use `1.0.0-beta.1`.
+
+## Prerequisites
+
+- Java 17+ and Spring Boot 3.2+
+- Maven 3.6+ or Gradle 7+
+- Auth0 API configured (not Application — must be API resource)
+- If you don't have Auth0 set up yet, use the `auth0-quickstart` skill first
+
+## When NOT to Use
+
+| Use Case | Recommended Skill |
+|----------|------------------|
+| Server-rendered web applications (Spring MVC with sessions) | Use `auth0-java` for Spring Boot web apps with login UI |
+| Single Page Applications | Use `auth0-react`, `auth0-vue`, or `auth0-angular` for client-side auth |
+| Mobile applications | Use `auth0-android` or `auth0-swift` for native mobile |
+| Non-Spring Java APIs | Use `auth0-spring-security-api` for plain Spring Security |
+
+---
+
+## Quick Start Workflow
+
+> **Agent instruction:** If the user's prompt already provides Auth0 credentials (domain, audience), use them directly — skip the bootstrap script and credential questions. Only offer setup options when credentials are missing.
+
+### 1. Install SDK
+
+**Gradle (build.gradle):**
+
+```groovy
+implementation 'com.auth0:auth0-springboot-api:1.0.0-beta.1'
+```
+
+**Maven (pom.xml):**
+
+```xml
+<dependency>
+    <groupId>com.auth0</groupId>
+    <artifactId>auth0-springboot-api</artifactId>
+    <version>1.0.0-beta.1</version>
+</dependency>
+```
+
+### 2. Create Auth0 API
+
+You need an **API** (not Application) in Auth0.
+
+> **STOP — ask the user before proceeding.**
+>
+> Ask exactly this question and wait for their answer before doing anything else:
+>
+> > "How would you like to create the Auth0 API resource?
+> > 1. **Automated** — I'll run Auth0 CLI scripts that create the resource and write the values to your application.yml automatically.
+> > 2. **Manual** — You create the API yourself in the Auth0 Dashboard (or via `auth0 apis create`) and provide me the Domain and Audience.
+> >
+> > Which do you prefer? (1 = Automated / 2 = Manual)"
+>
+> Do NOT proceed to any setup steps until the user has answered. Do NOT default to manual.
+
+**If the user chose Automated**, follow the [Setup Guide](references/setup.md) for complete CLI scripts. The automated path writes `application.yml` for you — skip Step 3 below and proceed directly to Step 4.
+
+**If the user chose Manual**, follow the [Setup Guide](references/setup.md) (Manual Setup section). Then continue with Step 3.
+
+Quick reference for manual API creation:
+
+```bash
+# Using Auth0 CLI
+auth0 apis create \
+  --name "My Spring Boot API" \
+  --identifier https://my-springboot-api
+```
+
+Or create manually in Auth0 Dashboard → Applications → APIs
+
+### 3. Configure application.yml
+
+```yaml
+auth0:
+  domain: "your-tenant.auth0.com"
+  audience: "https://my-springboot-api"
+```
+
+**Important:** Domain must NOT include `https://`. The library constructs the issuer URL automatically.
+
+Or use `application.properties`:
+
+```properties
+auth0.domain=your-tenant.auth0.com
+auth0.audience=https://my-springboot-api
+```
+
+### 4. Configure Spring Security
+
+```java
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    @Bean
+    SecurityFilterChain apiSecurity(
+            HttpSecurity http,
+            Auth0AuthenticationFilter authFilter
+    ) throws Exception {
+        return http
+            .csrf(csrf -> csrf.disable())
+            .sessionManagement(session ->
+                session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/public").permitAll()
+                .requestMatchers("/api/protected").authenticated()
+                .requestMatchers("/api/admin/**").hasAuthority("SCOPE_admin")
+                .anyRequest().authenticated())
+            .addFilterBefore(authFilter, UsernamePasswordAuthenticationFilter.class)
+            .build();
+    }
+}
+```
+
+### 5. Protect Endpoints
+
+```java
+@RestController
+@RequestMapping("/api")
+public class ApiController {
+
+    @GetMapping("/public")
+    public ResponseEntity<Map<String, Object>> publicEndpoint() {
+        return ResponseEntity.ok(Map.of("message", "Public endpoint - no token required"));
+    }
+
+    @GetMapping("/protected")
+    public ResponseEntity<Map<String, Object>> protectedEndpoint(Authentication authentication) {
+        Auth0AuthenticationToken token = (Auth0AuthenticationToken) authentication;
+        return ResponseEntity.ok(Map.of(
+            "user", authentication.getName(),
+            "email", token.getClaim("email"),
+            "scopes", token.getScopes()
+        ));
+    }
+}
+```
+
+### 6. Test API
+
+> **Agent instruction:** After writing all code, verify the build succeeds:
+> ```bash
+> ./gradlew bootRun
+> ```
+> or `./mvnw spring-boot:run`. If build fails, diagnose and fix. After 5-6 failed attempts, use `AskUserQuestion` to get help.
+
+Test public endpoint:
+
+```bash
+curl http://localhost:8080/api/public
+```
+
+Test protected endpoint (requires access token):
+
+```bash
+curl http://localhost:8080/api/protected \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
+Get a test token via Client Credentials flow or Auth0 Dashboard → APIs → Test tab.
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Domain includes `https://` | Use `your-tenant.auth0.com` format only — no scheme prefix |
+| Audience doesn't match API Identifier | Must exactly match the API Identifier set in Auth0 Dashboard |
+| Created Application instead of API in Auth0 | Must create API resource in Auth0 Dashboard → Applications → APIs |
+| Missing `addFilterBefore` in SecurityConfig | `Auth0AuthenticationFilter` must be added before `UsernamePasswordAuthenticationFilter` |
+| Using ID token instead of access token | Must use **access token** for API auth, not ID token |
+| Checking `scope` claim in wrong format | Scopes map to `SCOPE_` prefixed authorities: use `hasAuthority("SCOPE_read:data")` |
+| Spring Boot env var binding | Use `AUTH0_DOMAIN` not `AUTH0_DOMAIN` with underscores inside property names; Spring removes dashes and is case-insensitive |
+
+---
+
+## Scope-Based Authorization
+
+See [Integration Guide](references/integration.md) for defining and enforcing scope-based access control via filter chain, `@PreAuthorize`, or programmatic checks.
+
+---
+
+## DPoP Support
+
+Built-in proof-of-possession token binding per RFC 9449. See [Integration Guide](references/integration.md) for configuration modes (DISABLED, ALLOWED, REQUIRED).
+
+---
+
+## Related Skills
+
+- `auth0-quickstart` — Basic Auth0 setup and account creation
+- `auth0-java` — Spring Boot web apps with login UI (Regular Web Application)
+
+---
+
+## Quick Reference
+
+**Configuration Properties (`application.yml`):**
+- `auth0.domain` — Auth0 tenant domain, no `https://` prefix (required)
+- `auth0.audience` — API Identifier from Auth0 API settings (required)
+- `auth0.dpop-mode` — DPoP mode: `DISABLED`, `ALLOWED` (default), `REQUIRED`
+- `auth0.dpop-iat-offset-seconds` — DPoP proof time window (default: 300)
+- `auth0.dpop-iat-leeway-seconds` — DPoP proof time leeway (default: 30)
+
+**User Claims (via `Auth0AuthenticationToken`):**
+- `authentication.getName()` — User ID (subject / `sub` claim)
+- `token.getClaim("email")` — Any specific claim by name
+- `token.getClaims()` — All JWT claims as `Map<String, Object>`
+- `token.getScopes()` — Scopes as `Set<String>`
+
+**Common Use Cases:**
+- Protect routes → `requestMatchers("/path").authenticated()` (see Step 4)
+- Scope enforcement → `hasAuthority("SCOPE_read:data")` or `@PreAuthorize` (see [Integration Guide](references/integration.md))
+- DPoP token binding → [Integration Guide](references/integration.md)
+- Complete API reference → [API Reference](references/api.md)
+
+---
+
+## Detailed Documentation
+
+- **[Setup Guide](references/setup.md)** — Auth0 CLI automation, environment configuration, secret management
+- **[Integration Guide](references/integration.md)** — Scope policies, DPoP, controller patterns, error handling
+- **[API Reference](references/api.md)** — Complete configuration options, claims reference, testing checklist
+
+---
+
+## References
+
+- [Auth0 Java Spring Security API Quickstart](https://auth0.com/docs/quickstart/backend/java-spring-security5)
+- [SDK GitHub Repository](https://github.com/auth0/auth0-auth-java)
+- [Spring Security Documentation](https://docs.spring.io/spring-security/reference/)
+- [Access Tokens Guide](https://auth0.com/docs/secure/tokens/access-tokens)
+- [DPoP RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449)

--- a/main/.mintlify/skills/auth0-swift/SKILL.md
+++ b/main/.mintlify/skills/auth0-swift/SKILL.md
@@ -1,0 +1,259 @@
+---
+name: auth0-swift
+description: Use when adding Auth0 authentication to an iOS, macOS, tvOS, watchOS, or visionOS application — integrates the Auth0.swift SDK for native Apple platform authentication using Web Auth, CredentialsManager, and biometric protection.
+license: Proprietary
+metadata:
+  author: Auth0 <support@auth0.com>
+---
+
+# Auth0 Swift Integration
+
+Auth0.swift is the official Auth0 SDK for Apple platforms (iOS, macOS, tvOS, watchOS, visionOS). This skill adds complete native authentication to Swift apps using Web Auth (system browser redirect), secure Keychain credential storage via `CredentialsManager`, and optional biometric protection.
+
+> **Agent instruction:** Before providing SDK setup instructions, fetch the latest release version by running:
+> ```bash
+> gh api repos/auth0/Auth0.swift/releases/latest --jq '.tag_name'
+> ```
+> Use the returned version in all dependency lines instead of any hardcoded version below. Current known version: `2.18.0`.
+
+## When NOT to Use
+
+- **Android apps**: Use [auth0-android](/auth0-android)
+- **React Native apps**: Use [auth0-react-native](/auth0-react-native)
+- **Flutter apps**: Use the native Flutter Auth0 SDK
+- **Web SPAs** (React, Angular, Vue): Use [auth0-react](/auth0-react), [auth0-angular](/auth0-angular), or [auth0-vue](/auth0-vue)
+- **Node.js/Express servers**: Use [auth0-express](/auth0-express)
+
+## Prerequisites
+
+- **iOS** 14.0+ / **macOS** 11.0+ / tvOS 14.0+ / watchOS 7.0+ / visionOS 1.0+
+- **Xcode** 16.x
+- **Swift** 6.0+
+- Auth0 account — [Sign up free](https://auth0.com/signup)
+- Node.js 20+ (for bootstrap script automation)
+- Auth0 CLI — `brew install auth0/auth0-cli/auth0` (for bootstrap script)
+
+## Quick Start Workflow
+
+> **Agent instruction:** Follow these steps in order. If you encounter an error at any step, attempt to fix it up to 5 times before calling `AskUserQuestion` to ask the user for guidance. Always search existing code first — if there are existing login/logout handlers, hook into them rather than creating new ones.
+
+### Step 1 — Install SDK
+
+> **Agent instruction:** Check the project directory for an existing package manager file:
+> - `Podfile` present → **CocoaPods**
+> - `Cartfile` present → **Carthage**
+> - `Package.swift` present → **Swift Package Manager**
+>
+> If none are found, ask via `AskUserQuestion`: _"Which dependency manager does your project use — Swift Package Manager, CocoaPods, or Carthage?"_
+>
+> **Swift Package Manager — `Package.swift` project:** Run this command in the project root to add the dependency automatically, then add `"Auth0"` to the target's `dependencies` array in `Package.swift`:
+> ```bash
+> swift package add-dependency https://github.com/auth0/Auth0.swift --from 2.18.0
+> ```
+>
+> **Swift Package Manager — Xcode project (`.xcodeproj`, no `Package.swift`):** The CLI command does not apply. Instruct the user to add the package via Xcode: File → Add Package Dependencies → `https://github.com/auth0/Auth0.swift` → Up to Next Major Version from `2.18.0`.
+>
+> **CocoaPods or Carthage:** Follow the matching installation steps in [Setup Guide](./references/setup.md#sdk-installation). Do not just show the instructions — perform the file edits and run the commands.
+
+### Step 2 — Configure Auth0
+
+> **Agent instruction:**
+> - **If Auth0 credentials (domain AND client ID) are already in the user's prompt:** Write `Auth0.plist` directly with those values and proceed to Step 3.
+> - **If no credentials are provided:** Run the bootstrap script — do NOT ask the user to create or configure an Auth0 application manually. Always use the CLI path.
+>
+> Follow [Setup Guide — Auth0 Configuration](./references/setup.md#auth0-configuration) for pre-flight checks and the script command.
+
+### Step 3 — Configure Callback URLs
+
+> **Agent instruction:**
+> 1. Read `Auth0.plist` to obtain `ClientId` and `Domain`.
+> 2. Extract the bundle identifier from `project.pbxproj`: search for `PRODUCT_BUNDLE_IDENTIFIER`, skip values containing `$(` or `Tests`.
+> 3. Ask the user via `AskUserQuestion`: _"Which callback URL scheme would you like to use?"_
+>    - **Custom scheme** (`{bundle}://`) — simpler, works on all Apple platforms
+>    - **HTTPS Universal Links** — recommended for production; prevents URL scheme hijacking
+>
+> Then follow **only** the matching path below.
+
+#### Path A — Custom Scheme
+
+> **Agent instruction:** Register the callback URLs using the Auth0 CLI (substitute real values for `CLIENT_ID`, `BUNDLE_ID`, `DOMAIN`):
+> ```bash
+> auth0 apps update CLIENT_ID \
+>   --callbacks "BUNDLE_ID://DOMAIN/ios/BUNDLE_ID/callback" \
+>   --logout-urls "BUNDLE_ID://DOMAIN/ios/BUNDLE_ID/callback" \
+>   --no-input
+> ```
+> Then follow the [URL scheme registration steps in Setup Guide](./references/setup.md#register-url-scheme-required-for-custom-scheme-callbacks) to register `$(PRODUCT_BUNDLE_IDENTIFIER)` as a URL type in Xcode.
+
+#### Path B — HTTPS Universal Links
+
+> **Agent instruction:** All four steps below are required — skipping any one will cause the callback redirect to fail silently after login.
+>
+> **Step B1 — Register callback URLs via Auth0 CLI:**
+> Register both HTTPS and custom scheme so the app works in all scenarios:
+> ```bash
+> auth0 apps update CLIENT_ID \
+>   --callbacks "https://DOMAIN/ios/BUNDLE_ID/callback,BUNDLE_ID://DOMAIN/ios/BUNDLE_ID/callback" \
+>   --logout-urls "https://DOMAIN/ios/BUNDLE_ID/callback,BUNDLE_ID://DOMAIN/ios/BUNDLE_ID/callback" \
+>   --no-input
+> ```
+>
+> **Step B2 — Configure Device Settings via Auth0 CLI:**
+> Extract `DEVELOPMENT_TEAM` from `project.pbxproj` (10-character value, e.g. `ABC12DE34F`). If not found, ask via `AskUserQuestion`: _"What is your Apple Team ID? (developer.apple.com → Account → Membership Details)"_
+> ```bash
+> auth0 api patch applications/CLIENT_ID \
+>   --data '{"mobile":{"ios":{"team_id":"TEAM_ID","app_bundle_identifier":"BUNDLE_ID"}}}' \
+>   --no-input
+> ```
+> Auth0 will now host `https://DOMAIN/.well-known/apple-app-site-association` automatically — required for Universal Links to work on device.
+>
+> **Step B3 — Add Associated Domains entitlement in Xcode:**
+> Add `com.apple.developer.associated-domains` to the app's `.entitlements` file with both `applinks:` and `webcredentials:` entries for the Auth0 domain. See [Setup Guide — Associated Domains](./references/setup.md#associated-domains-setup-https-universal-links) for the complete entitlements XML, Xcode capability steps, and build settings verification.
+>
+> **Step B4 — Use `.useHTTPS()` in the SDK:**
+> ```swift
+> Auth0.webAuth().useHTTPS()
+> ```
+
+### Step 4 — Implement Authentication
+
+> **Agent instruction:** Search the project for `@main struct` (SwiftUI) or `AppDelegate`/`UIViewController` (UIKit) to detect the UI framework. If ambiguous, ask via `AskUserQuestion`: _"Does your app use SwiftUI or UIKit?"_ Then follow **only** the matching path below.
+
+#### SwiftUI
+
+> **Agent instruction:** Create `AuthenticationService.swift` as an `ObservableObject`, then wire it into the app entry point and root view. Search for the `@main` struct and `ContentView` (or equivalent root view) and update them as shown.
+
+```swift
+// AuthenticationService.swift
+import Auth0
+import Combine
+
+class AuthenticationService: ObservableObject {
+    @Published var isAuthenticated = false
+    private let credentialsManager = CredentialsManager(authentication: Auth0.authentication())
+
+    init() { isAuthenticated = credentialsManager.canRenew() }
+
+    func login() async {
+        do {
+            let credentials = try await Auth0
+                .webAuth()
+                .useHTTPS()
+                .scope("openid profile email offline_access")
+                .start()
+            _ = credentialsManager.store(credentials: credentials)
+            await MainActor.run { isAuthenticated = true }
+        } catch WebAuthError.userCancelled { }
+        catch { print("Login failed: \(error)") }
+    }
+
+    func logout() async {
+        do { try await Auth0.webAuth().useHTTPS().clearSession() }
+        catch { print("Logout failed: \(error)") }
+        _ = credentialsManager.clear()
+        await MainActor.run { isAuthenticated = false }
+    }
+}
+```
+
+```swift
+// @main App struct — inject AuthenticationService as environment object
+@StateObject private var auth = AuthenticationService()
+// In body: ContentView().environmentObject(auth)
+
+// Root ContentView — branch on authentication state
+@EnvironmentObject var auth: AuthenticationService
+// In body: if auth.isAuthenticated { HomeView() } else { LoginView() }
+```
+
+For complete SwiftUI app lifecycle wiring, see [Integration Patterns](./references/integration.md#swiftui-app-lifecycle-recommended).
+
+#### UIKit
+
+> **Agent instruction:** Create `AuthenticationService.swift` as a plain class, then add login/logout calls to the relevant `UIViewController`. Also check whether the app uses `SFSafariViewController` — if so, add `WebAuthentication.resume(with:)` to `AppDelegate`/`SceneDelegate` (see note below).
+
+```swift
+// AuthenticationService.swift
+import Auth0
+
+class AuthenticationService {
+    private let credentialsManager = CredentialsManager(authentication: Auth0.authentication())
+
+    var isAuthenticated: Bool { credentialsManager.canRenew() }
+
+    func login() async throws {
+        let credentials = try await Auth0
+            .webAuth()
+            .useHTTPS()
+            .scope("openid profile email offline_access")
+            .start()
+        _ = credentialsManager.store(credentials: credentials)
+    }
+
+    func logout() async throws {
+        try await Auth0.webAuth().useHTTPS().clearSession()
+        _ = credentialsManager.clear()
+    }
+}
+```
+
+```swift
+// In your UIViewController
+private let auth = AuthenticationService()
+
+@IBAction func loginTapped(_ sender: UIButton) {
+    Task {
+        do {
+            try await auth.login()
+            await MainActor.run { navigateToHome() }
+        } catch WebAuthError.userCancelled { }
+        catch { print("Login failed: \(error)") }
+    }
+}
+
+@IBAction func logoutTapped(_ sender: UIButton) {
+    Task {
+        do { try await auth.logout() }
+        catch { print("Logout failed: \(error)") }
+        await MainActor.run { navigateToLogin() }
+    }
+}
+```
+
+> **Note — SFSafariViewController only:** If the app uses `.provider(WebAuthentication.safariProvider())` instead of the default `ASWebAuthenticationSession`, add `WebAuthentication.resume(with: url)` to `AppDelegate.application(_:open:url:options:)` and `SceneDelegate.scene(_:openURLContexts:)`. See [Integration Patterns](./references/integration.md#uikit-app-lifecycle) for the exact code.
+
+### Step 5 — Verify Build
+
+> **Agent instruction:** Run a build to verify the integration compiles without errors:
+> ```bash
+> xcodebuild build -scheme YOUR_SCHEME -destination "platform=iOS Simulator,name=iPhone 16"
+> ```
+> If the build fails, review error messages and fix up to 5 times before asking the user.
+
+## Detailed Documentation
+
+- **[Setup Guide](./references/setup.md)** — Auth0 Dashboard configuration, bootstrap script, manual setup, URL scheme registration, CocoaPods/SPM/Carthage install
+- **[Integration Patterns](./references/integration.md)** — Web Auth login/logout, CredentialsManager, biometric protection, MFA, organizations, error handling, SwiftUI/UIKit patterns
+- **[API Reference & Testing](./references/api.md)** — Full API reference, configuration options, claims reference, testing checklist, troubleshooting
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Auth0 app type not set to **Native** | In Auth0 Dashboard, select "Native" when creating the application |
+| Missing callback URL in Auth0 Dashboard | Add both `https://` Universal Link and `{bundle}://` custom scheme to Allowed Callback URLs and Logout URLs |
+| `Auth0.plist` not added to Xcode target | Right-click file in Navigator → "Add Files to Target" → check your app target |
+| Missing `offline_access` scope | Add `"offline_access"` to scope string to receive a refresh token for silent renewal |
+| Tokens stored in `UserDefaults` | Always use `CredentialsManager` — it stores tokens in Keychain with access control |
+| Calling `credentialsManager.credentials()` before `store()` | Store credentials from login result before attempting to retrieve |
+| Opening `.xcodeproj` instead of `.xcworkspace` (CocoaPods) | Always open the `.xcworkspace` file after `pod install` |
+| Not calling `clearSession()` on logout | Always call `clearSession()` to remove the Auth0 session cookie from the browser |
+| Build error "No such module 'Auth0'" | Verify the package is added to the correct target; for CocoaPods, open `.xcworkspace` |
+
+## References
+
+- [Auth0.swift GitHub](https://github.com/auth0/Auth0.swift)
+- [iOS/macOS Quickstart](https://auth0.com/docs/quickstart/native/ios-swift)
+- [Auth0.swift API Documentation](https://auth0.github.io/Auth0.swift/documentation/auth0/)
+- [Auth0 Dashboard](https://manage.auth0.com)
+- [EXAMPLES.md](https://github.com/auth0/Auth0.swift/blob/master/EXAMPLES.md)

--- a/main/.mintlify/skills/express-oauth2-jwt-bearer/SKILL.md
+++ b/main/.mintlify/skills/express-oauth2-jwt-bearer/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: express-oauth2-jwt-bearer
+description: Use when adding Auth0 token validation to Express or Node.js APIs - integrates express-oauth2-jwt-bearer SDK to protect Node.js API endpoints with JWT Bearer authentication, scope-based RBAC, claim validation, and optional DPoP support
+license: Apache-2.0
+metadata:
+  author: Auth0 <support@auth0.com>
+---
+
+# Node OAuth2 JWT Bearer Integration
+
+The `express-oauth2-jwt-bearer` package provides Express middleware for validating Auth0 JWT Bearer access tokens. It handles token extraction, signature verification, audience and issuer validation, and expiry checks per RFC 6750 — letting you focus on business logic rather than JWT parsing.
+
+> **Agent instruction:** Before providing SDK setup instructions, fetch the latest release version by running:
+> ```bash
+> gh api repos/auth0/node-oauth2-jwt-bearer/releases/latest --jq '.tag_name'
+> ```
+> Use the returned version in all `package.json` dependency lines instead of any hardcoded version below.
+
+## Prerequisites
+
+- **Node.js** 18+ (20+ recommended; required for bootstrap script automation)
+- **Express** 4.x or 5.x
+- **npm** or **yarn**
+- An **Auth0 account** with a configured API (Resource Server)
+- **Auth0 CLI** (for automatic setup): `npm install -g @auth0/auth0-cli`
+
+## When NOT to Use
+
+| Use Case | Recommended Skill |
+|----------|------------------|
+| Building a server-side web app with login UI (Express sessions) | `auth0-express` |
+| Building a Next.js app with server-side auth | `auth0-nextjs` |
+| Building a React/Angular/Vue SPA | `auth0-react`, `auth0-angular`, `auth0-vue` |
+| Building a React Native or mobile app | `auth0-react-native`, `auth0-android`, `auth0-swift` |
+| ASP.NET Core Web API | `auth0-aspnetcore-api` |
+| Go API with JWT middleware | `go-jwt-middleware` |
+| Python API (Flask/FastAPI) | `auth0-api-python` |
+| Node.js API using the older `express-jwt` package | `express-jwt` |
+
+## Quick Start Workflow
+
+> **Agent instruction:** Follow these steps to integrate `express-oauth2-jwt-bearer` into the user's Node.js API project.
+>
+> 1. **Fetch latest version** (see instruction above).
+>
+> 2. **Install the SDK:**
+>    ```bash
+>    npm install express-oauth2-jwt-bearer
+>    ```
+>
+> 3. **Configure Auth0** — follow `references/setup.md`. If the user already provided their Auth0 Domain and API Audience in the prompt, use them directly — skip the bootstrap script and do NOT call `AskUserQuestion` to re-confirm. Otherwise, offer automatic setup via bootstrap script or manual setup.
+>
+> 4. **Set up middleware** — add to `app.js` or `server.js`:
+>    ```javascript
+>    import { auth } from 'express-oauth2-jwt-bearer';
+>
+>    const checkJwt = auth({
+>      issuerBaseURL: `https://${process.env.AUTH0_DOMAIN}`,
+>      audience: process.env.AUTH0_AUDIENCE,
+>    });
+>
+>    app.use(checkJwt); // apply globally, or per-route
+>    ```
+>
+> 5. **Protect endpoints** — apply middleware globally or to specific routes:
+>    ```javascript
+>    // Global protection
+>    app.use(checkJwt);
+>
+>    // Or per-route
+>    app.get('/api/private', checkJwt, (req, res) => {
+>      res.json({ sub: req.auth.payload.sub });
+>    });
+>    ```
+>
+> 6. **Add RBAC** (optional) — use `requiredScopes()` or `claimIncludes()` for permission-based access:
+>    ```javascript
+>    import { auth, requiredScopes, claimIncludes } from 'express-oauth2-jwt-bearer';
+>
+>    app.get('/api/messages', checkJwt, requiredScopes('read:messages'), (req, res) => {
+>      res.json({ messages: [] });
+>    });
+>    ```
+>    > **Important:** `requiredScopes` accepts a single argument — a space-separated string or an array. Do NOT pass multiple string arguments: `requiredScopes('read:msg', 'write:msg')` silently ignores everything after the first. Use `requiredScopes('read:msg write:msg')` or `requiredScopes(['read:msg', 'write:msg'])` instead.
+>
+> 7. **Verify the integration** — build and test:
+>    ```bash
+>    node server.js
+>    curl http://localhost:3000/api/private         # should return 401
+>    curl -H "Authorization: Bearer <token>" http://localhost:3000/api/private  # should return 200
+>    ```
+>
+> 8. **Failcheck:** If the server fails to start or tokens are rejected unexpectedly, check `references/api.md` for common issues. After 5-6 failed iterations, use `AskUserQuestion` to ask the user for more details about their environment.
+
+## Detailed Documentation
+
+- **[Setup Guide](./references/setup.md)** — Auth0 API registration, .env configuration, bootstrap script for automated setup, and secret management
+- **[Integration Patterns](./references/integration.md)** — Protected endpoints, RBAC with scopes and claims, DPoP, CORS setup, error handling, and testing with curl
+- **[API Reference & Testing](./references/api.md)** — Full configuration options, claims reference, complete code example, testing checklist, and common issues
+
+## Common Mistakes
+
+| Mistake | Symptom | Fix |
+|---------|---------|-----|
+| Created an **Application** instead of an **API** in Auth0 Dashboard | Token validation fails; wrong audience | Create a new **API** (Resource Server) in Auth0 Dashboard → APIs |
+| Audience doesn't match API identifier exactly | `401 Unauthorized` — "Audience mismatch" | Copy the exact API Identifier string from Auth0 Dashboard → APIs |
+| Domain includes `https://` prefix | `Error: Invalid URL` at startup | Use hostname only: `your-tenant.us.auth0.com`, not `https://...` |
+| Checking `scope` claim instead of `permissions` for RBAC | 403 always returned or permissions ignored | Use `requiredScopes()` for scope-based RBAC; use `claimIncludes('permissions', 'read:data')` for Auth0 RBAC permission claims |
+| CORS not configured before auth middleware | Preflight OPTIONS requests return 401 | Add `cors()` middleware before `auth()` in the middleware chain |
+| `.env` file not loaded | `undefined` for domain/audience | Add `import 'dotenv/config'` at the top of the entry file |
+| `req.auth` is undefined | `TypeError: Cannot read properties of undefined` | Verify `checkJwt` middleware runs before the handler |
+
+## Related Skills
+
+- **[auth0-express](../auth0-express)** — For Express web apps with login UI (sessions, cookies)
+- **[auth0-nextjs](../auth0-nextjs)** — For Next.js server-side web apps
+- **[auth0-aspnetcore-api](../auth0-aspnetcore-api)** — BACKEND_API reference implementation for .NET
+- **[go-jwt-middleware](../go-jwt-middleware)** — JWT middleware for Go APIs
+- **[auth0-api-python](../auth0-api-python)** — JWT validation for Python APIs (Flask/FastAPI)
+
+## Quick Reference
+
+### Core Middleware
+
+| Function | Description | Returns |
+|----------|-------------|---------|
+| `auth(options?)` | JWT Bearer validation middleware | `Handler` — 401 if token invalid/missing |
+| `requiredScopes(scopes)` | Validates token has all required scopes | `Handler` — 403 if scopes missing |
+| `scopeIncludesAny(scopes)` | Validates token has at least one scope | `Handler` — 403 if no match |
+| `claimEquals(claim, value)` | Validates a claim equals a value | `Handler` — 401 if mismatch |
+| `claimIncludes(claim, ...values)` | Validates claim includes all values | `Handler` — 401 if incomplete |
+| `claimCheck(fn, desc?)` | Custom claim validation function | `Handler` — 401 if fn returns false |
+
+### Configuration Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `issuerBaseURL` | `string` | Auth0 domain with `https://` (required unless using env vars) |
+| `audience` | `string` | API Identifier from Auth0 Dashboard (required unless using env vars) |
+| `tokenSigningAlg` | `string` | Signing algorithm (default: `RS256`; use `HS256` for symmetric) |
+| `authRequired` | `boolean` | Set `false` to make authentication optional (default: `true`) |
+| `clockTolerance` | `number` | Clock skew tolerance in seconds (no default; undefined unless set) |
+| `dpop` | `DPoPOptions` | DPoP configuration (see integration.md) |
+
+### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `ISSUER_BASE_URL` | Auth0 domain with `https://` (auto-detected by SDK) |
+| `AUDIENCE` | API Identifier (auto-detected by SDK) |
+
+### Request Object
+
+After successful validation, `req.auth` contains:
+```typescript
+req.auth.payload    // Decoded JWT payload (sub, iss, aud, exp, permissions, etc.)
+req.auth.header     // JWT header (alg, typ, kid)
+req.auth.token      // Raw JWT string
+```
+
+## SDK Architecture
+
+The `node-oauth2-jwt-bearer` monorepo contains three packages:
+
+| Package | Purpose |
+|---------|---------|
+| `express-oauth2-jwt-bearer` | **Main package.** Express middleware for JWT Bearer validation. Published to npm. |
+| `access-token-jwt` | Low-level JWT verification utilities (used internally). |
+| `oauth2-bearer` | RFC 6750 Bearer token extraction (used internally). |
+
+In practice, you only install and import `express-oauth2-jwt-bearer`.
+
+## Auth Flow Comparison
+
+| Auth Pattern | SDK | When to Use |
+|-------------|-----|-------------|
+| JWT Bearer (stateless) | `express-oauth2-jwt-bearer` | APIs called by SPAs, mobile apps, M2M clients |
+| Session-based (stateful) | `@auth0/express-openid-connect` | Web apps with login UI and server-side sessions |
+
+## Testing Quick Reference
+
+```bash
+# Get test token from Auth0 Dashboard → APIs → your API → Test tab
+# Copy the token, then:
+
+# 1. Verify 401 on protected route (no token)
+curl -v http://localhost:3000/api/private
+
+# 2. Verify 200 with valid token
+curl -H "Authorization: Bearer <paste-token-here>" http://localhost:3000/api/private
+
+# 3. Verify 403 with valid token but missing scope
+curl -H "Authorization: Bearer <paste-token-here>" http://localhost:3000/api/admin
+
+# 4. Verify CORS preflight
+curl -v -X OPTIONS http://localhost:3000/api/private \
+  -H "Origin: http://localhost:5173" \
+  -H "Access-Control-Request-Method: GET" \
+  -H "Access-Control-Request-Headers: Authorization"
+```
+
+## References
+
+- [express-oauth2-jwt-bearer on npm](https://www.npmjs.com/package/express-oauth2-jwt-bearer)
+- [GitHub: auth0/node-oauth2-jwt-bearer](https://github.com/auth0/node-oauth2-jwt-bearer)
+- [Auth0 Node.js API Quickstart](https://auth0.com/docs/quickstart/backend/nodejs/interactive)
+- [Auth0 APIs Dashboard](https://manage.auth0.com/#/apis)
+- [RFC 6750 — Bearer Token Usage](https://datatracker.ietf.org/doc/html/rfc6750)

--- a/main/skill.md
+++ b/main/skill.md
@@ -1,10 +1,10 @@
 ---
 name: Auth0
-description: Use when adding authentication to any application — detects your framework, sets up Auth0, and provides production-ready integration guides for 14+ frameworks and platforms.
+description: Use when adding authentication to any application — detects your framework, sets up Auth0, and provides production-ready integration guides for 23 frameworks and platforms.
 license: Apache-2.0
 metadata:
   author: Auth0 <support@auth0.com>
-  version: "1.0.0"
+  version: "1.1.0"
   repository: https://github.com/auth0/agent-skills
 ---
 
@@ -22,7 +22,8 @@ Start here — this skill detects your framework and routes to the correct integ
 
 - **auth0-react** — React SPAs (Vite, CRA) with `@auth0/auth0-react`
 - **auth0-vue** — Vue.js 3 applications with `@auth0/auth0-vue`
-- **auth0-angular** — Angular 12+ with `@auth0/auth0-angular`
+- **auth0-angular** — Angular 13+ with `@auth0/auth0-angular`
+- **auth0-spa-js** — Vanilla JS, Svelte, SolidJS, or any SPA with `@auth0/auth0-spa-js`
 
 ## Full-Stack Frameworks
 
@@ -32,28 +33,35 @@ Start here — this skill detects your framework and routes to the correct integ
 ## Backend Frameworks
 
 - **auth0-express** — Express.js web applications with `express-openid-connect`
+- **auth0-flask** — Flask web applications with `auth0-server-python`
 - **auth0-fastify** — Fastify web applications with `@auth0/auth0-fastify`
+- **auth0-java-mvc-common** — Java Servlet applications with `mvc-auth-commons`
+
+## API Protection
+
+- **express-oauth2-jwt-bearer** — Node.js/Express API JWT validation with `express-oauth2-jwt-bearer`
 - **auth0-fastify-api** — Fastify API JWT validation with `@auth0/auth0-fastify`
-- **auth0-aspnetcore-api** — ASP.NET Core API authentication
+- **auth0-fastapi-api** — Python FastAPI JWT validation with `auth0-fastapi-api`
+- **auth0-springboot-api** — Spring Boot API JWT validation with `auth0-springboot-api`
+- **auth0-aspnetcore-api** — ASP.NET Core API JWT validation with `Auth0.AspNetCore.Authentication`
 
 ## Mobile
 
-- **auth0-react-native** — React Native and Expo with `react-native-auth0`
-- **auth0-android** — Android (Kotlin) with `Auth0.Android`
+- **auth0-react-native** — React Native CLI (bare workflow) with `react-native-auth0`
+- **auth0-expo** — Expo managed workflow with `react-native-auth0`
+- **auth0-android** — Android (Kotlin/Java) with `Auth0.Android`
+- **auth0-swift** — iOS, macOS, tvOS, watchOS, visionOS with `Auth0.swift`
 
 ## Advanced Features
 
 - **auth0-mfa** — Multi-Factor Authentication (TOTP, SMS, Email, Push, WebAuthn)
-- **auth0-migration** — Migrate from Firebase, Cognito, Supabase, or custom auth
+- **auth0-migration** — Migrate from Firebase, Cognito, Supabase, Clerk, or custom auth
+- **acul-screen-generator** — Custom Universal Login screens with `@auth0/auth0-acul-react` or `@auth0/auth0-acul-js`
 
 ## Installation
 
 ```bash
-# Install all skills via CLI
 npx skills add auth0/agent-skills
-
-# Or install individually
-npx skills add auth0/agent-skills/plugins/auth0-sdks/skills/auth0-react
 ```
 
 ## Resources


### PR DESCRIPTION
## Summary

The `.well-known/skills/` discovery endpoint (served by Mintlify from `main/.mintlify/skills/`) was serving **14 skills** but the [agent-skills repo](https://github.com/auth0/agent-skills) now has **23 skills**. This PR adds the 9 missing skills and updates the `skill.md` manifest.

### Skills added
- `auth0-spa-js` — Vanilla JS / Svelte / SolidJS SPAs
- `auth0-flask` — Flask web applications
- `auth0-java-mvc-common` — Java Servlet applications
- `auth0-expo` — Expo managed workflow (React Native)
- `auth0-swift` — iOS, macOS, tvOS, watchOS, visionOS
- `auth0-springboot-api` — Spring Boot API protection
- `auth0-fastapi-api` — FastAPI API protection
- `acul-screen-generator` — Custom Universal Login screens (ACUL)
- `express-oauth2-jwt-bearer` — Node.js/Express API JWT validation

### Also updated
- `main/skill.md` manifest: lists all 23 skills with correct descriptions, version bumped to 1.1.0

### Why now
The weekly sync workflow (`sync-agent-skills.yml`) hasn't picked these up yet because they were added after the last Monday run. This PR brings the discovery endpoint current immediately.

### Endpoints affected
- `https://auth0.com/docs/.well-known/skills/index.json` (auto-generated by Mintlify from `.mintlify/skills/`)
- `https://auth0.com/docs/.well-known/skills/auth0/skill.md` (from `main/skill.md`)