### PR TITLE
chore: remove front-end languages from code samples

### DIFF
--- a/main/docs/authenticate/database-connections/password-change.mdx
+++ b/main/docs/authenticate/database-connections/password-change.mdx
@@ -123,35 +123,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"client_id": @"{yourClientId}",
-                              @"email": @"",
-                              @"connection": @"Username-Password-Authentication" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/dbconnections/change_password"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -213,37 +184,6 @@ request.body = "{"client_id": "{yourClientId}","email": "","connection": "Userna
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/json"]
-let parameters = [
-  "client_id": "{yourClientId}",
-  "email": "",
-  "connection": "Username-Password-Authentication"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/dbconnections/change_password")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -367,35 +307,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer {yourMgmtApiAccessToken}" };
-NSDictionary *parameters = @{ @"password": @"newPassword",
-                              @"connection": @"connectionName" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users/%7BuserId%7D"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -462,39 +373,6 @@ request.body = "{"password": "newPassword","connection": "connectionName"}"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer {yourMgmtApiAccessToken}"
-]
-let parameters = [
-  "password": "newPassword",
-  "connection": "connectionName"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users/%7BuserId%7D")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/authenticate/identity-providers/calling-an-external-idp-api.mdx
+++ b/main/docs/authenticate/identity-providers/calling-an-external-idp-api.mdx
@@ -165,29 +165,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourAccessToken}" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users/%7BuserId%7D"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -245,29 +222,6 @@ request["authorization"] = 'Bearer {yourAccessToken}'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer {yourAccessToken}"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users/%7BuserId%7D")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/authenticate/identity-providers/enterprise-identity-providers/saml.mdx
+++ b/main/docs/authenticate/identity-providers/enterprise-identity-providers/saml.mdx
@@ -191,37 +191,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-NSDictionary *parameters = @{ @"strategy": @"samlp",
-                              @"name": @"CONNECTION_NAME",
-                              @"options": @{ @"signInEndpoint": @"SIGN_IN_ENDPOINT_URL", @"signOutEndpoint": @"SIGN_OUT_ENDPOINT_URL", @"signatureAlgorithm": @"rsa-sha256", @"digestAlgorithm": @"sha256", @"fieldsMap": @{  }, @"signingCert": @"BASE64_SIGNING_CERT" } };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/connections"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -291,48 +260,6 @@ request.body = "{ "strategy": "samlp", "name": "CONNECTION_NAME", "options": { "
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-let parameters = [
-  "strategy": "samlp",
-  "name": "CONNECTION_NAME",
-  "options": [
-    "signInEndpoint": "SIGN_IN_ENDPOINT_URL",
-    "signOutEndpoint": "SIGN_OUT_ENDPOINT_URL",
-    "signatureAlgorithm": "rsa-sha256",
-    "digestAlgorithm": "sha256",
-    "fieldsMap": [],
-    "signingCert": "BASE64_SIGNING_CERT"
-  ]
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/connections")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -455,37 +382,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-NSDictionary *parameters = @{ @"strategy": @"samlp",
-                              @"name": @"CONNECTION_NAME",
-                              @"options": @{ @"metadataXml": @"<EntityDescriptor entityID='urn:saml-idp' xmlns='urn:oasis:names:tc:SAML:2.0:metadata'>...</EntityDescriptor>" } };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/connections"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -555,41 +451,6 @@ request.body = "{ "strategy": "samlp", "name": "CONNECTION_NAME", "options": { "
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-let parameters = [
-  "strategy": "samlp",
-  "name": "CONNECTION_NAME",
-  "options": ["metadataXml": "<EntityDescriptor entityID='urn:saml-idp' xmlns='urn:oasis:names:tc:SAML:2.0:metadata'>...</EntityDescriptor>"]
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/connections")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -681,37 +542,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-NSDictionary *parameters = @{ @"strategy": @"samlp",
-                              @"name": @"CONNECTION_NAME",
-                              @"options": @{ @"metadataUrl": @"https://saml-idp/samlp/metadata/uarlU13n63e0feZNJxOCNZ1To3a9H7jX" } };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/connections"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -781,41 +611,6 @@ request.body = "{ "strategy": "samlp", "name": "CONNECTION_NAME", "options": { "
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-let parameters = [
-  "strategy": "samlp",
-  "name": "CONNECTION_NAME",
-  "options": ["metadataUrl": "https://saml-idp/samlp/metadata/uarlU13n63e0feZNJxOCNZ1To3a9H7jX"]
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/connections")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/authenticate/identity-providers/promote-connections-to-domain-level.mdx
+++ b/main/docs/authenticate/identity-providers/promote-connections-to-domain-level.mdx
@@ -107,35 +107,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-NSDictionary *parameters = @{ @"is_domain_connection": @YES };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/connections/CONNECTION_ID"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -205,37 +176,6 @@ request.body = "{ "is_domain_connection": true }"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-let parameters = ["is_domain_connection": true] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/connections/CONNECTION_ID")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/authenticate/identity-providers/retrieve-connection-options.mdx
+++ b/main/docs/authenticate/identity-providers/retrieve-connection-options.mdx
@@ -70,29 +70,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/connections/CONNECTION-ID?fields=options"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -149,29 +126,6 @@ request["authorization"] = 'Bearer MGMT_API_ACCESS_TOKEN'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer MGMT_API_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/connections/CONNECTION-ID?fields=options")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/authenticate/identity-providers/social-identity-providers/oauth2.mdx
+++ b/main/docs/authenticate/identity-providers/social-identity-providers/oauth2.mdx
@@ -203,32 +203,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json" };
-
-NSData *postData = [[NSData alloc] initWithData:[@"{ "options": { "client_id": "...", "client_secret": "...", "icon_url": "https://cdn.example.com/assets/icon.png", "scripts": { "fetchUserProfile": "..." }, "authorizationURL": "https://public-auth.example.com/oauth2/authorize", "tokenURL": "https://auth.example.com/oauth2/token", "scope": "auth", "display_name": "Connection Name"} }", dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/connections/CONNECTION-ID"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -290,32 +264,6 @@ request.body = "{ "options": { "client_id": "...", "client_secret": "...", "icon
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/json"]
-
-let postData = NSData(data: "{ "options": { "client_id": "...", "client_secret": "...", "icon_url": "https://cdn.example.com/assets/icon.png", "scripts": { "fetchUserProfile": "..." }, "authorizationURL": "https://public-auth.example.com/oauth2/authorize", "tokenURL": "https://auth.example.com/oauth2/token", "scope": "auth" }, "display_name": "Connection Name"}.data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/connections/CONNECTION-ID")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -403,34 +351,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"options": @{ @"client_id": @"...", @"client_secret": @"...", @"authParams": @{ @"custom_param": @"custom.param.value" }, @"scripts": @{ @"fetchUserProfile": @"..." }, @"authorizationURL": @"https://public-auth.example.com/oauth2/authorize", @"tokenURL": @"https://auth.example.com/oauth2/token", @"scope": @"auth" }
-};
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/connections/CONNECTION-ID"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -492,43 +412,6 @@ request.body = "{ "options": { "client_id": "...", "client_secret": "...", "auth
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/json"]
-let parameters = [
-  "options": [
-    "client_id": "...",
-    "client_secret": "...",
-    "authParams": ["custom_param": "custom.param.value"],
-    "scripts": ["fetchUserProfile": "..."],
-    "authorizationURL": "https://public-auth.example.com/oauth2/authorize",
-    "tokenURL": "https://auth.example.com/oauth2/token",
-    "scope": "auth"
-  ],
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/connections/CONNECTION-ID")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -617,34 +500,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"options": @{ @"client_id": @"...", @"client_secret": @"...", @"authParamsMap": @{ @"custom_param": @"access_type" }, @"scripts": @{ @"fetchUserProfile": @"..." }, @"authorizationURL": @"https://auth.example.com/oauth2/authorize", @"tokenURL": @"https://auth.example.com/oauth2/token", @"scope": @"auth" }
-};
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/connections/CONNECTION-ID"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -708,43 +563,6 @@ request.body = "{ "options": { "client_id": "...", "client_secret": "...", "auth
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/json"]
-let parameters = [
-  "options": [
-    "client_id": "...",
-    "client_secret": "...",
-    "authParamsMap": ["custom_param": "access_type"],
-    "scripts": ["fetchUserProfile": "..."],
-    "authorizationURL": "https://auth.example.com/oauth2/authorize",
-    "tokenURL": "https://auth.example.com/oauth2/token",
-    "scope": "auth"
-  ],
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/connections/CONNECTION-ID")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/authenticate/login/auth0-universal-login/configure-default-login-routes.mdx
+++ b/main/docs/authenticate/login/auth0-universal-login/configure-default-login-routes.mdx
@@ -90,35 +90,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer API2_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-NSDictionary *parameters = @{ @"initiate_login_uri": @"<login_url>" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/clients/{yourClientId}"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -188,37 +159,6 @@ request.body = "{"initiate_login_uri": "<login_url>"}"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer API2_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-let parameters = ["initiate_login_uri": "<login_url>"] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/clients/{yourClientId}")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -302,35 +242,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer API2_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-NSDictionary *parameters = @{ @"default_redirection_uri": @"<login_url>" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/tenants/settings"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -400,37 +311,6 @@ request.body = "{"default_redirection_uri": "<login_url>"}"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer API2_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-let parameters = ["default_redirection_uri": "<login_url>"] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/tenants/settings")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -560,35 +440,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN" };
-NSDictionary *parameters = @{ @"user_id": @"A_USER_ID",
-                              @"client_id": @"A_CLIENT_ID" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/tickets/password-change"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -655,39 +506,6 @@ request.body = "{ "user_id": "A_USER_ID", "client_id": "A_CLIENT_ID" }"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN"
-]
-let parameters = [
-  "user_id": "A_USER_ID",
-  "client_id": "A_CLIENT_ID"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/tickets/password-change")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/authenticate/login/oidc-conformant-authentication/oidc-adoption-auth-code-flow.mdx
+++ b/main/docs/authenticate/login/oidc-conformant-authentication/oidc-adoption-auth-code-flow.mdx
@@ -140,36 +140,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=authorization_code" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_secret={yourClientSecret}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&code=YOUR_AUTHORIZATION_CODE" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&redirect_uri={https://yourApp/callback}" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -231,36 +201,6 @@ request.body = "grant_type=authorization_code&client_id={yourClientId}&client_se
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=authorization_code".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&client_secret={yourClientSecret}".data(using: String.Encoding.utf8)!)
-postData.append("&code=YOUR_AUTHORIZATION_CODE".data(using: String.Encoding.utf8)!)
-postData.append("&redirect_uri={https://yourApp/callback}".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -344,36 +284,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=authorization_code" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&code_verifier=YOUR_GENERATED_CODE_VERIFIER" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&code=YOUR_AUTHORIZATION_CODE" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&redirect_uri={https://yourApp/callback}" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -435,36 +345,6 @@ request.body = "grant_type=authorization_code&client_id={yourClientId}&code_veri
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=authorization_code".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&code_verifier=YOUR_GENERATED_CODE_VERIFIER".data(using: String.Encoding.utf8)!)
-postData.append("&code=YOUR_AUTHORIZATION_CODE".data(using: String.Encoding.utf8)!)
-postData.append("&redirect_uri={https://yourApp/callback}".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/authenticate/passwordless/authentication-methods/use-sms-gateway-passwordless.mdx
+++ b/main/docs/authenticate/passwordless/authentication-methods/use-sms-gateway-passwordless.mdx
@@ -88,29 +88,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourAccessToken}" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://your-auth0-tenant.com/api/v2/connections"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines
 $curl = curl_init();
@@ -170,29 +147,6 @@ request["authorization"] = 'Bearer {yourAccessToken}'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift lines
-import Foundation
-
-let headers = ["authorization": "Bearer {yourAccessToken}"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://your-auth0-tenant.com/api/v2/connections")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/authenticate/passwordless/implement-login/embedded-login/native.mdx
+++ b/main/docs/authenticate/passwordless/implement-login/embedded-login/native.mdx
@@ -88,36 +88,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"client_id": @"{yourClientId}",
-                              @"connection": @"email",
-                              @"email": @"USER_EMAIL",
-                              @"send": @"code" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/passwordless/start"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -179,38 +149,6 @@ request.body = "{"client_id": "{yourClientId}",  "connection": "email",   "email
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/json"]
-let parameters = [
-  "client_id": "{yourClientId}",
-  "connection": "email",
-  "email": "USER_EMAIL",
-  "send": "code"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/passwordless/start")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -287,36 +225,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"client_id": @"{yourClientId}",
-                              @"connection": @"email",
-                              @"email": @"USER_EMAIL",
-                              @"send": @"link" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/passwordless/start"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -378,38 +286,6 @@ request.body = "{ "client_id": "{yourClientId}", "connection": "email", "email":
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/json"]
-let parameters = [
-  "client_id": "{yourClientId}",
-  "connection": "email",
-  "email": "USER_EMAIL",
-  "send": "link"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/passwordless/start")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -486,36 +362,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"client_id": @"{yourClientId}",
-                              @"connection": @"sms",
-                              @"phone_number": @"USER_PHONE_NUMBER",
-                              @"send": @"code" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/passwordless/start"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -577,38 +423,6 @@ request.body = "{ "client_id": "{yourClientId}",  "connection": "sms",  "phone_n
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/json"]
-let parameters = [
-  "client_id": "{yourClientId}",
-  "connection": "sms",
-  "phone_number": "USER_PHONE_NUMBER",
-  "send": "code"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/passwordless/start")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -682,39 +496,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"grant_type": @"http://auth0.com/oauth/grant-type/passwordless/otp",
-                              @"client_id": @"{yourClientId}",
-                              @"username": @"USER_PHONE_NUMBER",
-                              @"otp": @"code",
-                              @"realm": @"sms",
-                              @"audience": @"your-api-audience",
-                              @"scope": @"openid profile email" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -776,41 +557,6 @@ request.body = "{ "grant_type": "http://auth0.com/oauth/grant-type/passwordless/
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-imimport Foundation
-
-let headers = ["content-type": "application/json"]
-let parameters = [
-  "grant_type": "http://auth0.com/oauth/grant-type/passwordless/otp",
-  "client_id": "{yourClientId}",
-  "username": "USER_PHONE_NUMBER",
-  "otp": "code",
-  "realm": "sms",
-  "audience": "your-api-audience",
-  "scope": "openid profile email"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -890,39 +636,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"grant_type": @"http://auth0.com/oauth/grant-type/passwordless/otp",
-                              @"client_id": @"{yourClientId}",
-                              @"username": @"USER_EMAIL",
-                              @"otp": @"code",
-                              @"realm": @"email",
-                              @"audience": @"your-api-audience",
-                              @"scope": @"openid profile email" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -984,41 +697,6 @@ request.body = "{"grant_type": "http://auth0.com/oauth/grant-type/passwordless/o
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/json"]
-let parameters = [
-  "grant_type": "http://auth0.com/oauth/grant-type/passwordless/otp",
-  "client_id": "{yourClientId}",
-  "username": "USER_EMAIL",
-  "otp": "code",
-  "realm": "email",
-  "audience": "your-api-audience",
-  "scope": "openid profile email"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/authenticate/passwordless/implement-login/embedded-login/webapps.mdx
+++ b/main/docs/authenticate/passwordless/implement-login/embedded-login/webapps.mdx
@@ -91,37 +91,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"client_id": @"{yourClientId}",
-                              @"client_secret": @"{yourClientSecret}",
-                              @"connection": @"email",
-                              @"email": @"{userEmail}",
-                              @"send": @"code" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/passwordless/start"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -183,39 +152,6 @@ request.body = "{"client_id": "{yourClientId}", "client_secret": "{yourClientSec
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/json"]
-let parameters = [
-  "client_id": "{yourClientId}",
-  "client_secret": "{yourClientSecret}",
-  "connection": "email",
-  "email": "{userEmail}",
-  "send": "code"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/passwordless/start")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -295,37 +231,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"client_id": @"{yourClientId}",
-                              @"client_secret": @"{yourClientSecret}",
-                              @"connection": @"email",
-                              @"email": @"{userEmail}",
-                              @"send": @"link" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/passwordless/start"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -387,39 +292,6 @@ request.body = "{"client_id": "{yourClientId}", "client_secret": "{yourClientSec
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/json"]
-let parameters = [
-  "client_id": "{yourClientId}",
-  "client_secret": "{yourClientSecret}",
-  "connection": "email",
-  "email": "{userEmail}",
-  "send": "link"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/passwordless/start")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -497,37 +369,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"client_id": @"{yourClientId}",
-                              @"client_secret": @"{yourClientSecret}",
-                              @"connection": @"sms",
-                              @"phone_number": @"{userPhoneNumber}",
-                              @"send": @"code" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/passwordless/start"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -589,39 +430,6 @@ request.body = "{"client_id": "{yourClientId}", "client_secret": "{yourClientSec
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/json"]
-let parameters = [
-  "client_id": "{yourClientId}",
-  "client_secret": "{yourClientSecret}",
-  "connection": "sms",
-  "phone_number": "{userPhoneNumber}",
-  "send": "code"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/passwordless/start")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -702,40 +510,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"grant_type": @"http://auth0.com/oauth/grant-type/passwordless/otp",
-                              @"client_id": @"{yourClientId}",
-                              @"client_secret": @"{yourClientSecret}",
-                              @"username": @"USER_PHONE_NUMBER",
-                              @"otp": @"code",
-                              @"realm": @"sms",
-                              @"audience": @"your-api-audience",
-                              @"scope": @"openid profile email" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -797,42 +571,6 @@ request.body = "{"grant_type": "http://auth0.com/oauth/grant-type/passwordless/o
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/json"]
-let parameters = [
-  "grant_type": "http://auth0.com/oauth/grant-type/passwordless/otp",
-  "client_id": "{yourClientId}",
-  "client_secret": "{yourClientSecret}",
-  "username": "USER_PHONE_NUMBER",
-  "otp": "code",
-  "realm": "sms",
-  "audience": "your-api-audience",
-  "scope": "openid profile email"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -913,40 +651,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"grant_type": @"http://auth0.com/oauth/grant-type/passwordless/otp",
-                              @"client_id": @"{yourClientId}",
-                              @"client_secret": @"{yourClientSecret}",
-                              @"username": @"{userPhoneNumber}",
-                              @"otp": @"code",
-                              @"realm": @"email",
-                              @"audience": @"your-api-audience",
-                              @"scope": @"openid profile email" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -1008,42 +712,6 @@ request.body = "{"grant_type": "http://auth0.com/oauth/grant-type/passwordless/o
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/json"]
-let parameters = [
-  "grant_type": "http://auth0.com/oauth/grant-type/passwordless/otp",
-  "client_id": "{yourClientId}",
-  "client_secret": "{yourClientSecret}",
-  "username": "{userPhoneNumber}",
-  "otp": "code",
-  "realm": "email",
-  "audience": "your-api-audience",
-  "scope": "openid profile email"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/authenticate/protocols/saml/saml-identity-provider-configuration-settings.mdx
+++ b/main/docs/authenticate/protocols/saml/saml-identity-provider-configuration-settings.mdx
@@ -107,29 +107,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourAccessToken}" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/connections/%7ByourConnectionID%7D"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -187,29 +164,6 @@ request["authorization"] = 'Bearer {yourAccessToken}'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer {yourAccessToken}"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/connections/%7ByourConnectionID%7D")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/customize/custom-domains/multiple-custom-domains.mdx
+++ b/main/docs/customize/custom-domains/multiple-custom-domains.mdx
@@ -182,39 +182,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourMgmtApiAccessToken}",
-                           @"content-type": @"application/json",
-                           @"accept": @"application/json" };
-NSDictionary *parameters = @{ @"domain": @"your.example-custom-domain.com",
-                              @"type": @"auth0_managed_certs",
-                              @"tls_policy": @"recommended",
-                              @"custom_client_ip_header": @"true-client-ip",
-                              @"domain_metadata": @{ @"environment": @"development" } };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/custom-domains"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -305,43 +272,6 @@ request.body = "{
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer {yourMgmtApiAccessToken}",
-  "content-type": "application/json",
-  "accept": "application/json"
-]
-let parameters = [
-  "domain": "your.example-custom-domain.com",
-  "type": "auth0_managed_certs",
-  "tls_policy": "recommended",
-  "custom_client_ip_header": "true-client-ip",
-  "domain_metadata": ["environment": "development"]
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/custom-domains")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/customize/hooks/create-hooks.mdx
+++ b/main/docs/customize/hooks/create-hooks.mdx
@@ -135,37 +135,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-NSDictionary *parameters = @{ @"name": @"HOOK_NAME",
-                              @"script": @"HOOK_SCRIPT",
-                              @"triggerId": @"EXTENSIBILITY_POINT_NAME" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/hooks"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -235,41 +204,6 @@ res = conn.getresponse()
 data = res.read()
 
 print(data.decode("utf-8"))
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-let parameters = [
-  "name": "HOOK_NAME",
-  "script": "HOOK_SCRIPT",
-  "triggerId": "EXTENSIBILITY_POINT_NAME"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/hooks")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/customize/hooks/delete-hooks.mdx
+++ b/main/docs/customize/hooks/delete-hooks.mdx
@@ -96,29 +96,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/hooks/HOOK_ID"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"DELETE"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -176,29 +153,6 @@ request["authorization"] = 'Bearer MGMT_API_ACCESS_TOKEN'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer MGMT_API_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/hooks/HOOK_ID")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "DELETE"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/customize/hooks/enable-disable-hooks.mdx
+++ b/main/docs/customize/hooks/enable-disable-hooks.mdx
@@ -132,35 +132,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-NSDictionary *parameters = @{ @"enabled": @"true" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/hooks/HOOK_ID"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -230,37 +201,6 @@ request.body = "{ "enabled": "true" }"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-let parameters = ["enabled": "true"] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/hooks/HOOK_ID")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/customize/hooks/hook-secrets/create-hook-secrets.mdx
+++ b/main/docs/customize/hooks/hook-secrets/create-hook-secrets.mdx
@@ -125,34 +125,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-
-NSData *postData = [[NSData alloc] initWithData:[@"{ [ "HOOK_SECRET_KEY", "HOOK_SECRET_VALUE" ], [ "HOOK_SECRET_KEY", "HOOK_SECRET_VALUE" ] }" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/hooks/HOOK_ID/secrets"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -222,36 +194,6 @@ request.body = "{ [ "HOOK_SECRET_KEY", "HOOK_SECRET_VALUE" ], [ "HOOK_SECRET_KEY
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-
-let postData = NSData(data: "{ [ "HOOK_SECRET_KEY", "HOOK_SECRET_VALUE" ], [ "HOOK_SECRET_KEY", "HOOK_SECRET_VALUE" ] }".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/hooks/HOOK_ID/secrets")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/customize/hooks/hook-secrets/delete-hook-secrets.mdx
+++ b/main/docs/customize/hooks/hook-secrets/delete-hook-secrets.mdx
@@ -106,32 +106,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN" };
-
-NSData *postData = [[NSData alloc] initWithData:[@"{ [ "HOOK_SECRET_NAME", "HOOK_SECRET_NAME" ] }" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/hooks/HOOK_ID/secrets"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"DELETE"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -193,32 +167,6 @@ request.body = "{ [ "HOOK_SECRET_NAME", "HOOK_SECRET_NAME" ] }"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer MGMT_API_ACCESS_TOKEN"]
-
-let postData = NSData(data: "{ [ "HOOK_SECRET_NAME", "HOOK_SECRET_NAME" ] }".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/hooks/HOOK_ID/secrets")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "DELETE"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/customize/hooks/hook-secrets/update-hook-secrets.mdx
+++ b/main/docs/customize/hooks/hook-secrets/update-hook-secrets.mdx
@@ -119,34 +119,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-
-NSData *postData = [[NSData alloc] initWithData:[@"{ [ "HOOK_SECRET_KEY", "HOOK_SECRET_VALUE" ], [ "HOOK_SECRET_KEY", "HOOK_SECRET_VALUE" ] }" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/hooks/HOOK_ID/secrets"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -216,36 +188,6 @@ request.body = "{ [ "HOOK_SECRET_KEY", "HOOK_SECRET_VALUE" ], [ "HOOK_SECRET_KEY
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-
-let postData = NSData(data: "{ [ "HOOK_SECRET_KEY", "HOOK_SECRET_VALUE" ], [ "HOOK_SECRET_KEY", "HOOK_SECRET_VALUE" ] }".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/hooks/HOOK_ID/secrets")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/customize/hooks/hook-secrets/view-hook-secrets.mdx
+++ b/main/docs/customize/hooks/hook-secrets/view-hook-secrets.mdx
@@ -98,29 +98,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/hooks/HOOK_ID/secrets"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -178,29 +155,6 @@ request["authorization"] = 'Bearer MGMT_API_ACCESS_TOKEN'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer MGMT_API_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/hooks/HOOK_ID/secrets")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/customize/hooks/update-hooks.mdx
+++ b/main/docs/customize/hooks/update-hooks.mdx
@@ -135,37 +135,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-NSDictionary *parameters = @{ @"name": @"HOOK_NAME",
-                              @"script": @"HOOK_SCRIPT",
-                              @"enabled": @"true" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/hooks/HOOK_ID"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -235,41 +204,6 @@ request.body = "{ "name": "HOOK_NAME", "script": "HOOK_SCRIPT", "enabled": "true
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-let parameters = [
-  "name": "HOOK_NAME",
-  "script": "HOOK_SCRIPT",
-  "enabled": "true"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/hooks/HOOK_ID")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/customize/hooks/view-hooks.mdx
+++ b/main/docs/customize/hooks/view-hooks.mdx
@@ -97,29 +97,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/hooks"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -177,29 +154,6 @@ request["authorization"] = 'Bearer MGMT_API_ACCESS_TOKEN'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer MGMT_API_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/hooks")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/customize/integrations/aws/aws-api-gateway-custom-authorizers.mdx
+++ b/main/docs/customize/integrations/aws/aws-api-gateway-custom-authorizers.mdx
@@ -426,26 +426,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://%7ByourInvokeUrl%7D/pets"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines
 $curl = curl_init();
@@ -499,25 +479,5 @@ request = Net::HTTP::Get.new(url)
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift lines
-import Foundation
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://%7ByourInvokeUrl%7D/pets")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>

--- a/main/docs/customize/integrations/google-cloud-endpoints.mdx
+++ b/main/docs/customize/integrations/google-cloud-endpoints.mdx
@@ -74,26 +74,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://%7ByourGceProject%7D.appspot.com/airportName?iataCode=SFO"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines
 $curl = curl_init();
@@ -147,26 +127,6 @@ request = Net::HTTP::Get.new(url)
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift lines
-import Foundation
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://%7ByourGceProject%7D.appspot.com/airportName?iataCode=SFO")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -372,26 +332,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://%7ByourGceProject%7D.appspot.com/airportName?iataCode=SFO"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines
 $curl = curl_init();
@@ -445,26 +385,6 @@ request = Net::HTTP::Get.new(url)
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift lines
-import Foundation
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://%7ByourGceProject%7D.appspot.com/airportName?iataCode=SFO")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -557,29 +477,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {accessToken}" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://%7ByourGceProject%7D.appspot.com/airportName?iataCode=SFO"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines
 $curl = curl_init();
@@ -639,29 +536,6 @@ request["authorization"] = 'Bearer {accessToken}'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift lines
-import Foundation
-
-let headers = ["authorization": "Bearer {accessToken}"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://%7ByourGceProject%7D.appspot.com/airportName?iataCode=SFO")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/customize/integrations/marketing-tool-integrations/marketo.mdx
+++ b/main/docs/customize/integrations/marketing-tool-integrations/marketo.mdx
@@ -105,53 +105,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C lines expandable
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {MARKETO_ACCESS_TOKEN}",
-                           @"content-type": @"multipart/form-data; boundary=---011000010111000001101001" };
-NSArray *parameters = @[ @{ @"name": @"file", @"fileName": @"auth0_users.csv", @"contentType": @"text/csv" },
-                         @{ @"name": @"format", @"value": @"csv", @"contentType": @"text/plan" } ];
-NSString *boundary = @"---011000010111000001101001";
-
-NSError *error;
-NSMutableString *body = [NSMutableString string];
-for (NSDictionary *param in parameters) {
-    [body appendFormat:@"--%@\r\n", boundary];
-    if (param[@"fileName"]) {
-        [body appendFormat:@"Content-Disposition:form-data; name=\"%@\"; filename=\"%@\"\r\n", param[@"name"], param[@"fileName"]];
-        [body appendFormat:@"Content-Type: %@\r\n\r\n", param[@"contentType"]];
-        [body appendFormat:@"%@", [NSString stringWithContentsOfFile:param[@"fileName"] encoding:NSUTF8StringEncoding error:&error]];
-        if (error) {
-            NSLog(@"%@", error);
-        }
-    } else {
-        [body appendFormat:@"Content-Disposition:form-data; name=\"%@\"\r\n\r\n", param[@"name"]];
-        [body appendFormat:@"%@", param[@"value"]];
-    }
-}
-[body appendFormat:@"\r\n--%@--\r\n", boundary];
-NSData *postData = [body dataUsingEncoding:NSUTF8StringEncoding];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://marketo_rest_api_base_url/bulk/v1/leads.json"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines expandable
 $curl = curl_init();
@@ -220,67 +173,6 @@ request.body = "-----011000010111000001101001\r\nContent-Disposition: form-data;
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift lines expandable
-import Foundation
-
-let headers = [
-  "authorization": "Bearer {MARKETO_ACCESS_TOKEN}",
-  "content-type": "multipart/form-data; boundary=---011000010111000001101001"
-]
-let parameters = [
-  [
-    "name": "file",
-    "fileName": "auth0_users.csv",
-    "contentType": "text/csv"
-  ],
-  [
-    "name": "format",
-    "value": "csv",
-    "contentType": "text/plan"
-  ]
-]
-
-let boundary = "---011000010111000001101001"
-
-var body = ""
-var error: NSError? = nil
-for param in parameters {
-  let paramName = param["name"]!
-  body += "--\(boundary)\r\n"
-  body += "Content-Disposition:form-data; name=\"\(paramName)\""
-  if let filename = param["fileName"] {
-    let contentType = param["content-type"]!
-    let fileContent = String(contentsOfFile: filename, encoding: String.Encoding.utf8)
-    if (error != nil) {
-      print(error)
-    }
-    body += "; filename=\"\(filename)\"\r\n"
-    body += "Content-Type: \(contentType)\r\n\r\n"
-    body += fileContent
-  } else if let paramValue = param["value"] {
-    body += "\r\n\r\n\(paramValue)"
-  }
-}
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://marketo_rest_api_base_url/bulk/v1/leads.json")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -365,29 +257,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {MARKETO_ACCESS_TOKEN}" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://marketo_rest_api_base_url/bulk/v1/leads/batch/BATCH_ID.json"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines
 $curl = curl_init();
@@ -447,29 +316,6 @@ request["authorization"] = 'Bearer {MARKETO_ACCESS_TOKEN}'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift lines
-import Foundation
-
-let headers = ["authorization": "Bearer {MARKETO_ACCESS_TOKEN}"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://marketo_rest_api_base_url/bulk/v1/leads/batch/BATCH_ID.json")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/customize/login-pages/custom-error-pages.mdx
+++ b/main/docs/customize/login-pages/custom-error-pages.mdx
@@ -122,34 +122,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {mgmtApiAccessToken}",
-                           @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"error_page": @{ @"html": @"", @"show_log_link": @NO, @"url": @"http://www.example.com" } };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/tenants/settings"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -216,40 +188,6 @@ request.body = "{"error_page": {"html": "", "show_log_link":false, "url": "http:
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer {mgmtApiAccessToken}",
-  "content-type": "application/json"
-]
-let parameters = ["error_page": [
-    "html": "",
-    "show_log_link": false,
-    "url": "http://www.example.com"
-  ]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/tenants/settings")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -363,34 +301,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C lines expandable
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"error_page": @{ @"html": @"<h1>{{error | escape }} {{error_description | escape }} This error was generated {{'now' | date: '%Y %h'}}.</h1>", @"show_log_link": @NO, @"url": @"" } };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://login.auth0.com/api/v2/tenants/settings"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines expandable
 $curl = curl_init();
@@ -459,40 +369,6 @@ request.body = "{\"error_page\": {\"html\": \"<h1>{{error | escape }} {{error_de
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift lines expandable
-import Foundation
-
-let headers = [
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "content-type": "application/json"
-]
-let parameters = ["error_page": [
-    "html": "<h1>{{error | escape }} {{error_description | escape }} This error was generated {{'now' | date: '%Y %h'}}.</h1>",
-    "show_log_link": false,
-    "url": ""
-  ]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://login.auth0.com/api/v2/tenants/settings")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/customize/login-pages/customize-consent-prompts.mdx
+++ b/main/docs/customize/login-pages/customize-consent-prompts.mdx
@@ -103,35 +103,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-NSDictionary *parameters = @{ @"flags": @{ @"use_scope_descriptions_for_consent": @YES } };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/tenants/settings"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -201,37 +172,6 @@ request.body = "{ "flags": { "use_scope_descriptions_for_consent": true } }"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-let parameters = ["flags": ["use_scope_descriptions_for_consent": true]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/tenants/settings")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -317,35 +257,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-NSDictionary *parameters = @{ @"flags": @{ @"use_scope_descriptions_for_consent": @NO } };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/tenants/settings"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -415,37 +326,6 @@ request.body = "{ "flags": { "use_scope_descriptions_for_consent": false } }"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-let parameters = ["flags": ["use_scope_descriptions_for_consent": false]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/tenants/settings")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/customize/login-pages/universal-login/customize-signup-and-login-prompts/connection-switching.mdx
+++ b/main/docs/customize/login-pages/universal-login/customize-signup-and-login-prompts/connection-switching.mdx
@@ -122,34 +122,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {mgmtApiToken}",
-                           @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"signup-password": @{ @"form-footer-start": @"<form method="post" data-form-secondary="true"><input type="hidden" name="state" value="{{state}}"> <input type="hidden" name="connection" value="email"> <button type="submit" id="switchConnectionButton" style="background: #635dff; width: 100%; padding: 12px 16px; border: none; color: white;" data-action-button-secondary="true"> <span>Send a secure code by email</span> </button></form>" } };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/prompts/signup-password/partials"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PUT"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -216,36 +188,6 @@ request.body = "{"signup-password":{"form-footer-start":"<form method=\\"post\\"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer {mgmtApiToken}",
-  "content-type": "application/json"
-]
-let parameters = ["signup-password": ["form-footer-start": "<form method="post" data-form-secondary="true"><input type="hidden" name="state" value="{{state}}"> <input type="hidden" name="connection" value="email"> <button type="submit" id="switchConnectionButton" style="background: #635dff; width: 100%; padding: 12px 16px; border: none; color: white;" data-action-button-secondary="true"> <span>Send a secure code by email</span> </button></form>"]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/prompts/signup-password/partials")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PUT"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -332,34 +274,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {mgmtApiToken}",
-                           @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"login-password": @{ @"form-footer-start": @"<form method='post' data-form-secondary='true'><input type='hidden' name='state' value='{{state}}'> <input type='hidden' name='connection' value='email'> <button type='submit' id='switchConnectionButton' style='background: #635dff; width: 100%; padding: 12px 16px; border: none; color: white;' data-action-button-secondary='true'> <span>Send a secure code by email</span> </button></form>" } };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/prompts/login-password/partials"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PUT"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -426,36 +340,6 @@ request.body = "{"login-password":{"form-footer-start":"<form method='post' data
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer {mgmtApiToken}",
-  "content-type": "application/json"
-]
-let parameters = ["login-password": ["form-footer-start": "<form method='post' data-form-secondary='true'><input type='hidden' name='state' value='{{state}}'> <input type='hidden' name='connection' value='email'> <button type='submit' id='switchConnectionButton' style='background: #635dff; width: 100%; padding: 12px 16px; border: none; color: white;' data-action-button-secondary='true'> <span>Send a secure code by email</span> </button></form>"]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/prompts/login-password/partials")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PUT"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -537,34 +421,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {mgmtApiToken}",
-                           @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"login-passwordless-email-code": @{ @"form-footer-start": @"<form method='post' data-form-secondary='true'><input type='hidden'  name='state' value='{{state}}'> <input type='hidden' name='connection' value='Username-Password-Authentication'> <button type='submit' id='switchConnectionButton' style='background: #635dff; width: 100%; padding: 12px 16px; border: none; color: white;' data-action-button-secondary='true'> <span>Use Password Instead</span> </button></form>" } };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/prompts/login-passwordless/partials"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PUT"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -631,35 +487,5 @@ request.body = "{"login-passwordless-email-code":{"form-footer-start":"<form met
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer {mgmtApiToken}",
-  "content-type": "application/json"
-]
-let parameters = ["login-passwordless-email-code": ["form-footer-start": "<form method='post' data-form-secondary='true'><input type='hidden'  name='state' value='{{state}}'> <input type='hidden' name='connection' value='Username-Password-Authentication'> <button type='submit' id='switchConnectionButton' style='background: #635dff; width: 100%; padding: 12px 16px; border: none; color: white;' data-action-button-secondary='true'> <span>Use Password Instead</span> </button></form>"]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/prompts/login-passwordless/partials")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PUT"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>

--- a/main/docs/customize/login-pages/universal-login/customize-signup-and-login-prompts/language-selection.mdx
+++ b/main/docs/customize/login-pages/universal-login/customize-signup-and-login-prompts/language-selection.mdx
@@ -211,51 +211,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"text/html",
-                           @"authorization": @"Bearer MANAGEMENT_API_TOKEN" };
-
-NSData *postData = [[NSData alloc] initWithData:[@"<!DOCTYPE html>
-<html>
-<head>{%- auth0:head -%}</head>
-<body class='_widget-auto-layout'>{%- auth0:widget -%}</body>
-<script>
-  function updateSelectedLanguage() {
-    const selectElement = document.getElementById('language');
-    const selectedValue = selectElement.value;
-    const options = selectElement.options;
-    for (let i = 0; i < options.length; i++) {
-      if (options[i].value === selectedValue) {
-        options[i].selected = true;
-      } else {
-        options[i].selected = false;
-      }
-    }
-    document.getElementById('changeLanguage').click();
-  }
-</script>" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/branding/templates/universal-login"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PUT"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -377,53 +332,6 @@ request.body = "<!DOCTYPE html>
 response = http.request(request)
 puts response.read_body
 ```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "text/html",
-  "authorization": "Bearer MANAGEMENT_API_TOKEN"
-]
-
-let postData = NSData(data: "<!DOCTYPE html>
-<html>
-<head>{%- auth0:head -%}</head>
-<body class='_widget-auto-layout'>{%- auth0:widget -%}</body>
-<script>
-  function updateSelectedLanguage() {
-    const selectElement = document.getElementById('language');
-    const selectedValue = selectElement.value;
-    const options = selectElement.options;
-    for (let i = 0; i < options.length; i++) {
-      if (options[i].value === selectedValue) {
-        options[i].selected = true;
-      } else {
-        options[i].selected = false;
-      }
-    }
-    document.getElementById('changeLanguage').click();
-  }
-</script>".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/branding/templates/universal-login")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PUT"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
-```
 </AuthCodeGroup>
 
 ### Configure individual Universal Login prompts
@@ -544,34 +452,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer {mgmtApiToken}" };
-NSDictionary *parameters = @{ @"signup": @{ @"form-content-start": @"<div class="ulp-field"><label for="language">Preferred Language</label><select name="language"id="language"  onchange=updateSelectedLanguage()><option></option><option value="en" {% if locale == "en" %}selected{% endif %}>English</option><option value="fr" {% if locale == "fr" %}selected{% endif %}>French</option><option value="es" {% if locale == "es" %}selected{% endif %}>Spanish</option></select></div><input type="hidden" name="persist" value="session"/><input name="action" id="changeLanguage" type="submit" value="change-language" style="display:none" formnovalidate/>" } };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/prompts/signup/partials"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PUT"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -650,36 +530,6 @@ request.body = "{
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer {mgmtApiToken}"
-]
-let parameters = ["signup": ["form-content-start": "<div class="ulp-field"><label for="language">Preferred Language</label><select name="language"id="language"  onchange=updateSelectedLanguage()><option></option><option value="en" {% if locale == "en" %}selected{% endif %}>English</option><option value="fr" {% if locale == "fr" %}selected{% endif %}>French</option><option value="es" {% if locale == "es" %}selected{% endif %}>Spanish</option></select></div><input type="hidden" name="persist" value="session"/><input name="action" id="changeLanguage" type="submit" value="change-language" style="display:none" formnovalidate/>"]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/prompts/signup/partials")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PUT"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -779,34 +629,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer {mgmtApiToken}" };
-NSDictionary *parameters = @{ @"login-id": @{ @"form-content-start": @"<div class="ulp-field"><label for="language">Preferred Language</label><select name="language"id="language"  onchange=updateSelectedLanguage()><option></option><option value="en" {% if locale == "en" %}selected{% endif %}>English</option><option value="fr" {% if locale == "fr" %}selected{% endif %}>French</option><option value="es" {% if locale == "es" %}selected{% endif %}>Spanish</option></select></div><input type="hidden" name="persist" value="session"/><input name="action" id="changeLanguage" type="submit" value="change-language" style="display:none" formnovalidate/>" } };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/prompts/login-id/partials"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PUT"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -885,36 +707,6 @@ request.body = "{
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer {mgmtApiToken}"
-]
-let parameters = ["login-id": ["form-content-start": "<div class="ulp-field"><label for="language">Preferred Language</label><select name="language"id="language"  onchange=updateSelectedLanguage()><option></option><option value="en" {% if locale == "en" %}selected{% endif %}>English</option><option value="fr" {% if locale == "fr" %}selected{% endif %}>French</option><option value="es" {% if locale == "es" %}selected{% endif %}>Spanish</option></select></div><input type="hidden" name="persist" value="session"/><input name="action" id="changeLanguage" type="submit" value="change-language" style="display:none" formnovalidate/>"]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/prompts/login-id/partials")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PUT"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -1014,34 +806,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer {mgmtApiToken}" };
-NSDictionary *parameters = @{ @"login-passwordless-email-code": @{ @"form-content-start": @"<div class="ulp-field"><label for="language">Preferred Language</label><select name="language"id="language"  onchange=updateSelectedLanguage()><option></option><option value="en" {% if locale == "en" %}selected{% endif %}>English</option><option value="fr" {% if locale == "fr" %}selected{% endif %}>French</option><option value="es" {% if locale == "es" %}selected{% endif %}>Spanish</option></select></div><input type="hidden" name="persist" value="session"/><input name="action" id="changeLanguage" type="submit" value="change-language" style="display:none" formnovalidate/>" } };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/prompts/login-passwordless/partials"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PUT"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -1120,36 +884,6 @@ request.body = "{
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer {mgmtApiToken}"
-]
-let parameters = ["login-passwordless-email-code": ["form-content-start": "<div class="ulp-field"><label for="language">Preferred Language</label><select name="language"id="language"  onchange=updateSelectedLanguage()><option></option><option value="en" {% if locale == "en" %}selected{% endif %}>English</option><option value="fr" {% if locale == "fr" %}selected{% endif %}>French</option><option value="es" {% if locale == "es" %}selected{% endif %}>Spanish</option></select></div><input type="hidden" name="persist" value="session"/><input name="action" id="changeLanguage" type="submit" value="change-language" style="display:none" formnovalidate/>"]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/prompts/login-passwordless/partials")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PUT"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/customize/login-pages/universal-login/customize-templates.mdx
+++ b/main/docs/customize/login-pages/universal-login/customize-templates.mdx
@@ -2198,33 +2198,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"content-type": @"text/html" };
-
-NSData *postData = [[NSData alloc] initWithData:[@"<!DOCTYPE html><html><head>{%- auth0:head -%}</head><body>{%- auth0:widget -%}</body></html>" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/branding/templates/universal-login"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PUT"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -2292,35 +2265,6 @@ request.body = "<!DOCTYPE html><html><head>{%- auth0:head -%}</head><body>{%- au
 response = http.request(request)
 puts response.read_body
 ```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "content-type": "text/html"
-]
-
-let postData = NSData(data: "<!DOCTYPE html><html><head>{%- auth0:head -%}</head><body>{%- auth0:widget -%}</body></html>".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/branding/templates/universal-login")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PUT"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
-```
 </AuthCodeGroup>
 
 To retrieve the template, you need to use the following endpoint:
@@ -2384,29 +2328,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/branding/templates/universal-login"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -2464,29 +2385,6 @@ request["authorization"] = 'Bearer MGMT_API_ACCESS_TOKEN'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer MGMT_API_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/branding/templates/universal-login")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -2551,29 +2449,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/branding/templates/universal-login"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"DELETE"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -2631,29 +2506,6 @@ request["authorization"] = 'Bearer MGMT_API_ACCESS_TOKEN'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer MGMT_API_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/branding/templates/universal-login")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "DELETE"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/customize/rules/create-rules.mdx
+++ b/main/docs/customize/rules/create-rules.mdx
@@ -139,36 +139,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-NSDictionary *parameters = @{ @"name": @"RULE_NAME",
-                              @"script": @"RULE_SCRIPT" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/rules"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -238,40 +208,6 @@ request.body = "{ "name": "RULE_NAME", "script": "RULE_SCRIPT" }"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-let parameters = [
-  "name": "RULE_NAME",
-  "script": "RULE_SCRIPT"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/rules")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/get-started/apis/add-api-permissions.mdx
+++ b/main/docs/get-started/apis/add-api-permissions.mdx
@@ -117,35 +117,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-NSDictionary *parameters = @{ @"scopes": @[ @{ @"value": @"PERMISSION_NAME", @"description": @"PERMISSION_DESC" }, @{ @"value": @"PERMISSION_NAME", @"description": @"PERMISSION_DESC" } ] };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/resource-servers/API_ID"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -215,46 +186,6 @@ request.body = "{ "scopes": [ { "value": "PERMISSION_NAME", "description": "PERM
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-let parameters = ["scopes": [
-    [
-      "value": "PERMISSION_NAME",
-      "description": "PERMISSION_DESC"
-    ],
-    [
-      "value": "PERMISSION_NAME",
-      "description": "PERMISSION_DESC"
-    ]
-  ]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/resource-servers/API_ID")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/get-started/apis/delete-api-permissions.mdx
+++ b/main/docs/get-started/apis/delete-api-permissions.mdx
@@ -104,35 +104,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-NSDictionary *parameters = @{ @"scopes": @[ @{ @"value": @"PERMISSION_NAME", @"description": @"PERMISSION_DESC" }, @{ @"value": @"PERMISSION_NAME", @"description": @"PERMISSION_DESC" } ] };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/resource-servers/API_ID"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -202,46 +173,6 @@ request.body = "{ "scopes": [ { "value": "PERMISSION_NAME", "description": "PERM
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-let parameters = ["scopes": [
-    [
-      "value": "PERMISSION_NAME",
-      "description": "PERMISSION_DESC"
-    ],
-    [
-      "value": "PERMISSION_NAME",
-      "description": "PERMISSION_DESC"
-    ]
-  ]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/resource-servers/API_ID")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/get-started/apis/enable-role-based-access-control-for-apis.mdx
+++ b/main/docs/get-started/apis/enable-role-based-access-control-for-apis.mdx
@@ -114,36 +114,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-NSDictionary *parameters = @{ @"enforce_policies": @"true",
-                              @"token_dialect": @"TOKEN_DIALECT" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/resource-servers/API_ID"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -213,40 +183,6 @@ request.body = "{ "enforce_policies": "true", "token_dialect": "TOKEN_DIALECT" }
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-let parameters = [
-  "enforce_policies": "true",
-  "token_dialect": "TOKEN_DIALECT"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/resource-servers/API_ID")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/get-started/applications/remove-applications.mdx
+++ b/main/docs/get-started/applications/remove-applications.mdx
@@ -78,29 +78,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourMgmtApiToken}" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/clients/%7ByourClientId%7D"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"DELETE"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -158,29 +135,6 @@ request["authorization"] = 'Bearer {yourMgmtApiToken}'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer {yourMgmtApiToken}"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/clients/%7ByourClientId%7D")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "DELETE"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/get-started/applications/rotate-client-secret.mdx
+++ b/main/docs/get-started/applications/rotate-client-secret.mdx
@@ -102,30 +102,6 @@ axios.request(options).then(function (response) {
 });
 
 ```
-```objc Obj-C
-   #import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourMgmtApiAccessToken}" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/clients/%7ByourClientId%7D/rotate-secret"]
-                                                      cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                  timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-
-```
 ```php PHP
    $curl = curl_init();
 
@@ -182,30 +158,6 @@ request = Net::HTTP::Post.new(url)
 request["authorization"] = 'Bearer {yourMgmtApiAccessToken}'
 response = http.request(request)
 puts response.read_body
-
-```
-```swift Swift
-   import Foundation
-
-let headers = ["authorization": "Bearer {yourMgmtApiAccessToken}"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/clients/%7ByourClientId%7D/rotate-secret")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 
 ```
 </AuthCodeGroup>

--- a/main/docs/get-started/applications/update-grant-types.mdx
+++ b/main/docs/get-started/applications/update-grant-types.mdx
@@ -100,35 +100,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer {yourMgmtApiAccessToken}",
-                           @"cache-control": @"no-cache" };
-NSDictionary *parameters = @{ @"grant_types": @"{grantTypes}" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/clients/%7ByourClientId%7D"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -198,37 +169,6 @@ request.body = "{ "grant_types": "{grantTypes}" }"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer {yourMgmtApiAccessToken}",
-  "cache-control": "no-cache"
-]
-let parameters = ["grant_types": "{grantTypes}"] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/clients/%7ByourClientId%7D")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/get-started/architecture-scenarios/mobile-api/part-3.mdx
+++ b/main/docs/get-started/architecture-scenarios/mobile-api/part-3.mdx
@@ -194,36 +194,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=authorization_code" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&code_verified=YOUR_GENERATED_CODE_VERIFIER" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&code=YOUR_AUTHORIZATION_CODE" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&redirect_uri=https://{https://yourApp/callback}" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -285,36 +255,6 @@ request.body = "grant_type=authorization_code&client_id={yourClientId}&code_veri
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=authorization_code".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&code_verified=YOUR_GENERATED_CODE_VERIFIER".data(using: String.Encoding.utf8)!)
-postData.append("&code=YOUR_AUTHORIZATION_CODE".data(using: String.Encoding.utf8)!)
-postData.append("&redirect_uri=https://{https://yourApp/callback}".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -454,32 +394,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSData *postData = [[NSData alloc] initWithData:[@"undefined" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -537,32 +451,6 @@ request["content-type"] = 'application/x-www-form-urlencoded'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSData(data: "undefined".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/get-started/authentication-and-authorization-flow/authorization-code-flow-with-pkce/add-login-using-the-authorization-code-flow-with-pkce.mdx
+++ b/main/docs/get-started/authentication-and-authorization-flow/authorization-code-flow-with-pkce/add-login-using-the-authorization-code-flow-with-pkce.mdx
@@ -306,36 +306,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=authorization_code" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&code_verifier={yourGeneratedCodeVerifier}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&code={yourAuthorizationCode}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&redirect_uri={https://yourApp/callback}" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -397,36 +367,6 @@ request.body = "grant_type=authorization_code&client_id={yourClientId}&code_veri
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=authorization_code".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&code_verifier={yourGeneratedCodeVerifier}".data(using: String.Encoding.utf8)!)
-postData.append("&code={yourAuthorizationCode}".data(using: String.Encoding.utf8)!)
-postData.append("&redirect_uri={https://yourApp/callback}".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/get-started/authentication-and-authorization-flow/authorization-code-flow-with-pkce/call-your-api-using-the-authorization-code-flow-with-pkce.mdx
+++ b/main/docs/get-started/authentication-and-authorization-flow/authorization-code-flow-with-pkce/call-your-api-using-the-authorization-code-flow-with-pkce.mdx
@@ -329,36 +329,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=authorization_code" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&code_verifier={yourGeneratedCodeVerifier}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&code={yourAuthorizationCode}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&redirect_uri={https://yourApp/callback}" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -420,36 +390,6 @@ request.body = "grant_type=authorization_code&client_id={yourClientId}&code_veri
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=authorization_code".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&code_verifier={yourGeneratedCodeVerifier}".data(using: String.Encoding.utf8)!)
-postData.append("&code={yourAuthorizationCode}".data(using: String.Encoding.utf8)!)
-postData.append("&redirect_uri={https://yourApp/callback}".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -564,30 +504,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer {accessToken}" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://myapi.com/api"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines expandable
 $curl = curl_init();
@@ -652,32 +568,6 @@ request["authorization"] = 'Bearer {accessToken}'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift lines
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer {accessToken}"
-]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://myapi.com/api")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -766,34 +656,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=refresh_token" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&refresh_token={yourRefreshToken}" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -855,34 +717,6 @@ request.body = "grant_type=refresh_token&client_id={yourClientId}&refresh_token=
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=refresh_token".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&refresh_token={yourRefreshToken}".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/get-started/authentication-and-authorization-flow/authorization-code-flow/add-login-auth-code-flow.mdx
+++ b/main/docs/get-started/authentication-and-authorization-flow/authorization-code-flow/add-login-auth-code-flow.mdx
@@ -164,36 +164,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=authorization_code" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_secret={yourClientSecret}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&code=yourAuthorizationCode}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&redirect_uri={https://yourApp/callback}" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -255,36 +225,6 @@ request.body = "grant_type=authorization_code&client_id={yourClientId}&client_se
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=authorization_code".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&client_secret={yourClientSecret}".data(using: String.Encoding.utf8)!)
-postData.append("&code=yourAuthorizationCode}".data(using: String.Encoding.utf8)!)
-postData.append("&redirect_uri={https://yourApp/callback}".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/get-started/authentication-and-authorization-flow/authorization-code-flow/call-your-api-using-the-authorization-code-flow.mdx
+++ b/main/docs/get-started/authentication-and-authorization-flow/authorization-code-flow/call-your-api-using-the-authorization-code-flow.mdx
@@ -184,36 +184,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=authorization_code" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_secret={yourClientSecret}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&code=yourAuthorizationCode}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&redirect_uri={https://yourApp/callback}" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -269,36 +239,6 @@ request.body = "grant_type=authorization_code&client_id={yourClientId}&client_se
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=authorization_code".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&client_secret={yourClientSecret}".data(using: String.Encoding.utf8)!)
-postData.append("&code=yourAuthorizationCode}".data(using: String.Encoding.utf8)!)
-postData.append("&redirect_uri={https://yourApp/callback}".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -416,31 +356,6 @@ axios.request(options).then(function (response) {
 });
 
 ```
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer {accessToken}" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://myapi.com/api"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-
-```
 
 ```php PHP lines expandable
 $curl = curl_init();
@@ -501,32 +416,6 @@ request["content-type"] = 'application/json'
 request["authorization"] = 'Bearer {accessToken}'
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift lines
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer {accessToken}"
-]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://myapi.com/api")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -617,34 +506,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=refresh_token" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&refresh_token={yourRefreshToken}" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -696,34 +557,6 @@ request["content-type"] = 'application/x-www-form-urlencoded'
 request.body = "grant_type=refresh_token&client_id={yourClientId}&refresh_token=%7ByourRefreshToken%7D"
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=refresh_token".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&refresh_token={yourRefreshToken}".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/get-started/authentication-and-authorization-flow/client-credentials-flow/call-your-api-using-the-client-credentials-flow.mdx
+++ b/main/docs/get-started/authentication-and-authorization-flow/client-credentials-flow/call-your-api-using-the-client-credentials-flow.mdx
@@ -116,36 +116,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=client_credentials" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_secret={yourClientSecret}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&audience=YOUR_API_IDENTIFIER" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -207,35 +177,6 @@ request.body = "grant_type=client_credentials&client_id={yourClientId}&client_se
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=client_credentials".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&client_secret={yourClientSecret}".data(using: String.Encoding.utf8)!)
-postData.append("&audience=YOUR_API_IDENTIFIER".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -336,30 +277,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://myapi.com/api"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines expandable
 $curl = curl_init();
@@ -424,32 +341,6 @@ request["authorization"] = 'Bearer ACCESS_TOKEN'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift lines
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer ACCESS_TOKEN"
-]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://myapi.com/api")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/get-started/authentication-and-authorization-flow/client-credentials-flow/customize-tokens-using-hooks-with-client-credentials-flow.mdx
+++ b/main/docs/get-started/authentication-and-authorization-flow/client-credentials-flow/customize-tokens-using-hooks-with-client-credentials-flow.mdx
@@ -163,35 +163,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=client_credentials" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_secret={yourClientSecret}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&audience=YOUR_API_IDENTIFIER" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -253,35 +224,6 @@ request.body = "grant_type=client_credentials&client_id={yourClientId}&client_se
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=client_credentials".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&client_secret={yourClientSecret}".data(using: String.Encoding.utf8)!)
-postData.append("&audience=YOUR_API_IDENTIFIER".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/get-started/authentication-and-authorization-flow/resource-owner-password-flow/call-your-api-using-resource-owner-password-flow.mdx
+++ b/main/docs/get-started/authentication-and-authorization-flow/resource-owner-password-flow/call-your-api-using-resource-owner-password-flow.mdx
@@ -149,38 +149,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=password" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&username={username}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&password={password}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&audience={yourApiIdentifier}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&scope=read:sample" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_secret={yourClientSecret}" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -242,38 +210,6 @@ request.body = "grant_type=password&username=%7Busername%7D&password=%7Bpassword
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=password".data(using: String.Encoding.utf8)!)
-postData.append("&username={username}".data(using: String.Encoding.utf8)!)
-postData.append("&password={password}".data(using: String.Encoding.utf8)!)
-postData.append("&audience={yourApiIdentifier}".data(using: String.Encoding.utf8)!)
-postData.append("&scope=read:sample".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&client_secret={yourClientSecret}".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -396,30 +332,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer {accessToken}" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://myapi.com/api"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines expandable
 $curl = curl_init();
@@ -484,32 +396,6 @@ request["authorization"] = 'Bearer {accessToken}'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift lines
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer {accessToken}"
-]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://myapi.com/api")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -598,34 +484,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=refresh_token" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&refresh_token={yourRefreshToken}" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -687,34 +545,6 @@ request.body = "grant_type=refresh_token&client_id={yourClientId}&refresh_token=
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=refresh_token".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&refresh_token={yourRefreshToken}".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/get-started/onboarding/self-service-m2m.mdx
+++ b/main/docs/get-started/onboarding/self-service-m2m.mdx
@@ -280,35 +280,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=client_credentials" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_secret={yourClientSecret}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&audience=YOUR_API_IDENTIFIER" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -370,35 +341,6 @@ request.body = "grant_type=client_credentials&client_id={yourClientId}&client_se
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=client_credentials".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&client_secret={yourClientSecret}".data(using: String.Encoding.utf8)!)
-postData.append("&audience=YOUR_API_IDENTIFIER".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/get-started/tenant-settings/signing-keys/revoke-signing-keys.mdx
+++ b/main/docs/get-started/tenant-settings/signing-keys/revoke-signing-keys.mdx
@@ -110,30 +110,6 @@ console.error(error);
 });
 
 ```
-```objc Obj-C
-   #import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourMgmtApiAccessToken}" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/keys/signing/%7ByourKeyId%7D/revoke"]
-                                                      cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PUT"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                          completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                   NSLog(@"%@", error);
-                                                } else {
-                                                   NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                   NSLog(@"%@", httpResponse);
-                                                }
-                                          }];
-[dataTask resume];
-
-```
 ```php PHP
    $curl = curl_init();
 
@@ -193,30 +169,6 @@ request["authorization"] = 'Bearer {yourMgmtApiAccessToken}'
 
 response = http.request(request)
 puts response.read_body
-
-```
-```swift Swift
-   import Foundation
-
-let headers = ["authorization": "Bearer {yourMgmtApiAccessToken}"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/keys/signing/%7ByourKeyId%7D/revoke")! as URL,
-                                       cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PUT"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-if (error != nil) {
-   print(error)
-} else {
-   let httpResponse = response as? HTTPURLResponse
-   print(httpResponse)
-}
-})
-
-dataTask.resume()
 
 ```
 </AuthCodeGroup>

--- a/main/docs/get-started/tenant-settings/signing-keys/rotate-signing-keys.mdx
+++ b/main/docs/get-started/tenant-settings/signing-keys/rotate-signing-keys.mdx
@@ -103,30 +103,6 @@ console.error(error);
 });
 
 ```
-```objc Obj-C
-   #import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourMgmtApiAccessToken}" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/keys/signing/rotate"]
-                                                      cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                          completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                   NSLog(@"%@", error);
-                                                } else {
-                                                   NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                   NSLog(@"%@", httpResponse);
-                                                }
-                                          }];
-[dataTask resume];
-
-```
 ```php PHP
    $curl = curl_init();
 
@@ -186,30 +162,6 @@ request["authorization"] = 'Bearer {yourMgmtApiAccessToken}'
 
 response = http.request(request)
 puts response.read_body
-
-```
-```swift Swift
-   import Foundation
-
-let headers = ["authorization": "Bearer {yourMgmtApiAccessToken}"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/keys/signing/rotate")! as URL,
-                                       cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-if (error != nil) {
-   print(error)
-} else {
-   let httpResponse = response as? HTTPURLResponse
-   print(httpResponse)
-}
-})
-
-dataTask.resume()
 
 ```
 </AuthCodeGroup>

--- a/main/docs/get-started/tenant-settings/signing-keys/view-signing-certificates.mdx
+++ b/main/docs/get-started/tenant-settings/signing-keys/view-signing-certificates.mdx
@@ -104,29 +104,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourMgmtApiAccessToken}" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/keys/signing"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -184,29 +161,6 @@ request["authorization"] = 'Bearer {yourMgmtApiAccessToken}'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer {yourMgmtApiAccessToken}"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/keys/signing")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -277,29 +231,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourMgmtApiAccessToken}" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/keys/signing/%7ByourKeyId%7D"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -357,29 +288,6 @@ request["authorization"] = 'Bearer {yourMgmtApiAccessToken}'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer {yourMgmtApiAccessToken}"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/keys/signing/%7ByourKeyId%7D")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/manage-users/access-control/configure-core-rbac/enable-role-based-access-control-for-apis.mdx
+++ b/main/docs/manage-users/access-control/configure-core-rbac/enable-role-based-access-control-for-apis.mdx
@@ -114,36 +114,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-NSDictionary *parameters = @{ @"enforce_policies": @"true",
-                              @"token_dialect": @"TOKEN_DIALECT" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/resource-servers/API_ID"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -213,40 +183,6 @@ request.body = "{ "enforce_policies": "true", "token_dialect": "TOKEN_DIALECT" }
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-let parameters = [
-  "enforce_policies": "true",
-  "token_dialect": "TOKEN_DIALECT"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/resource-servers/API_ID")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/manage-users/access-control/configure-core-rbac/rbac-users/assign-permissions-to-users.mdx
+++ b/main/docs/manage-users/access-control/configure-core-rbac/rbac-users/assign-permissions-to-users.mdx
@@ -131,35 +131,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-NSDictionary *parameters = @{ @"permissions": @[ @{ @"resource_server_identifier": @"API_IDENTIFIER", @"permission_name": @"PERMISSION_NAME" }, @{ @"resource_server_identifier": @"API_IDENTIFIER", @"permission_name": @"PERMISSION_NAME" } ] };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users/USER_ID/permissions"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -229,46 +200,6 @@ request.body = "{ "permissions": [ { "resource_server_identifier": "API_IDENTIFI
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-let parameters = ["permissions": [
-    [
-      "resource_server_identifier": "API_IDENTIFIER",
-      "permission_name": "PERMISSION_NAME"
-    ],
-    [
-      "resource_server_identifier": "API_IDENTIFIER",
-      "permission_name": "PERMISSION_NAME"
-    ]
-  ]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users/USER_ID/permissions")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/manage-users/access-control/configure-core-rbac/rbac-users/assign-roles-to-users.mdx
+++ b/main/docs/manage-users/access-control/configure-core-rbac/rbac-users/assign-roles-to-users.mdx
@@ -115,35 +115,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-NSDictionary *parameters = @{ @"roles": @[ @"ROLE_ID", @"ROLE_ID" ] };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users/USER_ID/roles"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -213,37 +184,6 @@ request.body = "{ "roles": [ "ROLE_ID", "ROLE_ID" ] }"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-let parameters = ["roles": ["ROLE_ID", "ROLE_ID"]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users/USER_ID/roles")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/manage-users/access-control/configure-core-rbac/rbac-users/remove-permissions-from-users.mdx
+++ b/main/docs/manage-users/access-control/configure-core-rbac/rbac-users/remove-permissions-from-users.mdx
@@ -106,35 +106,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-NSDictionary *parameters = @{ @"permissions": @[ @{ @"resource_server_identifier": @"API_ID", @"permission_name": @"PERMISSION_NAME" }, @{ @"resource_server_identifier": @"API_ID", @"permission_name": @"PERMISSION_NAME" } ] };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users/USER_ID/permissions"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"DELETE"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -204,46 +175,6 @@ request.body = "{ "permissions": [ { "resource_server_identifier": "API_ID", "pe
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-let parameters = ["permissions": [
-    [
-      "resource_server_identifier": "API_ID",
-      "permission_name": "PERMISSION_NAME"
-    ],
-    [
-      "resource_server_identifier": "API_ID",
-      "permission_name": "PERMISSION_NAME"
-    ]
-  ]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users/USER_ID/permissions")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "DELETE"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/manage-users/access-control/configure-core-rbac/rbac-users/remove-roles-from-users.mdx
+++ b/main/docs/manage-users/access-control/configure-core-rbac/rbac-users/remove-roles-from-users.mdx
@@ -99,35 +99,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-NSDictionary *parameters = @{ @"roles": @[ @"ROLE_ID", @"ROLE_ID" ] };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users/USER_ID/roles"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"DELETE"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -197,37 +168,6 @@ request.body = "{ "roles": [ "ROLE_ID", "ROLE_ID" ] }"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-let parameters = ["roles": ["ROLE_ID", "ROLE_ID"]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users/USER_ID/roles")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "DELETE"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/manage-users/access-control/configure-core-rbac/rbac-users/view-user-permissions.mdx
+++ b/main/docs/manage-users/access-control/configure-core-rbac/rbac-users/view-user-permissions.mdx
@@ -91,29 +91,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users/USER_ID/permissions"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -171,29 +148,6 @@ request["authorization"] = 'Bearer MGMT_API_ACCESS_TOKEN'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer MGMT_API_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users/USER_ID/permissions")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/manage-users/access-control/configure-core-rbac/rbac-users/view-user-roles.mdx
+++ b/main/docs/manage-users/access-control/configure-core-rbac/rbac-users/view-user-roles.mdx
@@ -87,29 +87,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users/USER_ID/roles"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -167,29 +144,6 @@ request["authorization"] = 'Bearer MGMT_API_ACCESS_TOKEN'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer MGMT_API_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users/USER_ID/roles")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/manage-users/access-control/configure-core-rbac/roles/add-permissions-to-roles.mdx
+++ b/main/docs/manage-users/access-control/configure-core-rbac/roles/add-permissions-to-roles.mdx
@@ -114,35 +114,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-NSDictionary *parameters = @{ @"permissions": @[ @{ @"resource_server_identifier": @"API_IDENTIFIER", @"permission_name": @"PERMISSION_NAME" }, @{ @"resource_server_identifier": @"API_IDENTIFIER", @"permission_name": @"PERMISSION_NAME" } ] };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/roles/ROLE_ID/permissions"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -212,46 +183,6 @@ request.body = "{ "permissions": [ { "resource_server_identifier": "API_IDENTIFI
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-let parameters = ["permissions": [
-    [
-      "resource_server_identifier": "API_IDENTIFIER",
-      "permission_name": "PERMISSION_NAME"
-    ],
-    [
-      "resource_server_identifier": "API_IDENTIFIER",
-      "permission_name": "PERMISSION_NAME"
-    ]
-  ]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/roles/ROLE_ID/permissions")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/manage-users/access-control/configure-core-rbac/roles/create-roles.mdx
+++ b/main/docs/manage-users/access-control/configure-core-rbac/roles/create-roles.mdx
@@ -101,36 +101,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-NSDictionary *parameters = @{ @"name": @"ROLE_NAME",
-                              @"description": @"ROLE_DESC" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/roles"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -200,40 +170,6 @@ request.body = "{ "name": "ROLE_NAME", "description": "ROLE_DESC" }"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-let parameters = [
-  "name": "ROLE_NAME",
-  "description": "ROLE_DESC"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/roles")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/manage-users/access-control/configure-core-rbac/roles/delete-roles.mdx
+++ b/main/docs/manage-users/access-control/configure-core-rbac/roles/delete-roles.mdx
@@ -78,29 +78,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/roles/ROLE_ID"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"DELETE"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -158,29 +135,6 @@ request["authorization"] = 'Bearer MGMT_API_ACCESS_TOKEN'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer MGMT_API_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/roles/ROLE_ID")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "DELETE"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/manage-users/access-control/configure-core-rbac/roles/edit-role-definitions.mdx
+++ b/main/docs/manage-users/access-control/configure-core-rbac/roles/edit-role-definitions.mdx
@@ -99,36 +99,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-NSDictionary *parameters = @{ @"name": @"ROLE_NAME",
-                              @"description": @"ROLE_DESC" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/roles/ROLE_ID"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -198,40 +168,6 @@ request.body = "{ "name": "ROLE_NAME", "description": "ROLE_DESC" }"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-let parameters = [
-  "name": "ROLE_NAME",
-  "description": "ROLE_DESC"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/roles/ROLE_ID")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/manage-users/access-control/configure-core-rbac/roles/remove-permissions-from-roles.mdx
+++ b/main/docs/manage-users/access-control/configure-core-rbac/roles/remove-permissions-from-roles.mdx
@@ -104,35 +104,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-NSDictionary *parameters = @{ @"permissions": @[ @{ @"resource_server_identifier": @"API_ID", @"permission_name": @"PERMISSION_NAME" }, @{ @"resource_server_identifier": @"API_ID", @"permission_name": @"PERMISSION_NAME" } ] };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/roles/ROLE_ID/permissions"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"DELETE"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -202,46 +173,6 @@ request.body = "{ "permissions": [ { "resource_server_identifier": "API_ID", "pe
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-let parameters = ["permissions": [
-    [
-      "resource_server_identifier": "API_ID",
-      "permission_name": "PERMISSION_NAME"
-    ],
-    [
-      "resource_server_identifier": "API_ID",
-      "permission_name": "PERMISSION_NAME"
-    ]
-  ]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/roles/ROLE_ID/permissions")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "DELETE"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/manage-users/access-control/configure-core-rbac/roles/view-role-permissions.mdx
+++ b/main/docs/manage-users/access-control/configure-core-rbac/roles/view-role-permissions.mdx
@@ -88,29 +88,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/roles/ROLE_ID/permissions"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -168,29 +145,6 @@ request["authorization"] = 'Bearer MGMT_API_ACCESS_TOKEN'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer MGMT_API_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/roles/ROLE_ID/permissions")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/manage-users/my-account-api.mdx
+++ b/main/docs/manage-users/my-account-api.mdx
@@ -170,26 +170,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/authorize?response_type=code&client_id={yourClientId}&redirect_uri=%7ByourRedirectUri%7D&scope=create%3Ame%3Aauthentication_methods&offline_access=&audience=https%3A%2F%2F{yourDomain}%2Fme%2F"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -241,26 +221,6 @@ request = Net::HTTP::Get.new(url)
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/authorize?response_type=code&client_id={yourClientId}&redirect_uri=%7ByourRedirectUri%7D&scope=create%3Ame%3Aauthentication_methods&offline_access=&audience=https%3A%2F%2F{yourDomain}%2Fme%2F")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -341,40 +301,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"grant_type": @"authorization_code",
-                              @"client_id": @"{yourClientId}",
-                              @"client_secret": @"{yourClientId}",
-                              @"code": @"{yourAuthorizationCode}",
-                              @"redirect_uri": @"{yourRedirectUri}",
-                              @"audience": @"{yourAudience}",
-                              @"scope": @"create:me:authentication_methods",
-                              @"offline_access": @"" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -436,42 +362,6 @@ request.body = "{"grant_type": "authorization_code","client_id": "{yourClientId}
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/json"]
-let parameters = [
-  "grant_type": "authorization_code",
-  "client_id": "{yourClientId}",
-  "client_secret": "{yourClientId}",
-  "code": "{yourAuthorizationCode}",
-  "redirect_uri": "{yourRedirectUri}",
-  "audience": "{yourAudience}",
-  "scope": "create:me:authentication_methods",
-  "offline_access": ""
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -545,33 +435,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"client_id": @"{yourDomain}" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/passkey/challenge"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -633,33 +496,6 @@ request.body = "{"client_id": "{yourDomain}"}"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/json"]
-let parameters = ["client_id": "{yourDomain}"] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/passkey/challenge")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -731,32 +567,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json" };
-
-NSData *postData = [[NSData alloc] initWithData:[@"{  "grant_type": "urn:okta:params:oauth:grant-type:webauthn",  "client_id": "{yourClientId}",  "scope": "create:me:authentication_methods offline_access",  "audience": "https://{yourDomain}/me/"  "auth_session": "{sessionIdFromTheFirstRequest}",  "authn_response": "{authenticatorResponse}"}" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -818,32 +628,6 @@ request.body = "{  "grant_type": "urn:okta:params:oauth:grant-type:webauthn",  "
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/json"]
-
-let postData = NSData(data: "{  "grant_type": "urn:okta:params:oauth:grant-type:webauthn",  "client_id": "{yourClientId}",  "scope": "create:me:authentication_methods offline_access",  "audience": "https://{yourDomain}/me/"  "auth_session": "{sessionIdFromTheFirstRequest}",  "authn_response": "{authenticatorResponse}"}".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/manage-users/organizations/configure-organizations/add-member-roles.mdx
+++ b/main/docs/manage-users/organizations/configure-organizations/add-member-roles.mdx
@@ -109,35 +109,6 @@ axios.request(options).then(function (response) {
 });
 ```
 
-```objc Obj-C lines expandable
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-NSDictionary *parameters = @{ @"roles": @[ @"ROLE_ID", @"ROLE_ID", @"ROLE_ID" ] };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/organizations/ORG_ID/members/USER_ID/roles"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines expandable
 $curl = curl_init();
@@ -212,37 +183,6 @@ response = http.request(request)
 puts response.read_body
 ```
 
-```swift Swift lines expandable
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-let parameters = ["roles": ["ROLE_ID", "ROLE_ID", "ROLE_ID"]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/organizations/ORG_ID/members/USER_ID/roles")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
-```
 
 </AuthCodeGroup><Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 

--- a/main/docs/manage-users/organizations/configure-organizations/assign-members.mdx
+++ b/main/docs/manage-users/organizations/configure-organizations/assign-members.mdx
@@ -107,35 +107,6 @@ axios.request(options).then(function (response) {
 });
 ```
 
-```objc Obj-C lines expandable
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-NSDictionary *parameters = @{ @"members": @[ @"USER_ID", @"USER_ID", @"USER_ID" ] };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/organizations/ORG_ID/members"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines expandable
 $curl = curl_init();
@@ -210,37 +181,6 @@ response = http.request(request)
 puts response.read_body
 ```
 
-```swift Swift lines expandable
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-let parameters = ["members": ["USER_ID", "USER_ID", "USER_ID"]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/organizations/ORG_ID/members")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
-```
 
 </AuthCodeGroup><Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 

--- a/main/docs/manage-users/organizations/configure-organizations/create-organizations.mdx
+++ b/main/docs/manage-users/organizations/configure-organizations/create-organizations.mdx
@@ -119,34 +119,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer {MGMT_API_ACCESS_TOKEN}",
-                           @"cache-control": @"no-cache" };
-
-NSData *postData = [[NSData alloc] initWithData:[@"{ "name": "ORG_NAME", "display_name": "ORG_DISPLAY_NAME", "branding": [ { "logo_url": "{orgLogo}", "colors": [ { "primary": "{orgPrimaryColor}", "page_background": "{orgPageBackground}" } ] } ], "metadata": [ { "{key}": "{value}", "{key}": "{value}", "{key}": "{value}" } ] }, "enabled_connections": [ { "connection_id": "{connectionId}", "assign_membership_on_login": "{assignMembershipOption}" }, { "connection_id": "{connectionId}", "assign_membership_on_login": "{assignMembershipOption}" } ] }" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/organizations"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -216,36 +188,6 @@ request.body = "{ "name": "ORG_NAME", "display_name": "ORG_DISPLAY_NAME", "brand
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer {MGMT_API_ACCESS_TOKEN}",
-  "cache-control": "no-cache"
-]
-
-let postData = NSData(data: "{ "name": "ORG_NAME", "display_name": "ORG_DISPLAY_NAME", "branding": [ { "logo_url": "{orgLogo}", "colors": [ { "primary": "{orgPrimaryColor}", "page_background": "{orgPageBackground}" } ] } ], "metadata": [ { "{key}": "{value}", "{key}": "{value}", "{key}": "{value}" } ] }, "enabled_connections": [ { "connection_id": "{connectionId}", "assign_membership_on_login": "{assignMembershipOption}" }, { "connection_id": "{connectionId}", "assign_membership_on_login": "{assignMembershipOption}" } ] }".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/organizations")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup><Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 

--- a/main/docs/manage-users/organizations/configure-organizations/define-organization-behavior.mdx
+++ b/main/docs/manage-users/organizations/configure-organizations/define-organization-behavior.mdx
@@ -117,36 +117,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-NSDictionary *parameters = @{ @"organization_usage": @"ORG_USAGE",
-                              @"organization_require_behavior": @"ORG_REQUIRE_BEHAVIOR" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/clients/CLIENT_ID"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -216,40 +186,6 @@ request.body = "{ "organization_usage": "ORG_USAGE", "organization_require_behav
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-let parameters = [
-  "organization_usage": "ORG_USAGE",
-  "organization_require_behavior": "ORG_REQUIRE_BEHAVIOR"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/clients/CLIENT_ID")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/manage-users/organizations/configure-organizations/delete-organizations.mdx
+++ b/main/docs/manage-users/organizations/configure-organizations/delete-organizations.mdx
@@ -86,29 +86,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/organizations/ORG_ID"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"DELETE"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -166,29 +143,6 @@ request["authorization"] = 'Bearer MGMT_API_ACCESS_TOKEN'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer MGMT_API_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/organizations/ORG_ID")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "DELETE"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup><Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 

--- a/main/docs/manage-users/organizations/configure-organizations/enable-connections.mdx
+++ b/main/docs/manage-users/organizations/configure-organizations/enable-connections.mdx
@@ -159,34 +159,6 @@ axios.request(options).then(function (response) {
 });
 ```
 
-```objc Obj-C lines expandable
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer {yourMgmtApiAccessToken}",
-                           @"cache-control": @"no-cache" };
-
-NSData *postData = [[NSData alloc] initWithData:[@"{ "connection_id": "{connectionId}", "assign_membership_on_login": "{assignMembershipOption}", "is_enabled": "{isEnabled}", "is_signup_enabled": "{isSignupEnabled}", "show_as_button": "{showAsButtonOption}", "organization_access_level": "{organizationAccessLevel}", "organization_connection_name": "{organizationConnectionName}" }" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://%7ByourAuth0Domain%7D/api/v2/organizations/%7BorgId%7D/connections"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines expandable
 $curl = curl_init();
@@ -261,36 +233,6 @@ response = http.request(request)
 puts response.read_body
 ```
 
-```swift Swift lines expandable
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer {yourMgmtApiAccessToken}",
-  "cache-control": "no-cache"
-]
-
-let postData = NSData(data: "{ "connection_id": "{connectionId}", "assign_membership_on_login": "{assignMembershipOption}", "is_enabled": "{isEnabled}", "is_signup_enabled": "{isSignupEnabled}", "show_as_button": "{showAsButtonOption}", "organization_access_level": "{organizationAccessLevel}", "organization_connection_name": "{organizationConnectionName}" }".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://%7ByourAuth0Domain%7D/api/v2/organizations/%7BorgId%7D/connections")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
-```
 
 </AuthCodeGroup>
 

--- a/main/docs/manage-users/organizations/configure-organizations/remove-member-roles.mdx
+++ b/main/docs/manage-users/organizations/configure-organizations/remove-member-roles.mdx
@@ -91,34 +91,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-NSDictionary *parameters = @{ @"roles": @[ @"ROLE_ID", @"ROLE_ID", @"ROLE_ID" ] };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/organizations/ORG_ID/members/USER_ID/roles"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"DELETE"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -185,36 +157,6 @@ request.body = "{ "roles": [ "ROLE_ID", "ROLE_ID", "ROLE_ID" ] }"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-let parameters = ["roles": ["ROLE_ID", "ROLE_ID", "ROLE_ID"]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/organizations/ORG_ID/members/USER_ID/roles")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "DELETE"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup><Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 

--- a/main/docs/manage-users/organizations/configure-organizations/remove-members.mdx
+++ b/main/docs/manage-users/organizations/configure-organizations/remove-members.mdx
@@ -91,34 +91,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-NSDictionary *parameters = @{ @"members": @[ @"USER_ID", @"USER_ID", @"USER_ID" ] };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/organizations/ORG_ID/members"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"DELETE"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -185,36 +157,6 @@ request.body = "{ "members": [ "USER_ID", "USER_ID", "USER_ID" ] }"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-let parameters = ["members": ["USER_ID", "USER_ID", "USER_ID"]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/organizations/ORG_ID/members")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "DELETE"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup><Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 

--- a/main/docs/manage-users/organizations/configure-organizations/retrieve-connections.mdx
+++ b/main/docs/manage-users/organizations/configure-organizations/retrieve-connections.mdx
@@ -83,29 +83,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/organizations/ORG_ID/connections"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -163,29 +140,6 @@ request["authorization"] = 'Bearer MGMT_API_ACCESS_TOKEN'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer MGMT_API_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/organizations/ORG_ID/connections")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup><Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 

--- a/main/docs/manage-users/organizations/configure-organizations/retrieve-member-roles.mdx
+++ b/main/docs/manage-users/organizations/configure-organizations/retrieve-member-roles.mdx
@@ -78,29 +78,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/organizations/ORG_ID/members/USER_ID/roles"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -158,29 +135,6 @@ request["authorization"] = 'Bearer MGMT_API_ACCESS_TOKEN'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer MGMT_API_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/organizations/ORG_ID/members/USER_ID/roles")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup><Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 

--- a/main/docs/manage-users/organizations/configure-organizations/retrieve-members.mdx
+++ b/main/docs/manage-users/organizations/configure-organizations/retrieve-members.mdx
@@ -84,29 +84,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/organizations/ORG_ID/members"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -164,29 +141,6 @@ request["authorization"] = 'Bearer MGMT_API_ACCESS_TOKEN'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer MGMT_API_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/organizations/ORG_ID/members")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup><Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 

--- a/main/docs/manage-users/organizations/configure-organizations/retrieve-organizations.mdx
+++ b/main/docs/manage-users/organizations/configure-organizations/retrieve-organizations.mdx
@@ -85,29 +85,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/organizations"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -165,29 +142,6 @@ request["authorization"] = 'Bearer MGMT_API_ACCESS_TOKEN'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer MGMT_API_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/organizations")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup><Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 
@@ -283,29 +237,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/organizations/ORG_ID"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -363,29 +294,6 @@ request["authorization"] = 'Bearer MGMT_API_ACCESS_TOKEN'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer MGMT_API_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/organizations/ORG_ID")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup><Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 
@@ -481,29 +389,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/organizations/name/ORG_NAME"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -561,29 +446,6 @@ request["authorization"] = 'Bearer MGMT_API_ACCESS_TOKEN'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer MGMT_API_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/organizations/name/ORG_NAME")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup><Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 

--- a/main/docs/manage-users/organizations/configure-organizations/retrieve-user-membership.mdx
+++ b/main/docs/manage-users/organizations/configure-organizations/retrieve-user-membership.mdx
@@ -77,29 +77,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users/USER_ID/organizations"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -157,29 +134,6 @@ request["authorization"] = 'Bearer MGMT_API_ACCESS_TOKEN'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer MGMT_API_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users/USER_ID/organizations")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup><Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 

--- a/main/docs/manage-users/sessions/configure-session-lifetime-settings.mdx
+++ b/main/docs/manage-users/sessions/configure-session-lifetime-settings.mdx
@@ -102,34 +102,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-
-NSData *postData = [[NSData alloc] initWithData:[@"{ "session_lifetime": SESSION_LIFETIME_VALUE, "idle_session_lifetime": IDLE_SESSION_LIFETIME_VALUE }" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/tenants/settings"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -199,36 +171,6 @@ request.body = "{ "session_lifetime": SESSION_LIFETIME_VALUE, "idle_session_life
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-
-let postData = NSData(data: "{ "session_lifetime": SESSION_LIFETIME_VALUE, "idle_session_lifetime": IDLE_SESSION_LIFETIME_VALUE }".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/tenants/settings")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/manage-users/user-accounts/change-user-picture.mdx
+++ b/main/docs/manage-users/user-accounts/change-user-picture.mdx
@@ -89,34 +89,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"user_metadata": @{ @"picture": @"https://example.com/some-image.png" } };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users/USER_ID"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -183,36 +155,6 @@ request.body = "{"user_metadata": {"picture": "https://example.com/some-image.pn
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "content-type": "application/json"
-]
-let parameters = ["user_metadata": ["picture": "https://example.com/some-image.png"]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users/USER_ID")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/manage-users/user-accounts/metadata/manage-metadata-api.mdx
+++ b/main/docs/manage-users/user-accounts/metadata/manage-metadata-api.mdx
@@ -103,36 +103,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"email": @"jane.doe@example.com",
-                              @"user_metadata": @{ @"hobby": @"surfing" },
-                              @"app_metadata": @{ @"plan": @"full" } };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -199,40 +169,6 @@ request.body = "{"email": "jane.doe@example.com", "user_metadata": {"hobby": "su
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "content-type": "application/json"
-]
-let parameters = [
-  "email": "jane.doe@example.com",
-  "user_metadata": ["hobby": "surfing"],
-  "app_metadata": ["plan": "full"]
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -339,34 +275,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"user_metadata": @{ @"addresses": @{ @"home": @"123 Main Street, Anytown, ST 12345" } } };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users/user_id"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -433,36 +341,6 @@ request.body = "{"user_metadata": {"addresses": {"home": "123 Main Street, Anyto
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "content-type": "application/json"
-]
-let parameters = ["user_metadata": ["addresses": ["home": "123 Main Street, Anytown, ST 12345"]]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users/user_id")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -588,34 +466,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"user_metadata": @{ @"addresses": @{ @"home": @"123 Main Street, Anytown, ST 12345", @"work": @"100 Industrial Way, Anytown, ST 12345" } } };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users/user_id"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -682,39 +532,6 @@ request.body = "{"user_metadata": {"addresses": {"home": "123 Main Street, Anyto
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "content-type": "application/json"
-]
-let parameters = ["user_metadata": ["addresses": [
-      "home": "123 Main Street, Anytown, ST 12345",
-      "work": "100 Industrial Way, Anytown, ST 12345"
-    ]]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users/user_id")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/manage-users/user-accounts/user-account-linking/link-user-accounts.mdx
+++ b/main/docs/manage-users/user-accounts/user-account-linking/link-user-accounts.mdx
@@ -420,34 +420,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MANAGEMENT_API_ACCESS_TOKEN",
-                           @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"link_with": @"SECONDARY_ACCOUNT_ID_TOKEN" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users/PRIMARY_ACCOUNT_USER_ID/identities"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -514,36 +486,6 @@ request.body = "{"link_with":"SECONDARY_ACCOUNT_ID_TOKEN"}"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer MANAGEMENT_API_ACCESS_TOKEN",
-  "content-type": "application/json"
-]
-let parameters = ["link_with": "SECONDARY_ACCOUNT_ID_TOKEN"] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users/PRIMARY_ACCOUNT_USER_ID/identities")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -631,35 +573,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MANAGEMENT_API_ACCESS_TOKEN",
-                           @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"provider": @"SECONDARY_ACCOUNT_PROVIDER",
-                              @"user_id": @"SECONDARY_ACCOUNT_USER_ID" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users/PRIMARY_ACCOUNT_USER_ID/identities"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -726,39 +639,6 @@ request.body = "{"provider":"SECONDARY_ACCOUNT_PROVIDER", "user_id": "SECONDARY_
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer MANAGEMENT_API_ACCESS_TOKEN",
-  "content-type": "application/json"
-]
-let parameters = [
-  "provider": "SECONDARY_ACCOUNT_PROVIDER",
-  "user_id": "SECONDARY_ACCOUNT_USER_ID"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users/PRIMARY_ACCOUNT_USER_ID/identities")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -842,34 +722,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MANAGEMENT_API_ACCESS_TOKEN",
-                           @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"link_with": @"SECONDARY_ACCOUNT_ID_TOKEN" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users/PRIMARY_ACCOUNT_USER_ID/identities"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -936,36 +788,6 @@ request.body = "{"link_with":"SECONDARY_ACCOUNT_ID_TOKEN"}"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer MANAGEMENT_API_ACCESS_TOKEN",
-  "content-type": "application/json"
-]
-let parameters = ["link_with": "SECONDARY_ACCOUNT_ID_TOKEN"] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users/PRIMARY_ACCOUNT_USER_ID/identities")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/manage-users/user-accounts/user-profiles/configure-connection-sync-with-auth0.mdx
+++ b/main/docs/manage-users/user-accounts/user-profiles/configure-connection-sync-with-auth0.mdx
@@ -110,35 +110,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-NSDictionary *parameters = @{ @"options": @{ @"set_user_root_attributes": @"ATTRIBUTE_UPDATE_VALUE" } };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/connections/CONNECTION_ID"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -208,37 +179,6 @@ request.body = "{"options":{"set_user_root_attributes": "ATTRIBUTE_UPDATE_VALUE"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-let parameters = ["options": ["set_user_root_attributes": "ATTRIBUTE_UPDATE_VALUE"]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/connections/CONNECTION_ID")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/manage-users/user-accounts/user-profiles/root-attributes/set-root-attributes-during-user-import.mdx
+++ b/main/docs/manage-users/user-accounts/user-profiles/root-attributes/set-root-attributes-during-user-import.mdx
@@ -83,33 +83,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"multipart/form-data ",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN" };
-
-NSData *postData = [[NSData alloc] initWithData:[@"{ "connection_id": "CONNECTION_ID", "users": "JSON_USER_FILE_PATH" }" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/jobs/usersimports"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -176,35 +149,6 @@ request.body = "{ "connection_id": "CONNECTION_ID", "users": "JSON_USER_FILE_PAT
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "multipart/form-data ",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN"
-]
-
-let postData = NSData(data: "{ "connection_id": "CONNECTION_ID", "users": "JSON_USER_FILE_PATH" }".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/jobs/usersimports")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/manage-users/user-accounts/user-profiles/root-attributes/set-root-attributes-during-user-sign-up.mdx
+++ b/main/docs/manage-users/user-accounts/user-profiles/root-attributes/set-root-attributes-during-user-sign-up.mdx
@@ -88,34 +88,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-
-NSData *postData = [[NSData alloc] initWithData:[@"{ "connection": CONNECTION_NAME, "email": EMAIL_VALUE, "password": PASSWORD_VALUE, "given_name": GIVEN_NAME_VALUE, "family_name": FAMILY_NAME_VALUE,"name": NAME_VALUE, "nickname": NICKNAME_VALUE,"picture": PICTURE_VALUE }" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -185,36 +157,6 @@ request.body = "{ "connection": CONNECTION_NAME, "email": EMAIL_VALUE, "password
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-
-let postData = NSData(data: "{ "connection": CONNECTION_NAME, "email": EMAIL_VALUE, "password": PASSWORD_VALUE, "given_name": GIVEN_NAME_VALUE, "family_name": FAMILY_NAME_VALUE,"name": NAME_VALUE, "nickname": NICKNAME_VALUE,"picture": PICTURE_VALUE }".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/manage-users/user-accounts/user-profiles/root-attributes/update-root-attributes-for-users.mdx
+++ b/main/docs/manage-users/user-accounts/user-profiles/root-attributes/update-root-attributes-for-users.mdx
@@ -90,34 +90,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"cache-control": @"no-cache" };
-
-NSData *postData = [[NSData alloc] initWithData:[@"{ "given_name": GIVEN_NAME_VALUE, "family_name": FAMILY_NAME_VALUE,"name": NAME_VALUE, "nickname": NICKNAME_VALUE,"picture": PICTURE_VALUE }" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users/USER_ID"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -187,36 +159,6 @@ request.body = "{ "given_name": GIVEN_NAME_VALUE, "family_name": FAMILY_NAME_VAL
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "cache-control": "no-cache"
-]
-
-let postData = NSData(data: "{ "given_name": GIVEN_NAME_VALUE, "family_name": FAMILY_NAME_VALUE,"name": NAME_VALUE, "nickname": NICKNAME_VALUE,"picture": PICTURE_VALUE }".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users/USER_ID")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/manage-users/user-migration/bulk-user-exports.mdx
+++ b/main/docs/manage-users/user-migration/bulk-user-exports.mdx
@@ -126,37 +126,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourMgmtAPIAccessToken}",
-                           @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"connection_id": @"{yourConnectionId}",
-                              @"format": @"csv",
-                              @"limit": @5,
-                              @"fields": @[ @{ @"name": @"email" }, @{ @"name": @"identities[0].connection", @"export_as": @"provider" } ] };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/jobs/users-exports"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -223,47 +192,6 @@ request.body = "{"connection_id": "{yourConnectionId}", "format": "csv", "limit"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer {yourMgmtAPIAccessToken}",
-  "content-type": "application/json"
-]
-let parameters = [
-  "connection_id": "{yourConnectionId}",
-  "format": "csv",
-  "limit": 5,
-  "fields": [
-    ["name": "email"],
-    [
-      "name": "identities[0].connection",
-      "export_as": "provider"
-    ]
-  ]
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/jobs/users-exports")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -410,37 +338,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourMgmtAPIAccessToken}",
-                           @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"connection_id": @"{yourConnectionId}",
-                              @"format": @"csv",
-                              @"limit": @5,
-                              @"fields": @[ @{ @"name": @"email" }, @{ @"name": @"user_metadata.consent.given" }, @{ @"name": @"user_metadata.consent.date" }, @{ @"name": @"user_metadata.consent.text_details" } ] };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/jobs/users-exports"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -507,41 +404,6 @@ request.body = "{"connection_id": "{yourConnectionId}", "format": "csv", "limit"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer {yourMgmtAPIAccessToken}",
-  "content-type": "application/json"
-]
-let parameters = [
-  "connection_id": "{yourConnectionId}",
-  "format": "csv",
-  "limit": 5,
-  "fields": [["name": "email"], ["name": "user_metadata.consent.given"], ["name": "user_metadata.consent.date"], ["name": "user_metadata.consent.text_details"]]
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/jobs/users-exports")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -645,37 +507,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourMgmtAPIAccessToken}",
-                           @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"connection_id": @"{yourConnectionId}",
-                              @"format": @"json",
-                              @"limit": @5,
-                              @"fields": @[ @{ @"name": @"email" }, @{ @"name": @"user_metadata.consent" } ] };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/jobs/users-exports"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -742,41 +573,6 @@ request.body = "{"connection_id": "{yourConnectionId}", "format": "json", "limit
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer {yourMgmtAPIAccessToken}",
-  "content-type": "application/json"
-]
-let parameters = [
-  "connection_id": "{yourConnectionId}",
-  "format": "json",
-  "limit": 5,
-  "fields": [["name": "email"], ["name": "user_metadata.consent"]]
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/jobs/users-exports")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -847,29 +643,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourMgmtAPIAccessToken}" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/jobs/%7ByourJobId%7D"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -927,29 +700,6 @@ request["authorization"] = 'Bearer {yourMgmtAPIAccessToken}'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer {yourMgmtAPIAccessToken}"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/jobs/%7ByourJobId%7D")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/manage-users/user-migration/bulk-user-imports.mdx
+++ b/main/docs/manage-users/user-migration/bulk-user-imports.mdx
@@ -177,62 +177,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN",
-                           @"content-type": @"multipart/form-data; boundary=---011000010111000001101001" };
-NSArray *parameters = @[ @{ @"name": @"users", @"fileName": @"USERS_IMPORT_FILE.json", @"contentType": @"text/json" },
-                         @{ @"name": @"connection_id", @"value": @"CONNECTION_ID" },
-                         @{ @"name": @"external_id", @"value": @"EXTERNAL_ID" } ];
-NSString *boundary = @"---011000010111000001101001";
-
-NSError *error;
-NSMutableString *body = [NSMutableString string];
-for (NSDictionary *param in parameters) {
-    [body appendFormat:@"--%@\r
-", boundary];
-    if (param[@"fileName"]) {
-        [body appendFormat:@"Content-Disposition:form-data; name="%@"; filename="%@"\r
-", param[@"name"], param[@"fileName"]];
-        [body appendFormat:@"Content-Type: %@\r
-\r
-", param[@"contentType"]];
-        [body appendFormat:@"%@", [NSString stringWithContentsOfFile:param[@"fileName"] encoding:NSUTF8StringEncoding error:&error]];
-        if (error) {
-            NSLog(@"%@", error);
-        }
-    } else {
-        [body appendFormat:@"Content-Disposition:form-data; name="%@"\r
-\r
-", param[@"name"]];
-        [body appendFormat:@"%@", param[@"value"]];
-    }
-}
-[body appendFormat:@"\r
---%@--\r
-", boundary];
-NSData *postData = [body dataUsingEncoding:NSUTF8StringEncoding];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/jobs/users-imports"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -341,76 +285,6 @@ EXTERNAL_ID\r
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN",
-  "content-type": "multipart/form-data; boundary=---011000010111000001101001"
-]
-let parameters = [
-  [
-    "name": "users",
-    "fileName": "USERS_IMPORT_FILE.json",
-    "contentType": "text/json"
-  ],
-  [
-    "name": "connection_id",
-    "value": "CONNECTION_ID"
-  ],
-  [
-    "name": "external_id",
-    "value": "EXTERNAL_ID"
-  ]
-]
-
-let boundary = "---011000010111000001101001"
-
-var body = ""
-var error: NSError? = nil
-for param in parameters {
-  let paramName = param["name"]!
-  body += "--\(boundary)\r
-"
-  body += "Content-Disposition:form-data; name="\(paramName)""
-  if let filename = param["fileName"] {
-    let contentType = param["content-type"]!
-    let fileContent = String(contentsOfFile: filename, encoding: String.Encoding.utf8)
-    if (error != nil) {
-      print(error)
-    }
-    body += "; filename="\(filename)"\r
-"
-    body += "Content-Type: \(contentType)\r
-\r
-"
-    body += fileContent
-  } else if let paramValue = param["value"] {
-    body += "\r
-\r
-\(paramValue)"
-  }
-}
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/jobs/users-imports")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -523,30 +397,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/jobs/JOB_ID"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -609,32 +459,6 @@ request["authorization"] = 'Bearer MGMT_API_ACCESS_TOKEN'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN"
-]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/jobs/JOB_ID")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -773,30 +597,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/jobs/JOB_ID/errors"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -859,32 +659,6 @@ request["authorization"] = 'Bearer MGMT_API_ACCESS_TOKEN'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN"
-]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/jobs/JOB_ID/errors")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/manage-users/user-search/retrieve-users-with-get-users-by-email-endpoint.mdx
+++ b/main/docs/manage-users/user-search/retrieve-users-with-get-users-by-email-endpoint.mdx
@@ -79,29 +79,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourMgmtApiAccessToken}" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users-by-email?email=%7BuserEmailAddress%7D"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -159,29 +136,6 @@ request["authorization"] = 'Bearer {yourMgmtApiAccessToken}'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer {yourMgmtApiAccessToken}"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users-by-email?email=%7BuserEmailAddress%7D")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/manage-users/user-search/retrieve-users-with-get-users-by-id-endpoint.mdx
+++ b/main/docs/manage-users/user-search/retrieve-users-with-get-users-by-id-endpoint.mdx
@@ -80,29 +80,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourMgmtApiAccessToken}" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users/%7BuserId%7D"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -160,29 +137,6 @@ request["authorization"] = 'Bearer {yourMgmtApiAccessToken}'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer {yourMgmtApiAccessToken}"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users/%7BuserId%7D")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/manage-users/user-search/retrieve-users-with-get-users-endpoint.mdx
+++ b/main/docs/manage-users/user-search/retrieve-users-with-get-users-endpoint.mdx
@@ -80,29 +80,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourMgmtApiAccessToken}" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users?q=email%3A%22jane%40exampleco.com%22&search_engine=v3"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -160,29 +137,6 @@ request["authorization"] = 'Bearer {yourMgmtApiAccessToken}'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer {yourMgmtApiAccessToken}"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users?q=email%3A%22jane%40exampleco.com%22&search_engine=v3")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/manage-users/user-search/sort-search-results.mdx
+++ b/main/docs/manage-users/user-search/sort-search-results.mdx
@@ -72,29 +72,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourMgmtApiAccessToken}" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users?q=logins_count%3A%5B100%20TO%20200%5D&sort=created_at%3A1&search_engine=v3"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -152,29 +129,6 @@ request["authorization"] = 'Bearer {yourMgmtApiAccessToken}'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer {yourMgmtApiAccessToken}"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users?q=logins_count%3A%5B100%20TO%20200%5D&sort=created_at%3A1&search_engine=v3")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/manage-users/user-search/user-search-query-syntax.mdx
+++ b/main/docs/manage-users/user-search/user-search-query-syntax.mdx
@@ -119,29 +119,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourMgmtApiAccessToken}" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users?q=name%3A%22jane%20smith%22&search_engine=v3"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -199,29 +176,6 @@ request["authorization"] = 'Bearer {yourMgmtApiAccessToken}'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer {yourMgmtApiAccessToken}"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users?q=name%3A%22jane%20smith%22&search_engine=v3")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -296,29 +250,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourMgmtApiAccessToken}" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users?q=name%3Ajohn*&search_engine=v3"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -376,29 +307,6 @@ request["authorization"] = 'Bearer {yourMgmtApiAccessToken}'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer {yourMgmtApiAccessToken}"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users?q=name%3Ajohn*&search_engine=v3")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -471,29 +379,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourMgmtApiAccessToken}" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users?q=logins_count%3A%7B100%20TO%20*%5D&search_engine=v3"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -551,29 +436,6 @@ request["authorization"] = 'Bearer {yourMgmtApiAccessToken}'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer {yourMgmtApiAccessToken}"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users?q=logins_count%3A%7B100%20TO%20*%5D&search_engine=v3")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/manage-users/user-search/view-search-results-by-page.mdx
+++ b/main/docs/manage-users/user-search/view-search-results-by-page.mdx
@@ -82,29 +82,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourMgmtApiAccessToken}" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users?q=logins_count%3A%5B100%20TO%20200%5D&page=2&per_page=10&include_totals=true&search_engine=v3"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -162,29 +139,6 @@ request["authorization"] = 'Bearer {yourMgmtApiAccessToken}'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer {yourMgmtApiAccessToken}"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users?q=logins_count%3A%5B100%20TO%20200%5D&page=2&per_page=10&include_totals=true&search_engine=v3")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/quickstart/backend/django/02-using.mdx
+++ b/main/docs/quickstart/backend/django/02-using.mdx
@@ -77,29 +77,6 @@ axios.request(options).then(function (response) {
 });
 ```
 
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer YOUR_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://localhost:3010/api/private"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines
 $curl = curl_init();
@@ -160,29 +137,6 @@ response = http.request(request)
 puts response.read_body
 ```
 
-```swift Swift lines
-import Foundation
-
-let headers = ["authorization": "Bearer YOUR_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "http://localhost:3010/api/private")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
-```
 </AuthCodeGroup>
 
 ## Obtaining an Access Token
@@ -270,35 +224,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=client_credentials" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_secret={yourClientSecret}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&audience=YOUR_API_IDENTIFIER" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -360,35 +285,6 @@ request.body = "grant_type=client_credentials&client_id=%24%7Baccount.clientId%7
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=client_credentials".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&client_secret={yourClientSecret}".data(using: String.Encoding.utf8)!)
-postData.append("&audience=YOUR_API_IDENTIFIER".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -457,26 +353,6 @@ axios.request(options).then(function (response) {
 });
 ```
 
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://localhost:3010/api/private"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP lines
 $curl = curl_init();
 
@@ -530,26 +406,6 @@ response = http.request(request)
 puts response.read_body
 ```
 
-```swift Swift lines
-import Foundation
-
-let request = NSMutableURLRequest(url: NSURL(string: "http://localhost:3010/api/private")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
-```
   
 </AuthCodeGroup>
 
@@ -623,29 +479,6 @@ axios.request(options).then(function (response) {
 });
 ```
 
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer YOUR_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://localhost:3010/api/private"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines
 $curl = curl_init();
@@ -706,29 +539,6 @@ response = http.request(request)
 puts response.read_body
 ```
 
-```swift Swift lines
-import Foundation
-
-let headers = ["authorization": "Bearer YOUR_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "http://localhost:3010/api/private")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
-```
 </AuthCodeGroup>
 
 This time the API will return a successful response:
@@ -804,29 +614,6 @@ axios.request(options).then(function (response) {
 });
 ```
 
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer YOUR_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://localhost:3010/api/private-scoped"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines
 $curl = curl_init();
@@ -887,29 +674,6 @@ response = http.request(request)
 puts response.read_body
 ```
 
-```swift Swift lines
-import Foundation
-
-let headers = ["authorization": "Bearer YOUR_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "http://localhost:3010/api/private-scoped")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
-```
 </AuthCodeGroup>
 
 If the required scope is present, the API call is successful:

--- a/main/docs/quickstart/backend/golang/02-using.mdx
+++ b/main/docs/quickstart/backend/golang/02-using.mdx
@@ -103,29 +103,6 @@ response = http.request(request)
 puts response.read_body
 ```
 
-```swift Swift lines
-import Foundation
-
-let headers = ["authorization": "Bearer YOUR_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "http://localhost:8080/api/private")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error as Any)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse as Any)
-  }
-})
-
-dataTask.resume()
-```
 </AuthCodeGroup>
 
 <Note>
@@ -275,35 +252,6 @@ request.body = "grant_type=client_credentials&client_id={yourClientId}&client_se
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=client_credentials".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&client_secret={yourClientSecret}".data(using: String.Encoding.utf8)!)
-postData.append("&audience=YOUR_API_IDENTIFIER".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error as Any)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse as Any)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -490,29 +438,6 @@ response = http.request(request)
 puts response.read_body
 ```
 
-```swift Swift lines
-import Foundation
-
-let headers = ["authorization": "Bearer YOUR_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "http://localhost:8080/api/private-scoped")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error as Any)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse as Any)
-  }
-})
-
-dataTask.resume()
-```
 </AuthCodeGroup>
 
 <Check>**Expected with scope**: 200 OK with `read:messages` permission</Check>

--- a/main/docs/quickstart/backend/java-spring-security5/02-using.mdx
+++ b/main/docs/quickstart/backend/java-spring-security5/02-using.mdx
@@ -77,29 +77,6 @@ axios.request(options).then(function (response) {
 });
 ```
 
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer YOUR_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://localhost:3010/api/private"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines
 $curl = curl_init();
@@ -160,29 +137,6 @@ response = http.request(request)
 puts response.read_body
 ```
 
-```swift Swift lines
-import Foundation
-
-let headers = ["authorization": "Bearer YOUR_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "http://localhost:3010/api/private")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
-```
 </AuthCodeGroup>
 
 ## Obtaining an Access Token
@@ -270,35 +224,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=client_credentials" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_secret={yourClientSecret}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&audience=YOUR_API_IDENTIFIER" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -360,35 +285,6 @@ request.body = "grant_type=client_credentials&client_id=%24%7Baccount.clientId%7
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=client_credentials".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&client_secret={yourClientSecret}".data(using: String.Encoding.utf8)!)
-postData.append("&audience=YOUR_API_IDENTIFIER".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -457,26 +353,6 @@ axios.request(options).then(function (response) {
 });
 ```
 
-```objc Obj-C lines 
-#import <Foundation/Foundation.h>
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://localhost:3010/api/private"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP lines
 $curl = curl_init();
 
@@ -530,26 +406,6 @@ response = http.request(request)
 puts response.read_body
 ```
 
-```swift Swift lines
-import Foundation
-
-let request = NSMutableURLRequest(url: NSURL(string: "http://localhost:3010/api/private")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
-```
   
 </AuthCodeGroup>
 
@@ -623,29 +479,6 @@ axios.request(options).then(function (response) {
 });
 ```
 
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer YOUR_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://localhost:3010/api/private"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines
 $curl = curl_init();
@@ -706,29 +539,6 @@ response = http.request(request)
 puts response.read_body
 ```
 
-```swift Swift lines
-import Foundation
-
-let headers = ["authorization": "Bearer YOUR_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "http://localhost:3010/api/private")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
-```
 </AuthCodeGroup>
 
 This time the API will return a successful response:
@@ -804,29 +614,6 @@ axios.request(options).then(function (response) {
 });
 ```
 
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer YOUR_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://localhost:3010/api/private-scoped"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines
 $curl = curl_init();
@@ -887,29 +674,6 @@ response = http.request(request)
 puts response.read_body
 ```
 
-```swift Swift lines
-import Foundation
-
-let headers = ["authorization": "Bearer YOUR_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "http://localhost:3010/api/private-scoped")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
-```
 </AuthCodeGroup>
 
 If the required scope is present, the API call is successful:

--- a/main/docs/quickstart/backend/nodejs/02-using.mdx
+++ b/main/docs/quickstart/backend/nodejs/02-using.mdx
@@ -77,29 +77,6 @@ axios.request(options).then(function (response) {
 });
 ```
 
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer YOUR_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://localhost:3010/api/private"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines
 $curl = curl_init();
@@ -160,29 +137,6 @@ response = http.request(request)
 puts response.read_body
 ```
 
-```swift Swift lines
-import Foundation
-
-let headers = ["authorization": "Bearer YOUR_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "http://localhost:3010/api/private")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
-```
 </AuthCodeGroup>
 
 ## Obtaining an Access Token
@@ -270,35 +224,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=client_credentials" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_secret={yourClientSecret}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&audience=YOUR_API_IDENTIFIER" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -360,35 +285,6 @@ request.body = "grant_type=client_credentials&client_id=%24%7Baccount.clientId%7
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=client_credentials".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&client_secret={yourClientSecret}".data(using: String.Encoding.utf8)!)
-postData.append("&audience=YOUR_API_IDENTIFIER".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -457,26 +353,6 @@ axios.request(options).then(function (response) {
 });
 ```
 
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://localhost:3010/api/private"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP lines
 $curl = curl_init();
 
@@ -530,26 +406,6 @@ response = http.request(request)
 puts response.read_body
 ```
 
-```swift Swift lines
-import Foundation
-
-let request = NSMutableURLRequest(url: NSURL(string: "http://localhost:3010/api/private")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
-```
   
 </AuthCodeGroup>
 
@@ -623,29 +479,6 @@ axios.request(options).then(function (response) {
 });
 ```
 
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer YOUR_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://localhost:3010/api/private"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines
 $curl = curl_init();
@@ -706,29 +539,6 @@ response = http.request(request)
 puts response.read_body
 ```
 
-```swift Swift lines
-import Foundation
-
-let headers = ["authorization": "Bearer YOUR_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "http://localhost:3010/api/private")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
-```
 </AuthCodeGroup>
 
 This time the API will return a successful response:
@@ -804,29 +614,6 @@ axios.request(options).then(function (response) {
 });
 ```
 
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer YOUR_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://localhost:3010/api/private-scoped"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines
 $curl = curl_init();
@@ -887,29 +674,6 @@ response = http.request(request)
 puts response.read_body
 ```
 
-```swift Swift lines
-import Foundation
-
-let headers = ["authorization": "Bearer YOUR_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "http://localhost:3010/api/private-scoped")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
-```
 </AuthCodeGroup>
 
 If the required scope is present, the API call is successful:

--- a/main/docs/quickstart/backend/python/02-using.mdx
+++ b/main/docs/quickstart/backend/python/02-using.mdx
@@ -77,29 +77,6 @@ axios.request(options).then(function (response) {
 });
 ```
 
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer YOUR_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://localhost:3010/api/private"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines
 $curl = curl_init();
@@ -160,29 +137,6 @@ response = http.request(request)
 puts response.read_body
 ```
 
-```swift Swift lines
-import Foundation
-
-let headers = ["authorization": "Bearer YOUR_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "http://localhost:3010/api/private")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
-```
 </AuthCodeGroup>
 
 ## Obtaining an Access Token
@@ -270,35 +224,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=client_credentials" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_secret={yourClientSecret}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&audience=YOUR_API_IDENTIFIER" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -360,35 +285,6 @@ request.body = "grant_type=client_credentials&client_id=%24%7Baccount.clientId%7
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=client_credentials".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&client_secret={yourClientSecret}".data(using: String.Encoding.utf8)!)
-postData.append("&audience=YOUR_API_IDENTIFIER".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -457,26 +353,6 @@ axios.request(options).then(function (response) {
 });
 ```
 
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://localhost:3010/api/private"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP lines
 $curl = curl_init();
 
@@ -530,26 +406,6 @@ response = http.request(request)
 puts response.read_body
 ```
 
-```swift Swift lines
-import Foundation
-
-let request = NSMutableURLRequest(url: NSURL(string: "http://localhost:3010/api/private")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
-```
   
 </AuthCodeGroup>
 
@@ -623,29 +479,6 @@ axios.request(options).then(function (response) {
 });
 ```
 
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer YOUR_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://localhost:3010/api/private"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines
 $curl = curl_init();
@@ -706,29 +539,6 @@ response = http.request(request)
 puts response.read_body
 ```
 
-```swift Swift lines
-import Foundation
-
-let headers = ["authorization": "Bearer YOUR_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "http://localhost:3010/api/private")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
-```
 </AuthCodeGroup>
 
 This time the API will return a successful response:
@@ -804,29 +614,6 @@ axios.request(options).then(function (response) {
 });
 ```
 
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer YOUR_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://localhost:3010/api/private-scoped"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines
 $curl = curl_init();
@@ -887,29 +674,6 @@ response = http.request(request)
 puts response.read_body
 ```
 
-```swift Swift lines
-import Foundation
-
-let headers = ["authorization": "Bearer YOUR_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "http://localhost:3010/api/private-scoped")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
-```
 </AuthCodeGroup>
 
 If the required scope is present, the API call is successful:

--- a/main/docs/quickstart/backend/rails/02-using.mdx
+++ b/main/docs/quickstart/backend/rails/02-using.mdx
@@ -77,29 +77,6 @@ axios.request(options).then(function (response) {
 });
 ```
 
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer YOUR_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://localhost:3010/api/private"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines
 $curl = curl_init();
@@ -160,29 +137,6 @@ response = http.request(request)
 puts response.read_body
 ```
 
-```swift Swift lines
-import Foundation
-
-let headers = ["authorization": "Bearer YOUR_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "http://localhost:3010/api/private")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
-```
 </AuthCodeGroup>
 
 ## Obtaining an Access Token
@@ -270,35 +224,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=client_credentials" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_secret={yourClientSecret}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&audience=YOUR_API_IDENTIFIER" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -360,35 +285,6 @@ request.body = "grant_type=client_credentials&client_id=%24%7Baccount.clientId%7
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=client_credentials".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&client_secret={yourClientSecret}".data(using: String.Encoding.utf8)!)
-postData.append("&audience=YOUR_API_IDENTIFIER".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -457,26 +353,6 @@ axios.request(options).then(function (response) {
 });
 ```
 
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://localhost:3010/api/private"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP lines
 $curl = curl_init();
 
@@ -530,26 +406,6 @@ response = http.request(request)
 puts response.read_body
 ```
 
-```swift Swift lines
-import Foundation
-
-let request = NSMutableURLRequest(url: NSURL(string: "http://localhost:3010/api/private")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
-```
   
 </AuthCodeGroup>
 
@@ -623,29 +479,6 @@ axios.request(options).then(function (response) {
 });
 ```
 
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer YOUR_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://localhost:3010/api/private"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines
 $curl = curl_init();
@@ -706,29 +539,6 @@ response = http.request(request)
 puts response.read_body
 ```
 
-```swift Swift lines
-import Foundation
-
-let headers = ["authorization": "Bearer YOUR_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "http://localhost:3010/api/private")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
-```
 </AuthCodeGroup>
 
 This time the API will return a successful response:
@@ -804,29 +614,6 @@ axios.request(options).then(function (response) {
 });
 ```
 
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer YOUR_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://localhost:3010/api/private-scoped"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines
 $curl = curl_init();
@@ -887,29 +674,6 @@ response = http.request(request)
 puts response.read_body
 ```
 
-```swift Swift lines
-import Foundation
-
-let headers = ["authorization": "Bearer YOUR_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "http://localhost:3010/api/private-scoped")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
-```
 </AuthCodeGroup>
 
 If the required scope is present, the API call is successful:

--- a/main/docs/quickstart/backend/webapi-owin/02-using.mdx
+++ b/main/docs/quickstart/backend/webapi-owin/02-using.mdx
@@ -77,29 +77,6 @@ axios.request(options).then(function (response) {
 });
 ```
 
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer YOUR_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://localhost:3010/api/private"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines
 $curl = curl_init();
@@ -160,29 +137,6 @@ response = http.request(request)
 puts response.read_body
 ```
 
-```swift Swift lines
-import Foundation
-
-let headers = ["authorization": "Bearer YOUR_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "http://localhost:3010/api/private")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
-```
 </AuthCodeGroup>
 
 ## Obtaining an Access Token
@@ -270,35 +224,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=client_credentials" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_secret={yourClientSecret}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&audience=YOUR_API_IDENTIFIER" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -360,35 +285,6 @@ request.body = "grant_type=client_credentials&client_id=%24%7Baccount.clientId%7
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=client_credentials".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&client_secret={yourClientSecret}".data(using: String.Encoding.utf8)!)
-postData.append("&audience=YOUR_API_IDENTIFIER".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -457,26 +353,6 @@ axios.request(options).then(function (response) {
 });
 ```
 
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://localhost:3010/api/private"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP lines
 $curl = curl_init();
 
@@ -530,26 +406,6 @@ response = http.request(request)
 puts response.read_body
 ```
 
-```swift Swift lines
-import Foundation
-
-let request = NSMutableURLRequest(url: NSURL(string: "http://localhost:3010/api/private")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
-```
   
 </AuthCodeGroup>
 
@@ -623,29 +479,6 @@ axios.request(options).then(function (response) {
 });
 ```
 
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer YOUR_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://localhost:3010/api/private"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines
 $curl = curl_init();
@@ -706,29 +539,6 @@ response = http.request(request)
 puts response.read_body
 ```
 
-```swift Swift lines
-import Foundation
-
-let headers = ["authorization": "Bearer YOUR_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "http://localhost:3010/api/private")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
-```
 </AuthCodeGroup>
 
 This time the API will return a successful response:
@@ -804,29 +614,6 @@ axios.request(options).then(function (response) {
 });
 ```
 
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer YOUR_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://localhost:3010/api/private-scoped"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines
 $curl = curl_init();
@@ -887,29 +674,6 @@ response = http.request(request)
 puts response.read_body
 ```
 
-```swift Swift lines
-import Foundation
-
-let headers = ["authorization": "Bearer YOUR_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "http://localhost:3010/api/private-scoped")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
-```
 </AuthCodeGroup>
 
 If the required scope is present, the API call is successful:

--- a/main/docs/quickstart/native/device/index.mdx
+++ b/main/docs/quickstart/native/device/index.mdx
@@ -133,34 +133,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&scope=SCOPE" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&audience=AUDIENCE" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/device/code"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -222,34 +194,6 @@ request.body = "client_id=%24%7Baccount.clientId%7D&scope=SCOPE&audience=AUDIENC
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&scope=SCOPE".data(using: String.Encoding.utf8)!)
-postData.append("&audience=AUDIENCE".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/device/code")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -403,34 +347,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=urn:ietf:params:oauth:grant-type:device_code" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&device_code=YOUR_DEVICE_CODE" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -492,34 +408,6 @@ request.body = "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_cod
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=urn:ietf:params:oauth:grant-type:device_code".data(using: String.Encoding.utf8)!)
-postData.append("&device_code=YOUR_DEVICE_CODE".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -725,30 +613,6 @@ axios.request(options).then(function (response) {
 });
 ```
 
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://myapi.com/api"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines
 $curl = curl_init();
@@ -816,32 +680,6 @@ response = http.request(request)
 puts response.read_body
 ```
 
-```swift Swift lines
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer ACCESS_TOKEN"
-]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://myapi.com/api")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
-```
 </AuthCodeGroup>
 
 ## Refresh Tokens
@@ -931,35 +769,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=refresh_token" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_secret={yourClientSecret}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&refresh_token=YOUR_REFRESH_TOKEN" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -1021,35 +830,6 @@ request.body = "grant_type=refresh_token&client_id=%24%7Baccount.clientId%7D&cli
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=refresh_token".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&client_secret={yourClientSecret}".data(using: String.Encoding.utf8)!)
-postData.append("&refresh_token=YOUR_REFRESH_TOKEN".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/secure/data-privacy-and-compliance/gdpr/gdpr-conditions-for-consent.mdx
+++ b/main/docs/secure/data-privacy-and-compliance/gdpr/gdpr-conditions-for-consent.mdx
@@ -135,29 +135,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer YOUR_MGMT_API_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users-by-email?email=USER_EMAIL_ADDRESS&fields=user_metadata"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -215,29 +192,6 @@ request["authorization"] = 'Bearer YOUR_MGMT_API_ACCESS_TOKEN'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer YOUR_MGMT_API_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users-by-email?email=USER_EMAIL_ADDRESS&fields=user_metadata")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -326,29 +280,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourMgmtApiAccessToken}" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users/%7ByourUserID%7D?fields=user_metadata"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -406,29 +337,6 @@ request["authorization"] = 'Bearer {yourMgmtApiAccessToken}'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer {yourMgmtApiAccessToken}"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users/%7ByourUserID%7D?fields=user_metadata")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -549,34 +457,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer YOUR_MGMT_API_ACCESS_TOKEN",
-                           @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"user_metadata": @{ @"consentDate": @"01/24/2018" } };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users/USER_ID"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -643,36 +523,6 @@ request.body = "{"user_metadata":{"consentDate":"01/24/2018"}}"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer YOUR_MGMT_API_ACCESS_TOKEN",
-  "content-type": "application/json"
-]
-let parameters = ["user_metadata": ["consentDate": "01/24/2018"]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users/USER_ID")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -767,34 +617,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer YOUR_MGMT_API_ACCESS_TOKEN",
-                           @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"user_metadata": @{ @"consent": @{ @"given": @YES, @"date": @"01/23/2018", @"text_details": @"some-url" } } };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users/USER_ID"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -861,40 +683,6 @@ request.body = "{"user_metadata":{"consent": {"given":true, "date":"01/23/2018",
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer YOUR_MGMT_API_ACCESS_TOKEN",
-  "content-type": "application/json"
-]
-let parameters = ["user_metadata": ["consent": [
-      "given": true,
-      "date": "01/23/2018",
-      "text_details": "some-url"
-    ]]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users/USER_ID")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -992,29 +780,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer YOUR_MGMT_API_ACCESS_TOKEN" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users/USER_ID"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"DELETE"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -1072,29 +837,6 @@ request["authorization"] = 'Bearer YOUR_MGMT_API_ACCESS_TOKEN'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer YOUR_MGMT_API_ACCESS_TOKEN"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users/USER_ID")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "DELETE"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -1185,34 +927,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer YOUR_MGMT_API_ACCESS_TOKEN",
-                           @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"app_metadata": @{ @"deleted": @YES } };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users/USER_ID"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -1279,36 +993,6 @@ request.body = "{"app_metadata":{"deleted":true}}"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer YOUR_MGMT_API_ACCESS_TOKEN",
-  "content-type": "application/json"
-]
-let parameters = ["app_metadata": ["deleted": true]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users/USER_ID")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/secure/data-privacy-and-compliance/gdpr/gdpr-track-consent-with-custom-ui.mdx
+++ b/main/docs/secure/data-privacy-and-compliance/gdpr/gdpr-track-consent-with-custom-ui.mdx
@@ -187,36 +187,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"client_id": @"{yourClientId}",
-                              @"email": @"YOUR_USER_EMAIL",
-                              @"password": @"YOUR_USER_PASSWORD",
-                              @"user_metadata": @{ @"consentGiven": @"true", @"consentTimestamp": @"1525101183" } };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/dbconnections/signup"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -278,41 +248,6 @@ request.body = "{"client_id": "{yourClientId}","email": "YOUR_USER_EMAIL","passw
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/json"]
-let parameters = [
-  "client_id": "{yourClientId}",
-  "email": "YOUR_USER_EMAIL",
-  "password": "YOUR_USER_PASSWORD",
-  "user_metadata": [
-    "consentGiven": "true",
-    "consentTimestamp": "1525101183"
-  ]
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/dbconnections/signup")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -404,34 +339,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer YOUR_ACCESS_TOKEN",
-                           @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"user_metadata": @{ @"consentGiven": @YES, @"consentTimestamp": @"1525101183" } };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users/%7BUSER_ID%7D"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -498,39 +405,6 @@ request.body = "{"user_metadata": {"consentGiven":true, "consentTimestamp": "152
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer YOUR_ACCESS_TOKEN",
-  "content-type": "application/json"
-]
-let parameters = ["user_metadata": [
-    "consentGiven": true,
-    "consentTimestamp": "1525101183"
-  ]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users/%7BUSER_ID%7D")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/secure/mdl-verification/create-mdl-api.mdx
+++ b/main/docs/secure/mdl-verification/create-mdl-api.mdx
@@ -119,33 +119,6 @@ axios.request(options).then(function (response) {
 });
 
 ```
-```objc Obj-C
-   #import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json" };
-
-NSData *postData = [[NSData alloc] initWithData:[@"{"name"}" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/resource-servers/post-resource-servers"]
-                                                      cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                          completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                   NSLog(@"%@", error);
-                                                } else {
-                                                   NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                   NSLog(@"%@", httpResponse);
-                                                }
-                                          }];
-[dataTask resume];
-
-```
 ```php PHP
    $curl = curl_init();
 
@@ -207,31 +180,6 @@ res = conn.getresponse()
 data = res.read()
 
 print(data.decode("utf-8"))
-
-```
-```swift Swift
-   import Foundation
-
-let headers = ["content-type": "application/json"]
-
-let postData = NSData(data: "{"name"}".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/resource-servers/post-resource-servers")! as URL,
-                                       cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-   if (error != nil) {
-      print(error)
-   } else {
-      let httpResponse = response as? HTTPURLResponse
-      print(httpResponse)
-   }
-})
 
 ```
 </AuthCodeGroup>

--- a/main/docs/secure/multi-factor-authentication/authenticate-using-ropg-flow-with-mfa.mdx
+++ b/main/docs/secure/multi-factor-authentication/authenticate-using-ropg-flow-with-mfa.mdx
@@ -96,38 +96,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=password" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&username=user@example.com" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&password=pwd" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_secret={yourClientSecret}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&audience=https://someapi.com/api" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&scope=openid profile read:sample" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -189,38 +157,6 @@ request.body = "grant_type=password&username=user%40example.com&password=pwd&cli
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=password".data(using: String.Encoding.utf8)!)
-postData.append("&username=user@example.com".data(using: String.Encoding.utf8)!)
-postData.append("&password=pwd".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&client_secret={yourClientSecret}".data(using: String.Encoding.utf8)!)
-postData.append("&audience=https://someapi.com/api".data(using: String.Encoding.utf8)!)
-postData.append("&scope=openid profile read:sample".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -307,30 +243,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MFA_TOKEN",
-                           @"content-type": @"application/json" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/mfa/authenticators"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -393,32 +305,6 @@ request["content-type"] = 'application/json'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer MFA_TOKEN",
-  "content-type": "application/json"
-]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/mfa/authenticators")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/secure/multi-factor-authentication/authenticate-using-ropg-flow-with-mfa/challenge-with-recovery-codes.mdx
+++ b/main/docs/secure/multi-factor-authentication/authenticate-using-ropg-flow-with-mfa/challenge-with-recovery-codes.mdx
@@ -107,37 +107,6 @@ console.error(error);
 });
 
 ```
-```objc Obj-C
-   #import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=http://auth0.com/oauth/grant-type/mfa-recovery-code" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_secret={yourClientSecret}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&mfa_token={mfaToken}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&recovery_code={recoveryCode}" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                      cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                          completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                   NSLog(@"%@", error);
-                                                } else {
-                                                   NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                   NSLog(@"%@", httpResponse);
-                                                }
-                                          }];
-[dataTask resume];
-
-```
 ```php PHP
    $curl = curl_init();
 
@@ -201,37 +170,6 @@ request.body = "grant_type=http%3A%2F%2Fauth0.com%2Foauth%2Fgrant-type%2Fmfa-rec
 
 response = http.request(request)
 puts response.read_body
-
-```
-```swift Swift
-   import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=http://auth0.com/oauth/grant-type/mfa-recovery-code".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&client_secret={yourClientSecret}".data(using: String.Encoding.utf8)!)
-postData.append("&mfa_token={mfaToken}".data(using: String.Encoding.utf8)!)
-postData.append("&recovery_code={recoveryCode}".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                       cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-if (error != nil) {
-   print(error)
-} else {
-   let httpResponse = response as? HTTPURLResponse
-   print(httpResponse)
-}
-})
-
-dataTask.resume()
 
 ```
 </AuthCodeGroup>

--- a/main/docs/secure/multi-factor-authentication/authenticate-using-ropg-flow-with-mfa/enroll-and-challenge-email-authenticators.mdx
+++ b/main/docs/secure/multi-factor-authentication/authenticate-using-ropg-flow-with-mfa/enroll-and-challenge-email-authenticators.mdx
@@ -119,36 +119,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MFA_TOKEN",
-                           @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"authenticator_types": @[ @"oob" ],
-                              @"oob_channels": @[ @"email" ],
-                              @"email": @"email@address.com" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/mfa/associate"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -215,40 +185,6 @@ request.body = "{ "authenticator_types": ["oob"], "oob_channels": ["email"], "em
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer MFA_TOKEN",
-  "content-type": "application/json"
-]
-let parameters = [
-  "authenticator_types": ["oob"],
-  "oob_channels": ["email"],
-  "email": "email@address.com"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/mfa/associate")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -346,34 +282,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=http://auth0.com/oauth/grant-type/mfa-oob" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&mfa_token={mfaToken}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&oob_code={oobCode}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&binding_code={userEmailOtpCode}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_secret={yourClientSecret}" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -429,34 +337,6 @@ request.body = "grant_type=http%3A%2F%2Fauth0.com%2Foauth%2Fgrant-type%2Fmfa-oob
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let postData = NSMutableData(data: "grant_type=http://auth0.com/oauth/grant-type/mfa-oob".data(using: String.Encoding.utf8)!)
-postData.append("&mfa_token={mfaToken}".data(using: String.Encoding.utf8)!)
-postData.append("&oob_code={oobCode}".data(using: String.Encoding.utf8)!)
-postData.append("&binding_code={userEmailOtpCode}".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&client_secret={yourClientSecret}".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -551,30 +431,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MFA_TOKEN",
-                           @"content-type": @"application/json" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/mfa/authenticators"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -637,32 +493,6 @@ request["content-type"] = 'application/json'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer MFA_TOKEN",
-  "content-type": "application/json"
-]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/mfa/authenticators")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -736,34 +566,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-NSDictionary *parameters = @{ @"client_id": @"{yourClientId}",
-                              @"client_secret": @"{yourClientSecret}",
-                              @"challenge_type": @"oob",
-                              @"authenticator_id": @"email|dev_NU1Ofuw3Cw0XCt5x",
-                              @"mfa_token": @"{mfaToken}" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/mfa/challenge"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -819,36 +621,6 @@ request.body = "{  "client_id": "{yourClientId}",  "client_secret": "{yourClient
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-let parameters = [
-  "client_id": "{yourClientId}",
-  "client_secret": "{yourClientSecret}",
-  "challenge_type": "oob",
-  "authenticator_id": "email|dev_NU1Ofuw3Cw0XCt5x",
-  "mfa_token": "{mfaToken}"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/mfa/challenge")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -944,37 +716,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=http://auth0.com/oauth/grant-type/mfa-oob" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_secret={yourClientSecret}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&mfa_token={mfaToken}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&oob_code={oobCode}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&binding_code={userEmailOtpCode}" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -1036,37 +777,6 @@ request.body = "grant_type=http%3A%2F%2Fauth0.com%2Foauth%2Fgrant-type%2Fmfa-oob
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=http://auth0.com/oauth/grant-type/mfa-oob".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&client_secret={yourClientSecret}".data(using: String.Encoding.utf8)!)
-postData.append("&mfa_token={mfaToken}".data(using: String.Encoding.utf8)!)
-postData.append("&oob_code={oobCode}".data(using: String.Encoding.utf8)!)
-postData.append("&binding_code={userEmailOtpCode}".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/secure/multi-factor-authentication/authenticate-using-ropg-flow-with-mfa/enroll-and-challenge-otp-authenticators.mdx
+++ b/main/docs/secure/multi-factor-authentication/authenticate-using-ropg-flow-with-mfa/enroll-and-challenge-otp-authenticators.mdx
@@ -99,34 +99,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MFA_TOKEN",
-                           @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"authenticator_types": @[ @"otp" ] };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/mfa/associate"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -194,36 +166,6 @@ request.body = "{ "authenticator_types": ["otp"] }"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer MFA_TOKEN",
-  "content-type": "application/json"
-]
-let parameters = ["authenticator_types": ["otp"]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/mfa/associate")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -324,36 +266,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=http://auth0.com/oauth/grant-type/mfa-otp" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&mfa_token={mfaToken}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_secret={yourClientSecret}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&otp={userOtpCode}" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -415,36 +327,6 @@ request.body = "grant_type=http%3A%2F%2Fauth0.com%2Foauth%2Fgrant-type%2Fmfa-otp
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=http://auth0.com/oauth/grant-type/mfa-otp".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&mfa_token={mfaToken}".data(using: String.Encoding.utf8)!)
-postData.append("&client_secret={yourClientSecret}".data(using: String.Encoding.utf8)!)
-postData.append("&otp={userOtpCode}".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -537,30 +419,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MFA_TOKEN",
-                           @"content-type": @"application/json" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/mfa/authenticators"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -623,32 +481,6 @@ request["content-type"] = 'application/json'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer MFA_TOKEN",
-  "content-type": "application/json"
-]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/mfa/authenticators")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -749,36 +581,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=http://auth0.com/oauth/grant-type/mfa-otp" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_secret={yourClientSecret}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&mfa_token={mfaToken}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&otp={userOtpCode}" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -840,36 +642,6 @@ request.body = "grant_type=http%3A%2F%2Fauth0.com%2Foauth%2Fgrant-type%2Fmfa-otp
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=http://auth0.com/oauth/grant-type/mfa-otp".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&client_secret={yourClientSecret}".data(using: String.Encoding.utf8)!)
-postData.append("&mfa_token={mfaToken}".data(using: String.Encoding.utf8)!)
-postData.append("&otp={userOtpCode}".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/secure/multi-factor-authentication/authenticate-using-ropg-flow-with-mfa/enroll-and-challenge-push-authenticators.mdx
+++ b/main/docs/secure/multi-factor-authentication/authenticate-using-ropg-flow-with-mfa/enroll-and-challenge-push-authenticators.mdx
@@ -101,35 +101,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MFA_TOKEN",
-                           @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"authenticator_types": @[ @"oob" ],
-                              @"oob_channels": @[ @"auth0" ] };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/mfa/associate"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -196,39 +167,6 @@ request.body = "{ "authenticator_types": ["oob"], "oob_channels": ["auth0"] }"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer MFA_TOKEN",
-  "content-type": "application/json"
-]
-let parameters = [
-  "authenticator_types": ["oob"],
-  "oob_channels": ["auth0"]
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/mfa/associate")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -339,37 +277,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {mfaToken}",
-                           @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=http://auth0.com/oauth/grant-type/mfa-oob" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_secret={yourClientSecret}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&mfa_token={mfaToken}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&oob_code={oobCode}" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -436,39 +343,6 @@ request.body = "grant_type=http%3A%2F%2Fauth0.com%2Foauth%2Fgrant-type%2Fmfa-oob
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer {mfaToken}",
-  "content-type": "application/x-www-form-urlencoded"
-]
-
-let postData = NSMutableData(data: "grant_type=http://auth0.com/oauth/grant-type/mfa-oob".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&client_secret={yourClientSecret}".data(using: String.Encoding.utf8)!)
-postData.append("&mfa_token={mfaToken}".data(using: String.Encoding.utf8)!)
-postData.append("&oob_code={oobCode}".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -570,30 +444,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MFA_TOKEN",
-                           @"content-type": @"application/json" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/mfa/authenticators"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -656,32 +506,6 @@ request["content-type"] = 'application/json'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer MFA_TOKEN",
-  "content-type": "application/json"
-]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/mfa/authenticators")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -781,34 +605,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-NSDictionary *parameters = @{ @"client_id": @"{yourClientId}",
-                              @"client_secret": @"{yourClientSecret",
-                              @"challenge_type": @"oob",
-                              @"authenticator_id": @"push|dev_ZUla9SQ6tAIHSz6y",
-                              @"mfa_token": @"{mfaToken}" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/mfa/challenge"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -864,36 +660,6 @@ request.body = "{ "client_id": "{yourClientId}",  "client_secret": "{yourClientS
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-let parameters = [
-  "client_id": "{yourClientId}",
-  "client_secret": "{yourClientSecret",
-  "challenge_type": "oob",
-  "authenticator_id": "push|dev_ZUla9SQ6tAIHSz6y",
-  "mfa_token": "{mfaToken}"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/mfa/challenge")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -986,36 +752,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=http://auth0.com/oauth/grant-type/mfa-oob" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_secret={yourClientSecret}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&mfa_token={mfaToken}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&oob_code={oobCode}" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -1077,36 +813,6 @@ request.body = "grant_type=http%3A%2F%2Fauth0.com%2Foauth%2Fgrant-type%2Fmfa-oob
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=http://auth0.com/oauth/grant-type/mfa-oob".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&client_secret={yourClientSecret}".data(using: String.Encoding.utf8)!)
-postData.append("&mfa_token={mfaToken}".data(using: String.Encoding.utf8)!)
-postData.append("&oob_code={oobCode}".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/secure/multi-factor-authentication/authenticate-using-ropg-flow-with-mfa/enroll-challenge-sms-voice-authenticators.mdx
+++ b/main/docs/secure/multi-factor-authentication/authenticate-using-ropg-flow-with-mfa/enroll-challenge-sms-voice-authenticators.mdx
@@ -99,36 +99,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {mfaToken}",
-                           @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"authenticator_types": @[ @"oob" ],
-                              @"oob_channels": @[ @"sms" ],
-                              @"phone_number": @"+11...9" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/mfa/associate"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -195,40 +165,6 @@ request.body = "{ "authenticator_types": ["oob"], "oob_channels": ["sms"], "phon
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer {mfaToken}",
-  "content-type": "application/json"
-]
-let parameters = [
-  "authenticator_types": ["oob"],
-  "oob_channels": ["sms"],
-  "phone_number": "+11...9"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/mfa/associate")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -346,38 +282,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {mfaToken}",
-                           @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=http://auth0.com/oauth/grant-type/mfa-oob" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_secret={yourClientSecret}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&mfa_token={mfaToken}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&oob_code={oobCode}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&binding_code={userOtpCode}" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -444,40 +348,6 @@ request.body = "grant_type=http%3A%2F%2Fauth0.com%2Foauth%2Fgrant-type%2Fmfa-oob
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer {mfaToken}",
-  "content-type": "application/x-www-form-urlencoded"
-]
-
-let postData = NSMutableData(data: "grant_type=http://auth0.com/oauth/grant-type/mfa-oob".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&client_secret={yourClientSecret}".data(using: String.Encoding.utf8)!)
-postData.append("&mfa_token={mfaToken}".data(using: String.Encoding.utf8)!)
-postData.append("&oob_code={oobCode}".data(using: String.Encoding.utf8)!)
-postData.append("&binding_code={userOtpCode}".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -566,30 +436,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer MFA_TOKEN",
-                           @"content-type": @"application/json" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/mfa/authenticators"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -652,32 +498,6 @@ request["content-type"] = 'application/json'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer MFA_TOKEN",
-  "content-type": "application/json"
-]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/mfa/authenticators")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -783,37 +603,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"client_id": @"{yourClientId}",
-                              @"client_secret": @"{yourClientSecret}",
-                              @"challenge_type": @"oob",
-                              @"authenticator_id": @"sms|dev_NU1Ofuw3Cw0XCt5x",
-                              @"mfa_token": @"{mfaToken}" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/mfa/challenge"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -875,39 +664,6 @@ request.body = "{ "client_id": "{yourClientId}",  "client_secret": "{yourClientS
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/json"]
-let parameters = [
-  "client_id": "{yourClientId}",
-  "client_secret": "{yourClientSecret}",
-  "challenge_type": "oob",
-  "authenticator_id": "sms|dev_NU1Ofuw3Cw0XCt5x",
-  "mfa_token": "{mfaToken}"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/mfa/challenge")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -1003,37 +759,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=http://auth0.com/oauth/grant-type/mfa-oob" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_secret={yourClientSecret}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&mfa_token={mfaToken}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&oob_code={oobCode}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&binding_code=USER_OTP_CODE" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -1095,37 +820,6 @@ request.body = "grant_type=http%3A%2F%2Fauth0.com%2Foauth%2Fgrant-type%2Fmfa-oob
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=http://auth0.com/oauth/grant-type/mfa-oob".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&client_secret={yourClientSecret}".data(using: String.Encoding.utf8)!)
-postData.append("&mfa_token={mfaToken}".data(using: String.Encoding.utf8)!)
-postData.append("&oob_code={oobCode}".data(using: String.Encoding.utf8)!)
-postData.append("&binding_code=USER_OTP_CODE".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/secure/multi-factor-authentication/manage-mfa-auth0-apis/manage-authentication-methods-with-management-api.mdx
+++ b/main/docs/secure/multi-factor-authentication/manage-mfa-auth0-apis/manage-authentication-methods-with-management-api.mdx
@@ -92,29 +92,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourMgmtApiAccessToken}" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://%7ByourDomain%7D/api/v2/users/%7BuserId%7D/authentication-methods"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines
 $curl = curl_init();
@@ -174,29 +151,6 @@ request["authorization"] = 'Bearer {yourMgmtApiAccessToken}'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift lines
-import Foundation
-
-let headers = ["authorization": "Bearer {yourMgmtApiAccessToken}"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://%7ByourDomain%7D/api/v2/users/%7BuserId%7D/authentication-methods")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -287,29 +241,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourMgmtApiAccessToken}" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://%7ByourDomain%7D/api/v2/users/%7BuserId%7D/authentication-methods/%7BauthenticationMethodId%7D"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines
 $curl = curl_init();
@@ -369,29 +300,6 @@ request["authorization"] = 'Bearer {yourMgmtApiAccessToken}'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift lines
-import Foundation
-
-let headers = ["authorization": "Bearer {yourMgmtApiAccessToken}"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://%7ByourDomain%7D/api/v2/users/%7BuserId%7D/authentication-methods/%7BauthenticationMethodId%7D")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -497,35 +405,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C lines expandable
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourMgmtApiAccessToken}" };
-NSDictionary *parameters = @{ @"type": @"phone",
-                              @"name": @"SMS",
-                              @"phone_number": @"+00000000000" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://%7ByourDomain%7D/api/v2/users/%7BuserId%7D/authentication-methods"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines expandable
 $curl = curl_init();
@@ -589,37 +468,6 @@ request.body = "{ \"type\": \"phone\", \"name\": \"SMS\", \"phone_number\": \"+0
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift lines expandable
-import Foundation
-
-let headers = ["authorization": "Bearer {yourMgmtApiAccessToken}"]
-let parameters = [
-  "type": "phone",
-  "name": "SMS",
-  "phone_number": "+00000000000"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://%7ByourDomain%7D/api/v2/users/%7BuserId%7D/authentication-methods")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -713,35 +561,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C lines expandable
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourMgmtApiAccessToken}" };
-NSDictionary *parameters = @{ @"type": @"email",
-                              @"name": @"Email Factor",
-                              @"email": @"user@example.com" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://%7ByourDomain%7D/api/v2/users/%7BuserId%7D/authentication-methods"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines expandable
 $curl = curl_init();
@@ -805,37 +624,6 @@ request.body = "{ \"type\": \"email\", \"name\": \"Email Factor\", \"email\": \"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift lines expandable
-import Foundation
-
-let headers = ["authorization": "Bearer {yourMgmtApiAccessToken}"]
-let parameters = [
-  "type": "email",
-  "name": "Email Factor",
-  "email": "user@example.com"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://%7ByourDomain%7D/api/v2/users/%7BuserId%7D/authentication-methods")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -927,35 +715,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourMgmtApiAccessToken}" };
-NSDictionary *parameters = @{ @"type": @"totp",
-                              @"name": @"OTP Application",
-                              @"totp_secret": @"{yourSecret}" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://%7ByourDomain%7D/api/v2/users/%7BuserId%7D/authentication-methods"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -1017,37 +776,6 @@ request.body = "{ "type": "totp", "name": "OTP Application", "totp_secret": "{yo
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer {yourMgmtApiAccessToken}"]
-let parameters = [
-  "type": "totp",
-  "name": "OTP Application",
-  "totp_secret": "{yourSecret}"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://%7ByourDomain%7D/api/v2/users/%7BuserId%7D/authentication-methods")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -1145,37 +873,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourMgmtApiAccessToken}" };
-NSDictionary *parameters = @{ @"type": @"webauthn_roaming",
-                              @"name": @"WebAuthn with security keys",
-                              @"public_key": @"{yourPublicKey}",
-                              @"key_id": @"{yourKeyId}",
-                              @"relying_party_identifier": @"{yourDomain}" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://%7ByourDomain%7D/api/v2/users/%7BuserId%7D/authentication-methods"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -1237,39 +934,6 @@ request.body = "{ "type": "webauthn_roaming", "name": "WebAuthn with security ke
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["authorization": "Bearer {yourMgmtApiAccessToken}"]
-let parameters = [
-  "type": "webauthn_roaming",
-  "name": "WebAuthn with security keys",
-  "public_key": "{yourPublicKey}",
-  "key_id": "{yourKeyId}",
-  "relying_party_identifier": "{yourDomain}"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://%7ByourDomain%7D/api/v2/users/%7BuserId%7D/authentication-methods")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -1374,33 +1038,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourMgmtApiAccessToken}" };
-NSDictionary *parameters = @[ @{ @"type": @"phone", @"preferred_authentication_method": @"sms", @"phone_number": @"+00000000000", @"name": @"SMS" } ];
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://%7ByourDomain%7D/api/v2/users/%7BuserId%7D/authentication-methods"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PUT"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines expandable
 $curl = curl_init();
@@ -1464,40 +1101,6 @@ request.body = "[{ \"type\": \"phone\", \"preferred_authentication_method\": \"s
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift lines expandable
-import Foundation
-
-let headers = ["authorization": "Bearer {yourMgmtApiAccessToken}"]
-let parameters = [
-  [
-    "type": "phone",
-    "preferred_authentication_method": "sms",
-    "phone_number": "+00000000000",
-    "name": "SMS"
-  ]
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://%7ByourDomain%7D/api/v2/users/%7BuserId%7D/authentication-methods")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PUT"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -1602,33 +1205,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourMgmtApiAccessToken}" };
-NSDictionary *parameters = @{ @"name": @"Mobile SMS" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://%7ByourDomain%7D/api/v2/users/%7BuserId%7D/authentication-methods/%7BauthenticationMethodId%7D"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines expandable
 $curl = curl_init();
@@ -1692,33 +1268,6 @@ request.body = "{ \"name\": \"Mobile SMS\" }"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift lines
-import Foundation
-
-let headers = ["authorization": "Bearer {yourMgmtApiAccessToken}"]
-let parameters = ["name": "Mobile SMS"] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://%7ByourDomain%7D/api/v2/users/%7BuserId%7D/authentication-methods/%7BauthenticationMethodId%7D")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -1815,29 +1364,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourMgmtApiAccessToken}" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://%7ByourDomain%7D/api/v2/users/%7BuserId%7D/authentication-methods"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"DELETE"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines
 $curl = curl_init();
@@ -1897,29 +1423,6 @@ request["authorization"] = 'Bearer {yourMgmtApiAccessToken}'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift lines
-import Foundation
-
-let headers = ["authorization": "Bearer {yourMgmtApiAccessToken}"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://%7ByourDomain%7D/api/v2/users/%7BuserId%7D/authentication-methods")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "DELETE"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -1996,29 +1499,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourMgmtApiAccessToken}" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://%7ByourDomain%7D/api/v2/users/%7BuserId%7D/authentication-methods/%7BauthenticationMethodId%7D"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"DELETE"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines
 $curl = curl_init();
@@ -2078,29 +1558,6 @@ request["authorization"] = 'Bearer {yourMgmtApiAccessToken}'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift lines
-import Foundation
-
-let headers = ["authorization": "Bearer {yourMgmtApiAccessToken}"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://%7ByourDomain%7D/api/v2/users/%7BuserId%7D/authentication-methods/%7BauthenticationMethodId%7D")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "DELETE"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/secure/multi-factor-authentication/multi-factor-authentication-developer-resources/create-custom-enrollment-tickets.mdx
+++ b/main/docs/secure/multi-factor-authentication/multi-factor-authentication-developer-resources/create-custom-enrollment-tickets.mdx
@@ -129,39 +129,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourMgmtApiAccessToken}",
-                           @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"user_id": @"string",
-                              @"email": @"user@exampleco.com",
-                              @"send_email": @"true",
-                              @"email_locale": @"string",
-                              @"factor": @"oob",
-                              @"allow_multiple_enrollments": @"true" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/guardian/post-ticket"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -249,43 +216,6 @@ request.body = "{
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer {yourMgmtApiAccessToken}",
-  "content-type": "application/json"
-]
-let parameters = [
-  "user_id": "string",
-  "email": "user@exampleco.com",
-  "send_email": "true",
-  "email_locale": "string",
-  "factor": "oob",
-  "allow_multiple_enrollments": "true"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/guardian/post-ticket")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/secure/multi-factor-authentication/multi-factor-authentication-factors/configure-sms-voice-notifications-mfa.mdx
+++ b/main/docs/secure/multi-factor-authentication/multi-factor-authentication-factors/configure-sms-voice-notifications-mfa.mdx
@@ -150,34 +150,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer MGMT_API_ACCESS_TOKEN" };
-NSDictionary *parameters = @{ @"message_types": @[ @"sms", @"voice" ] };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/guardian/factors/phone/message-types"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PUT"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -244,36 +216,6 @@ request.body = "{ "message_types": ["sms", "voice"] }"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer MGMT_API_ACCESS_TOKEN"
-]
-let parameters = ["message_types": ["sms", "voice"]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/guardian/factors/phone/message-types")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PUT"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/secure/security-guidance/data-security/denylist.mdx
+++ b/main/docs/secure/security-guidance/data-security/denylist.mdx
@@ -86,35 +86,6 @@ axios.request(options).then(function (response) {
 });
 
 ```
-```objc Obj-C
-    #import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer YOUR_TOKEN",
-                          @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"options": @{ @"non_persistent_attrs": @[ @"ethnicity", @"gender" ] } };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/connections/YOUR_CONNECTION_ID"]
-                                                      cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                  timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-
-```
 ```php PHP
     $curl = curl_init();
 
@@ -183,37 +154,6 @@ request.body = "{"options": {"non_persistent_attrs": ["ethnicity", "gender"]}}"
 
 response = http.request(request)
 puts response.read_body
-
-```
-```swift Swift
-    import Foundation
-
-let headers = [
-  "authorization": "Bearer YOUR_TOKEN",
-  "content-type": "application/json"
-]
-let parameters = ["options": ["non_persistent_attrs": ["ethnicity", "gender"]]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/connections/YOUR_CONNECTION_ID")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 
 ```
 </AuthCodeGroup>

--- a/main/docs/secure/security-guidance/data-security/user-data-storage.mdx
+++ b/main/docs/secure/security-guidance/data-security/user-data-storage.mdx
@@ -135,29 +135,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourIdToken}" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://%7ByourAccount%7D.auth0.com/api/v2/users/user_id"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines
 $curl = curl_init();
@@ -217,29 +194,6 @@ request["authorization"] = 'Bearer {yourIdToken}'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift lines
-import Foundation
-
-let headers = ["authorization": "Bearer {yourIdToken}"]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://%7ByourAccount%7D.auth0.com/api/v2/users/user_id")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -315,33 +269,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourAccessToken}",
-                           @"content-type": @"application/json" };
-
-NSData *postData = [[NSData alloc] initWithData:[@"{"user_metadata": {"displayName": "J-vald3z"}" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users/user_id"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -408,35 +335,6 @@ request.body = "{"user_metadata": {"displayName": "J-vald3z"}"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer {yourAccessToken}",
-  "content-type": "application/json"
-]
-
-let postData = NSData(data: "{"user_metadata": {"displayName": "J-vald3z"}".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users/user_id")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/secure/tokens/access-tokens/get-access-tokens.mdx
+++ b/main/docs/secure/tokens/access-tokens/get-access-tokens.mdx
@@ -95,35 +95,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=client_credentials" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_secret={yourClientSecret}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&audience=YOUR_API_IDENTIFIER" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -185,35 +156,6 @@ request.body = "grant_type=client_credentials&client_id={yourClientId}&client_se
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=client_credentials".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&client_secret={yourClientSecret}".data(using: String.Encoding.utf8)!)
-postData.append("&audience=YOUR_API_IDENTIFIER".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/secure/tokens/access-tokens/management-api-access-tokens/get-management-api-access-tokens-for-production.mdx
+++ b/main/docs/secure/tokens/access-tokens/management-api-access-tokens/get-management-api-access-tokens-for-production.mdx
@@ -92,35 +92,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=client_credentials" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_secret={yourClientSecret}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&audience=https://{yourDomain}/api/v2/" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -182,35 +153,6 @@ request.body = "grant_type=client_credentials&client_id={yourClientId}&client_se
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=client_credentials".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&client_secret={yourClientSecret}".data(using: String.Encoding.utf8)!)
-postData.append("&audience=https://{yourDomain}/api/v2/".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -320,30 +262,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer {yourMgmtApiAccessToken}" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http:///%7BmgmtApiEndpoint%7D"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 
 ```php PHP lines expandable
 $curl = curl_init();
@@ -405,32 +323,6 @@ request["authorization"] = 'Bearer {yourMgmtApiAccessToken}'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift lines
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer {yourMgmtApiAccessToken}"
-]
-
-let request = NSMutableURLRequest(url: NSURL(string: "http:///%7BmgmtApiEndpoint%7D")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -499,30 +391,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json",
-                           @"authorization": @"Bearer {yourAccessToken}" };
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/clients"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"GET"];
-[request setAllHTTPHeaderFields:headers];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -585,32 +453,6 @@ request["authorization"] = 'Bearer {yourAccessToken}'
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/json",
-  "authorization": "Bearer {yourAccessToken}"
-]
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/clients")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "GET"
-request.allHTTPHeaderFields = headers
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/secure/tokens/refresh-tokens/get-refresh-tokens.mdx
+++ b/main/docs/secure/tokens/refresh-tokens/get-refresh-tokens.mdx
@@ -100,36 +100,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=authorization_code" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_secret={yourClientSecret}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&code={yourAuthorizationCode}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&redirect_uri={https://yourApp/callback}" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -191,36 +161,6 @@ request.body = "grant_type=authorization_code&client_id={yourClientId}&client_se
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=authorization_code".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&client_secret={yourClientSecret}".data(using: String.Encoding.utf8)!)
-postData.append("&code={yourAuthorizationCode}".data(using: String.Encoding.utf8)!)
-postData.append("&redirect_uri={https://yourApp/callback}".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/secure/tokens/refresh-tokens/multi-resource-refresh-token/configure-and-implement-multi-resource-refresh-token.mdx
+++ b/main/docs/secure/tokens/refresh-tokens/multi-resource-refresh-token/configure-and-implement-multi-resource-refresh-token.mdx
@@ -192,34 +192,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer {yourMgmtApiAccessToken}",
-                           @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"refresh_token": @{ @"expiration_type": @"expiring", @"rotation_type": @"rotating", @"token_lifetime": @31557600, @"idle_token_lifetime": @2592000, @"leeway": @0, @"infinite_token_lifetime": @NO, @"infinite_idle_token_lifetime": @NO, @"policies": @[ @{ @"audience": @"https://api.example.com", @"scope": @[ @"read:data" ] }, @{ @"audience": @"https://billing.example.com", @"scope": @[ @"read:billing" ] } ] } };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/clients//{yourClientId}"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"PATCH"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -346,54 +318,6 @@ request.body = "{
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "authorization": "Bearer {yourMgmtApiAccessToken}",
-  "content-type": "application/json"
-]
-let parameters = ["refresh_token": [
-    "expiration_type": "expiring",
-    "rotation_type": "rotating",
-    "token_lifetime": 31557600,
-    "idle_token_lifetime": 2592000,
-    "leeway": 0,
-    "infinite_token_lifetime": false,
-    "infinite_idle_token_lifetime": false,
-    "policies": [
-      [
-        "audience": "https://api.example.com",
-        "scope": ["read:data"]
-      ],
-      [
-        "audience": "https://billing.example.com",
-        "scope": ["read:billing"]
-      ]
-    ]
-  ]] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/clients//{yourClientId}")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "PATCH"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -538,37 +462,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"grant_type": @"refresh_token",
-                              @"client_id": @"{yourClientId}",
-                              @"refresh_token": @"${refreshToken}",
-                              @"audience": @"https://billing.example.com",
-                              @"scope": @"read:billing write:billing" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -648,39 +541,6 @@ request.body = "{
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/json"]
-let parameters = [
-  "grant_type": "refresh_token",
-  "client_id": "{yourClientId}",
-  "refresh_token": "${refreshToken}",
-  "audience": "https://billing.example.com",
-  "scope": "read:billing write:billing"
-] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/secure/tokens/refresh-tokens/use-refresh-tokens.mdx
+++ b/main/docs/secure/tokens/refresh-tokens/use-refresh-tokens.mdx
@@ -99,35 +99,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded",
-                           @"authorization": @"Basic {yourApplicationCredentials}" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=refresh_token" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&refresh_token={yourRefreshToken}" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -194,37 +165,6 @@ request.body = "grant_type=refresh_token&client_id={yourClientId}&refresh_token=
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = [
-  "content-type": "application/x-www-form-urlencoded",
-  "authorization": "Basic {yourApplicationCredentials}"
-]
-
-let postData = NSMutableData(data: "grant_type=refresh_token".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&refresh_token={yourRefreshToken}".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 
@@ -304,35 +244,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"content-type": @"application/x-www-form-urlencoded" };
-
-NSMutableData *postData = [[NSMutableData alloc] initWithData:[@"grant_type=refresh_token" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_id={yourClientId}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&client_secret={yourClientSecret}" dataUsingEncoding:NSUTF8StringEncoding]];
-[postData appendData:[@"&refresh_token={yourRefreshToken}" dataUsingEncoding:NSUTF8StringEncoding]];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/oauth/token"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP
 $curl = curl_init();
 
@@ -394,35 +305,6 @@ request.body = "grant_type=refresh_token&client_id={yourClientId}&client_secret=
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift
-import Foundation
-
-let headers = ["content-type": "application/x-www-form-urlencoded"]
-
-let postData = NSMutableData(data: "grant_type=refresh_token".data(using: String.Encoding.utf8)!)
-postData.append("&client_id={yourClientId}".data(using: String.Encoding.utf8)!)
-postData.append("&client_secret={yourClientSecret}".data(using: String.Encoding.utf8)!)
-postData.append("&refresh_token={yourRefreshToken}".data(using: String.Encoding.utf8)!)
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/oauth/token")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 

--- a/main/docs/troubleshoot/product-lifecycle/past-migrations/link-user-accounts-with-access-tokens-migration.mdx
+++ b/main/docs/troubleshoot/product-lifecycle/past-migrations/link-user-accounts-with-access-tokens-migration.mdx
@@ -294,34 +294,6 @@ axios.request(options).then(function (response) {
   console.error(error);
 });
 ```
-```objc Obj-C lines
-#import <Foundation/Foundation.h>
-
-NSDictionary *headers = @{ @"authorization": @"Bearer ACCESS_TOKEN",
-                           @"content-type": @"application/json" };
-NSDictionary *parameters = @{ @"link_with": @"SECONDARY_ACCOUNT_ID_TOKEN" };
-
-NSData *postData = [NSJSONSerialization dataWithJSONObject:parameters options:0 error:nil];
-
-NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://{yourDomain}/api/v2/users/PRIMARY_ACCOUNT_USER_ID/identities"]
-                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                                   timeoutInterval:10.0];
-[request setHTTPMethod:@"POST"];
-[request setAllHTTPHeaderFields:headers];
-[request setHTTPBody:postData];
-
-NSURLSession *session = [NSURLSession sharedSession];
-NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
-                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                                                if (error) {
-                                                    NSLog(@"%@", error);
-                                                } else {
-                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
-                                                    NSLog(@"%@", httpResponse);
-                                                }
-                                            }];
-[dataTask resume];
-```
 ```php PHP lines
 $curl = curl_init();
 
@@ -388,36 +360,6 @@ request.body = "{"link_with":"SECONDARY_ACCOUNT_ID_TOKEN"}"
 
 response = http.request(request)
 puts response.read_body
-```
-```swift Swift lines
-import Foundation
-
-let headers = [
-  "authorization": "Bearer ACCESS_TOKEN",
-  "content-type": "application/json"
-]
-let parameters = ["link_with": "SECONDARY_ACCOUNT_ID_TOKEN"] as [String : Any]
-
-let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
-
-let request = NSMutableURLRequest(url: NSURL(string: "https://{yourDomain}/api/v2/users/PRIMARY_ACCOUNT_USER_ID/identities")! as URL,
-                                        cachePolicy: .useProtocolCachePolicy,
-                                    timeoutInterval: 10.0)
-request.httpMethod = "POST"
-request.allHTTPHeaderFields = headers
-request.httpBody = postData as Data
-
-let session = URLSession.shared
-let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
-  if (error != nil) {
-    print(error)
-  } else {
-    let httpResponse = response as? HTTPURLResponse
-    print(httpResponse)
-  }
-})
-
-dataTask.resume()
 ```
 </AuthCodeGroup>
 


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

big ol' maintenance task per technical correctness checklist. removes obj-c and swift samples from management API calls.

programmatically removed with trusty `sed`.

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

### References

https://oktainc.atlassian.net/wiki/spaces/~712020f3e4dcd8d82140ad9eb149b4b5898a43/pages/425689608/Technical+Correctness+Checklist

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

build locally. peek at diff.

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
