### PR TITLE
fix: api explorer typography

### DIFF
--- a/auth4genai/style.css
+++ b/auth4genai/style.css
@@ -679,32 +679,10 @@ a.card[href^="http"]::after {
   color: var(--text-tertiary);
 }
 
-#sidebar-group > li > a {
-  padding-top: 8px;
-  padding-bottom: 8px;
-  padding-left: 12px;
-  padding-right: 12px;
-  border-radius: 8px;
-  margin: 0;
-  font-size: 0.875rem;
-  min-height: 32px;
-  line-height: 1.5;
-  font-weight: 500;
-  letter-spacing: -0.12px;
-  color: var(--text-secondary);
-  transition: all 0.15s ease-out;
-  text-shadow: none;
-}
-
-#sidebar-group > li > a > div > svg {
-  width: 24px;
-  height: 24px;
-  transition: all 0.15s ease-out;
-}
-
-#sidebar-group > li > button {
-  padding-top: 4px;
-  padding-bottom: 4px;
+#sidebar-group > li > :is(a, button),
+#sidebar-group > li > ul > li > a {
+  padding-top: var(--sidebar-padding-y, 6px);
+  padding-bottom: var(--sidebar-padding-y, 6px);
   padding-left: 12px;
   padding-right: 12px;
   border: none;
@@ -720,7 +698,17 @@ a.card[href^="http"]::after {
   text-shadow: none;
 }
 
-#sidebar-group > li > button > div > svg {
+#sidebar-group > li > a {
+  --sidebar-padding-y: 8px;
+}
+
+#sidebar-group > li > button {
+  --sidebar-padding-y: 4px;
+}
+
+#sidebar-group > li > a > div > svg,
+#sidebar-group > li > button > div > svg,
+#sidebar-group > li > ul > li > a > div > svg {
   width: 24px;
   height: 24px;
   transition: all 0.15s ease-out;
@@ -742,27 +730,7 @@ a.card[href^="http"]::after {
 }
 
 #sidebar-group > li > ul > li > a {
-  padding-top: 6px;
-  padding-bottom: 6px;
   padding-left: 12px !important;
-  padding-right: 12px;
-  border: none;
-  border-radius: 8px;
-  margin: 0;
-  font-size: 0.875rem;
-  min-height: 32px;
-  line-height: 1.5;
-  font-weight: 500;
-  letter-spacing: -0.12px;
-  color: var(--text-secondary);
-  transition: all 0.15s ease-out;
-  text-shadow: none;
-}
-
-#sidebar-group > li > ul > li > a > div > svg {
-  width: 24px;
-  height: 24px;
-  transition: all 0.15s ease-out;
 }
 
 #sidebar-group > li > button > div {

