### PR TITLE
fix: correct Expo quickstart callback URL format to use bundleIdentifier in path

### DIFF
--- a/main/docs/quickstart/native/react-native-expo/index.mdx
+++ b/main/docs/quickstart/native/react-native-expo/index.mdx
@@ -126,14 +126,14 @@ Your AI assistant will automatically create your Auth0 application, fetch creden
 
     **Allowed Callback URLs:**
     ```
-    auth0sample://{yourDomain}/ios/auth0sample/callback,
-    auth0sample://{yourDomain}/android/auth0sample/callback
+    auth0sample://{yourDomain}/ios/com.auth0.samples.expo/callback,
+    auth0sample://{yourDomain}/android/com.auth0.samples.expo/callback
     ```
 
     **Allowed Logout URLs:**
     ```
-    auth0sample://{yourDomain}/ios/auth0sample/callback,
-    auth0sample://{yourDomain}/android/auth0sample/callback
+    auth0sample://{yourDomain}/ios/com.auth0.samples.expo/callback,
+    auth0sample://{yourDomain}/android/com.auth0.samples.expo/callback
     ```
 
     Replace `{yourDomain}` with your actual Auth0 domain (e.g., `dev-abc123.us.auth0.com`).
@@ -143,11 +143,11 @@ Your AI assistant will automatically create your Auth0 application, fetch creden
 
       **Allowed Logout URLs** are essential for providing a seamless user experience upon signing out. Without a matching URL, users will not be redirected back to your application after logout and will instead be left on a generic Auth0 page.
 
-      The `customScheme` must match exactly with the value in your `app.json` plugin configuration.
+      The callback URL format is: `{customScheme}://{yourDomain}/{platform}/{bundleIdentifier or packageName}/callback`. The URL scheme uses the `customScheme` from your `app.json`, but the path always contains the `bundleIdentifier` (iOS) or `package` (Android) — not the custom scheme. If you don't specify a `customScheme`, the SDK defaults to `{bundleIdentifier}.auth0` / `{packageName}.auth0` as the URL scheme.
     </Info>
 
     <Warning>
-      **Important**: Ensure the `customScheme` in your callback URLs matches exactly with the value in your `app.json` plugin configuration. Mismatched values will cause authentication to fail.
+      **Important**: Ensure the `customScheme` in your callback URLs matches exactly with the value in your `app.json` plugin configuration, and that the path contains your actual `bundleIdentifier` (iOS) or `package` (Android). Mismatched values will cause authentication to fail.
     </Warning>
   </Step>
 


### PR DESCRIPTION
- Fixed callback URLs in the Expo quickstart that incorrectly used `customScheme` in the path component instead of                       
  `bundleIdentifier`/`packageName`                                                                                                         
- Updated the Info and Warning boxes to clearly explain the callback URL format   