### PR TITLE
feat: plan customization for release stage notices

### DIFF
--- a/main/docs/authenticate/custom-token-exchange.mdx
+++ b/main/docs/authenticate/custom-token-exchange.mdx
@@ -1,14 +1,16 @@
 ---
-description: Learn about Custom Token Exchange Early Access features.
+description: Learn about Custom Token Exchange features.
 title: Custom Token Exchange
 sidebarTitle: Overview
 ---
+import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
 
-<Warning>
-
-Custom Token Exchange is currently available in Early Access for all Auth0 Enterprise and B2B Pro customers. By using this feature, you agree to the applicable Free Trial terms in [Okta’s Master Subscription Agreement](https://www.okta.com/legal/). To learn more about Auth0’s product release cycle, read [Product Release Stages](/docs/troubleshoot/product-lifecycle/product-release-stages). To learn more about subscription types, review the Auth0 [pricing](https://auth0.com/pricing) page.
-
-</Warning>
+<ReleaseStageNotice
+    feature="Custom Token Exchange (CTE)"
+    stage="ea"
+    plans="B2B Professional and Enterprise"
+    terms="true"
+/>
 
 Custom Token Exchange enables applications to exchange their existing tokens for Auth0 tokens when calling the `/oauth/token` endpoint, as defined in [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693). Common use cases for the Custom Token Exchange include:
 
@@ -46,7 +48,7 @@ Use the tenant logs to help you troubleshoot any issues you encounter with your 
 
 ## Limitations
 
-Custom Token Exchange in Early Access does not support the following:
+Custom Token Exchange does not support the following:
 
 * MFA API methods `api.authentication.challengeWith()` and `api.authentication.EnrollWith()`
 * Custom DB Connections with import mode `ON` are not supported for `setUserByConnection()` operations

--- a/main/docs/authenticate/custom-token-exchange/configure-custom-token-exchange.mdx
+++ b/main/docs/authenticate/custom-token-exchange/configure-custom-token-exchange.mdx
@@ -2,12 +2,14 @@
 description: Learn how to configure the Custom Token Exchange by associating an Action with a Custom Token Profile.
 title: Configure Custom Token Exchange
 ---
+import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
 
-<Warning>
-
-Custom Token Exchange (CTE) is currently available in Early Access for all Auth0 Enterprise and B2B Pro customers. By using this feature, you agree to the applicable Free Trial terms in [Okta’s Master Subscription Agreement](https://www.okta.com/legal/). To learn more about Auth0’s product release cycle, read [Product Release Stages](/docs/troubleshoot/product-lifecycle/product-release-stages). To learn more about subscription types, review the Auth0 [pricing](https://auth0.com/pricing) page.
-
-</Warning>
+<ReleaseStageNotice
+    feature="Custom Token Exchange (CTE)"
+    stage="ea"
+    plans="B2B Professional and Enterprise"
+    terms="true"
+/>
 
 To configure the Custom Token Exchange for your application, you need to:
 

--- a/main/docs/authenticate/custom-token-exchange/cte-attack-protection.mdx
+++ b/main/docs/authenticate/custom-token-exchange/cte-attack-protection.mdx
@@ -2,12 +2,14 @@
 description: Learn how to use Attack Protection with Custom Token Exchange.
 title: Attack Protection with Custom Token Exchange
 ---
+import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
 
-<Warning>
-
-Custom Token Exchange (CTE) is currently available in Early Access for all Auth0 Enterprise and B2B Pro customers. By using this feature, you agree to the applicable Free Trial terms in [Okta’s Master Subscription Agreement](https://www.okta.com/legal/). To learn more about Auth0’s product release cycle, read [Product Release Stages](/docs/troubleshoot/product-lifecycle/product-release-stages). To learn more about subscription types, review the Auth0 [pricing](https://auth0.com/pricing) page.
-
-</Warning>
+<ReleaseStageNotice
+    feature="Custom Token Exchange (CTE)"
+    stage="ea"
+    plans="B2B Professional and Enterprise"
+    terms="true"
+/>
 
 To protect against spoofing and replay attacks, which involve unauthorized attempts to compromise or reuse a `subject_token`, Custom Token Exchange supports [Suspicious IP Throttling](/docs/secure/attack-protection/suspicious-ip-throttling). This enables you to indicate in your Actions code when a subject token is invalid, allowing Auth0 to count the number of failed attempts sent from that external IP.
 

--- a/main/docs/authenticate/custom-token-exchange/cte-example-use-cases.mdx
+++ b/main/docs/authenticate/custom-token-exchange/cte-example-use-cases.mdx
@@ -2,12 +2,14 @@
 description: Learn about Custom Token Exchange example use cases with code samples for implementation.
 title: Example Use Cases
 ---
+import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
 
-<Warning>
-
-Custom Token Exchange is currently available in Early Access for all Auth0 Enterprise and B2B Pro customers. By using this feature, you agree to the applicable Free Trial terms in [Okta’s Master Subscription Agreement](https://www.okta.com/legal/). To learn more about Auth0’s product release cycle, read [Product Release Stages](/docs/troubleshoot/product-lifecycle/product-release-stages). To learn more about subscription types, review the Auth0 [pricing](https://auth0.com/pricing) page.
-
-</Warning>
+<ReleaseStageNotice
+    feature="Custom Token Exchange (CTE)"
+    stage="ea"
+    plans="B2B Professional and Enterprise"
+    terms="true"
+/>
 
 You can use Custom Token Exchange to solve advanced integration scenarios where normal federated login strategies based on redirecting the end user cannot be applied due to technical or user experience constraints. The code provided for the use cases is incomplete and only aims at showing the logical steps you can follow with your code to address the use case. Refer to [code samples](#code-samples) for more detailed code examples.
 
@@ -173,11 +175,6 @@ exports.onExecuteCustomTokenExchange = async (event, api) => {
   }
 };
 ```
-
-
-
-
-
 
 Read [code samples](#code-samples) for a more detailed example on how to securely validate <Tooltip tip="JSON Web Token (JWT): Standard ID Token format (and often Access Token format) used to represent claims securely between two parties." cta="View Glossary" href="/docs/glossary?term=JWTs">JWTs</Tooltip>.
 
@@ -470,11 +467,6 @@ exports.onExecuteCustomTokenExchange = async (event, api) => {
 };
 ```
 
-
-
-
-
-
 ### Validate JWTs signed with symmetric keys
 
 Consider the following recommendations:
@@ -540,11 +532,6 @@ async function validateToken(subjectToken, symmetricKey) {
   }
 }
 ```
-
-
-
-
-
 
 ### Validate opaque token with an external service
 

--- a/main/docs/authenticate/custom-token-exchange/cte-multi-factor-authentication.mdx
+++ b/main/docs/authenticate/custom-token-exchange/cte-multi-factor-authentication.mdx
@@ -2,12 +2,14 @@
 description: Learn how to use Multi-Factor Authentication (MFA) with Custom Token Exchange.
 title: Multi-Factor Authentication (MFA) with Custom Token Exchange
 ---
+import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
 
-<Warning>
-
-Custom Token Exchange is currently available in Early Access for all Auth0 Enterprise and B2B Pro customers. By using this feature, you agree to the applicable Free Trial terms in [Okta’s Master Subscription Agreement](https://www.okta.com/legal/). To learn more about Auth0’s product release cycle, read [Product Release Stages](/docs/troubleshoot/product-lifecycle/product-release-stages). To learn more about subscription types, review the Auth0 [pricing](https://auth0.com/pricing) page.
-
-</Warning>
+<ReleaseStageNotice
+    feature="Custom Token Exchange (CTE)"
+    stage="ea"
+    plans="B2B Professional and Enterprise"
+    terms="true"
+/>
 
 To add protection against token theft or other security risks, you can add Multi-factor Authentication to a Custom Token Exchange request using one of the following methods:
 
@@ -18,7 +20,7 @@ When you add MFA, the Auth0 Authorization Server rejects the initial Custom Toke
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 
-Custom Token Exchange Early Access does not support `api.authentication.challengeWith()` or `api.authentication.enrollWith()`. If you use those methods with your Post-Login Action, the transaction will fail with a non-recoverable error. Make sure you don't use those methods when `event.transaction.protocol==oauth2-token-exchange` depending on the `subject_token_type` value.
+Custom Token Exchange does not support `api.authentication.challengeWith()` or `api.authentication.enrollWith()`. If you use those methods with your Post-Login Action, the transaction will fail with a non-recoverable error. Make sure you don't use those methods when `event.transaction.protocol==oauth2-token-exchange` depending on the `subject_token_type` value.
 
 </Callout>
 

--- a/main/docs/authenticate/database-connections/non-unique-emails.mdx
+++ b/main/docs/authenticate/database-connections/non-unique-emails.mdx
@@ -2,11 +2,12 @@
 description: How to set up non-unique emails and their related identifiers
 title: Non-Unique Emails
 ---
-<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
 
-Non-Unique Emails is currently in Early Access. To learn more about Auth0 releases, review [Product Release Stages](/docs/troubleshoot/product-lifecycle/product-release-stages).
-
-</Callout>
+<ReleaseStageNotice
+    feature="Non-Unique Emails"
+    stage="ea"
+/>
 
 Non-Unique Emails allows multiple user accounts that share a database connection to use one email address while another attribute (like username or phone number) serves as the primary identifier. Whether you're a parent managing multiple child accounts with one email address or a small business with one email per location, Non-Unique Emails allows you to maintain a secure, account-specific login and password reset experience.
 
@@ -93,11 +94,6 @@ Below is an example of a request body to create a database connection that uses 
  }
 }
 ```
-
-
-
-
-
 
 ### Shared Email Risk Disclaimer
 

--- a/main/docs/authenticate/database-connections/passkeys.mdx
+++ b/main/docs/authenticate/database-connections/passkeys.mdx
@@ -3,6 +3,7 @@ title: Passkey Authentication for Database Connections
 sidebarTitle: Overview
 description: Learn about passkeys as an authentication method and how they work on Auth0.
 ---
+import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
 
 Passkeys are a secure, passwordless authentication method modeled on the [FIDO2 (WebAuthn and CTAP) standards](https://en.wikipedia.org/wiki/WebAuthn). They have several advantages over traditional identifier/password authentication:
 
@@ -101,9 +102,12 @@ To learn more, read [Reduce friction with passkeys](/docs/customize/actions/expl
 
 ### Passkeys with Multiple Custom Domains (MCD)
 
-<Warning>
-Multiple Custom Domains is in Early Access. To use this feature, you must have an Enterprise plan. By using this feature, you agree to the applicable Free Trial terms in Okta’s [Master Subscription Agreement](https://www.okta.com/legal). To learn more about Auth0's product release cycle, read [Product Release Stages](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages).
-</Warning>
+<ReleaseStageNotice
+    feature="Multiple Custom Domains"
+    stage="ea"
+    plans="Enterprise"
+    terms="true"
+/>
 
 If you have Multiple Custom Domains enabled on your tenant, Auth0 maintains a one-to-one relationship between a domain and the passkey for that domain. Users with a passkey-enabled database can sign up and log in with a passkey, tied to the specific domain it was created on. Users can enroll a passkey for only one domain (the first one they enroll with, among the multiple custom domains on the tenant).
 
@@ -111,9 +115,11 @@ For passwordless login, the selected custom domain should be reflected in the Ma
 
 ### Relying party ID for Passkeys
 
-<Warning>
-Relying Party ID for Passkeys is in Early Access. By using this feature, you agree to the applicable Free Trial terms in Okta’s [Master Subscription Agreement](https://www.okta.com/legal).
-</Warning>
+<ReleaseStageNotice
+    feature="Relying Party ID for Passkeys"
+    stage="ea"
+    terms="true"
+/>
 
 The [relying party identifier (RP ID)](https://www.w3.org/TR/webauthn-2/#relying-party-identifier) is a domain that WebAuthn binds to credentials like passkeys. The RP ID defines which request origins are allowed for authentication.
 

--- a/main/docs/authenticate/database-connections/passkeys/configure-passkey-policy.mdx
+++ b/main/docs/authenticate/database-connections/passkeys/configure-passkey-policy.mdx
@@ -3,6 +3,7 @@ title: Enable and Configure Passkey Authentication for Database Connections
 sidebarTitle: Configure Passkeys
 description: Use the Auth0 Dashboard to enable passkeys as an authentication method on a database connection and configure the passkey authentication UI, progressive enrollment, and local enrollment.
 ---
+import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
 
 ## Prerequisites
 
@@ -33,9 +34,12 @@ Passkey authentication now supports using your own database without user import 
 As a prerequisite, you must update the Get User and Create [database action scripts](/docs/authenticate/database-connections/custom-db/templates) to support user handling by both identifier and `user_id`.
 
 <Accordion title="How to update database action scripts to enable passkeys for your own database without user import enabled">
-<Warning>
-Passkey support for using your own database without user import enabled is currently in Early Access. By using this feature, you agree to the applicable Free Trial terms in Okta’s [Master Subscription Agreement](https://www.okta.com/legal). To learn more about Auth0's product release cycle, read [Product Release Stages](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages).
-</Warning>
+
+<ReleaseStageNotice
+    feature="passkeys for using your own database wihtout user import enabled"
+    stage="ea"
+    terms="true"
+/>
 
 1. First, confirm that user import is disabled for your database connection.
 
@@ -168,9 +172,11 @@ To ensure the best experience for end users when using passkeys, you may want to
 
 ### <Badge color="yellow">Early Access</Badge> Configure relying party ID (RP ID)
 
-<Warning>
-Relying Party ID for Passkeys is in Early Access. By using this feature, you agree to the applicable Free Trial terms in Okta’s [Master Subscription Agreement](https://www.okta.com/legal).
-</Warning>
+<ReleaseStageNotice
+    feature="Relying Party ID for Passkeys"
+    stage="ea"
+    terms="true"
+/>
 
 To allow users to use a single passkey to authenticate across all subdomains (for example, both a native application served at `app.example.com` and a web application served at `login.example.com`), you can set the RP ID to the parent or root domain.
 

--- a/main/docs/authenticate/database-connections/passkeys/native-passkeys-api.mdx
+++ b/main/docs/authenticate/database-connections/passkeys/native-passkeys-api.mdx
@@ -2,15 +2,17 @@
 description: Auth0 Authentication API specs for Native Passkeys
 title: Native Passkeys API
 ---
-<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
 
-Native passkeys is currently available in Early Access. To particpate, contact [Auth0 Support](https://support.auth0.com). To learn more about Auth0 release stages, review [Product Release Stages](/docs/troubleshoot/product-lifecycle/product-release-stages).
-
-</Callout>
+<ReleaseStageNotice
+    feature="Native Passkeys"
+    stage="ea"
+    contact="Auth0 support"
+/>
 
 Passkeys are a phishing-resistant alternative to traditional forms of authentication (such as username and password) that offer an easier and more secure user experience. For complete implementation details, review [Native Passkeys for Mobile Applications](/docs/authenticate/database-connections/passkeys/native-passkeys-for-mobile-applications).
 
-Native passkeys use a combination of Auth0 and native iOS or Android APIs to embed challenge flows directly into your mobile application. The endpoints listed below are a subset of the Auth0 Authentication API and are currently available in Early Access. To learn more about using this API, review the [Authentication API Introduction](https://auth0.com/docs/api/authentication#introduction).
+Native passkeys use a combination of Auth0 and native iOS or Android APIs to embed challenge flows directly into your mobile application. The endpoints listed below are a subset of the Auth0 Authentication API. To learn more about using this API, review the [Authentication API Introduction](https://auth0.com/docs/api/authentication#introduction).
 
 Passkeys have three related flows:
 
@@ -56,11 +58,6 @@ Content-Type: application/json
 }
 ```
 
-
-
-
-
-
 ##### Response
 
 ```json lines expandable
@@ -94,11 +91,6 @@ Content-Type: application/json
 }
 ```
 
-
-
-
-
-
 #### Remarks
 
 * After the challenge request is complete, your application can continue the user registration process using native [Android](https://developer.android.com/identity/passkeys/create-passkeys) or [iOS](https://developer.apple.com/documentation/authenticationservices/supporting-passkeys#Register-a-new-account-on-a-service) APIs.
@@ -107,9 +99,7 @@ Content-Type: application/json
 ### Authenticate New User
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-
 Native Passkey registration is not currently supported when SMS/Email OTP verification is required on the same connection during signup.
-
 </Callout>
 
 `POST /oauth/token`
@@ -167,11 +157,6 @@ Content-Type: application/json
 }
 ```
 
-
-
-
-
-
 ##### Response
 
 ```json lines
@@ -186,11 +171,6 @@ Content-Type: application/json
   "expires_in": {SECONDS}
 }
 ```
-
-
-
-
-
 
 ## Enrollment Flow
 
@@ -224,11 +204,6 @@ The first step is to initiate the enrollment process. This is done by making a P
 }
 ```
 
-
-
-
-
-
 ##### Response
 
 ```json lines
@@ -258,11 +233,6 @@ The first step is to initiate the enrollment process. This is done by making a P
   "auth_session": "SESSION_ID"
 }
 ```
-
-
-
-
-
 
 #### Remarks
 
@@ -437,11 +407,6 @@ Content-Type: application/json
 }
 ```
 
-
-
-
-
-
 ##### Response
 
 ```json lines
@@ -456,6 +421,3 @@ Content-Type: application/json
   "expires_in": {SECONDS}
 }
 ```
-
-
-

--- a/main/docs/authenticate/database-connections/passkeys/native-passkeys-for-mobile-applications.mdx
+++ b/main/docs/authenticate/database-connections/passkeys/native-passkeys-for-mobile-applications.mdx
@@ -2,11 +2,13 @@
 description: Learn how to implement native passkey flows for Android and iOS applications
 title: Native Passkeys for Mobile Applications
 ---
-<Warning>
+import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
 
-Native passkeys is currently available in Early Access. By using this feature, you agree to the applicable Free Trial terms in [Okta’s Master Subscription Agreement](https://www.okta.com/legal/). To learn more about Auth0 releases, review [Product Release Stages](/docs/troubleshoot/product-lifecycle/product-release-stages).
-
-</Warning>
+<ReleaseStageNotice
+    feature="Native Passkeys"
+    stage="ea"
+    terms="true"
+/>
 
 Passkeys are a phishing-resistant alternative to traditional forms of authentication (such as username and password) that offer an easier and more secure user experience. They are modeled from FIDO® W3C Web Authentication (WebAuthn) and Client to Authenticator Protocol (CTAP) [specifications](https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#intro).
 

--- a/main/docs/authenticate/enterprise-connections/enable-dpop-enterprise-connections.mdx
+++ b/main/docs/authenticate/enterprise-connections/enable-dpop-enterprise-connections.mdx
@@ -2,10 +2,13 @@
 description: Learn how to secure OIDC and Okta Enterprise connections with cryptographic token binding.
 title: Configure Enterprise Connections with Demonstrating Proof-of-Possession (DPoP)
 ---
+import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
 
-<Warning>
-Enterprise Connections with Demonstrating Proof-of-Possession (DPoP) is currently in Early Access. By using this feature, you agree to the applicable Free Trial terms in [Okta’s Master Subscription Agreement](https://www.okta.com/legal). To learn more about product release stages, read [Product Release Stages](/docs/troubleshoot/product-lifecycle/product-release-stages).
-</Warning>
+<ReleaseStageNotice
+    feature="Enterprise Connections with Demonstrating Proof-of-Possession (DPoP)"
+    stage="ea"
+    terms="true"
+/>
 
 Demonstrating Proof-of-Possession (DPoP) is an [OAuth 2.0 framework extension](https://datatracker.ietf.org/doc/draft-ietf-oauth-dpop/). To learn more about DPoP protocol and how it is used to sender constrain tokens, read [Demonstrating Proof-of-Possession (DPoP)](/docs/secure/sender-constraining). If you use Okta or OpenID Connect (OIDC) as your identity provider (IdP) and have configured them as an Enterprise connection in Auth0, then you can enable and configure DPoP to bind access tokens from your IdP to cryptographic keys. Using DPoP prevents token replay attacks and helps meet compliance requirements, such as [Interoperability Profiling for Secure Identity in the Enterprise (IPSIE) OIDC](https://openid.net/specs/ipsie-openid-connect-sl1-profile-1_0.html) Security Level 1 or [Financial-grade API (FAPI) 2.0](https://openid.net/specs/fapi-security-profile-2_0-final.html).
 
@@ -148,7 +151,7 @@ In the `dpop_signing_alg` response, check for the following:
 If Auth0 success (`s`) or failure (`f`) logs for the enterprise connection do not contain `dpop_signing_alg` or `idp_token_type` fields, it could be due to one of the following causes:
 
 * DPoP is not configured. Verify `dpop_signing_alg` is set in the connection `options` object using the Management API's [Update a connection](https://auth0.com/docs/api/management/v2/connections/patch-connections-by-id) endpoint as described above.
-* Unsupported algorithm.  Auth0 supports ES256 and Ed25519 during Early Access. If `dpop_signing_alg` is set to an unsupported value (for example, RS256), DPoP is silently disabled. No error is logged. Update the connection to use ES256 or Ed25519.
+* Unsupported algorithm.  Auth0 supports ES256 and Ed25519. If `dpop_signing_alg` is set to an unsupported value (for example, RS256), DPoP is silently disabled. No error is logged. Update the connection to use ES256 or Ed25519.
 * Front-channel connection. DPoP requires a connection type of `back_channel` token exchange. You may need to [update the grant type](/docs/get-started/applications/update-grant-types#update-grant-types) to a back-channel flow like Authorization Code Flow or Authorization Code Flow + PKCE.
 
 ### Authentication fails after enabling DPoP
@@ -179,7 +182,7 @@ Check the IdP supports DPoP and if the configured algorithm (either ES256 or Ed2
 curl https://YOUR_IDP_DOMAIN/.well-known/openid-configuration
 ```
 
-In the IdP response, look for `dpop_signing_alg_values_supported`. If this field is missing, the IdP may not support DPoP. If the field lists only algorithms that Auth0 does not support (for example, only RS256), DPoP cannot be used with this connection during Early Access. You should disable DPoP for this connection or contact your IdP to enable support for ES256 or Ed25519.
+In the IdP response, look for `dpop_signing_alg_values_supported`. If this field is missing, the IdP may not support DPoP. If the field lists only algorithms that Auth0 does not support (for example, only RS256), DPoP cannot be used with this connection. You should disable DPoP for this connection or contact your IdP to enable support for ES256 or Ed25519.
 
 #### Token exchange fails for a non-DPoP reason
 

--- a/main/docs/authenticate/enterprise-connections/user-attribute-profile.mdx
+++ b/main/docs/authenticate/enterprise-connections/user-attribute-profile.mdx
@@ -3,27 +3,31 @@ description: Learn how the User Attribute Profile allows you configure users for
 sidebarTitle: User Attribute Profile
 title: User Attribute Profile
 ---
+import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
 
-<Warning>
-User Attribute Profile with Self-Service Enterprise Configuration is currently in Early Access for B2B Professional and B2B Enterprise customers. By using this feature, you agree to the applicable Free Trial terms in Okta’s [Master Subscription Agreement](https://www.okta.com/legal/). To learn more about Auth0 release stages, read [Product Release Stages](/docs/troubleshoot/product-lifecycle/product-release-stages).
-</Warning>
+<ReleaseStageNotice
+    feature="User Attribute Profile with Self-Service Enterprise Configuration"
+    stage="ea"
+    plans="B2B Professional and B2B Enterprise"
+    terms="true"
+/>
 
 The User Attribute Profile (UAP) provides a consistent way to define, manage, and map user attributes across protocols such as [SCIM](/docs/authenticate/protocols/scim), [SAML](/docs/authenticate/protocols/saml), and [OIDC](/docs/authenticate/login/oidc-conformant-authentication). UAP with [Self-Service Enterprise Configuration](/docs/authenticate/enterprise-connections/self-service-enterprise-configuration) gives administrators greater control over user identity data by defining user attributes and applying the profile across authentication protocols.
 
 ## How it works
-* **Profile Definition**<p></p>
+* **Profile Definition**
 An administrator creates a User Attribute Profile to define attributes, including:
   * How to display attributes
   * How to make attributes required
   * How attributes map to Auth0 and external identity systems
 
-* **Flexible Scope**<p></p>
+* **Flexible Scope**
 Profiles are linked to Self-Service Enterprise Configuration flows but are designed for provisioning, onboarding, and entitlement management.
 
-* **Unified Mapping Layer**<p></p>
+* **Unified Mapping Layer**
 Each attribute supports mappings across authentication protocols with the option to override values for specific providers or connection strategies, such as Okta and Entra ID.
 
-## Attribute mapping and override<p></p>
+## Attribute mapping and override
 UAP supports multi-protocol attribute definitions and strategy overrides for provider-specific needs.
 
 **Attribute mapping**

--- a/main/docs/authenticate/identity-providers/enterprise-identity-providers/google-directory-sync.mdx
+++ b/main/docs/authenticate/identity-providers/enterprise-identity-providers/google-directory-sync.mdx
@@ -4,12 +4,13 @@ sidebarTitle: Use Directory Sync
 desciprition: Update user profiles, group structures, and group memberships in Auth0 from Google Workspace automatically using Directory Sync.
 validatedOn: 2026-04-16
 ---
+import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
 
-<Warning>
-**Google Workspace Directory Sync for Groups is currently available in Early Access.**
-
-By using this feature, you agree to the applicable Free Trial terms in Okta's [Master Subscription Agreement](https://www.okta.com/legal). To learn more about Auth0's product release cycle, read [Product Release Stages](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages). 
-</Warning>
+<ReleaseStageNotice
+    feature="Google Workplace Directory Sync for Groups"
+    stage="ea"
+    terms="true"
+/>
 
 Enabling Directory Sync for your [Google Workspace enterprise connection](/docs/authenticate/identity-providers/enterprise-identity-providers/google-apps) lets you synchronize the user profiles, group structures, and group membership from Google Workspace to Auth0.
 

--- a/main/docs/authenticate/login/auth0-universal-login.mdx
+++ b/main/docs/authenticate/login/auth0-universal-login.mdx
@@ -4,6 +4,7 @@ sidebarTitle: Overview
 title: Auth0 Universal Login
 ---
 import {AuthCodeBlock} from "/snippets/AuthCodeBlock.jsx";
+import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
 
 Auth0 <Tooltip tip="Universal Login: Your application redirects to Universal Login, hosted on Auth0's Authorization Server, to verify a user's identity." cta="View Glossary" href="/docs/glossary?term=Universal+Login">Universal Login</Tooltip> provides the essential feature of an <Tooltip tip="Universal Login: Your application redirects to Universal Login, hosted on Auth0's Authorization Server, to verify a user's identity." cta="View Glossary" href="/docs/glossary?term=authorization+server">authorization server</Tooltip>: the login flow. When a user needs to prove their identity to gain access to your application, you can redirect them to Universal Login and let Auth0 handle the authentication process.
 
@@ -87,9 +88,12 @@ Optionally, you can include the `connection` parameter to prompt users to authen
 
 ### Correlation ID
 
-<Warning>
-Correlation ID is currently in Early Access. By using this feature, you agree to the applicable Free Trial terms in Okta’s [Master Subscription Agreement](https://www.okta.com/legal). To learn more about Auth0's product release cycle, read [Product Release Stages](/docs/troubleshoot/product-lifecycle/product-release-stages). To participate in this program, contact [Auth0 Support](https://support.auth0.com) or your Technical Account Manager.
-</Warning>
+<ReleaseStageNotice
+    feature="Correlation ID"
+    stage="ea"
+    terms="true"
+    contact="Auth0 Support or your Techncial Account Manager"
+/>
 
 Universal Login supports Correlated Events across all authentication flows. Once you implement Universal Login, your application generates a unique ID you pass as the `correlation_id` to the `/authorize` endpoint. The unique ID persists through the following authentication events:
 

--- a/main/docs/authenticate/login/configure-correlation-id.mdx
+++ b/main/docs/authenticate/login/configure-correlation-id.mdx
@@ -2,10 +2,14 @@
 description: Learn how to use Correlation ID to track events in the authentication flow.
 title: Configure Correlation ID
 ---
+import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
 
-<Warning>
-Correlation ID is currently in Early Access. By using this feature, you agree to the applicable Free Trial terms in Okta's [Master Subscription Agreement](https://www.okta.com/legal). To learn more about Auth0's product release cycle, read [Product Release Stages](/docs/troubleshoot/product-lifecycle/product-release-stages). To participate in this program, contact [Auth0 Support](https://support.auth0.com) or your Technical Account Manager.
-</Warning>
+<ReleaseStageNotice
+    feature="Correlation ID"
+    stage="ea"
+    terms="true"
+    contact="Auth0 Support or your Techncial Account Manager"
+/>
 
 <Card title="Prerequisites">
 
@@ -54,7 +58,6 @@ loginWithRedirect({
 
 All Universal Login flows support `correlation_id`. Once you pass the correlation ID value to the `/authorize` endpoint, authentication events generate tenant logs with the correlation ID you can use for tracking. Use the Management API SDK to retrieve and filter recent events to isolate a specific transaction.
 
-**Example** <br></br>
 The following sample call uses the Management API SDK to retrieve the latest authentication events. Then, it filters locally to isolate a specific event:
 
 ```javascript wrap lines
@@ -73,7 +76,6 @@ console.log(`Found ${transactionEvents.length} events for this transaction.`);
 ### Login Page Template
 If you customize your login experience with [Universal Login Page Templates](/docs/customize/login-pages/universal-login/customize-templates), add the `correlation_id` to your template to track authentication events with custom login.
 
-**Example**<br></br>
 The following sample demonstrates `correlationId: "{{correlation_id}}"` added to the `{%- auth0:widget -%}`.
 
 ```html wrap lines
@@ -97,7 +99,6 @@ The following sample demonstrates `correlationId: "{{correlation_id}}"` added to
 
 You can include `correlation_id` in [Email Templates](/docs/customize/email/email-templates/customize-email-templates) to help trace authentication events that trigger email notifications, such as password resets or verification emails.
 
-**Example**<br></br>
 The following sample demonstrates `{{correlation_id}}` added to an email template body.
 
 ```liquid wrap lines
@@ -109,7 +110,6 @@ The following sample demonstrates `{{correlation_id}}` added to an email templat
 
 You can include `correlation_id` in [SMS Templates](/docs/customize/phone-messages/phone-templates) to trace authentication events that trigger SMS notifications, such as MFA challenges.
 
-**Example**<br></br>
 The following sample demonstrates `{{correlation_id}}` added to an SMS template.
 
 ```liquid wrap lines
@@ -120,7 +120,6 @@ Your verification code is: {{code}}. Ref: {{correlation_id}}
 
 You can include `correlation_id` in [Custom Error Pages](/docs/customize/login-pages/custom-error-pages) to surface the tracking reference directly on error pages, making it easier for users to report issues and for your support team to trace the failed transaction.
 
-**Example**<br></br>
 The following sample demonstrates `{{correlation_id}}` added to a custom error page template.
 
 ```liquid wrap lines
@@ -143,7 +142,6 @@ The following event objects support `correlation_id`:
 * [MFA Notification send-phone-message](/docs/customize/actions/explore-triggers/mfa-notifications-trigger/send-phone-message-event-object)
 * [Credential Exchange](/docs/customize/actions/explore-triggers/machine-to-machine-trigger/credentials-exchange-event-object)
 
-**Example**<br></br>
 The sample Post-Login Action demonstrates how to extract the `correlation_id` from the `event` object.
 ```javascript wrap lines
 exports.onExecutePostLogin = async (event, api) => {

--- a/main/docs/authenticate/passwordless/implement-login/embedded-login/native.mdx
+++ b/main/docs/authenticate/passwordless/implement-login/embedded-login/native.mdx
@@ -3,8 +3,8 @@ description: Describes implementing Passwordless authentication with embedded lo
 title: Embedded Passwordless Login in Native Applications
 ---
 import {AuthCodeBlock} from "/snippets/AuthCodeBlock.jsx";
-
 import {AuthCodeGroup} from "/snippets/AuthCodeGroup.jsx";
+import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
 
 To use the Embedded <Tooltip tip="Passwordless: Form of authentication that does not rely on a password as the first factor." cta="View Glossary" href="/docs/glossary?term=Passwordless">Passwordless</Tooltip> APIs in Native applications, make sure you enable the **Passwordless OTP** grant at [Auth0 Dashboard > Applications > Applications](https://manage.auth0.com/#/applications) in your application's settings under **Advanced Settings** > **Grant Types**.
 
@@ -709,9 +709,12 @@ If you prefer, you can use the Android or iOS SDKs, which wrap this APIs in a pl
 
 ## Customize MFA with Embedded
 
-<Warning>
-Customizable MFA with the Resource Owner Password Grant, Embedded, or Refresh Token flows is in Early Access. By using this feature, you agree to the applicable Free Trial terms in Okta’s [Master Subscription Agreement](https://www.okta.com/legal/). To learn more, read [Product Release Stages](/docs/troubleshoot/product-lifecycle/product-release-stages). To participate in the early access, contact [Auth0 Support](https://support.auth0.com/).
-</Warning>
+<ReleaseStageNotice
+    feature="Customizable MFA with the Resource Owner Password Grant, Embedded, or Refresh Token flows"
+    stage="ea"
+    terms="true"
+    contact="Auth0 Support"
+/>
 
 Customize <Tooltip tip="Multi-factor authentication (MFA): User authentication process that uses a factor in addition to username and password such as a code via SMS." cta="View Glossary" href="/docs/glossary?term=MFA">MFA</Tooltip> with embedded flows. Use the MFA API to allow users to enroll and challenge with factors of their choice that are supported by your application.
 

--- a/main/docs/authenticate/passwordless/implement-login/embedded-login/relevant-api-endpoints.mdx
+++ b/main/docs/authenticate/passwordless/implement-login/embedded-login/relevant-api-endpoints.mdx
@@ -3,6 +3,7 @@ description: Describes how to implement Passwordless authentication using Auth0 
 title: Using Passwordless APIs
 ---
 import {AuthCodeBlock} from "/snippets/AuthCodeBlock.jsx";
+import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
 
 <Tooltip tip="Passwordless: Form of authentication that does not rely on a password as the first factor." cta="View Glossary" href="/docs/glossary?term=Passwordless">Passwordless</Tooltip> APIs can be used in two scenarios:
 
@@ -119,9 +120,12 @@ For a complete explanation, read [Avoid Common Issues with Resource Owner Passwo
 
 ## Customize MFA
 
-<Warning>
-Customizable MFA with the Resource Owner Password Grant, Embedded, or Refresh Token flows is in Early Access. By using this feature, you agree to the applicable Free Trial terms in Okta’s [Master Subscription Agreement](https://www.okta.com/legal/). To learn more, read [Product Release Stages](/docs/troubleshoot/product-lifecycle/product-release-stages). To participate in the early access, contact [Auth0 Support](https://support.auth0.com/).
-</Warning>
+<ReleaseStageNotice
+    feature="Customizable MFA with the Resource Owner Password Grant, Embedded, or Refresh Token flows"
+    stage="ea"
+    terms="true"
+    contact="Auth0 Support"
+/>
 
 Customize <Tooltip tip="Multi-factor authentication (MFA): User authentication process that uses a factor in addition to username and password such as a code via SMS." cta="View Glossary" href="/docs/glossary?term=MFA">MFA</Tooltip> with the Passwordless API. When your application calls `/oauth/token` endpoint to request an access token, the <Tooltip tip="Authorization Server: Centralized server that contributes to defining the boundaries of a user’s access. For example, your authorization server can control the data, tasks, and features available to a user." cta="View Glossary" href="/docs/glossary?term=authorization+server">authorization server</Tooltip> returns an `mfa_required` error which provides:
 

--- a/main/docs/authenticate/passwordless/implement-login/embedded-login/spa.mdx
+++ b/main/docs/authenticate/passwordless/implement-login/embedded-login/spa.mdx
@@ -2,10 +2,10 @@
 description: Describes implementing Passwordless authentication with embedded login in single-page applications (SPAs).
 title: Embedded Passwordless Authentication for SPAs
 ---
+import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
+
 <Warning>
-
 Embedded login for web applications uses [cross-origin authentication](/docs/authenticate/login/cross-origin-authentication) unless you [configure a custom domain](/docs/customize/custom-domains) for your tenant. Cross-origin authentication uses third-party cookies to allow for secure authentication transactions across different origins.
-
 </Warning>
 
 ## Using Auth0's SDKs to implement Embedded Login
@@ -24,13 +24,14 @@ For security purposes, your app's origin URL must be listed as an approved URL. 
 
 ## Customize MFA
 
-<Warning>
-Customizable MFA with the Resource Owner Password Grant, Embedded, or Refresh Token flows is in Early Access. By using this feature, you agree to the applicable Free Trial terms in Okta’s [Master Subscription Agreement](https://www.okta.com/legal/). To learn more, read [Product Release Stages](/docs/troubleshoot/product-lifecycle/product-release-stages). To participate in the early access, contact [Auth0 Support](https://support.auth0.com/).
-</Warning>
+<ReleaseStageNotice
+    feature="Customizable MFA with the Resource Owner Password Grant, Embedded, or Refresh Token flows"
+    stage="ea"
+    terms="true"
+    contact="Auth0 Support"
+/>
 
 Customize <Tooltip tip="Multi-factor authentication (MFA): User authentication process that uses a factor in addition to username and password such as a code via SMS." cta="View Glossary" href="/docs/glossary?term=MFA">MFA</Tooltip> with embedded flows. Use the MFA API to allow users to enroll and challenge with factors of their choice that are supported by your application.
-
-
 
 When using [Lock for Web](/docs/libraries/lock#2-authenticating-and-getting-user-info), the `oauth/token` endpoint returns the `mfa_required` error and includes the `mfa_token` you need to use the MFA API and `mfa_requirements` parameter with a list of authenticators your application currently supports:
 
@@ -50,8 +51,6 @@ When using [Lock for Web](/docs/libraries/lock#2-authenticating-and-getting-user
   }
 }
 ```
-
-
 
 Use the `mfa_token` to call the [`mfa/authenticator`](https://auth0.com/docs/api/authentication/muti-factor-authentication/list-authenticators) endpoint to list all factors the user has enrolled and match the same `type` your application supports. You also need to obtain the matching `authenticator_type` to issue challenges:
 

--- a/main/docs/authenticate/passwordless/implement-login/embedded-login/webapps.mdx
+++ b/main/docs/authenticate/passwordless/implement-login/embedded-login/webapps.mdx
@@ -3,8 +3,8 @@ description: Describes implementing Passwordless authentication with embedded lo
 title: Embedded Passwordless Login in Regular Web Applications
 ---
 import {AuthCodeBlock} from "/snippets/AuthCodeBlock.jsx";
-
 import {AuthCodeGroup} from "/snippets/AuthCodeGroup.jsx";
+import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
 
 To use the Embedded <Tooltip tip="Passwordless: Form of authentication that does not rely on a password as the first factor." cta="View Glossary" href="/docs/glossary?term=Passwordless">Passwordless</Tooltip> APIs in Regular Web Applications, make sure you enable the **Passwordless OTP** grant at [Auth0 Dashboard > Applications > Applications](https://manage.auth0.com/#/applications) in your application's settings under **Advanced Settings** > **Grant Types**.
 
@@ -725,9 +725,12 @@ The `/passwordless/start` endpoint has a [rate limit](/docs/troubleshoot/custome
 
 ## Customize MFA
 
-<Warning>
-Customizable MFA with the Resource Owner Password Grant, Embedded, or Refresh Token flows is in Early Access. By using this feature, you agree to the applicable Free Trial terms in Okta’s [Master Subscription Agreement](https://www.okta.com/legal/). To learn more, read [Product Release Stages](/docs/troubleshoot/product-lifecycle/product-release-stages). To participate in the early access, contact [Auth0 Support](https://support.auth0.com/).
-</Warning>
+<ReleaseStageNotice
+    feature="Customizable MFA with the Resource Owner Password Grant, Embedded, or Refresh Token flows"
+    stage="ea"
+    terms="true"
+    contact="Auth0 Support"
+/>
 
 Customize <Tooltip tip="Multi-factor authentication (MFA): User authentication process that uses a factor in addition to username and password such as a code via SMS." cta="View Glossary" href="/docs/glossary?term=MFA">MFA</Tooltip> with embedded flows. Use the MFA API to allow users to enroll and challenge with factors of their choice that are supported by your application.
 

--- a/main/snippets/README.md
+++ b/main/snippets/README.md
@@ -11,7 +11,7 @@ Option | Description
 `feature` | The name of the feature. Displayed in the first sentence.
 `stage`   | The release stage. Must be either `ea` or `beta`.
 `terms`<br/>*(Optional)*   | Set to `true` to include the free trial terms.
-`enterprise`<br/>*(Optional)* | Set to `true` to include the Enterprise plan requirement.
+`plans`<br/>*(Optional)* | Set to a string (like "B2C Essentials" or "B2C Professional, B2B Professional, and Enterprise")  to include plan requirements.
 `contact`<br/>*(Optional)* | Set to a string (like `support` or `your Technical Account Manager`) to include participation instructions.
 
 Example:

--- a/main/snippets/ReleaseStageNotice.jsx
+++ b/main/snippets/ReleaseStageNotice.jsx
@@ -1,7 +1,7 @@
 export const ReleaseStageNotice = ({
     feature,
     stage,
-    enterprise,
+    plans,
     contact,
     terms
 }) => {
@@ -18,13 +18,13 @@ export const ReleaseStageNotice = ({
         )
     };
 
-    const includeDetails = (enterprise, contact, terms) => {
-        const hasDetails = terms || enterprise || contact;
+    const includeDetails = (plans, contact, terms) => {
+        const hasDetails = terms || plans || contact;
         if (!hasDetails) return null;
 
         return (
         <span data-as="p">
-            { enterprise && "This feature requires an Enterprise plan. " } 
+            { plans && (<>This feature is available for {linkify(`${plans} plans`, "https://auth0.com/pricing")}. </>) }
             { contact && ("To participate, contact " + contact + ". ") }
             { terms && (<>By using this feature, you agree to the applicable Free Trial terms in Okta's {linkify("Master Subscription Agreement", "https://www.okta.com/legal")}.</>) }
         </span>
@@ -37,7 +37,7 @@ export const ReleaseStageNotice = ({
                 <strong>The {feature} feature is in {linkify(stageText, prsLink)}.</strong>
             </span>
 
-            {includeDetails(enterprise, contact, terms)}
+            {includeDetails(plans, contact, terms)}
         </Warning>
     )
 }


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

changes the former `enterprise="true"` param to `plans` param that takes a generic string to be able to specify different plan requirements for release stage notices.

also converts all the manual notices in the authenticate section to use the component. 

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

build locally. view components. :)

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