--- a/main/snippets/ApiScopes.jsx
+++ b/main/snippets/ApiScopes.jsx
@@ -9,7 +9,7 @@ export const Scopes = ({ scopes = [] }) => {
       </div>
       <div class="mt-4">
         <div class="space-y-4 whitespace-normal prose prose-sm prose-gray dark:prose-invert overflow-wrap-anywhere [&amp;_*]:overflow-wrap-anywhere">
-          <p class="whitespace-pre-line">
+          <p class="whitespace-pre-line text-xs">
             {
               "Scopes define permissions and access levels for API requests and authentication tokens."
             }
@@ -46,8 +46,8 @@ export const Scopes = ({ scopes = [] }) => {
                 <span
                   class="flex items-center px-2 py-0.5 rounded-md bg-gray-100/50 dark:bg-white/5 text-gray-600 dark:text-gray-200 font-medium break-all"
                   style={{
-                    lineHeight: '1rem',
-                    fontSize: '0.75rem',
+                    lineHeight: "1rem",
+                    fontSize: "0.75rem",
                     fontFamily:
                       'var(--font-jetbrains-mono), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
                   }}

--- a/main/ui/css/apiExplorer.css
+++ b/main/ui/css/apiExplorer.css
@@ -37,22 +37,58 @@
 
   /* Code block styling — dark mode */
   /* :is(html.dark) & pre compiles to: html.dark #header pre */
-  :is(html.dark, html[data-appearance='dark'], html[data-theme='dark']) & pre {
+  :is(html.dark, html[data-appearance="dark"], html[data-theme="dark"]) & pre {
     background-color: #13141a !important;
     border-color: #2d2f3e !important;
   }
 
-  :is(html.dark, html[data-appearance='dark'], html[data-theme='dark'])
+  :is(html.dark, html[data-appearance="dark"], html[data-theme="dark"])
     &
     pre
     code {
     background-color: transparent !important;
   }
 
-  :is(html.dark, html[data-appearance='dark'], html[data-theme='dark'])
+  :is(html.dark, html[data-appearance="dark"], html[data-theme="dark"])
     &
     code:not(pre > code) {
     background-color: #1e1f2b !important;
     border-color: #2d2f3e !important;
+  }
+}
+
+.primitive-param-field {
+  font-size: 0.875rem;
+
+  .prose,
+  .prose :where(*) {
+    font-size: 0.875rem;
+  }
+}
+
+.array-param-field {
+  font-size: 0.875rem;
+
+  .prose,
+  .prose :where(*) {
+    font-size: 0.875rem;
+  }
+}
+
+.object-param-field {
+  font-size: 0.875rem;
+
+  .prose,
+  .prose :where(*) {
+    font-size: 0.875rem;
+  }
+}
+
+.api-section-heading-subtitle {
+  font-size: 0.875rem;
+
+  .prose,
+  .prose :where(*) {
+    font-size: 0.875rem;
   }
 }

--- a/main/ui/css/styles.css
+++ b/main/ui/css/styles.css
@@ -982,69 +982,28 @@ html[style*="color-scheme: dark"] {
   color: var(--text-tertiary);
 }
 
-#sidebar-group > li > a {
-  display: flex;
-  align-items: center;
-  padding-top: 6px;
-  padding-bottom: 6px;
-  padding-left: 12px;
-  padding-right: 12px;
-  border-radius: 8px;
-  margin: 0;
-  font-size: 0.875rem;
-  min-height: 32px;
-  line-height: 1.5;
-  font-weight: 600;
-  letter-spacing: -0.1px;
-  color: var(--text-secondary);
-  transition: all 0.15s ease-out;
-  text-shadow: none;
-  max-width: stretch;
-}
-
 #sidebar-group > li :where(.text-primary) {
   color: var(--accent) !important;
 }
 
-#sidebar-group > li > ul > li > a {
+#sidebar-group > li > :is(a, button),
+#sidebar-group > li > ul > li > :is(a, button),
+#sidebar-group > li > ul > li > ul > li > :is(a, button),
+#sidebar-group > li > ul > li > ul > li > ul > li > :is(a, button),
+#sidebar-group > li > ul > li > ul > li > ul > li > ul > li > :is(a, button) {
   display: flex;
   align-items: center;
-  padding-top: 6px;
-  padding-bottom: 6px;
-  padding-left: 12px;
-  padding-right: 12px;
-  border-radius: 8px;
-  margin: 0;
-  font-size: 0.875rem;
-  min-height: 32px;
-  line-height: 1.5;
-  font-weight: 600;
-  letter-spacing: -0.1px;
-  color: var(--text-secondary);
-  transition: all 0.15s ease-out;
-  text-shadow: none;
-  max-width: stretch;
-}
-
-#sidebar-group > li > a > div > svg {
-  width: 24px;
-  height: 24px;
-  transition: all 0.15s ease-out;
-}
-
-#sidebar-group > li > button {
-  display: flex;
-  align-items: center;
-  padding-top: 4px;
-  padding-bottom: 4px;
+  padding-top: var(--sidebar-padding-y, 6px);
+  padding-bottom: var(--sidebar-padding-y, 6px);
   padding-left: 12px;
   padding-right: 12px;
   border: none;
   border-radius: 8px;
   margin: 0;
