### PR TITLE
feat: add organization authentication notes for Connected Accounts flow

### DIFF
--- a/auth4genai/get-started/call-others-apis-on-users-behalf.mdx
+++ b/auth4genai/get-started/call-others-apis-on-users-behalf.mdx
@@ -17,9 +17,9 @@ import FastApiCallOthersApi from "/snippets/get-started/langchain-fastapi-py/cal
 
 Use Auth0 SDKs to fetch access tokens for social and enterprise identity providers from Auth0's [Token Vault](https://auth0.com/docs/secure/tokens/token-vault). Using these access tokens, AI agents integrated with the application can call third-party APIs to perform tasks on the user's behalf.
 
-<Note>
-If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), authenticate the user in the target organization before you initiate the Connected Accounts flow. Each organization member connects and authorizes their own external account.
-</Note>
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), authenticate the user with the target organization before initiating the Connected Accounts flow. Each organization member connects and authorizes their own external account.
+</Callout>
 
 By the end of this quickstart, you should have an AI application integrated with Auth0 that can:
 

--- a/auth4genai/get-started/call-others-apis-on-users-behalf.mdx
+++ b/auth4genai/get-started/call-others-apis-on-users-behalf.mdx
@@ -17,6 +17,10 @@ import FastApiCallOthersApi from "/snippets/get-started/langchain-fastapi-py/cal
 
 Use Auth0 SDKs to fetch access tokens for social and enterprise identity providers from Auth0's [Token Vault](https://auth0.com/docs/secure/tokens/token-vault). Using these access tokens, AI agents integrated with the application can call third-party APIs to perform tasks on the user's behalf.
 
+<Note>
+If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), authenticate the user in the target organization before you initiate the Connected Accounts flow. Each organization member connects and authorizes their own external account.
+</Note>
+
 By the end of this quickstart, you should have an AI application integrated with Auth0 that can:
 
 1. Initiate a Connected Accounts flow that will allow the user to connect their Google account and grant access to the AI agent.

--- a/auth4genai/how-tos/check-google-calendar-availability.mdx
+++ b/auth4genai/how-tos/check-google-calendar-availability.mdx
@@ -12,6 +12,7 @@ import LlamaIndexJSSample from "/snippets/how-tos/google-calendar/llamaindex.mdx
 import LlamaIndexSample from "/snippets/how-tos/google-calendar/llamaindex-python.mdx";
 import NextJSAuth0Sample from "/snippets/how-tos/google-calendar/nextjs-auth0.mdx";
 import GenKitSample from "/snippets/how-tos/google-calendar/genkit.mdx";
+import AccountLinking from "/snippets/how-tos/account-linking.mdx";
 
 import { GoogleCalendarPrereqs } from "/snippets/how-tos/google-calendar/prereqs.jsx";
 import { CustomApiClient } from "/snippets/common/custom-api-client.jsx";
@@ -72,8 +73,4 @@ import { CustomApiClient } from "/snippets/common/custom-api-client.jsx";
   </Tab>
 </Tabs>
 
