### PR TITLE
chore: add CODEOWNERS for main/config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,7 @@
 * @auth0/project-docs-writers-codeowner
 
 # Docs Management ownership for code, config, and related docs
+main/config          @auth0/project-docs-management-codeowner
 snippets             @auth0/project-docs-management-codeowner
 ui                   @auth0/project-docs-management-codeowner
 scripts              @auth0/project-docs-management-codeowner


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

This PR adds CODEOWNERS for the `main/config` path.

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
