### PR TITLE
fix: call-your-api-using-the-authorization-code-flow typo

### DIFF
--- a/main/docs/get-started/authentication-and-authorization-flow/authorization-code-flow/call-your-api-using-the-authorization-code-flow.mdx
+++ b/main/docs/get-started/authentication-and-authorization-flow/authorization-code-flow/call-your-api-using-the-authorization-code-flow.mdx
@@ -116,7 +116,7 @@ curl --request POST \
   --data grant_type=authorization_code \
   --data 'client_id={yourClientId}' \
   --data 'client_secret={yourClientSecret}' \
-  --data 'code=yourAuthorizationCode}' \
+  --data 'code={yourAuthorizationCode}' \
   --data 'redirect_uri={https://yourApp/callback}'
 ```
 ```csharp C#


### PR DESCRIPTION
## Description

Small typo omitted bracket in code sample.

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
