### PR TITLE
docs: document SAML assertion encryption algorithm options

### DIFF
--- a/main/docs/authenticate/protocols/saml/saml-sso-integrations/sign-and-encrypt-saml-requests.mdx
+++ b/main/docs/authenticate/protocols/saml/saml-sso-integrations/sign-and-encrypt-saml-requests.mdx
@@ -248,7 +248,7 @@ To configure signature validation:
 
 ### Send encrypted SAML authentication assertions
 
-If Auth0 is the SAML identity provider, you can use [Actions](/docs/customize/actions) to encrypt the SAML assertions it sends.
+If Auth0 is the SAML identity provider, you can use [Actions](/docs/customize/actions) to encrypt the SAML assertions it sends. You can also select the encryption algorithm used for assertion encryption. We recommend using `aes256-gcm` for a stronger security posture.
 
 You must obtain the certificate and the public key from the service provider. If you only got the certificate, you can derive the public key using `openssl`. Assuming that the certificate file is named `certificate.pem`, you can run:
 
@@ -271,6 +271,7 @@ exports.onExecutePostLogin = async (event, api) => {
 
     api.samlResponse.setEncryptionCert(encryptionCert);
     api.samlResponse.setEncryptionPublicKey(encryptionPublicKey);
+    api.samlResponse.setEncryptionAlgorithm("aes256-gcm");
   }
 };
 ```
@@ -280,10 +281,20 @@ exports.onExecutePostLogin = async (event, api) => {
 
 
 
-The following algorithms are used:
+The following algorithms are supported for assertion encryption:
 
-* [AES256](http://www.w3.org/2001/04/xmlenc#aes256-cbc) for assertion encryption
-* [RSA-OAEP](http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p) (including MGF1 and SHA1) for key transport
+* [aes256-gcm](http://www.w3.org/2001/04/xmlenc#aes256-gcm) **(Recommended)** — Authenticated encryption that provides both confidentiality and integrity. Resistant to format validity oracle attacks.
+* [aes256-cbc](http://www.w3.org/2001/04/xmlenc#aes256-cbc) — Current default. Does not provide integrity guarantees. Will be deprecated as the default in a future release.
+
+If you do not explicitly set an encryption algorithm using `setEncryptionAlgorithm`, Auth0 defaults to `aes256-cbc` and emits a deprecation warning in your tenant logs. Auth0 only emits this warning when no algorithm is explicitly selected. If you explicitly set the algorithm — even to `aes256-cbc` — no warning is emitted.
+
+We recommend using `setEncryptionAlgorithm` now to explicitly set your preferred algorithm, even if you are not ready to migrate to `aes256-gcm`. This suppresses the deprecation warning and ensures your integration behaves predictably when the default changes in a future release. Without an explicit selection, your integration will automatically switch to the new default, which may require unplanned coordination with your service provider.
+
+For key transport, [RSA-OAEP](http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p) (including MGF1 and SHA1) is used.
+
+<Warning>
+  At a later time, Auth0 intends to switch the default encryption algorithm to `aes256-gcm`. If your Action does not explicitly call `setEncryptionAlgorithm`, the algorithm will change automatically when the new default takes effect. To avoid unexpected changes, explicitly set your preferred algorithm now. Before switching to `aes256-gcm`, verify that your SAML service provider supports it. If it does not, contact your SP vendor to request support.
+</Warning>
 
 ## Learn more
 

--- a/main/docs/authenticate/protocols/saml/saml-sso-integrations/sign-and-encrypt-saml-requests.mdx
+++ b/main/docs/authenticate/protocols/saml/saml-sso-integrations/sign-and-encrypt-saml-requests.mdx
@@ -215,11 +215,6 @@ exports.onExecutePostLogin = async (event, api) => {
   };
 ```
 
-
-
-
-
-
 To learn how to turn the private key and certificate files into strings that you can use in a rule, see [Work with Certificates and Keys and Strings](/docs/authenticate/protocols/saml/saml-sso-integrations/work-with-certificates-and-keys-as-strings).
 
 ### Receive signed SAML authentication requests
