### PR TITLE
fix: correct Python http.client snippets in bulk user import docs

### DIFF
--- a/main/docs/manage-users/user-migration/bulk-user-imports.mdx
+++ b/main/docs/manage-users/user-migration/bulk-user-imports.mdx
@@ -279,30 +279,35 @@ if ($err) {
 ```python Python
 import http.client
 
-conn = http.client.HTTPSConnection("")
+conn = http.client.HTTPSConnection("{yourDomain}")
 
-payload = "-----011000010111000001101001\r
-Content-Disposition: form-data; name="users"; filename="USERS_IMPORT_FILE.json"\r
-Content-Type: text/json\r
-\r
-\r
------011000010111000001101001\r
-Content-Disposition: form-data; name="connection_id"\r
-\r
-CONNECTION_ID\r
------011000010111000001101001\r
-Content-Disposition: form-data; name="external_id"\r
-\r
-EXTERNAL_ID\r
------011000010111000001101001--\r
-"
+# Read the users import file
+with open("USERS_IMPORT_FILE.json", "rb") as f:
+    file_contents = f.read()
+
+payload = (
+    "-----011000010111000001101001\r\n"
+    "Content-Disposition: form-data; name=\"users\"; filename=\"USERS_IMPORT_FILE.json\"\r\n"
+    "Content-Type: application/json\r\n"
+    "\r\n"
+    + file_contents.decode("utf-8") + "\r\n"
+    "-----011000010111000001101001\r\n"
+    "Content-Disposition: form-data; name=\"connection_id\"\r\n"
+    "\r\n"
+    "CONNECTION_ID\r\n"
+    "-----011000010111000001101001\r\n"
+    "Content-Disposition: form-data; name=\"external_id\"\r\n"
+    "\r\n"
+    "EXTERNAL_ID\r\n"
+    "-----011000010111000001101001--\r\n"
+)
 
 headers = {
     'authorization': "Bearer MGMT_API_ACCESS_TOKEN",
     'content-type': "multipart/form-data; boundary=---011000010111000001101001"
     }
 
-conn.request("POST", "/{yourDomain}/api/v2/jobs/users-imports", payload, headers)
+conn.request("POST", "/api/v2/jobs/users-imports", payload, headers)
 
 res = conn.getresponse()
 data = res.read()
@@ -578,14 +583,14 @@ if ($err) {
 ```python Python
 import http.client
 
-conn = http.client.HTTPSConnection("")
+conn = http.client.HTTPSConnection("{yourDomain}")
 
 headers = {
     'content-type': "application/json",
     'authorization': "Bearer MGMT_API_ACCESS_TOKEN"
     }
 
-conn.request("GET", "/{yourDomain}/api/v2/jobs/JOB_ID", headers=headers)
+conn.request("GET", "/api/v2/jobs/JOB_ID", headers=headers)
 
 res = conn.getresponse()
 data = res.read()
@@ -828,14 +833,14 @@ if ($err) {
 ```python Python
 import http.client
 
-conn = http.client.HTTPSConnection("")
+conn = http.client.HTTPSConnection("{yourDomain}")
 
 headers = {
     'content-type': "application/json",
     'authorization': "Bearer MGMT_API_ACCESS_TOKEN"
     }
 
-conn.request("GET", "/{yourDomain}/api/v2/jobs/JOB_ID/errors", headers=headers)
+conn.request("GET", "/api/v2/jobs/JOB_ID/errors", headers=headers)
 
 res = conn.getresponse()
 data = res.read()


### PR DESCRIPTION
Fix three broken Python code examples on the bulk user imports page:
- Pass tenant domain to HTTPSConnection() constructor instead of empty string
- Move domain out of request path (path should start with /api/v2/...)
- Add actual file reading for the multipart POST payload

<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
