### PR TITLE
fix: image container sizing

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Ignore MDX files to preserve original formatting (e.g., * vs - for lists)
+*.mdx

--- a/auth4genai/style.css
+++ b/auth4genai/style.css
@@ -474,11 +474,13 @@ html[style*="color-scheme: dark"] {
   width: fit-content;
   max-width: 100%;
   margin-right: auto;
+  margin-left: auto;
 }
 
 .frame:has(img) > .relative:not(.absolute) {
   width: fit-content;
   max-width: 100%;
+  margin: 0 auto;
 }
 
 .frame > div > span[data-as="p"] {

--- a/auth4genai/style.css
+++ b/auth4genai/style.css
@@ -470,19 +470,31 @@ html[style*="color-scheme: dark"] {
   margin: 20px 0;
 }
 
+.frame:has(img) {
+  width: fit-content;
+  max-width: 100%;
+  margin-right: auto;
+}
+
+.frame:has(img) > .relative:not(.absolute) {
+  width: fit-content;
+  max-width: 100%;
+}
+
 .frame > div > span[data-as="p"] {
   margin-top: 0 !important;
   margin-bottom: 0 !important;
 }
 
 .frame :where(img) {
-  object-view-box: inset(9px 9px);
-  width: 97.5%;
+  object-view-box: inset(1px 1px);
+  width: auto;
+  max-width: calc(100% - 1rem);
   margin: 0.5rem auto;
   border-radius: 0.65rem;
   overflow: clip;
   box-shadow:
-    inset 0 0 0 0.5px oklch(from var(--shadow) l c h / 0.1),
+    inset 0 0 0 1px oklch(from var(--shadow) l c h / 0.1),
     0 0 0 1px oklch(from var(--shadow) l c h / 0.12),
     0 1px 1px 0 oklch(from var(--shadow) l c h / 0.04),
     0 1px 2px -1px oklch(from var(--shadow) l c h / 0.04),
@@ -497,7 +509,7 @@ div[data-component-part="frame-caption"] {
   padding-left: 12px;
   padding-top: 0;
   padding-bottom: 12px;
-  color: var(--);
+  color: var(--text-secondary);
 }
 
 /* ==========================================================================

--- a/main/ui/css/styles.css
+++ b/main/ui/css/styles.css
@@ -670,6 +670,17 @@ html[style*="color-scheme: dark"] {
   margin: 20px 0;
 }
 
+.frame:has(img) {
+  width: fit-content;
+  max-width: 100%;
+  margin-right: auto;
+}
+
+.frame:has(img) > .relative:not(.absolute) {
+  width: fit-content;
+  max-width: 100%;
+}
+
 .frame > div > span[data-as="p"] {
   margin-top: 0 !important;
   margin-bottom: 0 !important;
@@ -677,7 +688,8 @@ html[style*="color-scheme: dark"] {
 
 .frame :where(img) {
   object-view-box: inset(1px 1px);
-  width: 97.5%;
+  width: auto;
+  max-width: calc(100% - 1rem);
   margin: 0.5rem auto;
   border-radius: 0.65rem;
   overflow: clip;

--- a/main/ui/css/styles.css
+++ b/main/ui/css/styles.css
@@ -671,14 +671,15 @@ html[style*="color-scheme: dark"] {
 }
 
 .frame:has(img) {
-  width: fit-content;
   max-width: 100%;
   margin-right: auto;
+  margin-left: auto;
 }
 
 .frame:has(img) > .relative:not(.absolute) {
   width: fit-content;
   max-width: 100%;
+  margin: 0 auto;
 }
 
 .frame > div > span[data-as="p"] {


### PR DESCRIPTION
## Description

Fix for image sizing regression introduced in styling updates.

### Before
<img width="1442" height="1346" alt="CleanShot 2026-05-06 at 18 23 25@2x" src="https://github.com/user-attachments/assets/8933c6c5-04d3-4bda-a5f8-b7da489205b9" />

### After
<img width="1450" height="1936" alt="CleanShot 2026-05-06 at 18 40 42@2x" src="https://github.com/user-attachments/assets/f71baada-87f1-483d-8a76-7fc5b0125981" />

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

1. Navigate to `/docs/libraries/acul/js-sdk/Screens/classes/Login`
2. Check image sizing and frame

## Checklist

- [X] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [X] I've tested the site build for this change locally.
- [X] I've made appropriate docs updates for any code or config changes.
- [X] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
