### PR TITLE
fix: DOCS-5477 clarify event stream testing and delivery failure causes

### DIFF
--- a/main/docs/customize/events/event-testing-observability-and-failure-recovery.mdx
+++ b/main/docs/customize/events/event-testing-observability-and-failure-recovery.mdx
@@ -7,7 +7,7 @@ The following sections provide information about testing event streams and manag
 
 ## Test the event stream
 
-After you create and enable an event stream using either AWS EventBridge or webhooks, you can test the new stream. Currently, Auth0 does not support sending events to disabled event streams.
+After you create and enable an event stream, you can test the new stream. Currently, Auth0 does not support sending events to disabled event streams.
 
 To test your event stream, first create a user for your application by running the following with your preferred credentials:
 
@@ -115,6 +115,11 @@ If an empty delivery failure array is returned, your event stream is running cor
 ## Observability
 
 To ensure the reliability of event streams, implement a monitoring process that periodically checks for delivery failures and triggers alerts when necessary.
+
+Delivery failures can be a result of:
+* Disabled event streams.
+* Event streams not available.
+* Connection errors.
 
 ### Polling Deliveries endpoint
 


### PR DESCRIPTION
## Summary

- Remove AWS EventBridge/webhooks specificity from the test stream intro sentence
- Add bullet list of common delivery failure causes under the monitoring section

## Test plan

- [ ] Verify rendered page at `docs/customize/events/event-testing-observability-and-failure-recovery`
- [ ] Confirm bullet list renders correctly under the monitoring section

🤖 Generated with [Claude Code](https://claude.com/claude-code)