### PR TITLE
fix(angular): improve quickstart version compat and modernize patterns

### DIFF
--- a/main/docs/quickstart/spa/angular/index.mdx
+++ b/main/docs/quickstart/spa/angular/index.mdx
@@ -39,7 +39,7 @@ Your AI assistant will automatically create your Auth0 application, fetch creden
 
   Verify installation: `node --version && npm --version`
 
-  **Angular Version Compatibility:** This quickstart works with **Angular 18.x** and newer using the Angular CLI. For older versions of Angular, use the Auth0 Angular SDK v2.
+  **Angular Version Compatibility:** This quickstart works with **Angular 19 through 21** using the Angular CLI. The `@auth0/auth0-angular` SDK supports Angular 13 and newer.
 </Note>
 
 
@@ -147,18 +147,19 @@ export const localEnvSnippet = `export const environment = {
     </Tabs>
   </Step>
   <Step title="Configure the Auth0 module" stepNumber={4}>
-    With your environment file in place from the previous step, configure the Auth0 module in your app:
+    With your environment file in place from the previous step, add `provideAuth0` to the providers array in your `app.config.ts`:
 
-    ```typescript src/main.ts {3,4,5,9-15} lines
-    import { bootstrapApplication } from '@angular/platform-browser';
-    import { appConfig } from './app/app.config';
+    ```typescript src/app/app.config.ts {3,4,5,11-17} lines
+    import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+    import { provideRouter } from '@angular/router';
     import { provideAuth0 } from '@auth0/auth0-angular';
-    import { mergeApplicationConfig } from '@angular/core';
-    import { environment } from './environments/environment';
-    import { App } from './app/app';
+    import { environment } from '../environments/environment';
+    import { routes } from './app.routes';
 
-    const auth0Config = mergeApplicationConfig(appConfig, {
+    export const appConfig: ApplicationConfig = {
       providers: [
+        provideZoneChangeDetection({ eventCoalescing: true }),
+        provideRouter(routes),
         provideAuth0({
           domain: environment.auth0.domain,
           clientId: environment.auth0.clientId,
@@ -167,39 +168,23 @@ export const localEnvSnippet = `export const environment = {
           }
         })
       ]
