### PR TITLE
fix: fetch PR labels via 'gh'

### DIFF
--- a/.github/workflows/close-superseded-automation-prs.yml
+++ b/.github/workflows/close-superseded-automation-prs.yml
@@ -18,7 +18,8 @@ jobs:
         id: check
         env:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          CURRENT_PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
         run: |
           # Do not run if triggering PR is not created by the automation bot
           if [[ "$PR_AUTHOR" != "auth0-docs-automation[bot]" ]]; then
@@ -26,6 +27,10 @@ jobs:
             echo "should_run=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+
+          # Fetch labels via gh CLI to get live state (event payload labels may be stale
+          # if labels were added by another bot after the PR was opened)
+          PR_LABELS=$(gh pr view "$CURRENT_PR" --repo "$REPO" --json labels --jq '[.labels[].name]')
 
           # Do not run if triggering PR is not a `main` docs site PR (indicated by the "main-docs" label)
           if ! echo "$PR_LABELS" | jq -e 'index("main-docs")' > /dev/null; then


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

- Fix the `Close superseded automation PRs` workflow not seeing the right PR's labels by fetching them via `gh`

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

Verified by running the modified parts of the `bash` script locally

## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