@@ -239,16 +234,11 @@ To configure signature validation:
      [...], // other settings
      "signingCert": "-----BEGIN CERTIFICATE-----\nMIIC8jCCAdqgAwIBAgIJObB6jmhG0QIEMA0GCSqGSIb3DQEBBQUAMCAxHjAcBgNV\n[..all the other lines..]-----END CERTIFICATE-----\n"
    }
-   ```
-
-
-   
-
-   
+   ```   
 
 ### Send encrypted SAML authentication assertions
 
-If Auth0 is the SAML identity provider, you can use [Actions](/docs/customize/actions) to encrypt the SAML assertions it sends. You can also select the encryption algorithm used for assertion encryption. We recommend using `aes256-gcm` for a stronger security posture.
+If Auth0 is the SAML identity provider, you can use [Actions](/docs/customize/actions) to encrypt the SAML assertions it sends. You can also select the encryption algorithm used for assertion encryption. Auth0 recommends using `aes256-gcm` for a stronger security posture.
 
 You must obtain the certificate and the public key from the service provider. If you only got the certificate, you can derive the public key using `openssl`. Assuming that the certificate file is named `certificate.pem`, you can run:
 
@@ -276,25 +266,21 @@ exports.onExecutePostLogin = async (event, api) => {
 };
 ```
 
+Auth0 supports the following algorithms for assertion encryption:
 
-
-
-
-
-The following algorithms are supported for assertion encryption:
-
-* [aes256-gcm](http://www.w3.org/2001/04/xmlenc#aes256-gcm) **(Recommended)** — Authenticated encryption that provides both confidentiality and integrity. Resistant to format validity oracle attacks.
-* [aes256-cbc](http://www.w3.org/2001/04/xmlenc#aes256-cbc) — Current default. Does not provide integrity guarantees.
-
-If you do not explicitly set an encryption algorithm using `setEncryptionAlgorithm`, Auth0 defaults to `aes256-cbc` and emits a deprecation warning in your tenant logs. Auth0 only emits this warning when no algorithm is explicitly selected. If you explicitly set the algorithm — even to `aes256-cbc` — no warning is emitted.
-
-We recommend using `setEncryptionAlgorithm` now to explicitly set your preferred algorithm, even if you are not ready to migrate to `aes256-gcm`. This suppresses the deprecation warning and ensures your integration behaves predictably when the default changes in a future release. Without an explicit selection, your integration will automatically switch to the new default, which may require unplanned coordination with your service provider.
-
-For key transport, [RSA-OAEP](http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p) (including MGF1 and SHA1) is used.
+* [`aes256-gcm`](http://www.w3.org/2001/04/xmlenc#aes256-gcm) **(recommended)**: Authenticated encryption that provides both confidentiality and integrity. It is resistant to format validity oracle attacks.
+* [`aes256-cbc`](http://www.w3.org/2001/04/xmlenc#aes256-cbc) (default): It does not provide integrity guarantees. When an Action does not use the object [`api.samlResponse.setEncryptionAlgorithm`](/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-api-object#api-samlresponse-setencryptioncert-encryptioncert) to set the encryption algorithm, Auth0 defaults to the `aes256-cbc` algorithm and logs a deprecation warning in your tenant logs.
+* [`rsa-oaep`](http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p), including MGF1 and SHA1 used for key transport.
 
 <Warning>
-  At a later time, Auth0 intends to switch the default encryption algorithm to `aes256-gcm`. If your Action does not explicitly call `setEncryptionAlgorithm`, the algorithm will change automatically when the new default takes effect. To avoid unexpected changes, explicitly set your preferred algorithm now. Before switching to `aes256-gcm`, verify that your SAML service provider supports it. If it does not, contact your SP vendor to request support.
+Auth0 intends to update the default encryption algorithm to `aes256-gcm`.
+
+For consistent behavior after the default algorithm changes, we recommend switching to `aes256-gcm`:
+
+1. Verify that your SAML service provider supports `aes256-gcm`, and contact them for support if they do not.
+2. Set the encryption algorithm in your Action code with `api.samlResponse.setEncryptionAlgorithm("aes256-gcm");`.
 </Warning>
+
 
 ## Learn more
 

--- a/main/docs/authenticate/protocols/saml/saml-sso-integrations/sign-and-encrypt-saml-requests.mdx
+++ b/main/docs/authenticate/protocols/saml/saml-sso-integrations/sign-and-encrypt-saml-requests.mdx
@@ -5,7 +5,7 @@ title: Sign and Encrypt SAML Requests
 
 import {AuthLink} from "/snippets/AuthLink.jsx";
 
-To increase the security of your transactions, you can sign or encrypt both your requests and your responses in the <Tooltip tip="Security Assertion Markup Language (SAML): Standardized protocol allowing two parties to exchange authentication information without a password." cta="View Glossary" href="/docs/glossary?term=SAML">SAML</Tooltip> protocol. In this article, you'll find configurations for specific scenarios, separated under two use cases:
+To increase the security of your transactions, you can sign or encrypt both your requests and your responses in the <Tooltip tip="Security Assertion Markup Language (SAML): Standardized protocol allowing two parties to exchange authentication information without a password." cta="View Glossary" href="/docs/glossary?term=SAML">SAML</Tooltip> protocol. In this article, you'll find configurations for specific scenarios, separated under two use cases:
 
 * Auth0 as the SAML service provider (for example, a SAML connection)
 * Auth0 as the SAML <Tooltip tip="Identity Provider (IdP): Service that stores and manages digital identities." cta="View Glossary" href="/docs/glossary?term=identity+provider">identity provider</Tooltip> (for example, an application configured with the SAML Web App addon)
@@ -16,7 +16,7 @@ These scenarios apply when Auth0 is the SAML Service Provider, which means that 
 
 ### Sign the SAML authentication request
 
-If Auth0 is the SAML **service provider**, you can sign the authentication request Auth0 sends to the IdP as follows:
+If Auth0 is the SAML **service provider**, you can sign the authentication request Auth0 sends to the IdP as follows:
 
 1. Navigate to [Auth0 Dashboard > Authentication > Enterprise](https://manage.auth0.com/#/connections/enterprise), and select **SAML**.
 2. Select the name of the connection to view.
@@ -29,9 +29,9 @@ By default, SAML authentication requests are sent via HTTP-Redirect and use defl
 
 To turn off deflate encoding, you can make a [PATCH call to the Management API's Update a Connection endpoint](https://auth0.com/docs/api/management/v2#!/Connections/patch_connections_by_id) and set the `deflate` option to `false`.
 
-Updating the `options` object for a connection overrides the whole `options` object. To keep previous connection options, get the existing `options` object and add new key/values to it.
+Updating the `options` object for a connection overrides the whole `options` object. To keep previous connection options, get the existing `options` object and add new key/values to it.
 
-Endpoint: `https://{yourDomain}/api/v2/connections/{yourConnectionId}`
+Endpoint: `https://{yourDomain}/api/v2/connections/{yourConnectionId}`
 
 Payload:
 
