### PR TITLE
fix/en.json-add-acul-configure

### DIFF
--- a/main/config/navigation/en.json
+++ b/main/config/navigation/en.json
@@ -1205,7 +1205,13 @@
                       "group": "Advanced Customizations for Universal Login",
                       "pages": [
                         "docs/customize/login-pages/advanced-customizations",
-                        "docs/customize/login-pages/advanced-customizations/configure",
+                        {
+                          "group": "Configure",
+                          "pages": [
+                            "docs/customize/login-pages/advanced-customizations/configure/overview",
+                            "docs/customize/login-pages/advanced-customizations/configure/reference"
+                          ]
+                        },
                         "docs/customize/login-pages/advanced-customizations/quickstart",
                         "docs/customize/login-pages/advanced-customizations/development-workflow",
                         "docs/customize/login-pages/advanced-customizations/deployment-workflow",

--- a/main/config/redirects.json
+++ b/main/config/redirects.json
@@ -1,5 +1,9 @@
 [
   {
+    "source": "docs/customize/login-pages/advanced-customizations/configure",
+    "destination": "docs/customize/login-pages/advanced-customizations/configure/overview"
+  },
+  {
     "source": "docs/secure/tokens/manage-refresh-tokens-with-auth0-management-api",
     "destination": "docs/secure/tokens/refresh-tokens/revoke-refresh-tokens"
   },


### PR DESCRIPTION
## Summary

- Replaces the flat `docs/customize/login-pages/advanced-customizations/configure` page entry in `en.json` with a **Configure** group containing `overview` and `reference` as navigable sub-pages
- Fixes missing navigation for the two files inside `configure/` (`overview.mdx`, `reference.mdx`) which were orphaned — not reachable from the sidebar

## Test plan

- [ ] Run `mint dev` and verify the **Configure** group appears under **Advanced Customizations for Universal Login** in the sidebar
- [ ] Confirm both **Overview** and **Reference** sub-pages are accessible and render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)