+  margin-left: var(--sidebar-indent, 0);
   font-size: 0.875rem;
   min-height: 32px;
-  line-height: 1.4;
+  line-height: var(--sidebar-line-height, 1.4);
   font-weight: 600;
   letter-spacing: -0.1px;
   color: var(--text-secondary);
@@ -1053,141 +1012,68 @@ html[style*="color-scheme: dark"] {
   max-width: stretch;
 }
 
-#sidebar-group > li > button > div > svg {
-  width: 24px;
-  height: 24px;
-  transition: all 0.15s ease-out;
+#sidebar-group > li > a {
+  --sidebar-line-height: 1.5;
 }
 
-#sidebar-group > li > ul > li > button {
-  display: flex;
-  align-items: center;
-  padding-top: 4px;
-  padding-bottom: 4px;
-  padding-left: 12px !important;
-  padding-right: 12px;
-  border: none;
-  border-radius: 8px;
-  margin: 0;
-  margin-left: 4px;
-  font-size: 0.875rem;
-  min-height: 32px;
-  line-height: 1.4;
-  font-weight: 600;
-  letter-spacing: -0.1px;
-  color: var(--text-secondary);
-  transition: all 0.15s ease-out;
-  text-shadow: none;
-  max-width: stretch;
-}
-
-#sidebar-group > li > ul > li > button > div > svg {
-  width: 24px;
-  height: 24px;
-  transition: all 0.15s ease-out;
-}
-
+#sidebar-group > li > button,
+#sidebar-group > li > ul > li > button,
 #sidebar-group > li > ul > li > ul > li > button {
-  display: flex;
-  align-items: center;
-  padding-top: 4px;
-  padding-bottom: 4px;
-  padding-left: 12px !important;
-  padding-right: 12px;
-  border: none;
-  border-radius: 8px;
-  margin: 0;
-  margin-left: 24px;
-  font-size: 0.875rem;
-  min-height: 32px;
-  line-height: 1.4;
-  font-weight: 600;
-  letter-spacing: -0.1px;
-  color: var(--text-secondary);
-  transition: all 0.15s ease-out;
-  text-shadow: none;
-  max-width: stretch;
+  --sidebar-padding-y: 4px;
 }
 
+#sidebar-group > li > ul > li > :is(a, button) {
+  --sidebar-indent: 4px;
+  padding-left: 12px !important;
+}
+
+#sidebar-group > li > ul > li > ul > li > :is(a, button) {
+  --sidebar-indent: 24px;
+  padding-left: 12px !important;
+}
+
+#sidebar-group > li > ul > li > ul > li > ul > li > :is(a, button) {
+  --sidebar-indent: 40px;
+  padding-left: 12px !important;
+}
+
+#sidebar-group > li > ul > li > ul > li > ul > li > ul > li > :is(a, button) {
+  --sidebar-indent: 48px;
+  padding-left: 12px !important;
+}
+
+#sidebar-group > li > a > div > svg,
+#sidebar-group > li > button > div > svg,
+#sidebar-group > li > ul > li > button > div > svg,
 #sidebar-group > li > ul > li > ul > li > button > div > svg {
   width: 24px;
   height: 24px;
   transition: all 0.15s ease-out;
 }
 
-#sidebar-group > li > ul {
-  position: relative;
-  margin-left: 16px;
-}
-
-#sidebar-group > li > ul::after {
-  content: "";
-  display: block;
-  position: absolute;
-  top: 0;
-  left: 0;
-  height: 100%;
-  width: 0.5px;
-  background: var(--border-secondary);
-}
-
-#sidebar-group > li > ul > li > a {
-  display: flex;
-  align-items: center;
-  padding-top: 6px;
-  padding-bottom: 6px;
-  padding-left: 12px !important;
-  padding-right: 12px;
-  border: none;
-  border-radius: 12px;
-  margin: 0;
-  margin-left: 4px;
-  font-size: 0.875rem;
-  min-height: 32px;
-  line-height: 1.4;
-  font-weight: 600;
-  letter-spacing: -0.1px;
-  color: var(--text-secondary);
-  transition: all 0.15s ease-out;
-  text-shadow: none;
-  max-width: stretch;
-}
-
+#sidebar-group > li > ul,
 #sidebar-group > li > ul > li > ul {
   position: relative;
 }
 
