### PR TITLE
fix: expand truncated CDN reference on deprecation page for TLS deprecation

### DIFF
--- a/main/docs/troubleshoot/product-lifecycle/deprecations-and-migrations.mdx
+++ b/main/docs/troubleshoot/product-lifecycle/deprecations-and-migrations.mdx
@@ -50,7 +50,7 @@ After the end-of-life date, we will require the use of modern ciphers when conne
     * Public and private cloud tenants' default domains; for example, `[tenant_name].eu.auth0.com.`
     * Public and private cloud tenants' custom domains.
     * Service-related web applications, such as the Dashboard (`manage.auth0.com`) or the Marketplace (`marketplace.auth0.com`).
-    * The Auth0 CD.
+    * The Auth0 Content Delivery Network (CDN). (`cdn.auth0.com`)
 
 The list of discontinued cipher suites is available below. The list contains the unique hex code that identifies each cipher alongside its [IANA](https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4) name; for the corresponding OpenSSL names, follow the links to `ciphersuite.info`.
 

--- a/main/docs/troubleshoot/product-lifecycle/deprecations-and-migrations.mdx
+++ b/main/docs/troubleshoot/product-lifecycle/deprecations-and-migrations.mdx
@@ -50,7 +50,7 @@ After the end-of-life date, we will require the use of modern ciphers when conne
     * Public and private cloud tenants' default domains; for example, `[tenant_name].eu.auth0.com.`
     * Public and private cloud tenants' custom domains.
     * Service-related web applications, such as the Dashboard (`manage.auth0.com`) or the Marketplace (`marketplace.auth0.com`).
-    * The Auth0 Content Delivery Network (CDN). (`cdn.auth0.com`)
+    * The Auth0 Content Delivery Network (CDN).  To learn more, read [Auth0 Public Cloud Service Endpoints](/docs/troubleshoot/customer-support/operational-policies/public-cloud-service-endpoints)
 
 The list of discontinued cipher suites is available below. The list contains the unique hex code that identifies each cipher alongside its [IANA](https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4) name; for the corresponding OpenSSL names, follow the links to `ciphersuite.info`.
 


### PR DESCRIPTION
Noticed a typo on https://auth0.com/docs/troubleshoot/product-lifecycle/deprecations-and-migrations#weak-tls-1-2-cipher-suites

<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
