### PR TITLE
feat: separate generated events catalog nav

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,6 +18,7 @@ main/docs/oas           @auth0/project-docs-management-codeowner
 main/docs/events        @auth0/project-docs-management-codeowner
 main/docs/fr-ca/events  @auth0/project-docs-management-codeowner
 main/docs/ja-jp/events  @auth0/project-docs-management-codeowner
+config/navigation/generated @auth0/project-docs-management-codeowner
 
 # Shared ownership for shared config files
 .github         @auth0/project-docs-writers-codeowner @auth0/project-docs-management-codeowner

--- a/main/config/navigation/en.json
+++ b/main/config/navigation/en.json
@@ -3737,47 +3737,7 @@
     },
     {
       "tab": "Events Catalog",
-      "pages": [
-        "docs/events",
-        {
-          "group": " ",
-          "pages": [
-            {
-              "group": "Group",
-              "pages": [
-                "docs/events/group/group.created",
-                "docs/events/group/group.deleted",
-                "docs/events/group/group.member.added",
-                "docs/events/group/group.member.deleted",
-                "docs/events/group/group.updated"
-              ]
-            },
-            {
-              "group": "Organization",
-              "pages": [
-                "docs/events/organization/organization.connection.added",
-                "docs/events/organization/organization.connection.removed",
-                "docs/events/organization/organization.connection.updated",
-                "docs/events/organization/organization.created",
-                "docs/events/organization/organization.deleted",
-                "docs/events/organization/organization.member.added",
-                "docs/events/organization/organization.member.deleted",
-                "docs/events/organization/organization.member.role.assigned",
-                "docs/events/organization/organization.member.role.deleted",
-                "docs/events/organization/organization.updated"
-              ]
-            },
-            {
-              "group": "User",
-              "pages": [
-                "docs/events/user/user.created",
-                "docs/events/user/user.deleted",
-                "docs/events/user/user.updated"
-              ]
-            }
-          ]
-        }
-      ]
+      "$ref": "./generated/events-catalog.en.json"
     }
   ]
 }

--- a/main/config/navigation/fr-ca.json
+++ b/main/config/navigation/fr-ca.json
@@ -3244,47 +3244,7 @@
     },
     {
       "tab": "Events Catalog",
-      "pages": [
-        "docs/fr-ca/events",
-        {
-          "group": " ",
-          "pages": [
-            {
-              "group": "Group",
-              "pages": [
-                "docs/fr-ca/events/group/group.created",
-                "docs/fr-ca/events/group/group.deleted",
-                "docs/fr-ca/events/group/group.member.added",
-                "docs/fr-ca/events/group/group.member.deleted",
-                "docs/fr-ca/events/group/group.updated"
-              ]
-            },
-            {
-              "group": "Organization",
-              "pages": [
-                "docs/fr-ca/events/organization/organization.connection.added",
-                "docs/fr-ca/events/organization/organization.connection.removed",
-                "docs/fr-ca/events/organization/organization.connection.updated",
-                "docs/fr-ca/events/organization/organization.created",
-                "docs/fr-ca/events/organization/organization.deleted",
-                "docs/fr-ca/events/organization/organization.member.added",
-                "docs/fr-ca/events/organization/organization.member.deleted",
-                "docs/fr-ca/events/organization/organization.member.role.assigned",
-                "docs/fr-ca/events/organization/organization.member.role.deleted",
-                "docs/fr-ca/events/organization/organization.updated"
-              ]
-            },
-            {
-              "group": "User",
-              "pages": [
-                "docs/fr-ca/events/user/user.created",
-                "docs/fr-ca/events/user/user.deleted",
-                "docs/fr-ca/events/user/user.updated"
-              ]
-            }
-          ]
-        }
-      ]
+      "$ref": "./generated/events-catalog.fr-ca.json"
     }
   ]
 }