-    });
-
-    bootstrapApplication(App, auth0Config).catch((err) =>
-      console.error(err)
-    );
+    };
     ```
 
     <Note>
       If you set up your Auth0 app manually via the dashboard, create `src/environments/environment.ts` with your domain and client ID from the dashboard.
 
-      If you're using **Angular 18 or 19**, the CLI generates `app.component.ts` and exports `AppComponent` instead of `App`. Change lines 6 and 20 to match:
-      ```typescript
-      import { AppComponent } from './app/app.component';
-      // ...
-      bootstrapApplication(AppComponent, auth0Config).catch((err) => console.error(err));
-      ```
+      Angular 20+ projects also include `provideBrowserGlobalErrorListeners()` in this file — keep it in the array alongside `provideAuth0`. No changes to `main.ts` are needed.
     </Note>
   </Step>
   <Step title="Create Login, Logout and Profile Components" stepNumber={5}>
-    Create the component files manually for better control
+    Use the Angular CLI to scaffold the component files:
 
-    <CodeGroup>
-      ```shellscript Mac/Linux
-      mkdir -p src/app/components && touch src/app/components/login-button.component.ts && touch src/app/components/logout-button.component.ts && touch src/app/components/profile.component.ts
-      ```
-
-      ```powershell Windows
-      New-Item -ItemType Directory -Force -Path src/app/components
-      New-Item -ItemType File -Path src/app/components/login-button.component.ts
-      New-Item -ItemType File -Path src/app/components/logout-button.component.ts
-      New-Item -ItemType File -Path src/app/components/profile.component.ts
-      ```
-    </CodeGroup>
+    ```shellscript
+    ng generate component components/login-button --inline-template --inline-style --skip-tests && \
+    ng generate component components/logout-button --inline-template --inline-style --skip-tests && \
+    ng generate component components/profile --inline-template --inline-style --skip-tests
+    ```
 
     Add the following code to each component:
 
@@ -326,7 +311,7 @@ export const localEnvSnippet = `export const environment = {
 
     <Tabs>
       <Tab title="App Component">
-        Replace the contents of `src/app/app.ts`:
+        Replace the contents of your app component file (`src/app/app.ts` on Angular 20+, or `src/app/app.component.ts` on Angular 19):
 
         ```typescript src/app/app.ts expandable lines
         import { Component, inject } from '@angular/core';
@@ -721,7 +706,9 @@ export const localEnvSnippet = `export const environment = {
   ```
 
   <Note>
-    If you're using Angular 18 or 19, your generated files are typically `app.component.ts`, `app.module.ts`, and `app-routing.module.ts`, and `main.ts` typically uses `platformBrowserDynamic` instead.
+    If you're using **Angular 19**, your generated files are typically `app.component.ts`, `app.module.ts`, and `app-routing.module.ts`, and `main.ts` uses `platformBrowserDynamic` instead of `platformBrowser`.
+
+    **Angular 20+** generates `app.ts`, `app-module.ts`, and `app-routing-module.ts` (no dots in filenames), and `main.ts` uses `platformBrowser` as shown above.
 
     In all cases, NgModule projects bootstrap via `bootstrapModule()` rather than the `bootstrapApplication()` approach shown in the main quickstart.
   </Note>
@@ -749,15 +736,18 @@ export const localEnvSnippet = `export const environment = {
   ];
   ```
 
-  Then configure routing in your main.ts:
+  Then add `provideAuth0` and the router to your `app.config.ts` (if you haven't already from Step 4):
 
-  ```typescript src/main.ts
+  ```typescript src/app/app.config.ts
+  import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
   import { provideRouter } from '@angular/router';
-  import { environment } from './environments/environment';
-  import { routes } from './app/app.routes';
+  import { provideAuth0 } from '@auth0/auth0-angular';
+  import { environment } from '../environments/environment';
+  import { routes } from './app.routes';
 
-  const auth0Config = mergeApplicationConfig(appConfig, {
+  export const appConfig: ApplicationConfig = {
     providers: [
+      provideZoneChangeDetection({ eventCoalescing: true }),
       provideRouter(routes),
       provideAuth0({
         domain: environment.auth0.domain,
@@ -767,20 +757,25 @@ export const localEnvSnippet = `export const environment = {
         }
       })
     ]
-  });
+  };
   ```
 </Accordion>
 
 <Accordion title="Calling Protected APIs">
-  Configure the HTTP interceptor to automatically attach tokens to API calls:
+  Configure the HTTP interceptor to automatically attach tokens to API calls. Add `provideHttpClient` with the Auth0 interceptor and an `audience` to your `app.config.ts`:
 
-  ```typescript src/main.ts
+  ```typescript src/app/app.config.ts
+  import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+  import { provideRouter } from '@angular/router';
   import { provideHttpClient, withInterceptors } from '@angular/common/http';
-  import { authHttpInterceptorFn } from '@auth0/auth0-angular';
-  import { environment } from './environments/environment';
+  import { provideAuth0, authHttpInterceptorFn } from '@auth0/auth0-angular';
+  import { environment } from '../environments/environment';
+  import { routes } from './app.routes';
 
-  const auth0Config = mergeApplicationConfig(appConfig, {
+  export const appConfig: ApplicationConfig = {
     providers: [
+      provideZoneChangeDetection({ eventCoalescing: true }),
+      provideRouter(routes),
       provideAuth0({
         domain: environment.auth0.domain,
         clientId: environment.auth0.clientId,
@@ -798,6 +793,6 @@ export const localEnvSnippet = `export const environment = {
         withInterceptors([authHttpInterceptorFn])
       )
     ]
-  });
+  };
   ```
 </Accordion>


### PR DESCRIPTION
- Move Auth0 config from main.ts to app.config.ts, eliminating App vs AppComponent confusion across Angular 19/20/21
- Replace mkdir/touch commands with cross-platform ng generate
- Update version compat from "Angular 18.x+" to "Angular 19 through 21"
- Clarify NgModule section with Angular 19 vs 20+ filename differences
- Update AuthGuard and Protected APIs sections to use app.config.ts

<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
