### PR TITLE
refactor: restructure enterprise rate limit config into categorized s…

### DIFF
--- a/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/enterprise-public.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/enterprise-public.mdx
@@ -3,11 +3,11 @@ title: Enterprise Rate Limits
 description: Rate limits for the Enterprise subscription type.
 ---
 
-## Authentication API 
+## Authentication API
 
 Review the following table for Global Authentication API Rate Limits, or the rate limit policy protecting nearly all Authentication API endpoints.
 
-Rate limits for the Authentication API and API endpoints in the Enterprise subscription type:
+Rate limits for the Authentication API in the Enterprise subscription type:
 
 | Tenant | [Burst Request Limit](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy#rate-limit-algorithm) | [Sustained Request Limit](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy#rate-limit-algorithm) |
 |--------|--|--|
@@ -19,102 +19,101 @@ Rate limits for the Authentication API and API endpoints in the Enterprise subsc
 
 These limits are constrained to 48 hours per month. After 48 hours, these limits revert to product limits. For more information, read [Public Performance Burst](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy#public-performance).
 
-| [Endpoint](https://auth0.com/docs/api/authentication#introduction) | Method | [Burst Request Limit](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy#rate-limit-algorithm) | [Sustained Request Limit](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy#rate-limit-algorithm) | Limit Type |
-|--|--|--|--|--|
-| [User Info](https://auth0.com/docs/api/authentication/user-profile/get-user-info) | `GET`, `POST` | 10 | 5/minute | To a unique User ID |
-| [Change Password](https://auth0.com/docs/api/authentication/change-password/change-password) | `POST` | 10 | 1/minute | From an IP Address to a unique Email Address |
-| [Reset Password with Universal Login](/docs/authenticate/database-connections/password-change#universal-login-page) | `POST` | 10 | 1/minute | From an IP Address to a unique Email Address |
-| [Get Passwordless Code or Link](https://auth0.com/docs/api/authentication#passwordless) | `GET`, `POST` | 50 | 50/hour | From an IP Address |
-| [Native Social Login (Apple / Facebook Only)](https://auth0.com/docs/api/authentication#verify-with-one-time-password-otp-) | `POST` | 50 | 500/minute | Any Request for Apple or Facebook Native Social Login |
-| [Dynamic Application (Client) Registration](https://auth0.com/docs/api/authentication#dynamic-application-client-registration) | `POST` | 5 | 5/second | Any request |
-| [Universal Logout](https://auth0.com/docs/api/authentication#global-token-revocation) | `POST` | 35 | 35/second | Any request |
-| Pushed Authorization Requests (PAR) | `POST` | 100 | 100/second | From an IP Address |
-| Back-Channel authorize (CIBA) | `POST` | 500 | 500/minute | From an IP Address |
-| Device code activation (no prompt) | `POST` | 30 | 6/second | From an IP Address |
-| Device code authorization | `POST` | 5 | 5/second | From an IP Address |
-| MFA OOB token exchange | `POST` | 12 | 12/minute | To a unique session |
-| [Custom Token Exchange](/docs/authenticate/custom-token-exchange) | `POST` | 15 | 15/second | Any request |
-| [On-Behalf-Of Token Exchange](/docs/secure/call-apis-on-users-behalf/on-behalf-of-token-exchange) | `POST` | 30 | 30/second | Any Request |
+### Infrastructure Protection Limits
+
+| [Resource](https://auth0.com/docs/api/authentication#introduction) | [Burst Request Limit](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy#rate-limit-algorithm) | [Sustained Request Limit](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy#rate-limit-algorithm) |
+|--|--|--|
+| [Native Social Login (Apple / Facebook Only)](https://auth0.com/docs/api/authentication#verify-with-one-time-password-otp-) `POST` | 50 | 500/minute |
+| [Dynamic Application (Client) Registration](https://auth0.com/docs/api/authentication#dynamic-application-client-registration) `POST` | 5 | 5/second |
+| [Universal Logout](https://auth0.com/docs/api/authentication#global-token-revocation) `POST` | 35 | 35/second |
+| [Custom Token Exchange](/docs/authenticate/custom-token-exchange) `POST` | 15 | 15/second |
+| [On-Behalf-Of Token Exchange](/docs/secure/call-apis-on-users-behalf/on-behalf-of-token-exchange) `POST` | 30 | 30/second |
+
+### Attack Protection Limits
+
+| [Resource](https://auth0.com/docs/api/authentication#introduction) | [Burst Request Limit](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy#rate-limit-algorithm) | [Sustained Request Limit](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy#rate-limit-algorithm) | Limit Type |
+|--|--|--|--|
+| [User Info](https://auth0.com/docs/api/authentication/user-profile/get-user-info) `GET`, `POST` | 10 | 5/minute | User ID |
+| [Change Password](https://auth0.com/docs/api/authentication/change-password/change-password) `POST` | 10 | 1/minute | IP Address + Email |
+| [Reset Password with Universal Login](/docs/authenticate/database-connections/password-change#universal-login-page) `POST` | 10 | 1/minute | IP Address + Email |
+| [Get Passwordless Code or Link](https://auth0.com/docs/api/authentication#passwordless) `GET`, `POST` | 50 | 50/hour | IP Address |
+| Pushed Authorization Requests (PAR) `POST` | 100 | 100/second | IP Address |
+| Back-Channel authorize (CIBA) `POST` | 500 | 500/minute | IP Address |
+| Device code activation (no prompt) `POST` | 30 | 6/second | IP Address |
+| Device code authorization `POST` | 5 | 5/second | IP Address |
+| MFA OOB token exchange `POST` | 12 | 12/minute | Session |
+| Universal login prompts (global) `GET`, `POST` | 500 | 500/minute | IP Address |
+| Universal login prompts (per prompt) `GET` | 20 | 10/minute | IP Address + State |
+| Universal login prompts (per prompt) `POST` | 10 | 5/minute | IP Address |
+| Password reset prompt `GET` | 500 | 500/minute | IP Address |
+| MFA push enrollment prompt `GET`, `POST` | 500 | 500/minute | IP Address |
+| MFA push challenge prompt `GET`, `POST` | 500 | 500/minute | IP Address |
+| MFA SMS enrollment prompt `GET` | 20 | 10/minute | IP Address |
+| MFA SMS enrollment prompt `POST` | 10 | 5/minute | IP Address |
+| MFA SMS enrollment verify prompt `GET` | 20 | 10/minute | IP Address |
+| MFA SMS enrollment verify prompt `POST` | 10 | 5/minute | IP Address |
+| Passwordless SMS challenge prompt `GET`, `POST` | 5 | 5/minute | IP Address |
+| Passwordless email challenge prompt `GET`, `POST` | 5 | 5/minute | IP Address |
+| Phone verification enrollment prompt `GET`, `POST` | 5 | 5/minute | IP Address |
+| Phone verification challenge prompt `GET`, `POST` | 5 | 5/minute | IP Address |
+| Device code prompt `GET`, `POST` | 5 | 5/second | IP Address |
+| OTP (6 numeric digits) failures | 10 | 10/hour | User ID |
+| Recovery code failures | 10 | 10/hour | User ID |
+| Webauthn challenge failures | 15 | 15/minute | User ID |
+| Webauthn challenge generated | 15 | 15/minute | User ID |
+| Push notifications sent per user | 5 | 5/minute | User ID |
+| SMS sent per user | 10 | 1/hour | User ID |
+| Email sent per user | 20 | 1/minute | User ID |
 
 Represents the default limit. You can configure the Signup endpoint limit in Auth0 Dashboard. To learn more, read [Suspicious IP Throttling](/docs/secure/attack-protection/suspicious-ip-throttling#suspicious-ip-throttling).
 
 ## Management API
 
-Review the following table for Global Management API Rate Limits. Most Management API endpoints, except those listed under "endpoints", are protected by these rate limit policies.
+Review the following table for Global Management API Rate Limits. Most Management API endpoints, except those listed under "Infrastructure Protection Limits", are protected by these rate limit policies.
 
-Rate limits for the Management API, API endpoints, and API endpoint groups in the Enterprise subscription type:
+Rate limits for the Management API in the Enterprise subscription type:
 
 | Tenant Environment | [Burst Request Limit](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy#rate-limit-algorithm) | [Sustained Request Limit](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy#rate-limit-algorithm) |
 |--|--|--|
 | Production | 50 | 16/second |
 | Non-production | 10 | 2/second |
 
-| [Endpoint](https://auth0.com/docs/api/management/v2) | Method | [Burst Request Limit](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy#rate-limit-algorithm) | [Sustained Request Limit](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy#rate-limit-algorithm) | Limit Type |
-|--|--|--|--|--|
-| [Read Organizations by Name](https://auth0.com/docs/api/management/v2/organizations/get-name-by-name) | `GET` | 20 | 200/minute | Any request |
-| [Write Organizations](https://auth0.com/docs/api/management/v2/organizations/post-organizations) | `POST`, `PATCH`, `DELETE` | 5 | 150/minute | Any request |
-| [Read Organization Members](https://auth0.com/docs/api/management/v2/organizations/get-members) | `GET` | 40 | 500/minute | Any request |
-| [Write Organization Members](https://auth0.com/docs/api/management/v2/organizations/post-members) | `POST`, `DELETE` | 20 | 200/minute | Any request |
-| [Read Organization invitation](https://auth0.com/docs/api/management/v2/organizations/get-invitations-by-invitation-id) | `GET` | 20 | 200/minute | Any request |
-| [Write Organization invitation](https://auth0.com/docs/api/management/v2/organizations/get-invitations-by-invitation-id) | `POST` | 20 | 200/minute | Any request |
-| [Read Organization Member Roles](https://auth0.com/docs/api/management/v2/organizations/get-organization-member-roles) | `GET` | 20 | 200/minute | Any request |
-| [Write Organization Member Roles](https://auth0.com/docs/api/management/v2/organizations/post-organization-member-roles) | `POST`, `DELETE` | 20 | 200/minute | Any request |
-| [Read Organization Connections](https://auth0.com/docs/api/management/v2/organizations/get-enabled-connections) | `GET` | 10 | 100/minute | Any request |
-| [Write Organization Connections](https://auth0.com/docs/api/management/v2/organizations/post-enabled-connections) | `POST`, `PATCH`, `DELETE` | 5 | 150/minute | Any request |
-| [Write Custom Domains](https://auth0.com/docs/api/management/v2/custom-domains/post-verify) | `POST` | 5 | 5/minute | Any request |
-| [Read Status Connection](https://auth0.com/docs/api/management/v2/connections/get-status) | `GET` | 100 | 15/second | Any request |
-| [Write Signing Keys](https://auth0.com/docs/api/management/v2/keys/post-signing-keys) | `POST` | 5 | 5/day | Any request |
-| [Read Partials for a Prompt](https://auth0.com/docs/api/management/v2/prompts/get-partials) | `GET` | 5 | 5/minute | Any request |
-| [Write Partials for a Prompt](https://auth0.com/docs/api/management/v2/prompts/put-partials) | `PUT` | 5 | 5/minute | Any request |
-| [Read Clients](https://auth0.com/docs/api/management/v2/clients/get-clients) <br/> Only applies to the usage of the `q` parameter. | `GET` | 5 | 150/minute | Any request |
-| [Read Organization Client Grants](https://auth0.com/docs/api/management/v2/organizations/get-organization-client-grants) | `GET` | 10 | 100/minute | Any request |
-| [Write Organization Client Grants](https://auth0.com/docs/api/management/v2/organizations/create-organization-client-grants) | `POST` | 5 | 150/minute | Any request |
-| [Write email templates](https://auth0.com/docs/api/management/v2/email-templates/post-email-templates) | `POST`, `PATCH`, `DELETE` | 10 | 100/minute | Any request |
-| [Read email templates](https://auth0.com/docs/api/management/v2/email-templates/get-email-templates-by-template-name) | `GET` | 15 | 150/minute | Any request |
-| [Write email provider](https://auth0.com/docs/api/management/v2/emails/patch-provider) | `POST`, `PATCH`, `DELETE` | 10 | 100/minute | Any request |
-| [Read email provider](https://auth0.com/docs/api/management/v2/emails/get-provider) | `GET` | 15 | 150/minute | Any request |
-| [Write Token Exchange Profiles](/docs/authenticate/custom-token-exchange/configure-custom-token-exchange#create-custom-token-exchange-profile) | `POST`, `PATCH`, `DELETE` | 5 | 100/minute | Any request |
-| [Read Token Exchange Profiles](/docs/authenticate/custom-token-exchange/configure-custom-token-exchange#manage-custom-token-exchange-profile) | `GET` | 20 | 200/minute | Any request |
+### Infrastructure Protection Limits
+
+| [Resource](https://auth0.com/docs/api/management/v2) | [Burst Request Limit](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy#rate-limit-algorithm) | [Sustained Request Limit](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy#rate-limit-algorithm) |
+|--|--|--|
+| [Read Organizations by Name](https://auth0.com/docs/api/management/v2/organizations/get-name-by-name) `GET` | 20 | 200/minute |
+| [Write Organizations](https://auth0.com/docs/api/management/v2/organizations/post-organizations) `POST`, `PATCH`, `DELETE` | 5 | 150/minute |
+| [Read Organization Members](https://auth0.com/docs/api/management/v2/organizations/get-members) `GET` | 40 | 500/minute |
+| [Write Organization Members](https://auth0.com/docs/api/management/v2/organizations/post-members) `POST`, `DELETE` | 20 | 200/minute |
+| [Read Organization invitation](https://auth0.com/docs/api/management/v2/organizations/get-invitations-by-invitation-id) `GET` | 20 | 200/minute |
+| [Write Organization invitation](https://auth0.com/docs/api/management/v2/organizations/get-invitations-by-invitation-id) `POST` | 20 | 200/minute |
+| [Read Organization Member Roles](https://auth0.com/docs/api/management/v2/organizations/get-organization-member-roles) `GET` | 20 | 200/minute |
+| [Write Organization Member Roles](https://auth0.com/docs/api/management/v2/organizations/post-organization-member-roles) `POST`, `DELETE` | 20 | 200/minute |
+| [Read Organization Connections](https://auth0.com/docs/api/management/v2/organizations/get-enabled-connections) `GET` | 10 | 100/minute |
+| [Write Organization Connections](https://auth0.com/docs/api/management/v2/organizations/post-enabled-connections) `POST`, `PATCH`, `DELETE` | 5 | 150/minute |
+| [Write Custom Domains](https://auth0.com/docs/api/management/v2/custom-domains/post-verify) `POST` | 5 | 5/minute |
+| [Read Status Connection](https://auth0.com/docs/api/management/v2/connections/get-status) `GET` | 100 | 15/second |
+| [Write Signing Keys](https://auth0.com/docs/api/management/v2/keys/post-signing-keys) `POST` | 5 | 5/day |
+| [Read Partials for a Prompt](https://auth0.com/docs/api/management/v2/prompts/get-partials) `GET` | 5 | 5/minute |
+| [Write Partials for a Prompt](https://auth0.com/docs/api/management/v2/prompts/put-partials) `PUT` | 5 | 5/minute |
+| [Read Clients](https://auth0.com/docs/api/management/v2/clients/get-clients) `GET` <br/> Only applies to the usage of the `q` parameter. | 5 | 150/minute |
+| [Read Organization Client Grants](https://auth0.com/docs/api/management/v2/organizations/get-organization-client-grants) `GET` | 10 | 100/minute |
+| [Write Organization Client Grants](https://auth0.com/docs/api/management/v2/organizations/create-organization-client-grants) `POST` | 5 | 150/minute |
+| [Write email templates](https://auth0.com/docs/api/management/v2/email-templates/post-email-templates) `POST`, `PATCH`, `DELETE` | 10 | 100/minute |
+| [Read email templates](https://auth0.com/docs/api/management/v2/email-templates/get-email-templates-by-template-name) `GET` | 15 | 150/minute |
+| [Write email provider](https://auth0.com/docs/api/management/v2/emails/patch-provider) `POST`, `PATCH`, `DELETE` | 10 | 100/minute |
+| [Read email provider](https://auth0.com/docs/api/management/v2/emails/get-provider) `GET` | 15 | 150/minute |
+| [Write Token Exchange Profiles](/docs/authenticate/custom-token-exchange/configure-custom-token-exchange#create-custom-token-exchange-profile) `POST`, `PATCH`, `DELETE` | 5 | 100/minute |
+| [Read Token Exchange Profiles](/docs/authenticate/custom-token-exchange/configure-custom-token-exchange#manage-custom-token-exchange-profile) `GET` | 20 | 200/minute |
 
 ## SCIM API
 
 Rate limits for the inbound SCIM API endpoints in public cloud subscriptions that include Enterprise connections:
 
-| Limit Type | Endpoint Path | Operation | Limit |
-|------------|---------------|-----------|-------|
-| Single SCIM connection endpoint | `/scim/v2/connections/{connection-id}` | Any request | 25 requests per second |
-| Global tenant limit for all SCIM connections | `/scim/v2/connections/*` | Any request | 100 requests per second |
+### Infrastructure Protection Limits
 
-## Universal Login Flow Endpoints
-
-Rate limits for the endpoints utilized for the Universal Login Authentication Flow for all subscription types:
-
-| Endpoint | Method | [Burst Request Limit](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy#rate-limit-algorithm) | [Sustained Request Limit](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy#rate-limit-algorithm) | Limit Type |
-|--|--|--|--|--|
-| Universal login prompts (global) | `GET`, `POST` | 500 | 500/minute | From an IP Address |
-| Universal login prompts (per prompt) | `GET` | 20 | 10/minute | From an IP Address and state value. |
-| Universal login prompts (per prompt) | `POST` | 10 | 5/minute | From an IP Address |
-| Password reset prompt | `GET` | 500 | 500/minute | From an IP Address |
-| MFA push enrollment prompt | `GET`, `POST` | 500 | 500/minute | From an IP Address |
-| MFA push challenge prompt | `GET`, `POST` | 500 | 500/minute | From an IP Address |
-| MFA SMS enrollment prompt | `GET` | 20 | 10/minute | From an IP Address |
-| MFA SMS enrollment prompt | `POST` | 10 | 5/minute | From an IP Address |
-| MFA SMS enrollment verify prompt | `GET` | 20 | 10/minute | From an IP Address |
-| MFA SMS enrollment verify prompt | `POST` | 10 | 5/minute | From an IP Address |
-| Passwordless SMS challenge prompt | `GET`, `POST` | 5 | 5/minute | From an IP Address |
-| Passwordless email challenge prompt | `GET`, `POST` | 5 | 5/minute | From an IP Address |
-| Phone verification enrollment prompt | `GET`, `POST` | 5 | 5/minute | From an IP Address |
-| Phone verification challenge prompt | `GET`, `POST` | 5 | 5/minute | From an IP Address |
-| Device code prompt | `GET`, `POST` | 5 | 5/second | From an IP Address |
-
-## Additional MFA rate limits
-
-| Endpoint | [Burst Request Limit](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy#rate-limit-algorithm) | [Sustained Request Limit](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy#rate-limit-algorithm) | Limit Type | Limit |
-|--|--|--|--|--|
-| OTP (6 numeric digits) failures | 10 | 10 | per hour | To a unique User ID |
-| Recovery code failures | 10 | 10 | per hour | To a unique User ID |
-| Webauthn challenge failures | 15 | 15 | per minute | To a unique User ID |
-| Webauthn challenge generated | 15 | 15 | per minute | To a unique User ID |
-| Push notifications sent per user | 5 | 5 | per minute | To a unique User ID |
-| SMS sent per user | 10 | 1 | per hour | To a unique User ID |
-| Email sent per user | 20 | 1 | per minute | To a unique User ID |
+| Resource | Operation | Limit |
+|----------|-----------|-------|
+| Single SCIM connection endpoint `/scim/v2/connections/{connection-id}` | Any request | 25 requests per second |
+| Global tenant limit for all SCIM connections `/scim/v2/connections/*` | Any request | 100 requests per second |


### PR DESCRIPTION

Reorganize enterprise-public.mdx to improve readability by grouping rate limits into Infrastructure Protection and Attack Protection categories. Merge Endpoint/Method columns into a single Resource column and consolidate Universal Login and MFA limits under the Authentication API section.

<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