--- a/main/config/navigation/generated/events-catalog.en.json
+++ b/main/config/navigation/generated/events-catalog.en.json
@@ -1,0 +1,43 @@
+{
+  "pages": [
+    "docs/events",
+    {
+      "group": " ",
+      "pages": [
+        {
+          "group": "Group",
+          "pages": [
+            "docs/events/group/group.created",
+            "docs/events/group/group.deleted",
+            "docs/events/group/group.member.added",
+            "docs/events/group/group.member.deleted",
+            "docs/events/group/group.updated"
+          ]
+        },
+        {
+          "group": "Organization",
+          "pages": [
+            "docs/events/organization/organization.connection.added",
+            "docs/events/organization/organization.connection.removed",
+            "docs/events/organization/organization.connection.updated",
+            "docs/events/organization/organization.created",
+            "docs/events/organization/organization.deleted",
+            "docs/events/organization/organization.member.added",
+            "docs/events/organization/organization.member.deleted",
+            "docs/events/organization/organization.member.role.assigned",
+            "docs/events/organization/organization.member.role.deleted",
+            "docs/events/organization/organization.updated"
+          ]
+        },
+        {
+          "group": "User",
+          "pages": [
+            "docs/events/user/user.created",
+            "docs/events/user/user.deleted",
+            "docs/events/user/user.updated"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/main/config/navigation/generated/events-catalog.fr-ca.json
+++ b/main/config/navigation/generated/events-catalog.fr-ca.json
@@ -1,0 +1,43 @@
+{
+  "pages": [
+    "docs/fr-ca/events",
+    {
+      "group": " ",
+      "pages": [
+        {
+          "group": "Group",
+          "pages": [
+            "docs/fr-ca/events/group/group.created",
+            "docs/fr-ca/events/group/group.deleted",
+            "docs/fr-ca/events/group/group.member.added",
+            "docs/fr-ca/events/group/group.member.deleted",
+            "docs/fr-ca/events/group/group.updated"
+          ]
+        },
+        {
+          "group": "Organization",
+          "pages": [
+            "docs/fr-ca/events/organization/organization.connection.added",
+            "docs/fr-ca/events/organization/organization.connection.removed",
+            "docs/fr-ca/events/organization/organization.connection.updated",
+            "docs/fr-ca/events/organization/organization.created",
+            "docs/fr-ca/events/organization/organization.deleted",
+            "docs/fr-ca/events/organization/organization.member.added",
+            "docs/fr-ca/events/organization/organization.member.deleted",
+            "docs/fr-ca/events/organization/organization.member.role.assigned",
+            "docs/fr-ca/events/organization/organization.member.role.deleted",
+            "docs/fr-ca/events/organization/organization.updated"
+          ]
+        },
+        {
+          "group": "User",
+          "pages": [
+            "docs/fr-ca/events/user/user.created",
+            "docs/fr-ca/events/user/user.deleted",
+            "docs/fr-ca/events/user/user.updated"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/main/config/navigation/generated/events-catalog.ja-jp.json
+++ b/main/config/navigation/generated/events-catalog.ja-jp.json
@@ -1,0 +1,43 @@
+{
+  "pages": [
+    "docs/ja-jp/events",
+    {
+      "group": " ",
+      "pages": [
+        {
+          "group": "Group",
+          "pages": [
+            "docs/ja-jp/events/group/group.created",
+            "docs/ja-jp/events/group/group.deleted",
+            "docs/ja-jp/events/group/group.member.added",
+            "docs/ja-jp/events/group/group.member.deleted",
+            "docs/ja-jp/events/group/group.updated"
+          ]
+        },
+        {
+          "group": "Organization",
+          "pages": [
+            "docs/ja-jp/events/organization/organization.connection.added",
+            "docs/ja-jp/events/organization/organization.connection.removed",
+            "docs/ja-jp/events/organization/organization.connection.updated",
+            "docs/ja-jp/events/organization/organization.created",
+            "docs/ja-jp/events/organization/organization.deleted",
+            "docs/ja-jp/events/organization/organization.member.added",
+            "docs/ja-jp/events/organization/organization.member.deleted",
+            "docs/ja-jp/events/organization/organization.member.role.assigned",
+            "docs/ja-jp/events/organization/organization.member.role.deleted",
+            "docs/ja-jp/events/organization/organization.updated"
+          ]
+        },
+        {
+          "group": "User",
+          "pages": [
+            "docs/ja-jp/events/user/user.created",
+            "docs/ja-jp/events/user/user.deleted",
+            "docs/ja-jp/events/user/user.updated"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/main/config/navigation/ja-jp.json
+++ b/main/config/navigation/ja-jp.json
@@ -3243,47 +3243,7 @@
     },
     {
       "tab": "Events Catalog",
-      "pages": [
-        "docs/ja-jp/events",
-        {
-          "group": " ",
-          "pages": [
-            {
-              "group": "Group",
-              "pages": [
-                "docs/ja-jp/events/group/group.created",
-                "docs/ja-jp/events/group/group.deleted",
-                "docs/ja-jp/events/group/group.member.added",
-                "docs/ja-jp/events/group/group.member.deleted",
-                "docs/ja-jp/events/group/group.updated"
-              ]
-            },
-            {
-              "group": "Organization",
-              "pages": [
-                "docs/ja-jp/events/organization/organization.connection.added",
-                "docs/ja-jp/events/organization/organization.connection.removed",
-                "docs/ja-jp/events/organization/organization.connection.updated",
-                "docs/ja-jp/events/organization/organization.created",
-                "docs/ja-jp/events/organization/organization.deleted",
-                "docs/ja-jp/events/organization/organization.member.added",
-                "docs/ja-jp/events/organization/organization.member.deleted",
-                "docs/ja-jp/events/organization/organization.member.role.assigned",
-                "docs/ja-jp/events/organization/organization.member.role.deleted",
-                "docs/ja-jp/events/organization/organization.updated"
-              ]
-            },
-            {
-              "group": "User",
-              "pages": [
-                "docs/ja-jp/events/user/user.created",
-                "docs/ja-jp/events/user/user.deleted",
-                "docs/ja-jp/events/user/user.updated"
-              ]
-            }
-          ]
-        }
-      ]
+      "$ref": "./generated/events-catalog.ja-jp.json"
     }
   ]
 }

--- a/main/docs/events.mdx
+++ b/main/docs/events.mdx
@@ -1,4 +1,20 @@
 ---
-title: "Events Catalog"
-description: "Reference documentation for Auth0 event schemas delivered via Event Streams."
+title: Events Catalog Overview
+sidebarTitle: Overview
+description: Events provide an API-based method of synchronizing, correlating, or orchestrating changes that occur within Auth0 or third-party identity providers to external apps or third-party services.
 ---
+
+## Use cases
+
+Events are real-time notifications about specific actions – initially changes to a user and organizations, but eventually others – that have occurred within your Auth0 tenant. You can create event streams that listen for these events to orchestrate asynchronous changes (i.e., changes to an entity or flow that have been completed) in Auth0 and forward them to one of many destinations for external processing. Events support a variety of use cases, including:
+
+* Sending emails to new customers to welcome them or ask them to verify their email address.
+* Monitoring user lifecycle changes so that you can update CRM (customer relationship management) or billing systems.
+
+## Resources
+
+| Read... | To learn... |
+| --- | --- |
+| [Create an Event Stream](/docs/customize/events/create-an-event-stream) | How to get started with an Event Stream. |
+| [Event Testing, Observability, and Failure Recovery](/docs/customize/events/event-testing-observability-and-failure-recovery) | How to test and manage your active event streams. |
+| [Events Best Practices](/docs/customize/events/events-best-practices) | Best practices for working with events. |

--- a/main/docs/fr-ca/events.mdx
+++ b/main/docs/fr-ca/events.mdx
@@ -1,4 +1,20 @@
 ---
-title: "Events Catalog"
-description: "Reference documentation for Auth0 event schemas delivered via Event Streams."
+title: Events Catalog Overview
+sidebarTitle: Overview
+description: Events provide an API-based method of synchronizing, correlating, or orchestrating changes that occur within Auth0 or third-party identity providers to external apps or third-party services.
 ---
+
+## Use cases
+
+Events are real-time notifications about specific actions – initially changes to a user and organizations, but eventually others – that have occurred within your Auth0 tenant. You can create event streams that listen for these events to orchestrate asynchronous changes (i.e., changes to an entity or flow that have been completed) in Auth0 and forward them to one of many destinations for external processing. Events support a variety of use cases, including:
+
+* Sending emails to new customers to welcome them or ask them to verify their email address.
+* Monitoring user lifecycle changes so that you can update CRM (customer relationship management) or billing systems.
+
+## Resources
+
+| Read... | To learn... |
+| --- | --- |
+| [Create an Event Stream](/docs/customize/events/create-an-event-stream) | How to get started with an Event Stream. |
+| [Event Testing, Observability, and Failure Recovery](/docs/customize/events/event-testing-observability-and-failure-recovery) | How to test and manage your active event streams. |
+| [Events Best Practices](/docs/customize/events/events-best-practices) | Best practices for working with events. |

--- a/main/docs/ja-jp/events.mdx
+++ b/main/docs/ja-jp/events.mdx
@@ -1,4 +1,20 @@
 ---
-title: "Events Catalog"
-description: "Reference documentation for Auth0 event schemas delivered via Event Streams."
+title: Events Catalog Overview
+sidebarTitle: Overview
+description: Events provide an API-based method of synchronizing, correlating, or orchestrating changes that occur within Auth0 or third-party identity providers to external apps or third-party services.
 ---
+
+## Use cases
+
+Events are real-time notifications about specific actions – initially changes to a user and organizations, but eventually others – that have occurred within your Auth0 tenant. You can create event streams that listen for these events to orchestrate asynchronous changes (i.e., changes to an entity or flow that have been completed) in Auth0 and forward them to one of many destinations for external processing. Events support a variety of use cases, including:
+
+* Sending emails to new customers to welcome them or ask them to verify their email address.
+* Monitoring user lifecycle changes so that you can update CRM (customer relationship management) or billing systems.
+
+## Resources
+
+| Read... | To learn... |
+| --- | --- |
+| [Create an Event Stream](/docs/customize/events/create-an-event-stream) | How to get started with an Event Stream. |
+| [Event Testing, Observability, and Failure Recovery](/docs/customize/events/event-testing-observability-and-failure-recovery) | How to test and manage your active event streams. |
+| [Events Best Practices](/docs/customize/events/events-best-practices) | Best practices for working with events. |


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

moves generated events catalog nav into their own files.

also restores the events catalog landing page content and updates CODEOWNERS so @auth0/project-docs-management-codeowner own the generated config.

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

### References

https://auth0.slack.com/archives/C09UBR8CWRL/p1777566592731679

https://github.com/atko-cic/docs-content-pipeline/pull/177

DM-613

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

check build locally.

do not merge; will rely on my companion docs-content-pipeline PR.

## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
