### PR TITLE
fix: redirect destinations

### DIFF
--- a/main/config/redirects.json
+++ b/main/config/redirects.json
@@ -1,19 +1,19 @@
 [
   {
-    "source": "docs/customize/login-pages/advanced-customizations/configure",
-    "destination": "docs/customize/login-pages/advanced-customizations/configure/overview"
+    "source": "/docs/customize/login-pages/advanced-customizations/configure",
+    "destination": "/docs/customize/login-pages/advanced-customizations/configure/overview"
   },
   {
-    "source": "docs/secure/tokens/manage-refresh-tokens-with-auth0-management-api",
-    "destination": "docs/secure/tokens/refresh-tokens/revoke-refresh-tokens"
+    "source": "/docs/secure/tokens/manage-refresh-tokens-with-auth0-management-api",
+    "destination": "/docs/secure/tokens/refresh-tokens/revoke-refresh-tokens"
   },
   {
-    "source": "docs/customize/phone-messages/customize-phone-templates",
-    "destination": "docs/customize/phone-messages/phone-templates"
+    "source": "/docs/customize/phone-messages/customize-phone-templates",
+    "destination": "/docs/customize/phone-messages/phone-templates"
   },
   {
-    "source": "docs/authenticate/database-connections/password-strength",
-    "destination": "docs/authenticate/database-connections/password-options"
+    "source": "/docs/authenticate/database-connections/password-strength",
+    "destination": "/docs/authenticate/database-connections/password-options"
   },
   {
     "source": "/docs/authenticate/database-connections/auth0-user-store",
@@ -66,30 +66,6 @@
   {
     "source": "/docs/api/myaccount/delete-connected-account",
     "destination": "/docs/api/myaccount/connected-accounts/delete-connected-account"
-  },
-  {
-    "source": "/docs/api/management/v2/self-service-profiles/post-sso-ticket",
-    "destination": "/docs/api/management/v2/self-service-profiles/create-an-sso-access-ticket-to-initiate-the-self-service-sso-flow"
-  },
-  {
-    "source": "/docs/api/management/v2/self-service-profiles/post-revoke",
-    "destination": "/docs/api/management/v2/self-service-profiles/revoke-an-sso-access-ticket"
-  },
-  {
-    "source": "/docs/api/management/v2/users/get-enrollments",
-    "destination": "/docs/api/management/v2/users/get-the-first-confirmed-multi-factor-authentication-enrollment"
-  },
-  {
-    "source": "/docs/api/management/v2/users/post-invalidate-remember-browser",
-    "destination": "/docs/api/management/v2/users/invalidate-all-remembered-browsers-for-multi-factor-authentication"
-  },
-  {
-    "source": "/docs/api/management/v2/users/post-recovery-code-regeneration",
-    "destination": "/docs/api/management/v2/users/generate-new-multi-factor-authentication-recovery-code"
-  },
-  {
-    "source": "/docs/api/management/v2/verifiable-credentials/get-vc-templates",
-    "destination": "/docs/api/management/v2/verifiable-credentials/list-verifiable-credentials-template-for-tenant"
   },
   {
     "source": "/docs/native-passkeys-api",
@@ -273,7 +249,7 @@
   },
   {
     "source": "/docs/troubleshoot/product-lifecycle/deprecations-and-migrations/migrate-actions-nodejs-16-to-nodejs-18",
-    "destination": "/docs/troubleshoot/product-lifecycle/deprecations-and-migrations/migrate-nodejs-16-to-nodejs-18"
+    "destination": "/docs/troubleshoot/product-lifecycle/past-migrations/migrate-nodejs-16-to-nodejs-18"
   },
   {
     "source": "/docs/intro-to-forms",
@@ -297,7 +273,7 @@
   },
   {
     "source": "/docs/quickstart/backend/acul/interactive",
-    "destination": "/docs/customize/login-pages/advanced-customizations/getting-started/sdk-quickstart"
+    "destination": "/docs/customize/login-pages/advanced-customizations/quickstart"
   },
   {
     "source": "/docs/get-started/mcp/mcp-guides/understanding-scopes",
@@ -317,7 +293,7 @@
   },
   {
     "source": "/docs/get-started/mcp/model-context-protocol-mcp-tools-reference",
-    "destination": "/docsget-started/auth0-mcp-server/auth0-mcp-tools-reference"
+    "destination": "/docs/get-started/auth0-mcp-server/auth0-mcp-tools-reference"
   },
   {
     "source": "/docs/get-started/mcp/getting-started-with-model-context-protocol-mcp",
@@ -357,7 +333,7 @@
   },
   {
     "source": "/docs/acul-javascript-sdk",
-    "destination": "/docs/customize/login-pages/advanced-customizations/getting-started/sdk-quickstart"
+    "destination": "/docs/customize/login-pages/advanced-customizations/quickstart"
   },
   {
     "source": "/docs/deploy-monitor/logs/export-log-events-with-rules",
@@ -6284,16 +6260,12 @@
     "destination": "/docs/libraries/auth0-android/auth0-android-user-management"
   },
   {
-    "source": "/docs/libraries/lock-android/android-development-keystores-hashes",
-    "destination": "/docs/libraries/auth0-android/android-development-keystores-hashes"
-  },
-  {
     "source": "/docs/libraries/lock-android/keystore",
-    "destination": "/docs/libraries/auth0-android/android-development-keystores-hashes"
+    "destination": "/docs/libraries/lock-android/android-development-keystores-hashes"
   },
   {
     "source": "/docs/libraries/lock-android/v2/keystore",
-    "destination": "/docs/libraries/auth0-android/android-development-keystores-hashes"
+    "destination": "/docs/libraries/lock-android/android-development-keystores-hashes"
   },
   {
     "source": "/docs/libraries/lock-android/v1/passwordless-magic-link",
@@ -17360,24 +17332,24 @@
     "destination": "/docs/authenticate/enterprise-connections/self-service-enterprise-configuration"
   },
   {
-    "source": "docs/authenticate/enterprise-connections/self-service-SSO/manage-self-service-sso",
-    "destination": "docs/authenticate/enterprise-connections/self-service-enterprise-configuration/manage-self-service-enterprise-config"
+    "source": "/docs/authenticate/enterprise-connections/self-service-SSO/manage-self-service-sso",
+    "destination": "/docs/authenticate/enterprise-connections/self-service-enterprise-configuration/manage-self-service-enterprise-config"
   },
   {
-    "source": "docs/ja-jp/authenticate/enterprise-connections/self-service-SSO",
-    "destination": "docs/ja-jp/authenticate/enterprise-connections/self-service-enterprise-configuration"
+    "source": "/docs/ja-jp/authenticate/enterprise-connections/self-service-SSO",
+    "destination": "/docs/ja-jp/authenticate/enterprise-connections/self-service-enterprise-configuration"
   },
   {
     "source": "docs/ja-jp/authenticate/enterprise-connections/self-service-SSO/manage-self-service-sso",
-    "destination": "docs/ja-jp/authenticate/enterprise-connections/self-service-enterprise-configuration/manage-self-service-enterprise-config"
+    "destination": "/docs/ja-jp/authenticate/enterprise-connections/self-service-SSO/manage-self-service-enterprise-config"
   },
   {
-    "source": "docs/fr-ca/authenticate/enterprise-connections/self-service-SSO",
-    "destination": "docs/fr-ca/authenticate/enterprise-connections/self-service-enterprise-configuration"
+    "source": "/docs/fr-ca/authenticate/enterprise-connections/self-service-SSO",
+    "destination": "/docs/fr-ca/authenticate/enterprise-connections/self-service-enterprise-configuration"
   },
   {
     "source": "docs/fr-ca/authenticate/enterprise-connections/self-service-SSO/manage-self-service-sso",
-    "destination": "docs/fr-ca/authenticate/enterprise-connections/self-service-enterprise-configuration/manage-self-service-enterprise-config"
+    "destination": "/docs/fr-ca/authenticate/enterprise-connections/self-service-SSO/manage-self-service-enterprise-config"
   },
   {
     "source": "/docs/api/authentication/get-ws-federation-metadata",


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

This PR updates and fixes broken links in `redirects.json`.

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

- Validated the updated destination values exist. 
- Removed the offending `management/v2` destinations that do not exist.
- There was one value `/docs/libraries/lock-android/android-development-keystores-hashes` that was a destination, but was also a source to a destination that did not exist - this was removed.

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