-## Account Linking
-
-If you're integrating with Google, but users in your app or agent can sign in using other methods (e.g., a username and password or another social provider), you'll need to link these identities into a single user account. Auth0 refers to this process as [Account Linking](https://auth0.com/docs/manage-users/user-accounts/user-account-linking).
-
-**Account Linking** logic and handling will vary depending on your app or agent. You can find an example of how to implement it in a Next.js chatbot app [here](https://github.com/auth0-lab/market0/blob/main/app/api/auth/%5Bauth0%5D/route.ts#L43). If you have questions or are looking for best practices, [join our Discord](http://discord.gg/XbQpZSF2Ys) and ask in the `#auth0-for-gen-ai` channel.
+<AccountLinking connectionLabel="Google" />

--- a/auth4genai/how-tos/list-github-repositories.mdx
+++ b/auth4genai/how-tos/list-github-repositories.mdx
@@ -74,8 +74,4 @@ import { CustomApiClient } from "/snippets/common/custom-api-client.jsx";
   </Tab>
 </Tabs>
 
-## Account Linking
-
-If you're integrating with Google, but users in your app or agent can sign in using other methods (e.g., a username and password or another social provider), you'll need to link these identities into a single user account. Auth0 refers to this process as [Account Linking](https://auth0.com/docs/manage-users/user-accounts/user-account-linking).
-
-**Account Linking** logic and handling will vary depending on your app or agent. You can find an example of how to implement it in a Next.js chatbot app [here](https://github.com/auth0-lab/market0/blob/main/app/api/auth/%5Bauth0%5D/route.ts#L43). If you have questions or are looking for best practices, [join our Discord](http://discord.gg/XbQpZSF2Ys) and ask in the `#auth0-for-gen-ai` channel.
+<AccountLinking connectionLabel="GitHub" />

--- a/auth4genai/how-tos/list-slack-channels.mdx
+++ b/auth4genai/how-tos/list-slack-channels.mdx
@@ -11,6 +11,7 @@ import LangGraphSample from "/snippets/how-tos/slack/langgraph-python.mdx";
 import LlamaIndexSample from "/snippets/how-tos/slack/llamaindex-python.mdx";
 import GenKitSample from "/snippets/how-tos/slack/genkit.mdx";
 import LlamaIndexJSSample from "/snippets/how-tos/slack/llamaindex.mdx";
+import AccountLinking from "/snippets/how-tos/account-linking.mdx";
 
 import { SlackPrereqs } from "/snippets/how-tos/slack/prereqs.jsx";
 import { CustomApiClient } from "/snippets/common/custom-api-client.jsx";
@@ -66,8 +67,4 @@ import { CustomApiClient } from "/snippets/common/custom-api-client.jsx";
   </Tab>
 </Tabs>
 
-## Account Linking
-
-If you're integrating with Google, but users in your app or agent can sign in using other methods (e.g., a username and password or another social provider), you'll need to link these identities into a single user account. Auth0 refers to this process as [Account Linking](https://auth0.com/docs/manage-users/user-accounts/user-account-linking).
-
-**Account Linking** logic and handling will vary depending on your app or agent. You can find an example of how to implement it in a Next.js chatbot app [here](https://github.com/auth0-lab/market0/blob/main/app/api/auth/%5Bauth0%5D/route.ts#L43). If you have questions or are looking for best practices, [join our Discord](http://discord.gg/XbQpZSF2Ys) and ask in the `#auth0-for-gen-ai` channel.
+<AccountLinking connectionLabel="Slack" />

--- a/auth4genai/integrations/github.mdx
+++ b/auth4genai/integrations/github.mdx
@@ -77,6 +77,10 @@ GitHub apps [use fine grained permissions](https://docs.github.com/en/enterprise
   </Step>
 </Steps>
 
+<Note>
+If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), have the user sign in to the correct organization before you initiate the Connected Accounts flow. Token Vault still stores the GitHub connected account on the user's Auth0 profile, so each organization member authorizes their own GitHub account.
+</Note>
+
 <IntegrationInfoBlock providerName="GitHub" />
 
 ## Token Vault configuration Example

--- a/auth4genai/integrations/github.mdx
+++ b/auth4genai/integrations/github.mdx
@@ -77,9 +77,9 @@ GitHub apps [use fine grained permissions](https://docs.github.com/en/enterprise
   </Step>
 </Steps>
 
-<Note>
-If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), have the user sign in to the correct organization before you initiate the Connected Accounts flow. Token Vault still stores the GitHub connected account on the user's Auth0 profile, so each organization member authorizes their own GitHub account.
-</Note>
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), authenticate the user with the target organization before initiating the Connected Accounts flow. Token Vault still stores the GitHub connected account on the user's Auth0 profile, so each organization member authorizes their own GitHub account.
+</Callout>
 
 <IntegrationInfoBlock providerName="GitHub" />
 

--- a/auth4genai/integrations/google.mdx
+++ b/auth4genai/integrations/google.mdx
@@ -153,9 +153,9 @@ Use the [Auth0 Dashboard](https://manage.auth0.com/) to create a new Google soci
   </Step>
 </Steps>
 
-<Note>
-If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), have the user sign in to the correct organization before you initiate the Connected Accounts flow. Token Vault still stores the Google connected account on the user's Auth0 profile, so each organization member authorizes their own Google account.
-</Note>
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), authenticate the user with the target organization before initiating the Connected Accounts flow. Token Vault still stores the Google connected account on the user's Auth0 profile, so each organization member authorizes their own Google account.
+</Callout>
 
 ### Test connection
 

--- a/auth4genai/integrations/google.mdx
+++ b/auth4genai/integrations/google.mdx
@@ -153,6 +153,10 @@ Use the [Auth0 Dashboard](https://manage.auth0.com/) to create a new Google soci
   </Step>
 </Steps>
 
+<Note>
+If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), have the user sign in to the correct organization before you initiate the Connected Accounts flow. Token Vault still stores the Google connected account on the user's Auth0 profile, so each organization member authorizes their own Google account.
+</Note>
+
 ### Test connection
 
 Once you have created your Google social connection, [test your connection](https://auth0.com/docs/dashboard/guides/connections/test-connections-social).

--- a/auth4genai/integrations/oauth2.mdx
+++ b/auth4genai/integrations/oauth2.mdx
@@ -23,8 +23,8 @@ To learn more and configure a custom OAuth2 connection with Auth0, see our [Conn
 
 After creating the connection, in the **Purpose** section, toggle on **Connected Accounts for Token Vault**. This allows your connection to retrieve and securely store access tokens for external APIs. To learn more, read [Connected Accounts for Token Vault](https://auth0.com/docs/secure/tokens/token-vault/connected-accounts-for-token-vault).
 
-<Note>
-If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), have the user sign in to the correct organization before you initiate the Connected Accounts flow. Token Vault still stores the connected account on the user's Auth0 profile, so each organization member authorizes their own external account.
-</Note>
+<Callout>
+If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), authenticate the user with the target organization before initiating the Connected Accounts flow. Token Vault still stores the connected account on the user's Auth0 profile, so each organization member authorizes their own external account.
+</Callout>
 
 <LearnMore />

--- a/auth4genai/integrations/oauth2.mdx
+++ b/auth4genai/integrations/oauth2.mdx
@@ -23,4 +23,8 @@ To learn more and configure a custom OAuth2 connection with Auth0, see our [Conn
 
 After creating the connection, in the **Purpose** section, toggle on **Connected Accounts for Token Vault**. This allows your connection to retrieve and securely store access tokens for external APIs. To learn more, read [Connected Accounts for Token Vault](https://auth0.com/docs/secure/tokens/token-vault/connected-accounts-for-token-vault).
 
+<Note>
+If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), have the user sign in to the correct organization before you initiate the Connected Accounts flow. Token Vault still stores the connected account on the user's Auth0 profile, so each organization member authorizes their own external account.
+</Note>
+
 <LearnMore />

--- a/auth4genai/integrations/oauth2.mdx
+++ b/auth4genai/integrations/oauth2.mdx
@@ -23,7 +23,7 @@ To learn more and configure a custom OAuth2 connection with Auth0, see our [Conn
 
 After creating the connection, in the **Purpose** section, toggle on **Connected Accounts for Token Vault**. This allows your connection to retrieve and securely store access tokens for external APIs. To learn more, read [Connected Accounts for Token Vault](https://auth0.com/docs/secure/tokens/token-vault/connected-accounts-for-token-vault).
 
-<Callout>
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), authenticate the user with the target organization before initiating the Connected Accounts flow. Token Vault still stores the connected account on the user's Auth0 profile, so each organization member authorizes their own external account.
 </Callout>
 

--- a/auth4genai/integrations/slack.mdx
+++ b/auth4genai/integrations/slack.mdx
@@ -79,11 +79,15 @@ Connect your AI Agents to Slack for team communication and workflow automation.
   </Step>
 </Steps>
 
+<Note>
+If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), have the user sign in to the correct organization before you initiate the Connected Accounts flow. Token Vault still stores the Slack connected account on the user's Auth0 profile, so each organization member authorizes their own Slack account.
+</Note>
+
 <IntegrationInfoBlock providerName="Slack" />
 
 ## Token Vault configuration Example
 
-To configure the Token Vault for your GitHub connection, you can use the following code snippet in your application:
+To configure the Token Vault for your Slack connection, you can use the following code snippet in your application:
 
 <TokenVaultConfigBlock
   providerName="Slack"

--- a/auth4genai/integrations/slack.mdx
+++ b/auth4genai/integrations/slack.mdx
@@ -79,9 +79,9 @@ Connect your AI Agents to Slack for team communication and workflow automation.
   </Step>
 </Steps>
 
-<Note>
-If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), have the user sign in to the correct organization before you initiate the Connected Accounts flow. Token Vault still stores the Slack connected account on the user's Auth0 profile, so each organization member authorizes their own Slack account.
-</Note>
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), authenticate the user with the target organization before initiating the Connected Accounts flow. Token Vault still stores the Slack connected account on the user's Auth0 profile, so each organization member authorizes their own Slack account.
+</Callout>
 
 <IntegrationInfoBlock providerName="Slack" />
 

--- a/auth4genai/intro/call-others-apis-on-users-behalf.mdx
+++ b/auth4genai/intro/call-others-apis-on-users-behalf.mdx
@@ -13,9 +13,9 @@ permalink: "/intro/call-others-apis-on-users-behalf"
 
 In a typical scenario, a user interacts with a frontend application (e.g., a chatbot interface). This frontend communicates with a secure backend service, often a Backend for Frontend (BFF) or an agent, which is responsible for calling the external API. Such applications can use refresh tokens for long-lived sessions and use the same refresh tokens to securely call external APIs on the user's behalf via Token Vault.
 
-<Note>
-If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), the user still signs in to the target organization before authorizing the external provider through Connected Accounts. Organizations determine the session context, but Token Vault still exchanges tokens for the individual signed-in user.
-</Note>
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), authenticate the user with the target organization before authorizing the external provider through Connected Accounts. Organizations determine the session context, but Token Vault still exchanges tokens for the individual signed-in user.
+</Callout>
 
 <Frame caption="Token Vault using Refresh Tokens">
   <img

--- a/auth4genai/intro/call-others-apis-on-users-behalf.mdx
+++ b/auth4genai/intro/call-others-apis-on-users-behalf.mdx
@@ -13,6 +13,10 @@ permalink: "/intro/call-others-apis-on-users-behalf"
 
 In a typical scenario, a user interacts with a frontend application (e.g., a chatbot interface). This frontend communicates with a secure backend service, often a Backend for Frontend (BFF) or an agent, which is responsible for calling the external API. Such applications can use refresh tokens for long-lived sessions and use the same refresh tokens to securely call external APIs on the user's behalf via Token Vault.
 
+<Note>
+If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), the user still signs in to the target organization before authorizing the external provider through Connected Accounts. Organizations determine the session context, but Token Vault still exchanges tokens for the individual signed-in user.
+</Note>
+
 <Frame caption="Token Vault using Refresh Tokens">
   <img
     className="hidden dark:block"

--- a/auth4genai/intro/integrations.mdx
+++ b/auth4genai/intro/integrations.mdx
@@ -52,9 +52,9 @@ Auth0 provides a large number of Connection types for use with your AI Agents, i
 
 To enable your AI agents to call APIs on a user’s behalf, you will need to:
 
-<Note>
-If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), configure the Connection the same way, then have the user sign in to the correct organization before you initiate the Connected Accounts flow. The connected account and stored tokens remain tied to the user's Auth0 profile.
-</Note>
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), configure the connection, then authenticate the user with the target organization before initiating the Connected Accounts flow. The connected account and stored tokens remain linked to the user's Auth0 profile.
+</Callout>
 
 <Steps>
   <Step title="Obtain client credentials">

