### PR TITLE
fix: update export-password-hashes-and-mfa-secrets

### DIFF
--- a/main/docs/manage-users/user-migration/export-password-hashes-and-mfa-secrets.mdx
+++ b/main/docs/manage-users/user-migration/export-password-hashes-and-mfa-secrets.mdx
@@ -80,7 +80,7 @@ Do not export or share your private key. Auth0 only needs your public key to enc
   You receive an email containing a pre-signed, secure download URL hosted on Amazon S3. This link:
 
   - Is accessible only to tenant administrators associated with the request.
-  - Expires after **1 day**. Download the file before it expires. After expiration, you must submit a new request.
+  - Expires after **3 days**. Download the file before it expires. After expiration, you must submit a new request.
 
   </Step>
 


### PR DESCRIPTION
## Description

Increases link expiration from 1 day to 3 days.

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
