### PR TITLE
Revert "chore: add CODEOWNERS for main/config"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,6 @@
 * @auth0/project-docs-writers-codeowner
 
 # Docs Management ownership for code, config, and related docs
-main/config          @auth0/project-docs-management-codeowner
 snippets             @auth0/project-docs-management-codeowner
 ui                   @auth0/project-docs-management-codeowner
 scripts              @auth0/project-docs-management-codeowner


### PR DESCRIPTION
Reverts auth0/docs-v2#1080 to restore CODEOWNERS access for writers to navigation config.