### PR TITLE
fix: configure-and-implement-multi-resource-refresh-token

### DIFF
--- a/main/docs/secure/tokens/refresh-tokens/multi-resource-refresh-token/configure-and-implement-multi-resource-refresh-token.mdx
+++ b/main/docs/secure/tokens/refresh-tokens/multi-resource-refresh-token/configure-and-implement-multi-resource-refresh-token.mdx
@@ -564,7 +564,7 @@ To learn more, read [Auth0 Swift SDK](https://github.com/auth0/Auth0.swift/blob/
 
 If you are using the Auth0 Android SDK, you can exchange the refresh token using the following code:
 
-```swift lines
+```kotlin lines
 credentialsManager.getApiCredentials(
     audience = "https://example.com/me", scope = " create:me:authentication_methods",
     callback = object : Callback<APICredentials, CredentialsManagerException> {


### PR DESCRIPTION
## Description

Swapping syntax callout from swift -> kotlin 

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