@@ -49,7 +49,7 @@ Payload:
 
 ### Use a custom key to sign requests
 
-By default, Auth0 uses the tenant private key to sign SAML requests (when the **Sign Request** toggle is enabled). You can also provide your own private/public key pair to sign requests coming from a specific connection.
+By default, Auth0 uses the tenant private key to sign SAML requests (when the **Sign Request** toggle is enabled). You can also provide your own private/public key pair to sign requests coming from a specific connection.
 
 You can generate your own certificate and private key using this command:
 
@@ -62,9 +62,9 @@ openssl req -x509 -nodes -sha256 -days 3650 -newkey rsa:2048 -keyout private_key
 
 
 
-Changing the key used to sign requests in the connection can't be done on the Dashboard UI, so you will have to use the [Update a Connection endpoint](https://auth0.com/docs/api/management/v2#!/Connections/patch_connections_by_id) from the <Tooltip tip="Management API: A product to allow customers to perform administrative tasks." cta="View Glossary" href="/docs/glossary?term=Management+API">Management API</Tooltip> v2, and add a `signing_key` property to the `options` object, as shown in the payload example below.
+Changing the key used to sign requests in the connection can't be done on the Dashboard UI, so you will have to use the [Update a Connection endpoint](https://auth0.com/docs/api/management/v2#!/Connections/patch_connections_by_id) from the <Tooltip tip="Management API: A product to allow customers to perform administrative tasks." cta="View Glossary" href="/docs/glossary?term=Management+API">Management API</Tooltip> v2, and add a `signing_key` property to the `options` object, as shown in the payload example below.
 
