### PR TITLE
docs: fix 'good' password policy validation rule

### DIFF
--- a/main/docs/authenticate/database-connections/password-options.mdx
+++ b/main/docs/authenticate/database-connections/password-options.mdx
@@ -41,8 +41,8 @@ To enable or disable password policies from the Auth0 Dashboard:
 
     * **None**: Requires a non-empty password.
     * **Low**: Requires a character length you specify.
-    * **Fair**: All previous, and additionally requires a lower-case letter, an upper-case letter, and a number.
-    * **Good**: All previous, and additionally requires a special character (`!@#$%^&*`).
+    * **Fair**: All previous, and additionally requires a lowercase letter, an uppercase letter, and a number.
+    * **Good**: Additionally requires at least three of a lowercase letter, an uppercase letter, a number, and a special character (`!@#$%^&*`).
     * **Excellent**: All previous, and additionally requires there to be no more than 2 identical characters in a row.
 
 5. Click **Save**.


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

corrects the description of the 'good' password policy preset.

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

### References

DR-2763

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
