### PR TITLE
fix: rename index page to actual directory root

### DIFF
--- a/main/config/navigation/en.json
+++ b/main/config/navigation/en.json
@@ -3737,7 +3737,7 @@
     {
       "tab": "Events Catalog",
       "pages": [
-        "docs/events/index",
+        "docs/events",
         {
           "group": " ",
           "pages": [

--- a/main/config/navigation/fr-ca.json
+++ b/main/config/navigation/fr-ca.json
@@ -3245,7 +3245,7 @@
     {
       "tab": "Events Catalog",
       "pages": [
-        "docs/fr-ca/events/index",
+        "docs/fr-ca/events",
         {
           "group": " ",
           "pages": [

--- a/main/config/navigation/ja-jp.json
+++ b/main/config/navigation/ja-jp.json
@@ -3244,7 +3244,7 @@
     {
       "tab": "Events Catalog",
       "pages": [
-        "docs/ja-jp/events/index",
+        "docs/ja-jp/events",
         {
           "group": " ",
           "pages": [


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

mintlify doesn't support implicit directory roots. having this file serves the page at `/docs/events/index` instead of `/docs/events`.


### References

restoring changes from https://github.com/auth0/docs-v2/pull/884#issuecomment-4194501718 lost in revert

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

page served at `/docs/events`.

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