-#sidebar-group > li > ul > li > ul::after {
+#sidebar-group > li > ul {
+  margin-left: 16px;
+}
+
+#sidebar-group > li > ul::after,
+#sidebar-group > li > ul > li > ul::after,
+#sidebar-group > li > ul > li > ul > li > ul > li::after {
   content: "";
   display: block;
   position: absolute;
   top: 0;
-  left: 20px;
   height: 100%;
   width: 0.5px;
   background: var(--border-secondary);
 }
 
-#sidebar-group > li > ul > li > ul > li > a {
-  display: flex;
-  align-items: center;
-  padding-top: 6px;
-  padding-bottom: 6px;
-  padding-left: 12px !important;
-  padding-right: 12px;
-  border: none;
-  border-radius: 12px;
-  margin: 0;
-  margin-left: 24px;
-  font-size: 0.875rem;
-  min-height: 32px;
-  line-height: 1.4;
-  font-weight: 600;
-  letter-spacing: -0.1px;
-  color: var(--text-secondary);
-  transition: all 0.15s ease-out;
-  text-shadow: none;
-  max-width: stretch;
+#sidebar-group > li > ul::after {
+  left: 0;
 }
 
 #sidebar-group > li > ul > li > a > svg {
@@ -1196,37 +1082,12 @@ html[style*="color-scheme: dark"] {
   transition: all 0.15s ease-out;
 }
 
-#sidebar-group > li > ul > li > ul > li > ul > li > a {
-  display: flex;
-  align-items: center;
-  padding-top: 6px;
-  padding-bottom: 6px;
-  padding-left: 12px !important;
-  padding-right: 12px;
-  border: none;
-  border-radius: 12px;
-  margin: 0;
-  margin-left: 40px;
-  font-size: 0.875rem;
-  min-height: 32px;
-  line-height: 1.4;
-  font-weight: 600;
-  letter-spacing: -0.1px;
-  color: var(--text-secondary);
-  transition: all 0.15s ease-out;
-  text-shadow: none;
-  max-width: stretch;
+#sidebar-group > li > ul > li > ul::after {
+  left: 20px;
 }
 
 #sidebar-group > li > ul > li > ul > li > ul > li::after {
-  content: "";
-  display: block;
-  position: absolute;
-  top: 0;
   left: 36px;
-  height: 100%;
-  width: 0.5px;
-  background: var(--border-secondary);
 }
 
 #sidebar-group a:focus-visible,

--- a/main/ui/css/styles.css
+++ b/main/ui/css/styles.css
@@ -214,8 +214,8 @@ span.fixed.inset-0.pointer-events-none {
 }
 
 .prose {
-  font-size: 1.125rem;
-  line-height: 1.625;
+  font-size: 1rem;
+  line-height: 1.625rem;
   letter-spacing: 0;
   font-weight: 400;
 }


### PR DESCRIPTION
## Description

### Before
<img width="1152" height="1564" alt="image" src="https://github.com/user-attachments/assets/335b5fe3-38ee-497f-9b1f-650ae468cfca" />

### After
<img width="1152" height="1682" alt="image" src="https://github.com/user-attachments/assets/99c71ffa-57bc-43f1-ac10-caa3d1b1cbd7" />

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

1. Navigate to API Explorer
2. Choose an API from the dropdown
3. Navigate to an endpoint

## Checklist

- [X] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [X] I've tested the site build for this change locally.
- [X] I've made appropriate docs updates for any code or config changes.
- [X] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