-Updating the `options` object for a connection overrides the whole `options` object. To keep previous connection options, get the existing `options` object and add new key/values to it.
+Updating the `options` object for a connection overrides the whole `options` object. To keep previous connection options, get the existing `options` object and add new key/values to it.
 
 Endpoint: `https://{yourDomain}/api/v2/connections/{yourConnectionId}`
 
@@ -102,7 +102,7 @@ Auth0 can accept a signed response for the assertion, the response, or both.
 
 ### Receive encrypted SAML authentication assertions
 
-If Auth0 is the SAML service provider, it may need to receive encrypted assertions from an identity provider. To do this, you must provide the tenant's public key certificate to the IdP. The IdP encrypts the SAML assertion using the public key and sends it to Auth0, which decrypts it using the tenant's private key.
+If Auth0 is the SAML service provider, it may need to receive encrypted assertions from an identity provider. To do this, you must provide the tenant's public key certificate to the IdP. The IdP encrypts the SAML assertion using the public key and sends it to Auth0, which decrypts it using the tenant's private key.
 
 Use the following links to obtain the public key in different formats:
 
@@ -118,11 +118,11 @@ Download the certificate in the format requested by the IdP.
 
 As noted above, Auth0 will by default use your tenant's private/public key pair to handle encryption. You can also provide your own public/private key pair if an advanced scenario requires so.
 
-Changing the key pair used to encrypt and decrypt requests in the connection can't be done on the Dashboard UI, so you will have to use the [Update a Connection endpoint](https://auth0.com/docs/api/management/v2#!/Connections/patch_connections_by_id) from the Management API v2, and add a `decryptionKey` property to the `options` object, as shown in the payload example below.
+Changing the key pair used to encrypt and decrypt requests in the connection can't be done on the Dashboard UI, so you will have to use the [Update a Connection endpoint](https://auth0.com/docs/api/management/v2#!/Connections/patch_connections_by_id) from the Management API v2, and add a `decryptionKey` property to the `options` object, as shown in the payload example below.
 
-Updating the `options` object for a connection overrides the whole `options` object. To keep previous connection options, get the existing `options` object and add new key/values to it.
+Updating the `options` object for a connection overrides the whole `options` object. To keep previous connection options, get the existing `options` object and add new key/values to it.
 
-Endpoint: `https://{yourDomain}/api/v2/connections/{yourConnectionId}`
+Endpoint: `https://{yourDomain}/api/v2/connections/{yourConnectionId}`
 
 Payload:
 