--- a/auth4genai/intro/integrations.mdx
+++ b/auth4genai/intro/integrations.mdx
@@ -52,6 +52,10 @@ Auth0 provides a large number of Connection types for use with your AI Agents, i
 
 To enable your AI agents to call APIs on a user’s behalf, you will need to:
 
+<Note>
+If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), configure the Connection the same way, then have the user sign in to the correct organization before you initiate the Connected Accounts flow. The connected account and stored tokens remain tied to the user's Auth0 profile.
+</Note>
+
 <Steps>
   <Step title="Obtain client credentials">
     To enable your application to call APIs on a user’s behalf, you will need to

--- a/auth4genai/intro/token-vault.mdx
+++ b/auth4genai/intro/token-vault.mdx
@@ -45,7 +45,7 @@ The AI Agent then fetches the stored credentials in Token Vault to interact with
 
 ## Using Token Vault with Organizations
 
-If your B2B application uses [Organizations](https://auth0.com/docs/manage-users/organizations), authenticate the user in the target organization first and then initiate the Connected Accounts flow for the external provider you want to use.
+If your B2B application uses [Organizations](https://auth0.com/docs/manage-users/organizations), authenticate the user with the target organization first and then initiate the Connected Accounts flow for the external provider you want to use.
 
 When you use Organizations with Token Vault:
 
@@ -74,7 +74,7 @@ By using Token Vault, you can:
 
 The process of using Token Vault involves the following key steps:
 
-1. **User authentication and consent:** The user authenticates to your application first. If your application uses Organizations, the user signs in to the target organization before continuing. The AI agent then triggers the Connected Accounts flow, which redirects the user to authenticate with an external Identity Provider (for example, Google). The user grants your application permission to access their data by approving the requested OAuth scopes. Upon completion, the external account is added to the user profile.
+1. **User authentication and consent:** The user authenticates to your application first. If your application uses Organizations, the user signs in to the target organization before continuing. The AI agent then triggers the Connected Accounts flow, which redirects the user to authenticate with an external identity provider (for example, Google). The user grants your application permission to access their data by approving the requested OAuth scopes. Upon completion, the external account is added to the user profile.
 2. **Secure token storage:** Auth0 receives access and refresh tokens from the external provider and stores them securely within Token Vault.
 3. **Token exchange:** Your application can then exchange a valid Auth0 refresh token or access token for an external provider's access token from Token Vault. This allows your application to obtain the necessary credentials to call external APIs without the user having to re-authenticate. It also means your application does not need to store or manage any credentials.
 4. **API call:** With the external provider's access token, your AI agent can make authorized calls to the external API on the user's behalf.

--- a/auth4genai/intro/token-vault.mdx
+++ b/auth4genai/intro/token-vault.mdx
@@ -16,7 +16,7 @@ For example, a sales assistant AI agent might need to:
 - Access a user's documents to summarize them.
 - Connect to a CRM like Salesforce to retrieve customer information.
 
-You can securely access external APIs on the user's behalf using Auth0's **Token Vault**. Once an AI agent has authenticated a user with a supported external provider, the user is prompted to authorize the connection and connect their external account. With the user's consent, the AI agent can initiate a [Connect Account flow](https://auth0.com/docs/secure/tokens/token-vault/connected-accounts-for-token-vault#how-it-works), linking the user profile to external services like Google, GitHub, Slack, and more.
+You can securely access external APIs on the user's behalf using Auth0's **Token Vault**. Once your application has authenticated a user, including when the user signs in through an Auth0 Organization, the user is prompted to authorize the connection and connect their external account. With the user's consent, the AI agent can initiate a [Connect Account flow](https://auth0.com/docs/secure/tokens/token-vault/connected-accounts-for-token-vault#how-it-works), linking the user profile to external services like Google, GitHub, Slack, and more.
 
 Once the external account has been successfully connected, the AI agent can fetch the stored credentials in Token Vault to access external APIs on the user's behalf. For example, the user can provide consent for your AI agent to access their Google Calendar to view their schedule or set up meetings, or their Salesforce account to retrieve customer information.
 
@@ -43,6 +43,16 @@ Once a user successfully connects and authorizes access to a supported external 
 
 The AI Agent then fetches the stored credentials in Token Vault to interact with external APIs on the user’s behalf.
 
+## Using Token Vault with Organizations
+
+If your B2B application uses [Organizations](https://auth0.com/docs/manage-users/organizations), authenticate the user in the target organization first and then initiate the Connected Accounts flow for the external provider you want to use.
+
+When you use Organizations with Token Vault:
+
+- Organizations define the login, branding, and access policy context for the session.
+- Connected Accounts still link the external provider to the individual Auth0 user profile.
+- Each organization member connects and authorizes their own external account; Token Vault does not create a shared organization account.
+
 ## What is Token Vault
 
 Auth0's Token Vault is a secure service for storing and managing tokens for external services. Your AI agents can use the access tokens from Token Vault to call external APIs on behalf of your users. This capability is essential for building trustworthy AI agents that can securely interact with services from external providers, such as Google, Microsoft, Salesforce, or any other API provider that uses OAuth 2.0.
@@ -64,7 +74,7 @@ By using Token Vault, you can:
 
 The process of using Token Vault involves the following key steps:
 
-1. **User authentication and consent:** The AI agent triggers the Connected Accounts flow, which redirects the user to authenticate with an external Identity Provider (e.g., Google. The user then grants your application permission to access their data by approving the requested OAuth scopes.  Upon completion, the external account is added to the user profile.
+1. **User authentication and consent:** The user authenticates to your application first. If your application uses Organizations, the user signs in to the target organization before continuing. The AI agent then triggers the Connected Accounts flow, which redirects the user to authenticate with an external Identity Provider (for example, Google). The user grants your application permission to access their data by approving the requested OAuth scopes. Upon completion, the external account is added to the user profile.
 2. **Secure token storage:** Auth0 receives access and refresh tokens from the external provider and stores them securely within Token Vault.
 3. **Token exchange:** Your application can then exchange a valid Auth0 refresh token or access token for an external provider's access token from Token Vault. This allows your application to obtain the necessary credentials to call external APIs without the user having to re-authenticate. It also means your application does not need to store or manage any credentials.
 4. **API call:** With the external provider's access token, your AI agent can make authorized calls to the external API on the user's behalf.

--- a/auth4genai/snippets/how-tos/account-linking.mdx
+++ b/auth4genai/snippets/how-tos/account-linking.mdx
@@ -2,4 +2,11 @@
 
 If you're integrating with {props.connectionLabel || "any Identity Provider"}, but users in your app or agent can sign in using other methods (e.g., a username and password or another social provider), you'll need to link these identities into a single user account. Auth0 refers to this process as [Account Linking](https://auth0.com/docs/manage-users/user-accounts/user-account-linking).
 
+Account Linking is separate from [Connected Accounts for Token Vault](https://auth0.com/docs/secure/tokens/token-vault/connected-accounts-for-token-vault):
+
+- Account Linking merges multiple Auth0 identities into one user profile for sign-in.
+- Connected Accounts for Token Vault lets that signed-in user authorize an external provider so Auth0 can store the provider's tokens in Token Vault.
+
+If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), sign the user in to the correct organization before you start the Connected Accounts flow. Organizations define the session context; they do not create a shared external account for the organization.
+
 **Account Linking** logic and handling will vary depending on your app or agent. You can find an example of how to implement it in a Next.js chatbot app [here](https://github.com/auth0-lab/market0/blob/main/app/api/auth/%5Bauth0%5D/route.ts#L43). If you have questions or are looking for best practices, [join our Discord](http://discord.gg/XbQpZSF2Ys) and ask in the `#auth0-for-gen-ai` channel.

--- a/auth4genai/snippets/how-tos/account-linking.mdx
+++ b/auth4genai/snippets/how-tos/account-linking.mdx
@@ -5,8 +5,8 @@ If you're integrating with {props.connectionLabel || "any Identity Provider"}, b
 Account Linking is separate from [Connected Accounts for Token Vault](https://auth0.com/docs/secure/tokens/token-vault/connected-accounts-for-token-vault):
 
 - Account Linking merges multiple Auth0 identities into one user profile for sign-in.
-- Connected Accounts for Token Vault lets that signed-in user authorize an external provider so Auth0 can store the provider's tokens in Token Vault.
+- Connected Accounts for Token Vault allows that signed-in user to authorize an external provider so Auth0 can store the provider's tokens in Token Vault.
 
-If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), sign the user in to the correct organization before you start the Connected Accounts flow. Organizations define the session context; they do not create a shared external account for the organization.
+If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), authenticate the user with the target organization before initiating the Connected Accounts flow. Organizations define the session context; they do not create a shared external account for the organization.
 
 **Account Linking** logic and handling will vary depending on your app or agent. You can find an example of how to implement it in a Next.js chatbot app [here](https://github.com/auth0-lab/market0/blob/main/app/api/auth/%5Bauth0%5D/route.ts#L43). If you have questions or are looking for best practices, [join our Discord](http://discord.gg/XbQpZSF2Ys) and ask in the `#auth0-for-gen-ai` channel.

--- a/auth4genai/snippets/integrations/NextStepsBlock.mdx
+++ b/auth4genai/snippets/integrations/NextStepsBlock.mdx
@@ -1,4 +1,5 @@
 ## Next steps
 
 - To learn how to configure applications to access Token Vault, read [Configure Token Vault](https://auth0.com/docs/secure/tokens/token-vault/configure-token-vault).
+- If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), sign the user in to the correct organization before you initiate the Connected Accounts flow. Connected accounts remain tied to the individual user profile.
 - To learn how to get an access token to make a tool call, complete the [Call other's APIs on user's behalf Quickstart](https://auth0.com/ai/docs/get-started/call-others-apis-on-users-behalf).

--- a/auth4genai/snippets/integrations/NextStepsBlock.mdx
+++ b/auth4genai/snippets/integrations/NextStepsBlock.mdx
@@ -1,5 +1,5 @@
 ## Next steps
 
 - To learn how to configure applications to access Token Vault, read [Configure Token Vault](https://auth0.com/docs/secure/tokens/token-vault/configure-token-vault).
-- If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), sign the user in to the correct organization before you initiate the Connected Accounts flow. Connected accounts remain tied to the individual user profile.
+- If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), authenticate the user with the target organization before initiating the Connected Accounts flow. Connected accounts remain linked to the individual user profile.
 - To learn how to get an access token to make a tool call, complete the [Call other's APIs on user's behalf Quickstart](https://auth0.com/ai/docs/get-started/call-others-apis-on-users-behalf).

--- a/auth4genai/snippets/integrations/learn-more.mdx
+++ b/auth4genai/snippets/integrations/learn-more.mdx
@@ -1,4 +1,5 @@
 ## Learn more
 
 - Auth0 stores the access and refresh tokens for each connected account in the [Token Vault](https://auth0.com/docs/secure/tokens/token-vault). Applications can then access the Token Vault to retrieve access tokens to call external APIs. To learn more, read [Configure Token Vault](https://auth0.com/docs/secure/tokens/token-vault/configure-token-vault).
+- If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), sign the user in to the correct organization before you initiate the Connected Accounts flow. Each user still connects their own external account.
 - Learn how to get an access token to make a tool call by completing the [Call other's APIs on user's behalf quickstart](/get-started/call-others-apis-on-users-behalf).

--- a/auth4genai/snippets/integrations/learn-more.mdx
+++ b/auth4genai/snippets/integrations/learn-more.mdx
@@ -1,5 +1,5 @@
 ## Learn more
 
 - Auth0 stores the access and refresh tokens for each connected account in the [Token Vault](https://auth0.com/docs/secure/tokens/token-vault). Applications can then access the Token Vault to retrieve access tokens to call external APIs. To learn more, read [Configure Token Vault](https://auth0.com/docs/secure/tokens/token-vault/configure-token-vault).
-- If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), sign the user in to the correct organization before you initiate the Connected Accounts flow. Each user still connects their own external account.
+- If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), authenticate the user with the target organization before initiating the Connected Accounts flow. Each user still connects their own external account.
 - Learn how to get an access token to make a tool call by completing the [Call other's APIs on user's behalf quickstart](/get-started/call-others-apis-on-users-behalf).

--- a/auth4genai/snippets/integrations/next-step.mdx
+++ b/auth4genai/snippets/integrations/next-step.mdx
@@ -1,4 +1,5 @@
 ## Next steps
 
 - To learn how to configure applications to access Token Vault, read [Configure Token Vault](https://auth0.com/docs/secure/tokens/token-vault/configure-token-vault).
+- If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), sign the user in to the correct organization before you initiate the Connected Accounts flow. Connected accounts remain tied to the individual user profile.
 - To learn how to get an access token to make a tool call, complete the [Call other's APIs on user's behalf Quickstart](https://auth0.com/ai/docs/get-started/call-others-apis-on-users-behalf).

--- a/auth4genai/snippets/integrations/next-step.mdx
+++ b/auth4genai/snippets/integrations/next-step.mdx
@@ -1,5 +1,5 @@
 ## Next steps
 
 - To learn how to configure applications to access Token Vault, read [Configure Token Vault](https://auth0.com/docs/secure/tokens/token-vault/configure-token-vault).
-- If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), sign the user in to the correct organization before you initiate the Connected Accounts flow. Connected accounts remain tied to the individual user profile.
+- If your application uses [Organizations](https://auth0.com/docs/manage-users/organizations), authenticate the user with the target organization before initiating the Connected Accounts flow. Connected accounts remain linked to the individual user profile.
 - To learn how to get an access token to make a tool call, complete the [Call other's APIs on user's behalf Quickstart](https://auth0.com/ai/docs/get-started/call-others-apis-on-users-behalf).

--- a/main/docs/secure/call-apis-on-users-behalf/token-vault.mdx
+++ b/main/docs/secure/call-apis-on-users-behalf/token-vault.mdx
@@ -49,7 +49,7 @@ When a user connects with a supported external provider and authorizes the conne
 
 ## Use with Organizations
 
-If your application uses [Organizations](/docs/manage-users/organizations), authenticate the user in the target organization first and then initiate the Connected Accounts flow for the external provider you want to use.
+If your application uses [Organizations](/docs/manage-users/organizations), authenticate the user with the target organization first and then initiate the Connected Accounts flow for the external provider you want to use.
 
 When you use Organizations with Token Vault:
 

--- a/main/docs/secure/call-apis-on-users-behalf/token-vault.mdx
+++ b/main/docs/secure/call-apis-on-users-behalf/token-vault.mdx
@@ -47,6 +47,16 @@ When a user connects with a supported external provider and authorizes the conne
 * The application calls Auth0 to exchange a user’s valid Auth0 token for an external provider’s access token, issued to that user. To learn more, read [Supported token exchanges](#supported-token-exchanges).
 * Using the external provider’s access token, your application can then call external APIs on the user's behalf.
 
+## Use with Organizations
+
+If your application uses [Organizations](/docs/manage-users/organizations), authenticate the user in the target organization first and then initiate the Connected Accounts flow for the external provider you want to use.
+
+When you use Organizations with Token Vault:
+
+- Organizations define the login, branding, and access policy context for the session.
+- Connected Accounts still link the external provider to the individual Auth0 user profile.
+- Each organization member connects and authorizes their own external account; Token Vault does not create a shared organization account.
+
 ## Supported token exchanges
 
 To call an external provider’s APIs, your application must exchange a valid Auth0 token for an external provider’s access token from Token Vault. The type of Auth0 token used for the exchange depends on your client application type and use case.

--- a/main/docs/secure/call-apis-on-users-behalf/token-vault/access-token-exchange-with-token-vault.mdx
+++ b/main/docs/secure/call-apis-on-users-behalf/token-vault/access-token-exchange-with-token-vault.mdx
@@ -36,7 +36,7 @@ Before getting started, you must [configure the access token exchange with Token
 ## Step 1: Connect and authorize access
 
 To schedule the meeting, the SPA needs to connect with Google via Auth0 and then receive the user’s permission to access the Google Calendar API.
-The user logs into the application via Google with the [Connected Accounts flow](/docs/secure/tokens/token-vault/connected-accounts-for-token-vault#how-it-works), which uses the [My Account API](/docs/manage-users/my-account-api).
+The user logs into the application via Google with the [Connected Accounts flow](/docs/secure/tokens/token-vault/connected-accounts-for-token-vault#how-it-works), which uses the [My Account API](/docs/manage-users/my-account-api). If the application uses [Organizations](/docs/manage-users/organizations), the user signs in to the target organization before continuing.
 
 After the My Account API validates and completes the Connected Accounts request, it stores the Google access and refresh tokens with the requested calendar scopes in the Token Vault.
 

--- a/main/docs/secure/call-apis-on-users-behalf/token-vault/access-token-exchange-with-token-vault.mdx
+++ b/main/docs/secure/call-apis-on-users-behalf/token-vault/access-token-exchange-with-token-vault.mdx
@@ -36,7 +36,7 @@ Before getting started, you must [configure the access token exchange with Token
 ## Step 1: Connect and authorize access
 
 To schedule the meeting, the SPA needs to connect with Google via Auth0 and then receive the user’s permission to access the Google Calendar API.
-The user logs into the application via Google with the [Connected Accounts flow](/docs/secure/tokens/token-vault/connected-accounts-for-token-vault#how-it-works), which uses the [My Account API](/docs/manage-users/my-account-api). If the application uses [Organizations](/docs/manage-users/organizations), the user signs in to the target organization before continuing.
+The user logs in to the application via Google with the [Connected Accounts flow](/docs/secure/tokens/token-vault/connected-accounts-for-token-vault#how-it-works), which uses the [My Account API](/docs/manage-users/my-account-api). If the application uses [Organizations](/docs/manage-users/organizations), the user signs in to the target organization before continuing.
 
 After the My Account API validates and completes the Connected Accounts request, it stores the Google access and refresh tokens with the requested calendar scopes in the Token Vault.
 

--- a/main/docs/secure/call-apis-on-users-behalf/token-vault/configure-token-vault.mdx
+++ b/main/docs/secure/call-apis-on-users-behalf/token-vault/configure-token-vault.mdx
@@ -26,7 +26,7 @@ If you need to trigger MFA challenges for interactive flows, enable **Customize 
 Connected Accounts for Token Vault manages a unified Auth0 user profile linked to multiple external accounts. Your application then fetches the stored credentials in Token Vault to interact with external APIs on the user’s behalf.
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-If your application uses [Organizations](/docs/manage-users/organizations), configure the connection the same way, then have the user sign in to the correct organization before you initiate the Connected Accounts flow. The connected account and stored tokens remain tied to the user’s Auth0 profile.
+If your application uses [Organizations](/docs/manage-users/organizations), configure the connection, then authenticate the user with the target organization before initiating the Connected Accounts flow. The connected account and stored tokens remain tied to the user’s Auth0 profile.
 </Callout>
 
 You can configure Connected Accounts for supported social and enterprise connections. To learn more, read [Configure Connected Accounts](/docs/secure/tokens/token-vault/connected-accounts-for-token-vault#configure-connected-accounts).

--- a/main/docs/secure/call-apis-on-users-behalf/token-vault/configure-token-vault.mdx
+++ b/main/docs/secure/call-apis-on-users-behalf/token-vault/configure-token-vault.mdx
@@ -25,6 +25,10 @@ If you need to trigger MFA challenges for interactive flows, enable **Customize 
 
 Connected Accounts for Token Vault manages a unified Auth0 user profile linked to multiple external accounts. Your application then fetches the stored credentials in Token Vault to interact with external APIs on the user’s behalf.
 
+<Note>
+If your application uses [Organizations](/docs/manage-users/organizations), configure the connection the same way, then have the user sign in to the correct organization before you initiate the Connected Accounts flow. The connected account and stored tokens remain tied to the user’s Auth0 profile.
+</Note>
+
 You can configure Connected Accounts for supported social and enterprise connections. To learn more, read [Configure Connected Accounts](/docs/secure/tokens/token-vault/connected-accounts-for-token-vault#configure-connected-accounts).
 
 ## Configure application

--- a/main/docs/secure/call-apis-on-users-behalf/token-vault/configure-token-vault.mdx
+++ b/main/docs/secure/call-apis-on-users-behalf/token-vault/configure-token-vault.mdx
@@ -25,9 +25,9 @@ If you need to trigger MFA challenges for interactive flows, enable **Customize 
 
 Connected Accounts for Token Vault manages a unified Auth0 user profile linked to multiple external accounts. Your application then fetches the stored credentials in Token Vault to interact with external APIs on the user’s behalf.
 
-<Note>
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 If your application uses [Organizations](/docs/manage-users/organizations), configure the connection the same way, then have the user sign in to the correct organization before you initiate the Connected Accounts flow. The connected account and stored tokens remain tied to the user’s Auth0 profile.
-</Note>
+</Callout>
 
 You can configure Connected Accounts for supported social and enterprise connections. To learn more, read [Configure Connected Accounts](/docs/secure/tokens/token-vault/connected-accounts-for-token-vault#configure-connected-accounts).
 

--- a/main/docs/secure/call-apis-on-users-behalf/token-vault/connected-accounts-for-token-vault.mdx
+++ b/main/docs/secure/call-apis-on-users-behalf/token-vault/connected-accounts-for-token-vault.mdx
@@ -37,9 +37,9 @@ The Connected Accounts flow uses the [My Account API](/docs/manage-users/my-acco
 
 Before the user can initiate a Connected Accounts request from the client application, the client application needs to [get an access token](/docs/manage-users/my-account-api#get-an-access-token) with the Connected Accounts scopes to access the My Account API.
 
-<Note>
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 If your application uses [Organizations](/docs/manage-users/organizations), have the user sign in to the correct organization before you initiate the Connected Accounts flow. Token Vault stores the connected account on the user's Auth0 profile, so each organization member connects and authorizes their own external account.
-</Note>
+</Callout>
 
 The following sequence diagram illustrates the end-to-end Connected Accounts flow:
 

--- a/main/docs/secure/call-apis-on-users-behalf/token-vault/connected-accounts-for-token-vault.mdx
+++ b/main/docs/secure/call-apis-on-users-behalf/token-vault/connected-accounts-for-token-vault.mdx
@@ -37,6 +37,10 @@ The Connected Accounts flow uses the [My Account API](/docs/manage-users/my-acco
 
 Before the user can initiate a Connected Accounts request from the client application, the client application needs to [get an access token](/docs/manage-users/my-account-api#get-an-access-token) with the Connected Accounts scopes to access the My Account API.
 
+<Note>
+If your application uses [Organizations](/docs/manage-users/organizations), have the user sign in to the correct organization before you initiate the Connected Accounts flow. Token Vault stores the connected account on the user's Auth0 profile, so each organization member connects and authorizes their own external account.
+</Note>
+
 The following sequence diagram illustrates the end-to-end Connected Accounts flow:
 
 <Frame>![](/docs/images/token-vault/connected_accounts_flow_diagram.png)</Frame>

--- a/main/docs/secure/call-apis-on-users-behalf/token-vault/connected-accounts-for-token-vault.mdx
+++ b/main/docs/secure/call-apis-on-users-behalf/token-vault/connected-accounts-for-token-vault.mdx
@@ -38,7 +38,7 @@ The Connected Accounts flow uses the [My Account API](/docs/manage-users/my-acco
 Before the user can initiate a Connected Accounts request from the client application, the client application needs to [get an access token](/docs/manage-users/my-account-api#get-an-access-token) with the Connected Accounts scopes to access the My Account API.
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-If your application uses [Organizations](/docs/manage-users/organizations), have the user sign in to the correct organization before you initiate the Connected Accounts flow. Token Vault stores the connected account on the user's Auth0 profile, so each organization member connects and authorizes their own external account.
+If your application uses [Organizations](/docs/manage-users/organizations), authenticate the user with the target organization before initiating the Connected Accounts flow. Token Vault stores the connected account on the user's Auth0 profile, so each organization member connects and authorizes their own external account.
 </Callout>
 
 The following sequence diagram illustrates the end-to-end Connected Accounts flow:

--- a/main/docs/secure/call-apis-on-users-behalf/token-vault/refresh-token-exchange-with-token-vault.mdx
+++ b/main/docs/secure/call-apis-on-users-behalf/token-vault/refresh-token-exchange-with-token-vault.mdx
@@ -29,7 +29,7 @@ Before getting started, you must [configure the refresh token exchange with Toke
 
 To schedule the meeting, the web application needs to connect with Google via Auth0 and then receive the user’s permission to access the Google Calendar API.
 
-The user logs into the application via Google with the [Connected Accounts flow](/docs/secure/tokens/token-vault/connected-accounts-for-token-vault#how-it-works), which uses the [My Account API](/docs/manage-users/my-account-api). If the application uses [Organizations](/docs/manage-users/organizations), the user signs in to the target organization before continuing. After the My Account API validates and completes the Connected Accounts request, it stores the Google access and refresh tokens with the requested calendar scopes in the Token Vault.
+The user logs in to the application via Google with the [Connected Accounts flow](/docs/secure/tokens/token-vault/connected-accounts-for-token-vault#how-it-works), which uses the [My Account API](/docs/manage-users/my-account-api). If the application uses [Organizations](/docs/manage-users/organizations), the user signs in to the target organization before continuing. After the My Account API validates and completes the Connected Accounts request, it stores the Google access and refresh tokens with the requested calendar scopes in the Token Vault.
 
 ## Step 2: Perform refresh token exchange
 

--- a/main/docs/secure/call-apis-on-users-behalf/token-vault/refresh-token-exchange-with-token-vault.mdx
+++ b/main/docs/secure/call-apis-on-users-behalf/token-vault/refresh-token-exchange-with-token-vault.mdx
@@ -29,7 +29,7 @@ Before getting started, you must [configure the refresh token exchange with Toke
 
 To schedule the meeting, the web application needs to connect with Google via Auth0 and then receive the user’s permission to access the Google Calendar API.
 
-The user logs into the application via Google with the [Connected Accounts flow](/docs/secure/tokens/token-vault/connected-accounts-for-token-vault#how-it-works), which uses the [My Account API](/docs/manage-users/my-account-api). After the My Account API validates and completes the Connected Accounts request, it stores the Google access and refresh tokens with the requested calendar scopes in the Token Vault.
+The user logs into the application via Google with the [Connected Accounts flow](/docs/secure/tokens/token-vault/connected-accounts-for-token-vault#how-it-works), which uses the [My Account API](/docs/manage-users/my-account-api). If the application uses [Organizations](/docs/manage-users/organizations), the user signs in to the target organization before continuing. After the My Account API validates and completes the Connected Accounts request, it stores the Google access and refresh tokens with the requested calendar scopes in the Token Vault.
 
 ## Step 2: Perform refresh token exchange
 


### PR DESCRIPTION
feat: add organization authentication notes for Connected Accounts flow

## Description

The changes add extra information on how organizations affect the connected accounts/token vault flows

---

### 1. Token Vault — Intro paragraph rewording

**File:** `auth4genai/intro/token-vault.mdx`

The intro now says _"including when the user signs in through an Auth0 Organization"_ instead of _"Once an AI agent has authenticated a user with a supported external provider"_.

| Before | After |
|--------|-------|
| <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/3902bc37-29b6-4ebd-b309-1152c68c04a9" /> | <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/1fb40ff8-15c7-40ac-a6ff-f63f219661f9" /> |

---

### 2. Token Vault — New "Using Token Vault with Organizations" section

**File:** `auth4genai/intro/token-vault.mdx`

A new section was added between the flow description and "What is Token Vault". It explains that Organizations define session context, Connected Accounts link to the individual user profile, and Token Vault does not create a shared organization account.

| Before | After |
|--------|-------|
| <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/5b68fcb9-f25a-4016-9b82-d86aefb8d414" /> | <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/3a2ad6c2-7523-4174-9abd-e77c5e3960e2" /> |

---

### 3. Token Vault — "How it works" step 1 rewording

**File:** `auth4genai/intro/token-vault.mdx`

Step 1 now explains that the user authenticates to the application first (including via Organizations) before the AI agent triggers the Connected Accounts flow.

| Before | After |
|--------|-------|
| <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/ad39d018-4c66-4a48-b9a4-16e3d590ed66" /> | <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/42d53405-0a2a-4f7a-a02f-cca02cc75bf1" /> |

---

### 4. Integrations overview — New Note before Steps

**File:** `auth4genai/intro/integrations.mdx`

A `<Note>` was added before the setup Steps, telling org-enabled apps to configure the Connection the same way but have the user sign in to the correct organization first.

| Before | After |
|--------|-------|
| <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/1264549d-12a9-41a9-b3f0-e9bc594936e3" /> | <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/43c1328b-e8fd-4ac1-9450-596e1c1a9f37" /> |

---

### 5. Intro / Call Others' APIs — New Note after intro

**File:** `auth4genai/intro/call-others-apis-on-users-behalf.mdx`

A `<Note>` clarifies that Organizations affect session context, but Token Vault still exchanges tokens for the individual signed-in user.

| Before | After |
|--------|-------|
| <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/fdb17564-8584-47b6-a911-1d0d33312857" /> | <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/fb245043-4edb-456c-95db-dd33b58f7e1b" /> |

---

### 6. Get Started / Call Others' APIs — New Note before quickstart

**File:** `auth4genai/get-started/call-others-apis-on-users-behalf.mdx`

A `<Note>` tells org-enabled readers to authenticate in the target organization before initiating the Connected Accounts flow.

| Before | After |
|--------|-------|
| <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/dda0fb83-8f74-4f89-9866-d78bdfa45866" /> | <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/63c25350-ff0f-48c8-8883-21fb8399dc6a" /> |

---

### 7-9. How-To pages — Account Linking section replaced with shared snippet

**Files:** `check-google-calendar-availability.mdx`, `list-github-repositories.mdx`, `list-slack-channels.mdx`

The inline Account Linking text was replaced with `<AccountLinking connectionLabel="Google|GitHub|Slack" />` from the shared snippet `snippets/how-tos/account-linking.mdx`.

The new snippet adds:
- A clarification that Account Linking (merging Auth0 identities) is separate from Connected Accounts for Token Vault (authorizing external providers)
- An Organizations note: sign the user in to the correct organization before starting the Connected Accounts flow

**Before** (shown below — old inline text on all three pages):

| Google Calendar | GitHub | Slack |
|-----------------|--------|-------|
| <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/13792406-e934-4eaf-b262-a7dbbaac5d3d" /> | <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/ceb97911-1d4c-4a28-b2ca-190520e42d4f" /> | <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/b78b2f01-bac9-4247-a1f6-7d94445ec61c" /> |

---

### 10. Google Integration — New Organization Note

**File:** `auth4genai/integrations/google.mdx`

A `<Note>` was added after the setup Steps, before "Test connection", explaining that each organization member authorizes their own Google account.

| Before | After |
|--------|-------|
| <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/ccbf3701-a60f-4b05-97bf-773d81202f45" /> | <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/e1542941-5c9d-4f50-8daf-0edad190eac3" /> |

---

### 11. GitHub Integration — New Organization Note

**File:** `auth4genai/integrations/github.mdx`

Same pattern: `<Note>` added after Steps, before "Token Vault configuration Example".

| Before | After |
|--------|-------|
| <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/91a6f644-ad56-4300-bf85-802e32afa9bc" /> | <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/9e5953ab-48b3-431a-b838-4935c5229fa5" /> |

---

### 12. Slack Integration — New Organization Note + text fix

**File:** `auth4genai/integrations/slack.mdx`

`<Note>` added after Steps. Also fixes a copy-paste bug: the Token Vault config text previously said "GitHub" instead of "Slack".

| Before | After |
|--------|-------|
| <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/fefb9ed0-7867-40f1-8a67-10083601e85a" /> | <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/d8b0c95c-c10b-4be8-87bf-4c9c27f901dd" /> |

---

### 13. OAuth2 Integration — New Organization Note

**File:** `auth4genai/integrations/oauth2.mdx`

`<Note>` added before "Learn more", explaining the org-aware setup pattern for custom OAuth2 connections.

| Before | After |
|--------|-------|
| <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/9fa5170c-7250-449d-8bd3-eed0bd951767" /> | <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/498e6de3-b897-424a-870e-4734acd3d908" /> |

---

### Shared snippets (propagate through includes)

These snippets are included in the pages above:

| Snippet | Change |
|---------|--------|
| `snippets/how-tos/account-linking.mdx` | Expanded: Account Linking vs Connected Accounts clarification + Organizations note |
| `snippets/integrations/learn-more.mdx` | New bullet: sign in to correct org before Connected Accounts |
| `snippets/integrations/NextStepsBlock.mdx` | New bullet: Organizations + Connected Accounts note |
| `snippets/integrations/next-step.mdx` | New bullet: Organizations + Connected Accounts note |

---
## Changes in `docs/main`
---

### 1. Token Vault Overview — New "Use with Organizations" section

**File:** `main/docs/secure/call-apis-on-users-behalf/token-vault.mdx`

A new section was added between "How it works" and "Supported token exchanges". It explains that Organizations define the session context, Connected Accounts link to the individual user profile, and Token Vault does not create a shared organization account.

| Before | After |
|--------|-------|
| <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/68b95c2e-d0c8-4ad4-ae2c-e050a20ee506" /> | <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/96267359-b182-40e0-8301-414b418e783f" /> | 

---

### 2. Connected Accounts for Token Vault — New Note in "How it works"

**File:** `main/docs/secure/call-apis-on-users-behalf/token-vault/connected-accounts-for-token-vault.mdx`

A `<Note>` was added in the "How it works" section, before the flow diagram, advising users to sign in to the correct organization before initiating the Connected Accounts flow.

| Before | After |
|--------|-------|
| <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/70b63925-0b19-426b-9b45-02363ef19092" /> | <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/c7d01752-6c65-441e-9798-359394f49367" /> |

---

### 3. Configure Token Vault — New Note in "Configure Connected Accounts"

**File:** `main/docs/secure/call-apis-on-users-behalf/token-vault/configure-token-vault.mdx`

A `<Note>` was added in the "Configure Connected Accounts for Token Vault" section explaining that the connection is configured the same way, but the user must sign in to the correct organization first. Connected account and stored tokens remain tied to the user's Auth0 profile.

| Before | After |
|--------|-------|
| <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/bc4d5e57-2bc3-4a46-b490-9edbe6f7656e" /> | <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/adae3717-a456-4d8f-bbf9-1be9108c2eba" /> |

---

### 4. Refresh Token Exchange — Step 1 updated with org context

**File:** `main/docs/secure/call-apis-on-users-behalf/token-vault/refresh-token-exchange-with-token-vault.mdx`

Step 1 ("Connect and authorize access") now mentions that if the application uses Organizations, the user signs in to the target organization before continuing with the Connected Accounts flow.

| Before | After |
|--------|-------|
| <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/ae87b5eb-0d06-4e75-9f95-8e697a027563" /> | <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/4f879029-ea30-45d0-b353-094331da83aa" /> |

---

### 5. Access Token Exchange — Step 1 updated with org context

**File:** `main/docs/secure/call-apis-on-users-behalf/token-vault/access-token-exchange-with-token-vault.mdx`

Same pattern as the refresh token exchange: Step 1 now mentions that if the application uses Organizations, the user signs in to the target organization before continuing.

| Before | After |
|--------|-------|
| <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/6963e006-8658-45e2-b609-d2e37d52e127" /> | <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/ff162dfb-7d52-4509-95f3-ff50bea436a2" /> |

---

## Not changed

| File | Reason |
|------|--------|
| `privileged-worker-token-exchange-with-token-vault.mdx` | M2M/service worker flow where the user is not present in an interactive session — org sign-in guidance does not apply |

### References

[JIRA TICKET](https://auth0team.atlassian.net/browse/FGI-1909)

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
