### PR TITLE
fix: DOCS-5478 add inline links for MFA Action API methods and event object

### DIFF
--- a/main/docs/secure/multi-factor-authentication/customize-mfa/customize-mfa-selection-universal-login.mdx
+++ b/main/docs/secure/multi-factor-authentication/customize-mfa/customize-mfa-selection-universal-login.mdx
@@ -16,8 +16,8 @@ Auth0 supports a variety of factors for securing user access with [multi-factor 
 
 You can use [Actions](/docs/customize/actions) to customize your MFA flows. Specifically, you can modify the `post-login` trigger of the [Login Flow](/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger) with the following Authentication API methods:
 
-* `challengeWith`: Specifies the factor or factors users must use to authenticate, such as a one-time password (OTP). This method presents a default challenge to users and can optionally provide access to a factor picker that allows them to choose a different authentication method.
-* `challengeWithAny`: Sets a group of factors users can choose from when authenticating, such as email and OTP. By default, this method presents a factor picker to users rather than a specific challenge, in accordance with the following conditions:
+* [`challengeWith`](/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-api-object#api-authentication-challengewith-factor-options): Specifies the factor or factors users must use to authenticate, such as a one-time password (OTP). This method presents a default challenge to users and can optionally provide access to a factor picker that allows them to choose a different authentication method.
+* [`challengeWithAny`](/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-api-object#api-authentication-challengewithany-factors): Sets a group of factors users can choose from when authenticating, such as email and OTP. By default, this method presents a factor picker to users rather than a specific challenge, in accordance with the following conditions:
 
   + If two or more factors are specified, a factor picker displays to the user.
   + If the user has only enrolled in one of the specified factors (or only one factor is supplied), the factor picker is skipped.
@@ -40,7 +40,7 @@ When choosing MFA challenges for your commands, you can use the factors listed b
 * `webauthn-platform`
 * `webauthn-roaming`
 
-The array `event.authentication.methods` includes a `type` field when the name of the method is set to `mfa`. type is a string that contains factor values matching those used by the `type` field from `enrolledFactors` (listed above). When an MFA challenge is performed, `methods` contains an object of `name:mfa` with `type` set to the factor used for that challenge. `methods` is only updated when an Action begins. To see the results of a challenge, `methods` must be accessed in the next Action in the flow.
+The array [`event.authentication.methods`](/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-event-object#multi-factor-authentication) includes a `type` field when the name of the method is set to `mfa`. type is a string that contains factor values matching those used by the `type` field from `enrolledFactors` (listed above). When an MFA challenge is performed, `methods` contains an object of `name:mfa` with `type` set to the factor used for that challenge. `methods` is only updated when an Action begins. To see the results of a challenge, `methods` must be accessed in the next Action in the flow.
 
 To learn more, review the following resources:
 
@@ -287,7 +287,7 @@ exports.onExecutePostLogin = async (event, api) => {
 
 For a more flexible experience, you can present users with a **Try Another Method** link as part of their MFA challenge. This link allows users to select a different method of authentication than the default challenge.
 
-To achieve this, include the `additionalFactors` parameter in your Actions code. You can set this parameter to a specific factor for all users or use `enrolledFactors` to let users choose their preferred factor.
+To achieve this, include the [`additionalFactors`](/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-api-object#param-additional-factors) parameter in your Actions code. You can set this parameter to a specific factor for all users or use `enrolledFactors` to let users choose their preferred factor.
 
 **Specific Factor**
 


### PR DESCRIPTION
## Summary

- Link `challengeWith` and `challengeWithAny` to their API object reference docs
- Link `event.authentication.methods` to the post-login event object docs
- Link `additionalFactors` to its API parameter reference

## Test plan

- [ ] Verify all four new inline links resolve correctly
- [ ] Confirm page renders without broken markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)