@@ -268,11 +268,11 @@ exports.onExecutePostLogin = async (event, api) => {
 
 Auth0 supports the following algorithms for assertion encryption:
 
-* [`aes256-gcm`](http://www.w3.org/2001/04/xmlenc#aes256-gcm) **(recommended)**: Authenticated encryption that provides both confidentiality and integrity. It is resistant to format validity oracle attacks.
-* [`aes256-cbc`](http://www.w3.org/2001/04/xmlenc#aes256-cbc) (default): It does not provide integrity guarantees. When an Action does not use the object [`api.samlResponse.setEncryptionAlgorithm`](/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-api-object#api-samlresponse-setencryptioncert-encryptioncert) to set the encryption algorithm, Auth0 defaults to the `aes256-cbc` algorithm and logs a deprecation warning in your tenant logs.
+* [`aes256-gcm`](https://www.w3.org/TR/xmlenc-core1/#sec-AES-GCM) **(recommended)**: Authenticated encryption that provides both confidentiality and integrity. It is resistant to format validity oracle attacks.
+* [`aes256-cbc`](https://www.w3.org/TR/xmlenc-core1/#sec-AES) (default): It does not provide integrity guarantees. When an Action does not use the object [`api.samlResponse.setEncryptionAlgorithm`](/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-api-object#api-samlresponse-setencryptioncert-encryptioncert) to set the encryption algorithm, Auth0 defaults to the `aes256-cbc` algorithm and logs a deprecation warning in your tenant logs.
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-For key transport, Auth0 uses [`rsa-oaep`](http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p) including MGF1 and SHA1 functions.
+For key transport, Auth0 uses [`rsa-oaep`](https://www.w3.org/TR/xmlenc-core1/#rsa-oaep) including MGF1 and SHA1 functions.
 </Callout>
 
 <Warning>

--- a/main/docs/authenticate/protocols/saml/saml-sso-integrations/sign-and-encrypt-saml-requests.mdx
+++ b/main/docs/authenticate/protocols/saml/saml-sso-integrations/sign-and-encrypt-saml-requests.mdx
@@ -284,7 +284,7 @@ exports.onExecutePostLogin = async (event, api) => {
 The following algorithms are supported for assertion encryption:
 
 * [aes256-gcm](http://www.w3.org/2001/04/xmlenc#aes256-gcm) **(Recommended)** — Authenticated encryption that provides both confidentiality and integrity. Resistant to format validity oracle attacks.
-* [aes256-cbc](http://www.w3.org/2001/04/xmlenc#aes256-cbc) — Current default. Does not provide integrity guarantees. Will be deprecated as the default in a future release.
+* [aes256-cbc](http://www.w3.org/2001/04/xmlenc#aes256-cbc) — Current default. Does not provide integrity guarantees.
 
 If you do not explicitly set an encryption algorithm using `setEncryptionAlgorithm`, Auth0 defaults to `aes256-cbc` and emits a deprecation warning in your tenant logs. Auth0 only emits this warning when no algorithm is explicitly selected. If you explicitly set the algorithm — even to `aes256-cbc` — no warning is emitted.
 

--- a/main/docs/authenticate/protocols/saml/saml-sso-integrations/sign-and-encrypt-saml-requests.mdx
+++ b/main/docs/authenticate/protocols/saml/saml-sso-integrations/sign-and-encrypt-saml-requests.mdx
@@ -270,7 +270,10 @@ Auth0 supports the following algorithms for assertion encryption:
 
 * [`aes256-gcm`](http://www.w3.org/2001/04/xmlenc#aes256-gcm) **(recommended)**: Authenticated encryption that provides both confidentiality and integrity. It is resistant to format validity oracle attacks.
 * [`aes256-cbc`](http://www.w3.org/2001/04/xmlenc#aes256-cbc) (default): It does not provide integrity guarantees. When an Action does not use the object [`api.samlResponse.setEncryptionAlgorithm`](/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-api-object#api-samlresponse-setencryptioncert-encryptioncert) to set the encryption algorithm, Auth0 defaults to the `aes256-cbc` algorithm and logs a deprecation warning in your tenant logs.
-* [`rsa-oaep`](http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p), including MGF1 and SHA1 used for key transport.
+
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+For key transport, Auth0 uses [`rsa-oaep`](http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p) including MGF1 and SHA1 functions.
+</Callout>
 
 <Warning>
 Auth0 intends to update the default encryption algorithm to `aes256-gcm`.
@@ -280,7 +283,6 @@ For consistent behavior after the default algorithm changes, we recommend switch
 1. Verify that your SAML service provider supports `aes256-gcm`, and contact them for support if they do not.
 2. Set the encryption algorithm in your Action code with `api.samlResponse.setEncryptionAlgorithm("aes256-gcm");`.
 </Warning>
-
 
 ## Learn more
 


### PR DESCRIPTION
## Summary

- Documents the supported SAML assertion encryption algorithms (`aes256-gcm` and `aes256-cbc`)
- Recommends `aes256-gcm` as the stronger option and shows how to set it via `setEncryptionAlgorithm`
- Warns users that `aes256-cbc` will be deprecated as the default in a future release and advises explicitly setting an algorithm now to avoid unexpected behavior