### PR TITLE
chore: group root pages and directory listings for authenticate section

### DIFF
--- a/main/config/navigation/en.json
+++ b/main/config/navigation/en.json
@@ -513,6 +513,7 @@
         },
         {
           "dropdown": "Authenticate",
+          "directory": "accordion",
           "description": "Auth0 simplifies the use of open industry standards",
           "icon": "lock",
           "pages": [
@@ -522,24 +523,24 @@
               "pages": [
                 {
                   "group": "Login",
+                  "root": "docs/authenticate/login",
                   "pages": [
-                    "docs/authenticate/login",
                     {
                       "group": "Auth0 Universal Login",
+                      "root": "docs/authenticate/login/auth0-universal-login",
                       "pages": [
-                        "docs/authenticate/login/auth0-universal-login",
                         {
                           "group": "Universal Login vs. Classic Login",
+                          "root": "docs/authenticate/login/auth0-universal-login/universal-login-vs-classic-login",
                           "pages": [
-                            "docs/authenticate/login/auth0-universal-login/universal-login-vs-classic-login",
                             "docs/authenticate/login/auth0-universal-login/universal-login-vs-classic-login/universal-experience",
                             "docs/authenticate/login/auth0-universal-login/universal-login-vs-classic-login/classic-experience"
                           ]
                         },
                         {
                           "group": "Passwordless Login",
+                          "root": "docs/authenticate/login/auth0-universal-login/passwordless-login",
                           "pages": [
-                            "docs/authenticate/login/auth0-universal-login/passwordless-login",
                             "docs/authenticate/login/auth0-universal-login/passwordless-login/webauthn-device-biometrics",
                             "docs/authenticate/login/auth0-universal-login/passwordless-login/email-or-sms"
                           ]
@@ -558,23 +559,28 @@
                     "docs/authenticate/login/max-age-reauthentication",
                     {
                       "group": "Logout",
+                      "root": "docs/authenticate/login/logout",
                       "pages": [
-                        "docs/authenticate/login/logout",
-                        "docs/authenticate/login/logout/back-channel-logout",
-                        "docs/authenticate/login/logout/back-channel-logout/configure-back-channel-logout",
-                        "docs/authenticate/login/logout/back-channel-logout/oidc-back-channel-logout-initiators",
                         "docs/authenticate/login/logout/universal-logout",
                         "docs/authenticate/login/logout/log-users-out-of-applications",
                         "docs/authenticate/login/logout/log-users-out-of-auth0",
                         "docs/authenticate/login/logout/log-users-out-of-idps",
                         "docs/authenticate/login/logout/log-users-out-of-saml-idps",
-                        "docs/authenticate/login/logout/redirect-users-after-logout"
+                        "docs/authenticate/login/logout/redirect-users-after-logout",
+                        {
+                          "group": "OIDC Back-Channel Logout", 
+                          "root": "docs/authenticate/login/logout/back-channel-logout",
+                          "pages": [
+                            "docs/authenticate/login/logout/back-channel-logout/configure-back-channel-logout",
+                            "docs/authenticate/login/logout/back-channel-logout/oidc-back-channel-logout-initiators"
+                          ]
+                        }
                       ]
                     },
                     {
                       "group": "OIDC-Conformant Authentication",
+                      "root": "docs/authenticate/login/oidc-conformant-authentication",
                       "pages": [
-                        "docs/authenticate/login/oidc-conformant-authentication",
                         "docs/authenticate/login/oidc-conformant-authentication/oidc-adoption-access-tokens",
                         "docs/authenticate/login/oidc-conformant-authentication/oidc-adoption-apis",
                         "docs/authenticate/login/oidc-conformant-authentication/oidc-adoption-auth-code-flow",
@@ -590,17 +596,17 @@
                 },
                 {
                   "group": "Single Sign-On",
+                  "root": "docs/authenticate/single-sign-on",
                   "pages": [
-                    "docs/authenticate/single-sign-on",
                     "docs/authenticate/single-sign-on/inbound-single-sign-on",
                     {
                       "group": "Identity-Provider-Initiated Single Sign-On",
+                      "root": "docs/authenticate/single-sign-on/outbound-single-sign-on",
                       "pages": [
-                        "docs/authenticate/single-sign-on/outbound-single-sign-on",
                         {
                           "group": "Configure Auth0 as SAML Identity Provider",
+                          "root": "docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider",
                           "pages": [
-                            "docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider",
                             "docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-saml2-web-app-addon-for-aws",
                             "docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-auth0-as-identity-provider-for-atlassian",
                             "docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-auth0-as-identity-provider-for-cisco-webex",
@@ -626,8 +632,8 @@
                     },
                     {
                       "group": "Native to Web SSO",
+                      "root": "docs/authenticate/single-sign-on/native-to-web",
                       "pages": [
-                        "docs/authenticate/single-sign-on/native-to-web",
                         "docs/authenticate/single-sign-on/native-to-web/configure-implement-native-to-web",
                         "docs/authenticate/single-sign-on/native-to-web/configure-mobile-to-web-payment-flows",
                         "docs/authenticate/single-sign-on/native-to-web/native-to-web-sso-and-sessions",
@@ -640,12 +646,12 @@
                 },
                 {
                   "group": "Passwordless",
+                  "root": "docs/authenticate/passwordless",
                   "pages": [
-                    "docs/authenticate/passwordless",
                     {
                       "group": "Authentication Methods",
+                      "root": "docs/authenticate/passwordless/authentication-methods",
                       "pages": [
-                        "docs/authenticate/passwordless/authentication-methods",
                         "docs/authenticate/passwordless/authentication-methods/email-otp",
                         "docs/authenticate/passwordless/authentication-methods/email-magic-link",
                         "docs/authenticate/passwordless/authentication-methods/sms-otp",
@@ -654,13 +660,13 @@
                     },
                     {
                       "group": "Implement Login",
+                      "root": "docs/authenticate/passwordless/implement-login",
                       "pages": [
-                        "docs/authenticate/passwordless/implement-login",
                         "docs/authenticate/passwordless/implement-login/universal-login",
                         {
                           "group": "Embedded Login",
+                          "root": "docs/authenticate/passwordless/implement-login/embedded-login",
                           "pages": [
-                            "docs/authenticate/passwordless/implement-login/embedded-login",
                             "docs/authenticate/passwordless/implement-login/embedded-login/relevant-api-endpoints",
                             "docs/authenticate/passwordless/implement-login/embedded-login/spa",
                             "docs/authenticate/passwordless/implement-login/embedded-login/native",
@@ -677,8 +683,8 @@
                 },
                 {
                   "group": "Custom Token Exchange",
+                  "root": "docs/authenticate/custom-token-exchange",
                   "pages": [
-                    "docs/authenticate/custom-token-exchange",
                     "docs/authenticate/custom-token-exchange/cte-example-use-cases",
                     "docs/authenticate/custom-token-exchange/configure-custom-token-exchange",
                     "docs/authenticate/custom-token-exchange/cte-multi-factor-authentication",
@@ -692,21 +698,31 @@
               "pages": [
                 {
                   "group": "Identity Providers",
+                  "root": "docs/authenticate/identity-providers",
                   "pages": [
-                    "docs/authenticate/identity-providers",
                     {
                       "group": "Social Identity Providers",
+                      "root": "docs/authenticate/identity-providers/social-identity-providers",
                       "pages": [
-                        "docs/authenticate/identity-providers/social-identity-providers",
-                        "docs/authenticate/identity-providers/social-identity-providers/github",
-                        "docs/authenticate/identity-providers/social-identity-providers/google",
+                        {
+                          "group": "For Web Applications",
+                          "pages": [
+                            "docs/authenticate/identity-providers/social-identity-providers/github",
+                            "docs/authenticate/identity-providers/social-identity-providers/google"
+                          ]
+                        },
+                        {
+                          "group": "For Native Applications",
+                          "pages": [
+                            "docs/authenticate/identity-providers/social-identity-providers/apple-native",
+                            "docs/authenticate/identity-providers/social-identity-providers/facebook-native",
+                            "docs/authenticate/identity-providers/social-identity-providers/google-native",
+                            "docs/authenticate/identity-providers/social-identity-providers/tiktok"
+                          ]
+                        },
                         "docs/authenticate/identity-providers/social-identity-providers/oauth2",
-                        "docs/authenticate/identity-providers/social-identity-providers/apple-native",
-                        "docs/authenticate/identity-providers/social-identity-providers/facebook-native",
-                        "docs/authenticate/identity-providers/social-identity-providers/google-native",
                         "docs/authenticate/identity-providers/social-identity-providers/reprompt-permissions",
-                        "docs/authenticate/identity-providers/social-identity-providers/devkeys",
-                        "docs/authenticate/identity-providers/social-identity-providers/tiktok"
+                        "docs/authenticate/identity-providers/social-identity-providers/devkeys"
                       ]
                     },
                     {
@@ -728,12 +744,12 @@
                         },
                         {
                           "group": "Connect Your App to Active Directory using LDAP",
+                          "root": "docs/authenticate/identity-providers/enterprise-identity-providers/active-directory-ldap",
                           "pages": [
-                            "docs/authenticate/identity-providers/enterprise-identity-providers/active-directory-ldap",
                             {
                               "group": "AD/LDAP Connector",
+                              "root": "docs/authenticate/identity-providers/enterprise-identity-providers/active-directory-ldap/ad-ldap-connector",
                               "pages": [
-                                "docs/authenticate/identity-providers/enterprise-identity-providers/active-directory-ldap/ad-ldap-connector",
                                 "docs/authenticate/identity-providers/enterprise-identity-providers/active-directory-ldap/ad-ldap-connector/ad-ldap-connector-requirements",
                                 "docs/authenticate/identity-providers/enterprise-identity-providers/active-directory-ldap/ad-ldap-connector/install-configure-ad-ldap-connector",
                                 "docs/authenticate/identity-providers/enterprise-identity-providers/active-directory-ldap/ad-ldap-connector/configure-ad-ldap-connector-client-certificates",
@@ -777,20 +793,20 @@
                 },
                 {
                   "group": "Database Connections",
+                  "root": "docs/authenticate/database-connections",
                   "pages": [
-                    "docs/authenticate/database-connections",
                     {
-                      "group": "Your User Store",
+                      "group": "Custom Database Connections",
+                      "root": "docs/authenticate/database-connections/custom-db",
                       "pages": [
-                        "docs/authenticate/database-connections/custom-db",
                         "docs/authenticate/database-connections/custom-db/overview-custom-db-connections",
                         "docs/authenticate/database-connections/custom-db/create-db-connection",
                         "docs/authenticate/database-connections/custom-db/test-custom-database-connections",
                         "docs/authenticate/database-connections/custom-db/error-handling",
                         {
                           "group": "Action Script Templates",
+                          "root": "docs/authenticate/database-connections/custom-db/templates",
                           "pages": [
-                            "docs/authenticate/database-connections/custom-db/templates",
                             "docs/authenticate/database-connections/custom-db/templates/change-password",
                             "docs/authenticate/database-connections/custom-db/templates/create",
                             "docs/authenticate/database-connections/custom-db/templates/delete",
@@ -802,8 +818,8 @@
                         },
                         {
                           "group": "Custom Database and Action Script Best Practices",
+                          "root": "docs/authenticate/database-connections/custom-db/custom-database-connections-scripts",
                           "pages": [
-                            "docs/authenticate/database-connections/custom-db/custom-database-connections-scripts",
                             "docs/authenticate/database-connections/custom-db/custom-database-connections-scripts/anatomy",
                             "docs/authenticate/database-connections/custom-db/custom-database-connections-scripts/environment",
                             "docs/authenticate/database-connections/custom-db/custom-database-connections-scripts/execution",
@@ -814,8 +830,8 @@
                     },
                     {
                       "group": "Passkeys",
+                      "root": "docs/authenticate/database-connections/passkeys",
                       "pages": [
-                        "docs/authenticate/database-connections/passkeys",
                         "docs/authenticate/database-connections/passkeys/configure-passkey-policy",
                         "docs/authenticate/database-connections/passkeys/monitor-passkey-events-in-tenant-logs",
                         "docs/authenticate/database-connections/passkeys/native-passkeys-for-mobile-applications",
@@ -834,12 +850,12 @@
                 },
                 {
                   "group": "Enterprise Connections",
+                  "root": "docs/authenticate/enterprise-connections",
                   "pages": [
-                    "docs/authenticate/enterprise-connections",
                     {
                       "group": "Self-Service Enterprise Configuration",
+                      "root": "docs/authenticate/enterprise-connections/self-service-enterprise-configuration",
                       "pages": [
-                        "docs/authenticate/enterprise-connections/self-service-enterprise-configuration",
                         "docs/authenticate/enterprise-connections/self-service-enterprise-configuration/manage-self-service-enterprise-config",
                         "docs/authenticate/enterprise-connections/connection-profile",
                         "docs/authenticate/enterprise-connections/user-attribute-profile"
@@ -851,18 +867,18 @@
                 },
                 {
                   "group": "Protocols",
+                  "root": "docs/authenticate/protocols",
                   "pages": [
-                    "docs/authenticate/protocols",
                     {
                       "group": "SAML",
+                      "root": "docs/authenticate/protocols/saml",
                       "pages": [
-                        "docs/authenticate/protocols/saml",
                         "docs/authenticate/identity-providers/enterprise-identity-providers/ping-federate",
                         "docs/authenticate/protocols/saml/saml-identity-provider-configuration-settings",
                         {
                           "group": "SAML Configuration",
+                          "root": "docs/authenticate/protocols/saml/saml-configuration",
                           "pages": [
-                            "docs/authenticate/protocols/saml/saml-configuration",
                             "docs/authenticate/protocols/saml/saml-configuration/customize-saml-assertions",
                             "docs/authenticate/protocols/saml/saml-configuration/deprovision-users-in-saml-integrations",
                             "docs/authenticate/protocols/saml/saml-configuration/configure-auth0-as-service-and-identity-provider",
@@ -871,14 +887,14 @@
                         },
                         {
                           "group": "SAML Single Sign-On Integrations",
+                          "root": "docs/authenticate/protocols/saml/saml-sso-integrations",
                           "pages": [
-                            "docs/authenticate/protocols/saml/saml-sso-integrations",
                             "docs/authenticate/protocols/saml/saml-sso-integrations/identity-provider-initiated-single-sign-on",
                             "docs/authenticate/protocols/saml/saml-sso-integrations/configure-idp-initiated-saml-sign-on-to-oidc-apps",
                             {
                               "group": "Configure Auth0 as SAML Service Provider",
+                              "root": "docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider",
                               "pages": [
-                                "docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider",
                                 "docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider/configure-adfs-saml-connections",
                                 "docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider/configure-okta-as-saml-identity-provider",
                                 "docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider/configure-onelogin-as-saml-identity-provider",
@@ -901,8 +917,8 @@
                     "docs/authenticate/protocols/ldap-protocol",
                     {
                       "group": "System for Cross-domain Identity Management (SCIM)",
+                      "root": "docs/authenticate/protocols/scim",
                       "pages": [
-                        "docs/authenticate/protocols/scim",
                         "docs/authenticate/protocols/scim/configure-inbound-scim",
                         "docs/authenticate/protocols/scim/inbound-scim-for-azure-ad-saml-connections",
                         "docs/authenticate/protocols/scim/inbound-scim-for-older-azure-ad-connections",

--- a/main/docs/authenticate/custom-token-exchange.mdx
+++ b/main/docs/authenticate/custom-token-exchange.mdx
@@ -1,7 +1,6 @@
 ---
-description: Learn about Custom Token Exchange features.
 title: Custom Token Exchange
-sidebarTitle: Overview
+description: Custom Token Exchange enables applications to exchange their existing tokens for Auth0 tokens.
 ---
 import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
 
@@ -28,13 +27,11 @@ Each Custom Token Exchange request maps to a [Custom Token Exchange Profile](/do
 You can [configure multiple Custom Token Exchange Profiles](/docs/authenticate/custom-token-exchange/configure-custom-token-exchange#create-custom-token-exchange-profile) for an application. After the Auth0 Authorization Server validates that the Custom Token Exchange request is valid and maps to an existing Custom Token Exchange Profile, the [Custom Token Exchange trigger](/docs/customize/actions/explore-triggers/signup-and-login-triggers/custom-token-exchange-trigger) executes the single Action associated with that profile. The application can then leverage the Custom Token Exchange to authenticate and get Auth0 access, ID, and refresh tokens for the user.
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-
 Custom Token Exchange gives you the added flexibility to set the user for the transaction by taking on the additional responsibility of securely validating the corresponding subject token that identifies the user for the transaction.
 
 Remember that subject tokens used with Custom Token Exchange can be any token format or type you require, as long as your Action code can interpret them. **You must implement strong validation of the tokens you receive and accept.** If you fail to do so, you open yourself up to different attack vectors, such as spoofing or replay attacks, resulting in bad actors being able to authenticate with someone else’s user ID.
 
 To learn about different options for implementing secure validation of your subject tokens, read and apply the recommendations included in [Example Use Cases and Code Samples](/docs/authenticate/custom-token-exchange/cte-example-use-cases). Make sure you also take into consideration and apply [Attack Protection](/docs/authenticate/custom-token-exchange/cte-attack-protection) capabilities.
-
 </Callout>
 
 ## Tenant logs

--- a/main/docs/authenticate/database-connections.mdx
+++ b/main/docs/authenticate/database-connections.mdx
@@ -1,9 +1,10 @@
 ---
+title: Auth0 Database Connections
+sidebarTitle: Database Connections
 description: Learn how to create and use a database connection using either the Auth0 user store or your own user store.
-sidebarTitle: Overview
-title: Database Connections
 validatedOn: 2026-02-11
 ---
+
 Auth0 provides database connections to authenticate users with an identifier (email, username, or phone number) and password or [passkeys](/docs/authenticate/database-connections/passkeys/configure-passkey-policy). These credentials are securely stored in the Auth0 user store or in your own database.
 
 You can create a new database connection and manage existing ones at [Auth0 Dashboard > Authentication > Database](https://manage.auth0.com/#/connections/database).
@@ -17,7 +18,7 @@ Auth0 provides the database infrastructure to store your users by default. This 
 The Auth0-hosted database is highly secure. Passwords are never stored or logged in plain text but are hashed with **bcrypt**. Varying levels of password security requirements can also be enforced. To learn more, read [Password Strength in Auth0 Database Connections](/docs/authenticate/database-connections/password-strength).
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-      For database connections, Auth0 limits the number of repeat login attempts per user and IP address. To learn more, read [Database login limits](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy#database-login-limits).
+For database connections, Auth0 limits the number of repeat login attempts per user and IP address. To learn more, read [Database login limits](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy#database-login-limits).
 </Callout>
 
 To use Auth0's database infrastructure as your user store, you have options to migrate your users to Auth0. The [automatic migration](/docs/manage-users/user-migration/configure-automatic-migration-from-your-database) feature adds your users to the Auth0 database one-at-a-time as each logs in and avoids asking your users to reset their passwords all at the same time. Or, use Management API to create a job to [import users](/docs/manage-users/user-migration/bulk-user-imports). To learn more, read [User Migration Scenarios](/docs/manage-users/user-migration/user-migration-scenarios) for migration examples.
@@ -31,10 +32,3 @@ If you have an existing user store, or wish to store user credentials on your ow
 In this scenario, you provide the login script to authenticate the user that will execute each time a user attempts to log in. Optionally, you can [create scripts](/docs/authenticate/database-connections/custom-db/templates) for sign-up, email verification, password reset, and delete user functionality.
 
 The scripts are Node.js code. Auth0 provides [templates](/docs/authenticate/database-connections/custom-db/templates) for most common databases, such as ASP.NET Membership Provider, MongoDB, MySQL, PostgreSQL, SQL Server, Windows Azure SQL Database, and for a web service accessed by Basic Auth. Essentially, you can connect to almost any kind of database or web service with a custom script.
-
-## Learn more
-
-* [Custom Database Connections](docs/authenticate/database-connections/custom-db)
-* [Authenticate with Your Own User Store](/docs/authenticate/database-connections/custom-db/overview-custom-db-connections)
-* [Create Custom Database Connections](/docs/authenticate/database-connections/custom-db/create-db-connection)
-* [Manage Users](/docs/manage-users)

--- a/main/docs/authenticate/database-connections/custom-db.mdx
+++ b/main/docs/authenticate/database-connections/custom-db.mdx
@@ -1,8 +1,9 @@
 ---
-description: Learn about authenticating users using your database as an identity provider.
 title: Custom Database Connections
+description: Learn about authenticating users using your database as an identity provider.
 validatedOn: 2026-02-25
 ---
+
 Use a custom database connection when you want to provide Auth0 with access to your own independent (legacy) identity data store primarily for authentication (filling the role of an <Tooltip tip="Identity Provider (IdP): Service that stores and manages digital identities." cta="View Glossary" href="/docs/glossary?term=identity+provider">identity provider</Tooltip>) and for migrating user data to Auth0's data store.
 
 Auth0 [Extensibility](/docs/customize/extensions) allows you to add custom logic to build out last-mile solutions for Identity and Access Management (IdAM). Auth0 provides extensibility through [Actions](/docs/customize/actions) and [scripts](/docs/authenticate/database-connections/custom-db/templates) for both custom database connections and custom database migration. Each is implemented using [Node.js](https://nodejs.org/en/) running on the Auth0 platform in an Auth0 tenant.
@@ -16,14 +17,5 @@ Auth0 extensibility executes at different points in the IAM pipeline:
 Whatever the use case, Auth0 extensibility allows you to tailor IAM operations to your exact requirements. However, if not used in the right way, this can open up the potential for improper or unintended use which can lead to problematic situations down the line. In an attempt to address matters ahead of time, Auth0 provides [best practice guidance](/docs/authenticate/database-connections/custom-db/custom-database-connections-scripts) to both designers and implementers, and we recommend reading it in its entirety at least once, even if you've already started your journey with Auth0.
 
 <Card title="Availability varies by Auth0 plan">
-
 Your Auth0 plan or custom agreement affects whether this feature is available. To learn more, read [Pricing](https://auth0.com/pricing).
-
 </Card>
-
-## Learn more
-
-* [Authenticate with Your Own User Store](/docs/authenticate/database-connections/custom-db/overview-custom-db-connections)
-* [Create Custom Database Connections](/docs/authenticate/database-connections/custom-db/create-db-connection)
-* [Custom Database Action Script Templates](/docs/authenticate/database-connections/custom-db/templates)
-* [Troubleshoot Custom Databases](/docs/authenticate/database-connections/custom-db/error-handling)

--- a/main/docs/authenticate/database-connections/custom-db/templates.mdx
+++ b/main/docs/authenticate/database-connections/custom-db/templates.mdx
@@ -2,10 +2,9 @@
 description: Learn about custom database action script templates.
 title: Custom Database Action Script Templates
 ---
+
 <Card title="Availability varies by Auth0 plan">
-
 Your Auth0 plan or custom agreement affects whether this feature is available. To learn more, read [Pricing](https://auth0.com/pricing).
-
 </Card>
 
 If you have your own database (known as a legacy data store in Auth0) containing user identity data, you can use it as an <Tooltip tip="Identity Provider (IdP): Service that stores and manages digital identities." cta="View Glossary" href="/docs/glossary?term=identity+provider">identity provider</Tooltip> to authenticate users.
@@ -27,9 +26,7 @@ Auth0 provides the following custom database action scripts:
 * [Change Email](/docs/authenticate/database-connections/custom-db/templates/change-email)
 
 <Card title="Network firewall">
-
 If you are behind a firewall, this feature may require that you add the appropriate Auth0 IP addresses to the Allow List to work properly.
-
 </Card>
 
 ## Script execution
@@ -45,26 +42,15 @@ Action script execution supports the asynchronous nature of JavaScript, and cons
 The `callback` function supplied to each action script effectively acts as a signal to indicate completion of operation. An action script should complete immediately following a call to the `callback` function (either implicitly or by explicitly executing a JavaScript return statement) and should refrain from any other operation.
 
 <Warning>
-
 The Auth0 supplied `callback` function must be called exactly **once**; calling the function more than once within an action script will lead to unpredictable results and/or errors.
-
 </Warning>
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-
 Where `callback` is executed with no parameters, as in `callback()`, the implication is that function has been called as though `callback(null)` had been executed.
-
 </Callout>
 
 If an action script uses asynchronous processing, then a call to the `callback` function must be deferred to the point where asynchronous processing completes, and must be the final thing called. Asynchronous execution will result in a JavaScript `callback` being executed after the asynchronous operation is complete; this callback is typically fired at some point after the main (synchronous) body of a JavaScript function completes.
 
 <Warning>
-
 Failure to execute the `callback` function will result in a stall of execution, and ultimately in an error condition being returned. The action script must call the `callback` function exactly once: the `callback` function must be called at least once in order to prevent stall of execution, however it must not be called more than once otherwise unpredictable results and/or errors will occur.
-
 </Warning>
-
-## Learn more
-
-* [Custom Database Action Script Execution Best Practices](/docs/authenticate/database-connections/custom-db/custom-database-connections-scripts/execution)
-* [Troubleshoot Custom Databases](/docs/authenticate/database-connections/custom-db/error-handling)

--- a/main/docs/authenticate/database-connections/passkeys.mdx
+++ b/main/docs/authenticate/database-connections/passkeys.mdx
@@ -1,6 +1,6 @@
 ---
 title: Passkey Authentication for Database Connections
-sidebarTitle: Overview
+sidebarTitle: Passkeys
 description: Learn about passkeys as an authentication method and how they work on Auth0.
 ---
 import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
@@ -134,23 +134,3 @@ Defining the RP ID as a suffix of the origin lets users authenticate across subd
 With Auth0, you can customize the RP ID to the root or parent domain so users can authenticate on mobile applications or web applications using the same passkey. If you're using Multiple Custom Domains, you can also set `rp.id` for each custom domain.
 
 To learn how to customize the RP ID, read [Configure Passkey Policy](/docs/authenticate/database-connections/passkeys/configure-passkey-policy).
-
-## Learn more
-
-<Columns cols={2}>
-    <Card
-        title="Configure Passkey Authentication"
-        href="./configure-passkey-policy"
-        cta="Learn more"
-    >
-        How to enable and configure passkeys as an authentication method on a database connection.
-    </Card>
-
-    <Card
-        title="Monitor Passkey Events in Tenant Logs"
-        href="./monitor-passkey-events-in-tenant-logs"
-        cta="Learn more"
-    >
-    Event codes and descriptions for passkey events in tenant logs.
-    </Card>
-</Columns>

--- a/main/docs/authenticate/enterprise-connections.mdx
+++ b/main/docs/authenticate/enterprise-connections.mdx
@@ -1,42 +1,41 @@
 ---
+title: Auth0 Enterprise Connections
+sidebarTitle: Enterprise Connections
 description: Learn how to create, manage, and monitor usage of Enterprise connections to authenticate users with external identity providers.
-sidebarTitle: Overview
-title: Enterprise Connections
 ---
+
 Auth0 provides Enterprise connections to authenticate users in an external, federated <Tooltip tip="Identity Provider (IdP): Service that stores and manages digital identities." cta="View Glossary" href="/docs/glossary?term=identity+provider">identity provider</Tooltip> (IdP) such as Azure AD, Google Workspace, PingFederate, and more.
 
 <Card title="Availability varies by Auth0 plan">
-
 Your Auth0 plan or custom agreement affects the availability of this feature. To learn more, read [Auth0's Pricing Page](https://auth0.com/pricing).
-
 </Card>
 
 ## Create an Enterprise connection
 
 Auth0 supports many identity providers out of the box. To learn more, review [Enterprise Identity Providers](/docs/authenticate/identity-providers/enterprise-identity-providers).
 
-#### OpenID Connect (OIDC) protocol
+### OpenID Connect (OIDC) protocol
 
 Enterprise connections using <Tooltip tip="OpenID: Open standard for authentication that allows applications to verify users' identities without collecting and storing login information." cta="View Glossary" href="/docs/glossary?term=OpenID">OpenID</Tooltip> Connect or Okta Workforce as the identity provider can support the following:
 
-* Proof Key for Code Exchange (PKCE)
+* [Proof Key for Code Exchange (PKCE)](https://www.oauth.com/oauth2-servers/pkce/)
 
-  + For more information on PKCE, review [Protecting Apps with PKCE](https://www.oauth.com/oauth2-servers/pkce/).
 * Attribute claims and <Tooltip tip="Access Token: Authorization credential, in the form of an opaque string or JWT, used to access an API." cta="View Glossary" href="/docs/glossary?term=access+token">access token</Tooltip> mapping
+
 * UserInfo integration
 
-You can currently implement these features for [OpenID Connect](/docs/authenticate/identity-providers/enterprise-identity-providers/oidc) or [Okta Workforce](/docs/authenticate/identity-providers/enterprise-identity-providers/okta) connections. To learn more, review [Configure PKCE and Claim Mapping for OIDC Connections](/docs/authenticate/identity-providers/enterprise-identity-providers/configure-pkce-claim-mapping-for-oidc).
+You can implement these features for [OpenID Connect](/docs/authenticate/identity-providers/enterprise-identity-providers/oidc) or [Okta Workforce](/docs/authenticate/identity-providers/enterprise-identity-providers/okta) connections. To learn more, review [Configure PKCE and Claim Mapping for OIDC Connections](/docs/authenticate/identity-providers/enterprise-identity-providers/configure-pkce-claim-mapping-for-oidc).
 
 ## View Enterprise connections
 
-<Tabs><Tab title="Dashboard">
-
+<Tabs>
+<Tab title="Dashboard">
 Navigate to [**Auth0 Dashboard > Authentication > Enterprise**](https://manage.auth0.com/#/connections/enterprise) to see all available Enterprise connection types. Select a connection type (for example, SAML) to see if there are any configured connections of that type.
 
 You can also select a configured connection and check the **Applications** tab to see if it is enabled for any applications.
+</Tab>
 
-</Tab><Tab title="Management API">
-
+<Tab title="Management API">
 Call the Auth0 Management API [Get all Connections endpoint](https://auth0.com/docs/api/management/v2#!/Connections/get_connections) to get information about your connections. Include the `strategy` parameter to filter by connection type.
 
 The Enterprise connection type `strategy` values are:
@@ -52,8 +51,8 @@ The Enterprise connection type `strategy` values are:
 * `samlp` (SAML)
 * `sharepoint`
 * `waad` (Microsoft Azure AD)
-
-</Tab></Tabs>
+</Tab>
+</Tabs>
 
 ## What is an active Enterprise connection?
 
@@ -65,15 +64,5 @@ An Enterprise connection is considered active if (during the current month) it h
 If an Enterprise connection was never enabled for any application, or was enabled but did not have any user activity during the current month, it is not considered active.
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-
 The Okta Workforce Enterprise connection is not counted toward your active Enterprise connections limit.
-
 </Callout>
-
-## Learn more
-
-* [Enterprise Identity Providers](/docs/authenticate/identity-providers/enterprise-identity-providers)
-* [Enable Enterprise Connections](/docs/authenticate/identity-providers/enterprise-identity-providers/enable-enterprise-connections)
-* [View Connections](/docs/authenticate/identity-providers/view-connections)
-* [Test Enterprise Connections](/docs/authenticate/identity-providers/enterprise-identity-providers/test-enterprise-connections)
-* [Entity Limit Policy](/docs/troubleshoot/customer-support/operational-policies/entity-limit-policy)

--- a/main/docs/authenticate/enterprise-connections/connection-profile.mdx
+++ b/main/docs/authenticate/enterprise-connections/connection-profile.mdx
@@ -1,27 +1,28 @@
 ---
-sidebarTitle: Connection Profile
 title: Connection Profile
+description: Use a Connection Profile to specify how the private settings of an Auth0 connection should be configured when created by third parties.
 ---
 
 Auth0 provides Enterprise connections to authenticate users in an external, federated identity provider (IdP) such as Okta, Microsoft Entra ID, Google Workspace, and others. A configured connection will include protocol-specific settings for integrating single sign-in (SSO), user provisioning, and logout integrations with the external IDP, as well as private settings that govern how the connection interacts with Auth0’s Universal Login and Organizations features.
+
 The Connection Profile (CP) enables Auth0 developers to specify how the private settings of an Auth0 connection should be configured when created by third parties
 
 ## How it works
 
-*   **Profile Definition**<p></p>
-    An administrator creates a Connection Profile that defines the property values that should be written to the connection whenever they are created using one of Auth0 delegated administration features. 
+* **Profile Definition**: An administrator creates a Connection Profile that defines the property values that should be written to the connection whenever they are created using one of Auth0 delegated administration features. 
 
-*   **Flexible Scope**<p></p>
-    Profiles are linked to Self-Service Enterprise Configuration and Okta Express Configuration flows today but are designed for broader reuse, covering provisioning, onboarding, entitlement management, and future Auth0 capabilities.
+* **Flexible Scope**: Profiles are linked to Self-Service Enterprise Configuration and Okta Express Configuration flows today but are designed for broader reuse, covering provisioning, onboarding, entitlement management, and future Auth0 capabilities.
 
 ## Connection Profile properties
-A Connection Profile is a `JSON` object that supports these configurable properties, which are applied to all newly created connections.
+
+A Connection Profile is a JSON object that supports these configurable properties, which are applied to all newly created connections.
 
 | **Property** | **Description** |
 | ----- | ------- |
-| `connection_name_prefix_template` |  Represents the prefix that must be used for naming connections. Maps to the `name` parameter on a connection. This value supports variable substitution for the organization ID and the organization name. The OIN workflow must substitute these values to generate the final prefix. Variables are enclosed in braces ({}). <p></p> Supported variables: <p></p> <ul><li><code>org_id</code>: The Organization ID</li><li><code>org_name</code>: The <a href="https://auth0.com/docs/manage-users/organizations/configure-organizations/create-organizations#auth0-dashboard">Organization name</a></li></ul> <p></p> Example: `con-{org_id}-`|
-| `enabled_features` | This list specifies the features which will be supported by the configured connection. Features not on the list are not allowed.<p></p> Supported values: <ul><li><code>scim</code>: When present, SCIM may be configured on the connection.</li><li><code>universal_logout</code>: When present, the Universal Logout feature may be used with this connection.</li></ul>  |
+| `connection_name_prefix_template` |  Represents the prefix that must be used for naming connections. Maps to the `name` parameter on a connection. This value supports variable substitution for the organization ID and the organization name. The OIN workflow must substitute these values to generate the final prefix. Variables are enclosed in braces ({}). <p></p> Supported variables: <p></p> <ul><li>`org_id`: The Organization ID</li><li>`org_name`: The [Organization name](/docs/manage-users/organizations/configure-organizations/create-organizations#auth0-dashboard)</li></ul> <p></p> Example: `con-{org_id}-`|
+| `enabled_features` | This list specifies the features which will be supported by the configured connection. Features not on the list are not allowed.<p></p> Supported values: <ul><li>`scim`: When present, SCIM may be configured on the connection.</li><li>`universal_logout`: When present, the Universal Logout feature may be used with this connection.</li></ul>  |
 | `organization.assign_membership_on_login` | Specifies whether users should automatically be assigned membership in the organization on login. This maps to the `assign_membership_on_login` property of the `enabled_connections` sub-resource of the organization.  <Callout icon="file-lines" color="#0EA5E9" iconType="regular"> For Express Configuration integrations with Okta, `optional` is treated as `required`</Callout> <p></p>|
+
 | Connection Profile Value | Enable Connections`assign_membership_on_login`Value |
 | --- | --- |
 | `none` | `false` |
@@ -29,6 +30,7 @@ A Connection Profile is a `JSON` object that supports these configurable propert
 | `required` | `true` |
 |`organization`|  An object containing settings that are applied to the organization under which the connection is created. |
 | `organization.show_as_button` | Specifies whether the connection should be shown as a button on the login screen once an organization has been chosen. This maps to the `show_as_button` value on the enabled connection. |
+
 | Connection Profile Value | Connection `show_as_button` Value |
 | --- | --- |
 | `none` | `false` |
@@ -50,6 +52,7 @@ A Connection Profile is a `JSON` object that supports these configurable propert
   ]
 }
 ```
+
 ## Create and manage Connection Profiles
 
 A Connection Profile is automatically generated when using the [Express Configuration](/docs/authenticate/identity-providers/enterprise-identity-providers/okta/express-configuration) feature with Okta. In addition, create and manage Connection Profiles using the Auth0 Management API.
@@ -65,5 +68,6 @@ To use the Management API, you need to get a [Management API access token](/docs
 * `GET` `/api/v2/connection-profiles/templates`
 
 ## Learn More
+
 * [Express Configuration](/docs/authenticate/identity-providers/enterprise-identity-providers/okta/express-configuration)
 * [Manage Users Using Management API](/docs/manage-users/user-accounts/manage-users-using-the-management-api)

--- a/main/docs/authenticate/enterprise-connections/self-service-enterprise-configuration.mdx
+++ b/main/docs/authenticate/enterprise-connections/self-service-enterprise-configuration.mdx
@@ -1,7 +1,6 @@
 ---
-description: Learn how to use Self-Service Enterprise Configuration to delegate SSO setup to your B2B customers.
-sidebarTitle: Self-Service Enterprise Configuration
 title: Self-Service Enterprise Configuration
+description: Learn how to use Self-Service Enterprise Configuration to delegate SSO setup to your B2B customers.
 validatedOn: 2026-02-19
 ---
 
@@ -10,15 +9,13 @@ Self-Service Enterprise Configuration provides business-to-business (B2B) custom
 Self-Service Enterprise Configuration requires minimal configuration in your Auth0 tenant and provides your customers with a setup assistant that guides them through the enablement process. After a customer completes their setup, the SSO integration is automatically added to your tenant as an [Enterprise connection](/docs/authenticate/enterprise-connections).
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-
 Users with the following Dashboard roles can engage with this feature:
 
 * **Admin** and **Editor - Connections** users can create and manage self-service profiles.
 * **Viewer - Config** users can view self-service profiles only.
-
 </Callout>
 
-**Self-Service Enterprise Configuration supported providers**
+## Self-Service Enterprise Configuration supported providers
 
 Single-sign On (SSO) currently supports the following <Tooltip tip="Identity Provider (IdP): Service that stores and manages digital identities." cta="View Glossary" href="/docs/glossary?term=identity+providers">identity providers</Tooltip>:
 
@@ -33,6 +30,7 @@ Single-sign On (SSO) currently supports the following <Tooltip tip="Identity Pro
 * Generic <Tooltip tip="Security Assertion Markup Language (SAML): Standardized protocol allowing two parties to exchange authentication information without a password." cta="View Glossary" href="/docs/glossary?term=SAML">SAML</Tooltip>
 
 Provisioning currently supports the following identity providers:
+
 * Okta Workforce Identity
 * Entra ID
 * Generic OIDC
@@ -93,57 +91,55 @@ Depending on how you (the Auth0 customer) configure the access ticket, the exper
 | Domain Verification set to `Off` | Custom admins do nothing. This step does not appear to customer admins, and the flow ends after Test SSO. |
 | **Allow Use of Domains for Organization Discovery** is enabled| This option is available when generating a ticket for **one** Enabled Organization. When selected: <ul><li>**New Domains**: Any newly verified domain automatically populate both the Organization’s domain list and the Enterprise Connection's `matching_domains`.</li> <li>**Existing Domains**: Any pre-verified domains (limited to 5) or associated domains sync to both the connection and the Organization record upon completion and enables immediate email-based login for users.</li></ul>|
 
-
-
 To learn more, review [Manage Self-Service Enterprise Configuration](/docs/authenticate/enterprise-connections/self-service-enterprise-configuration/manage-self-service-enterprise-config).
 
 ### Example self-service assistant flow
 
 The images below demonstrate an example self-service assistant experience. In this example, a customer admin configures SSO with Okta Workforce as their IdP.
 
-**1. Select Single Sign-On**
+<AccordionGroup>
+
+<Accordion title="1. Select Single Sign-On">
 <Frame>![Enterprise-Connection>Self-Service-SSO](/docs/images/cdy7uua7fh8z/Enterprise-connections>Self-Service-SSO>IdP.png)</Frame>
+</Accordion>
 
-**2. Select Identity Provider**
-
+<Accordion title="2. Select Identity Provider">
 <Frame>![The first step of the self-service assistant that customer admins use to configure SSO. ](/docs/images/cdy7uua7fh8z/OktaDB-EnterpriseConnections.png)</Frame>
+</Accordion>
 
-**3. Create application (truncated)**
-
+<Accordion title="3. Create application (truncated)">
 <Frame>![The second step of the self-service assistant that customer admins use to configure SSO. ](/docs/images/cdy7uua7fh8z/Self-Service-SSO-create-application.png)</Frame>
+</Accordion>
 
-**4. Configure connection**
-
+<Accordion title="4. Configure connection">
 <Frame>![The third step of the self-service assistant that customer admins use to configure SSO. ](/docs/images/cdy7uua7fh8z/Self-Service-SSO-configure-connection.png)</Frame>
+</Accordion>
 
-**5. Claims mapping**
-
+<Accordion title="5. Claims mapping">
 <Frame>![The fourth step of the self-service assistant that customer admins use to configure SSO. ](/docs/images/cdy7uua7fh8z/Self-Service-SSO-claims-mapping.png)</Frame>
+</Accordion>
 
-**6. Assign access**
-
+<Accordion title="6. Assign access">
 <Frame>![The fifth step of the self-service assistant that customer admins use to configure SSO. ](/docs/images/cdy7uua7fh8z/Self-Service-SSO-assign-access.png)</Frame>
+</Accordion>
 
-**7. Test SSO**
-
+<Accordion title="7. Test SSO">
 <Frame>![The sixth step of the self-service assistant that customer admins use to configure SSO. ](/docs/images/cdy7uua7fh8z/Self-Service-SSO-Test-SSO.png)</Frame>
+</Accordion>
 
-**8. Provisioning - Create application**
-
+<Accordion title="8. Provisioning - Create application">
 <Frame>![Create an application to provision users.](/docs/images/cdy7uua7fh8z/Self-Service-SSO-Provisioning-Create-App.png)</Frame>
+</Accordion>
 
-**9. Provisioning - Configure SCIM**
-
+<Accordion title="9. Provisioning - Configure SCIM">
 <Frame>![Confgure SCIM to provision users to your application.](/docs/images/cdy7uua7fh8z/Self-Service-SSO-Provisioning-configure-scim.png)</Frame>
+</Accordion>
 
-**10. Provisioning - SCIM mapping**
-
+<Accordion title="10. Provisioning - SCIM mapping">
 <Frame>![Map user attributes to guarantee attributes are passed from IdP to SP.](/docs/images/cdy7uua7fh8z/Self-Service-SSO-Provisioning-SCIM-mapping.png)</Frame>
+</Accordion>
 
-**11. Domain verification**
-
+<Accordion title="11. Domain verification">
 <Frame>![The last step of the self-service assistant that customer admins use to configure SSO. ](/docs/images/cdy7uua7fh8z/Self-Service-SSO-domain-verification.png)</Frame>
-
-## Using Self-Service Enterprise Configuration
-
-To learn how you can use Self-Service Enterprise Configuration for your customers, review [Manage Self-Service Enterprise Configuration](/docs/authenticate/enterprise-connections/self-service-enterprise-configuration/manage-self-service-enterprise-config). This resource provides technical information for creating self-service profiles and managing access tickets, as well as useful reference information such as rate limits.
+</Accordion>
+</AccordionGroup>

--- a/main/docs/authenticate/identity-providers.mdx
+++ b/main/docs/authenticate/identity-providers.mdx
@@ -1,25 +1,10 @@
 ---
-description: Learn about types of identity providers supported by Auth0.
-sidebarTitle: Overview
 title: Identity Providers
+description: An introduction to sources of users for applications, including identity providers, databases, and passwordless authentication methods.
 ---
-Introduction to the various sources of users for applications, including <Tooltip tip="Identity Provider (IdP): Service that stores and manages digital identities." cta="View Glossary" href="/docs/glossary?term=identity+providers">identity providers</Tooltip>, databases, and <Tooltip tip="Identity Provider (IdP): Service that stores and manages digital identities." cta="View Glossary" href="/docs/glossary?term=passwordless">passwordless</Tooltip> authentication methods.
 
-A connection is the relationship between Auth0 and a source of users, which may include external Identity Providers (such as Google or LinkedIn), databases, or passwordless authentication methods. Auth0 sits between your application and its sources of users, which adds a level of abstraction, so your application is isolated from any changes to and idiosyncrasies of each source's implementation.
+A connection is the relationship between Auth0 and a source of users, which may include external identity providers (such as Google or LinkedIn), databases, or passwordless authentication methods. Auth0 sits between your application and its sources of users, which adds a level of abstraction, so your application is isolated from any changes to and idiosyncrasies of each source's implementation.
 
 By default, Auth0 automatically syncs user profile data with each user login, thereby ensuring that changes made in the connection source are automatically updated in Auth0. You can disable synchronization to allow for updating profile attributes from your application.
 
 You can configure any number of connections for your applications.
-
-| Read... | To learn... |
-| --- | --- |
-| [Social Identity Providers](/docs/authenticate/identity-providers/social-identity-providers) | About the external social Identity Providers supported by Auth0. |
-| [Enterprise Identity Providers](/docs/authenticate/identity-providers/enterprise-identity-providers) | About the external enterprise Identity Providers supported by Auth0. |
-| [Legal Identity Providers](/docs/authenticate/identity-providers/legal) | About the external legal Identity Providers supported by Auth0. |
-| [Pass Parameters to Identity Providers](/docs/authenticate/identity-providers/pass-parameters-to-idps) | How to pass provider-specific parameters to an Identity Provider during authentication. |
-| [Call an Identity Provider API](/docs/authenticate/identity-providers/calling-an-external-idp-api) | How to call an external Identity Provider's API. |
-| [Add Scopes/Permissions to Call Identity Provider APIs](/docs/authenticate/identity-providers/adding-scopes-for-an-external-idp) | How to work with scopes when calling an external Identity Provider's API. |
-| [View Connections](/docs/authenticate/identity-providers/view-connections) | How to view the configured connections for your application using the Auth0 Dashboard. |
-| [Retrieve Connection Options](/docs/authenticate/identity-providers/retrieve-connection-options) | How to retrieve the options object for a connection using Auth0's Management API. |
-| [Promote Connections to Domain Level](/docs/authenticate/identity-providers/promote-connections-to-domain-level) | How to allow third-party applications to use a connection when your tenant has Dynamic Client Registration enabled. |
-| [Test Partner Connections](/docs/authenticate/identity-providers/test-connections) | How partners can test connections. |

--- a/main/docs/authenticate/identity-providers/okta.mdx
+++ b/main/docs/authenticate/identity-providers/okta.mdx
@@ -1,7 +1,7 @@
 ---
-description: Learn how to connect to Okta as an OpenID Connect (OIDC) Identity Provider using an enterprise connection.
-sidebarTitle: Overview
 title: Connect Your Auth0 Application with Okta Workforce Enterprise Connection
+sidebarTitle: Connect Auth0 Apps to Okta
+description: Learn how to connect to Okta as an OpenID Connect (OIDC) Identity Provider using an enterprise connection.
 ---
 The Okta Workforce Enterprise connection is an officially-supported, streamlined integration, and the preferred method to implement Okta as an <Tooltip tip="Identity Provider (IdP): Service that stores and manages digital identities." cta="View Glossary" href="/docs/glossary?term=Identity+Provider">Identity Provider</Tooltip> (IdP) in Auth0.
 

--- a/main/docs/authenticate/identity-providers/social-identity-providers.mdx
+++ b/main/docs/authenticate/identity-providers/social-identity-providers.mdx
@@ -1,50 +1,20 @@
 ---
-description: Learn about the social identity providers supported by Auth0.
-sidebarTitle: Overview
 title: Social Identity Providers
+description: Learn about the social identity providers supported by Auth0.
 ---
-Auth0 supports social login for both web-based and native applications. Social login is a method of authentication that allows users to log in to an application using existing credentials from a social <Tooltip tip="Identity Provider (IdP): Service that stores and manages digital identities." cta="View Glossary" href="/docs/glossary?term=identity+provider">identity provider</Tooltip>, such as Google or Facebook. This is separate from connecting and authorizing applications for an external provider, allowing them to access external APIs on the user’s behalf. To learn more, read [User authentication vs Connected Accounts](/docs/secure/tokens/token-vault/connected-accounts-for-token-vault#user-authentication-vs-connected-accounts).
 
-As users frequently have their social credentials stored in their browser or device, social login provides a frictionless user experience that requires minimal manual interaction with an application.
+Social login is a method of authentication that allows users to log in to an application using existing credentials from a social <Tooltip tip="Identity Provider (IdP): Service that stores and manages digital identities." cta="View Glossary" href="/docs/glossary?term=identity+provider">identity provider</Tooltip>, such as Google or Facebook. As users frequently have their social credentials stored in their browser or device, social login provides a frictionless user experience that requires minimal manual interaction with an application.
 
-The sections below outline the social login options available for both web-based and native applications.
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+User authentication is separate from connecting and authorizing applications for an external provider, allowing them to access external APIs on the user’s behalf. To learn more, read [User authentication vs Connected Accounts](/docs/secure/tokens/token-vault/connected-accounts-for-token-vault#user-authentication-vs-connected-accounts).
+</Callout>
 
-## Web-based applications
+Auth0 supports social login for both web-based and native applications. You can review the list of supported social identity providers on the [Auth0 Marketplace](https://marketplace.auth0.com/categories/social-login) or the <Tooltip tip="Auth0 Dashboard: Auth0's main product to configure your services." cta="View Glossary" href="/docs/glossary?term=Auth0+Dashboard">Auth0 Dashboard</Tooltip>:
 
-Auth0 supports a variety of social identity providers for web-based applications. Implementing social login with one or more of these providers allows you to gather up-to-date information about your users while simultaneously offering them a streamlined authentication experience.
+* The [Auth0 Marketplace's Social Login category](https://marketplace.auth0.com/categories/social-login) provides information for each supported social connection. You can use the **Add Integration** button to launch the configuration process in your Auth0 tenant and the **Installation** tab to review implementation documentation.
 
-You can review the list of supported social identity providers on the [Auth0 Marketplace](https://marketplace.auth0.com/categories/social-login) or the <Tooltip tip="Auth0 Dashboard: Auth0's main product to configure your services." cta="View Glossary" href="/docs/glossary?term=Auth0+Dashboard">Auth0 Dashboard</Tooltip>. If a particular provider is not available, you can also configure custom social connections. To learn more, review [Connect Apps to Generic OAuth2 Authorization Servers](/docs/authenticate/identity-providers/social-identity-providers/oauth2).
-
-<Tabs><Tab title="Auth0 Marketplace">
-
-The [Social Login](https://marketplace.auth0.com/categories/social-login) section of the Auth0 Marketplace provides information for each supported social connection. To learn more about a specific provider, select the option from the list.
-
-From there, you can use the **Add Integration** button to launch the configuration process in your Auth0 tenant and the **Installation** tab to review implementation documentation. For a successful implementation, ensure you [register developer keys](/docs/authenticate/identity-providers/social-identity-providers/devkeys) for your selected provider.
-
-</Tab><Tab title="Auth0 Dashboard">
-
-To implement social login from the Auth0 Dashboard, navigate to [Authentication > Social](https://manage.auth0.com/#/connections/social) and select **Create Connection**. Then, choose a connection option from the list of supported social identity providers.
-
-After selecting an option from the list, the configuration process launches. Follow the prompts to configure your selected provider.
-
-For assistance, select the **Setup Guide** button to the top right to open relevant implementation documentation in a popup. The setup guide contains information on the necessary steps to configure the connection and links to relevant documentation from the social identity provider.
+* From [Auth0 Dashboard > Authentication > Social](https://manage.auth0.com/#/connections/social), select **Create Connection** to see a list of supported social identity providers. The **Setup Guide** has steps to configure the connection and links to relevant documentation from the social identity provider.
 
 For a successful implementation, ensure you [register developer keys](/docs/authenticate/identity-providers/social-identity-providers/devkeys) for your selected provider.
 
-You can also access the Auth0 Marketplace through the Auth0 Dashboard. Navigate to [Marketplace](https://manage.auth0.com/#/marketplace) on the main menu and choose the **Social Login** category. From there, you can review and implement connections with any of the available social identity providers.
-
-</Tab></Tabs>
-
-Auth0 also provides detailed setup guides for the following social providers:
-
-* [GitHub](/docs/authenticate/identity-providers/social-identity-providers/github)
-* [Google](/docs/authenticate/identity-providers/social-identity-providers/google)
-
-## Native applications
-
-Auth0 supports social login with select providers for native applications. To learn more, review the resources below:
-
-* [Apple](/docs/authenticate/identity-providers/social-identity-providers/apple-native)
-* [Facebook](/docs/authenticate/identity-providers/social-identity-providers/facebook-native)
-* [Google](/docs/authenticate/identity-providers/social-identity-providers/google-native)
-* [TikTok](/docs/authenticate/identity-providers/social-identity-providers/tiktok)
+If a particular provider is not available, you can also [configure custom social connections](/docs/authenticate/identity-providers/social-identity-providers/oauth2).

--- a/main/docs/authenticate/login.mdx
+++ b/main/docs/authenticate/login.mdx
@@ -1,28 +1,13 @@
 ---
+title: Login Authentication on Auth0
+sidebarTitle: Login
 description: Learn about the ways to implement login authentication for your users with Auth0 Universal Login or Embedded Login.
-sidebarTitle: Overview
-title: Login
 ---
+
 Auth0 offers two ways to implement login authentication for your applications:
 
 * **<Tooltip tip="Universal Login: Your application redirects to Universal Login, hosted on Auth0's Authorization Server, to verify a user's identity." cta="View Glossary" href="/docs/glossary?term=Universal+Login">Universal Login</Tooltip>** where users log in to your application through a page hosted by Auth0.
+
 * **Embedded Login** where users log in to your application through a page you host.
 
-For the vast majority of use cases, we recommend Universal Login. It's safe and easy to implement.
-
-| Read... | To learn... |
-| --- | --- |
-| [Universal Login](/docs/authenticate/login/auth0-universal-login) | What is Universal Login. |
-| [Universal vs. Embedded Login](/docs/authenticate/login/universal-vs-embedded-login) | What the differences are between Universal Login and Embedded Login. |
-| [Embedded Login](/docs/authenticate/login/embedded-login) | How Embedded Login works. |
-| [Cross-Origin Authentication](/docs/authenticate/login/cross-origin-authentication) | About the cross-origin authentication flow using third-party cookies. |
-| [Silent Authentication](/docs/authenticate/login/configure-silent-authentication) | How to keep users logged in to your application using silent authentication. |
-| [Redirect After Login](/docs/authenticate/login/redirect-users-after-login) | How to redirect users to URLs after login. |
-| [Logout](/docs/authenticate/login/logout) | How logging out works with Auth0. |
-| [Adopt OIDC Conformant Auth](/docs/authenticate/login/oidc-conformant-authentication) | What the OIDC-conformant application setting is and its effect on the authentication pipeline. |
-
-You can also use Client-Initiated Backchannel Authentication to authenticate users with a decoupled authentication flow:
-
-| Read... | To Learn... |
-| --- | --- |
-| [Client-Initiated Backchannel Authentication Flow](/docs/get-started/authentication-and-authorization-flow/client-initiated-backchannel-authentication-flow) | How to build a decoupled authentication flow. |
+For the vast majority of use cases, we recommend Universal Login, but you can also use Client-Initiated Backchannel Authentication to authenticate users with a decoupled authentication flow.

--- a/main/docs/authenticate/login/auth0-universal-login.mdx
+++ b/main/docs/authenticate/login/auth0-universal-login.mdx
@@ -1,7 +1,6 @@
 ---
-description: Describes how Auth0 Universal Login provides you with the means to prove your users' identities with our authorization server.
-sidebarTitle: Overview
 title: Auth0 Universal Login
+description: Universal Login provides you with the means to prove your users' identities with our authorization server.
 ---
 import {AuthCodeBlock} from "/snippets/AuthCodeBlock.jsx";
 import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
@@ -109,11 +108,3 @@ To learn more, read [Correlation ID](/docs/authenticate/login/configure-correlat
 ### Use the Quickstart guides
 
 For more information on how you can set up Universal Login for your application, review the [Quickstart guides](/docs/quickstarts). Choose the approach that best fits your technologies and follow the Quickstart for a walkthrough of the implementation.
-
-## Learn more
-
-* [Hosted Login vs. Embedded Login](/docs/authenticate/login/universal-vs-embedded-login)
-* [Universal Login Experience](/docs/authenticate/login/auth0-universal-login/universal-login-vs-classic-login/universal-experience)
-* [Classic Login Experience](/docs/authenticate/login/auth0-universal-login/universal-login-vs-classic-login/classic-experience)
-* [Universal Login vs. Classic Login](/docs/authenticate/login/auth0-universal-login/universal-login-vs-classic-login)
-* [Universal Login Internationalization](/docs/customize/internationalization-and-localization/universal-login-internationalization)

--- a/main/docs/authenticate/login/auth0-universal-login/passwordless-login.mdx
+++ b/main/docs/authenticate/login/auth0-universal-login/passwordless-login.mdx
@@ -1,11 +1,10 @@
 ---
-description: Learn how to configure your login page to use passwordless authentication using the Auth0 Dashboard.
 title: Configure Universal Login with Passwordless
+description: Learn how to configure your login page to use passwordless authentication using the Auth0 Dashboard.
 ---
+
 <Card title="Availability varies by Auth0 plan">
-
 Your Auth0 plan or custom agreement affects whether this feature is available. To learn more, read [Pricing](https://auth0.com/pricing).
-
 </Card>
 
 <Tooltip tip="Universal Login: Your application redirects to Universal Login, hosted on Auth0's Authorization Server, to verify a user's identity." cta="View Glossary" href="/docs/glossary?term=Universal+Login">Universal Login</Tooltip> is Auth0's implementation of the authentication flow, which is the key feature of an <Tooltip tip="Authorization Server: Centralized server that contributes to defining the boundaries of a user’s access. For example, your authorization server can control the data, tasks, and features available to a user." cta="View Glossary" href="/docs/glossary?term=Authorization+Server">Authorization Server</Tooltip>. Each time a user needs to prove their identity, your applications redirect to Universal Login and Auth0 guarantees the user's identity. You can choose to enable <Tooltip tip="Passwordless: Form of authentication that does not rely on a password as the first factor." cta="View Glossary" href="/docs/glossary?term=Passwordless">Passwordless</Tooltip> authentication when you configure Universal Login in the <Tooltip tip="Auth0 Dashboard: Auth0's main product to configure your services." cta="View Glossary" href="/docs/glossary?term=Auth0+Dashboard">Auth0 Dashboard</Tooltip>.
@@ -23,8 +22,3 @@ When using WebAuthn with Device Biometrics, users will be able to authenticate w
 Each time they login from a new device, Auth0 will offer them the option to use biometrics instead of a password. To learn more, read [Passwordless with WebAuthn with Device Biometrics](/docs/authenticate/login/auth0-universal-login/passwordless-login/webauthn-device-biometrics).
 
 <Frame>![Example of setting up a Face ID login for specific domain using WebAuthn](/docs/images/cdy7uua7fh8z/1JfsIYEo3O7xmTAxLRwNSs/2f2ba478ff32b0aa86f4f01cd6c0cf3b/2023-01-31_16-34-09.png)</Frame>
-
-## Learn more
-
-* [Configure Email or SMS for Passwordless Authentication](/docs/authenticate/login/auth0-universal-login/passwordless-login/email-or-sms)
-* [Configure WebAuthn with Device Biometrics for Passwordless Authentication](/docs/authenticate/login/auth0-universal-login/passwordless-login/webauthn-device-biometrics)

--- a/main/docs/authenticate/login/auth0-universal-login/universal-login-vs-classic-login.mdx
+++ b/main/docs/authenticate/login/auth0-universal-login/universal-login-vs-classic-login.mdx
@@ -1,16 +1,14 @@
 ---
-description: Compares features available in the Universal Login and Classic Login experiences
-sidebarTitle: Overview
 title: Universal Login vs. Classic Login
+description: Compares features available in the Universal Login and Classic Login experiences
 ---
+
 [Auth0 Universal Login](/docs/authenticate/login/auth0-universal-login) provides the essential feature of an <Tooltip tip="Authorization Server: Centralized server that contributes to defining the boundaries of a user’s access. For example, your authorization server can control the data, tasks, and features available to a user." cta="View Glossary" href="/docs/glossary?term=authorization+server">authorization server</Tooltip>: the login flow. When a user needs to prove their identity to gain access to your application, you can redirect them to <Tooltip tip="Authorization Server: Centralized server that contributes to defining the boundaries of a user’s access. For example, your authorization server can control the data, tasks, and features available to a user." cta="View Glossary" href="/docs/glossary?term=Universal+Login">Universal Login</Tooltip> and let Auth0 handle the authentication process.
 
 Universal Login is Auth0's primary hosted login solution. [Universal Login](/docs/authenticate/login/auth0-universal-login/universal-login-vs-classic-login/universal-experience) features easy-to-use customization tools and promotes a simpler, faster experience for end-users. Alternatively, Auth0 also supports [Classic Login](/docs/authenticate/login/auth0-universal-login/universal-login-vs-classic-login/classic-experience), a hosted login experience that uses JavaScript controls for customization.
 
 <Warning>
-
 At this time, Auth0’s active development efforts are focused on Universal Login, and Classic Login no longer receives updates. Unless your specific use case requires the Classic experience, implementing Universal Login is recommended.
-
 </Warning>
 
 To help you choose the best solution for your needs, the table below compares the features of both login experiences.
@@ -42,9 +40,3 @@ To help you choose the best solution for your needs, the table below compares th
 | **Custom URLs for password reset and user signup** | Yes, using page templates **and** a custom-built password reset or signup page | [Yes](/docs/libraries/lock/lock-configuration#forgotpasswordlink-string-) |
 | **Kerberos support for AD/LDAP connections** | No | [Yes](/docs/authenticate/identity-providers/enterprise-identity-providers/active-directory-ldap/ad-ldap-connector/configure-ad-ldap-connector-with-kerberos#auto-login-with-lock) |
 | **Requires exposing identity provider domains in a public endpoint** | No | [Yes](/docs/get-started/tenant-settings#advanced) |
-
-## Learn more
-
-* [Universal Login Experience](/docs/authenticate/login/auth0-universal-login/universal-login-vs-classic-login/universal-experience)
-* [Classic Login Experience](/docs/authenticate/login/auth0-universal-login/universal-login-vs-classic-login/classic-experience)
-* [Hosted Login vs. Embedded Login](/docs/authenticate/login/universal-vs-embedded-login)

--- a/main/docs/authenticate/login/logout.mdx
+++ b/main/docs/authenticate/login/logout.mdx
@@ -1,32 +1,19 @@
 ---
-description: Describes how logout works with Auth0.
-sidebarTitle: Overview
-title: Logout
+title: How Logout Works on Auth0
+sidebarTitle: Logout
+description: You can log a user out of the Auth0 session and (optionally) from the IdP session, and redirect users after logout.
 ---
-<Card title="Overview">
 
-Key Concepts
+## Logout Session Layers
 
-* Review different session layers.
-* Learn how to redirect users after logout.
-
-</Card>
-
-You can log a user out of the Auth0 session and (optionally) from the <Tooltip tip="Identity Provider (IdP): Service that stores and manages digital identities." cta="View Glossary" href="/docs/glossary?term=identity+provider">identity provider</Tooltip> (IdP) session. When you're implementing the logout functionality, there are typically three-session layers you need to consider:
+When you're implementing the logout functionality, there are typically three-session layers you need to consider:
 
 1. **Application Session Layer**: The first layer is the session inside your application. Though your application uses Auth0 to authenticate users, you'll still need to track that the user has logged in to your application. In a regular web application, you achieve this by storing information inside a cookie. [Log users out of your applications](/docs/authenticate/login/logout/log-users-out-of-applications) by clearing their sessions. You should handle the application session in your application.
+
 2. **Auth0 Session Layer**: Auth0 also maintains a session for the user and stores their information inside a cookie. The next time a user is redirected to the Auth0 Lock screen, the user's information will be remembered. [Log users out of Auth0](/docs/authenticate/login/logout/log-users-out-of-auth0) by clearing the Single Sign-on (SSO) cookie.
+
 3. **Identity Provider Session Layer**: The last session layer is the identity provider layer (for example, Facebook or Google). When users attempt to sign in with any of these providers and they are already signed into the provider, they will not be prompted again to sign in. The users may be asked to give permission to share their information with Auth0 and, in turn, your application. It is not necessary to log the users out of this session layer, but you can force the logout. (For more information, see [Log Users Out of Identity Providers](/docs/authenticate/login/logout/log-users-out-of-idps) and [Log Users Out of SAML Identity Providers](/docs/authenticate/login/logout/log-users-out-of-saml-idps).)
 
 ## Redirect users after logout
 
 After users log out, you can [redirect users](/docs/authenticate/login/logout/redirect-users-after-logout) to a specific URL. You need to register the redirect URL in your tenant or application settings. Auth0 only redirects to URLs from the allow list after logout. If you need different redirects for each application, you can add the URLs to your allow list in your application settings.
-
-## Learn more
-
-* [Log Users Out of Applications](/docs/authenticate/login/logout/log-users-out-of-applications)
-* [Log Users Out of Auth0 with OIDC Endpoint](/docs/authenticate/login/logout/log-users-out-of-auth0)
-* [Log Users Out of Identity Providers](/docs/authenticate/login/logout/log-users-out-of-idps)
-* [Log Users Out of SAML Identity Providers](/docs/authenticate/login/logout/log-users-out-of-saml-idps)
-* [Redirect Users with Alternative Logout](/docs/authenticate/login/logout/redirect-users-after-logout)
-* [Check Login and Logout Issues](/docs/troubleshoot/authentication-issues/check-login-and-logout-issues)

--- a/main/docs/authenticate/login/logout/back-channel-logout.mdx
+++ b/main/docs/authenticate/login/logout/back-channel-logout.mdx
@@ -1,7 +1,8 @@
 ---
-description: Describes Auth0's OIDC Back-Channel Logout feature.
 title: OIDC Back-Channel Logout
+description: Describes Auth0's OIDC Back-Channel Logout feature.
 ---
+
 Auth0 supports the [OpenID Connect Back-Channel Logout 1.0 specification](https://openid.net/specs/openid-connect-backchannel-1_0.html#Backchannel) in all tenants with an Enterprise plan subscription.
 
 This specification leverages the session ID (`sid`) included in <Tooltip tip="ID Token: Credential meant for the client itself, rather than for accessing a resource." cta="View Glossary" href="/docs/glossary?term=ID+tokens">ID tokens</Tooltip> and the Logout Tokens to coordinate session termination via back-channel communication. Different session IDs represent individual sessions of a user agent or device in your tenant. Logout Tokens identify the end-user and session to logout.
@@ -11,9 +12,7 @@ This specification leverages the session ID (`sid`) included in <Tooltip tip="ID
 To use Back-Channel Logout, an application must expose a Back-Channel Logout URI, reachable from the tenant server, where the application expects to receive the requests with the Logout Token. When an application receives this request, it is compelled to clear the local session state matching the claims in the token.
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-
 For back-channel logout to work, applications must be able to receive back-channel communications.
-
 </Callout>
 
 ### Tokens in OIDC Back-Channel Logout communications
@@ -30,9 +29,7 @@ When end-users successfully authenticate with Auth0 during login, the <Tooltip t
 4. Logout - The application’s backend needs to validate the Logout Token as per OIDC spec and extract the `sid`. Then the backend can use this token to find the session associated with the identifier and terminate it as necessary.
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-
 The expected response is `HTTP 200` for successful logout. If you receive `HTTP 400`, an incorrect or misunderstood request, you can use our tips to troubleshoot. To learn more, read [Configure Back-Channel Logout](/docs/authenticate/login/logout/back-channel-logout/configure-back-channel-logout).
-
 </Callout>
 
 ### How it works
@@ -45,7 +42,6 @@ The sample use case demonstrates how Back-Channel Logout works with more than on
 2. During application configuration, Application B registers a Back-Channel Logout URI with Auth0.
 
    <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-
    OIDC Back-Channel Logout URLs must:
 
    * Be accessible from the IdP
@@ -87,11 +83,6 @@ Once your application validates and decodes your token, the contents are similar
 }
 ```
 
-
-
-
-
-
 ### Auth0 SDKs
 
 A full example and production code is already included under the **Back-Channel Logout Example** section of our [express-openid-connect SDK](https://github.com/auth0/express-openid-connect/blob/master/EXAMPLES.md#11-back-channel-logout).
@@ -105,14 +96,10 @@ The session storage example is built in Node (Express) and based on the [Express
 In your application sessions tab, expose the route you configured to receive the Logout Token. Validate the token and terminate the user session.
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-
 This example uses an in-memory session store for demonstration purposes.
-
 </Callout>
 
-**routes/index.js**
-
-```javascript JavaScript lines expandable
+```javascript routes/index.js lines expandable
 const express = require('express');
 const router = express.Router();
 const { requiresAuth } = require('express-openid-connect');
@@ -168,13 +155,7 @@ module.exports = router;
 ```
 
 
-
-
-
-
-**middlewares/validateLogoutToken.js**
-
-```javascript JavaScript lines expandable
+```javascript middlewares/validateLogoutToken.js lines expandable
 // This middleware validates the logout token as defined here:
 // https://openid.net/specs/openid-connect-backchannel-1_0.html#Validation
 
@@ -244,11 +225,6 @@ async function requiresValidLogoutToken(req, res, next) {
 module.exports = requiresValidLogoutToken;
 ```
 
-
-
-
-
-
 ### Logout token store
 
 A common approach for token storage is to define a logout store as an alternative to the session store model. Your application(s) keeps a collection of Logout Tokens in the persistence level.
@@ -270,12 +246,3 @@ Back-Channel Logout Tokens are delivered over the internet, therefore the callba
 * Apps are recommended to follow the general best practices in terms of monitoring, logging and rate limiting - however details of these are outside of scope of this document.
 * Apps are recommended to regularly clean stale or expired sessions.
 * Any changes in the endpoint address must be synchronised with the tenant configuration in order to ensure the Logout Tokens are always delivered to the correct Back-Channel Logout Callback URL.
-
-## Learn more
-
-* [Configure OIDC Back-Channel Logout](/docs/authenticate/login/logout/back-channel-logout/configure-back-channel-logout)
-* [Check Login and Logout Issues](/docs/troubleshoot/authentication-issues/check-login-and-logout-issues)
-* [Log Users Out of SAML Identity Providers](/docs/authenticate/login/logout/log-users-out-of-saml-idps)
-* [Log Users Out of Auth0 with OIDC Endpoint](/docs/authenticate/login/logout/log-users-out-of-auth0)
-* [Log Users Out of Applications](/docs/authenticate/login/logout/log-users-out-of-applications)
-* [Log Users Out of Identity Providers](/docs/authenticate/login/logout/log-users-out-of-idps)

--- a/main/docs/authenticate/login/universal-vs-embedded-login.mdx
+++ b/main/docs/authenticate/login/universal-vs-embedded-login.mdx
@@ -1,7 +1,8 @@
 ---
-description: Describes the differences between hosted login (Universal Login) and embedded login.
 title: Hosted Login vs. Embedded Login
+description: Describes the differences between hosted login (Universal Login) and embedded login.
 ---
+
 When you design the login experience for your application, you’ll need to decide if you want it to be hosted ([Universal Login](/docs/authenticate/login/auth0-universal-login)) or embedded.
 
 ## Hosted login
@@ -39,8 +40,3 @@ For web applications, embedded login uses [cross-origin authentication](/docs/au
 ## Best practice
 
 According to [RFC 8252: OAuth 2.0 for Native Apps on IETF](https://www.rfc-editor.org/rfc/rfc8252.txt), only external user-agents (such as the browser) should be used by native applications for authentication flows.
-
-## Learn more
-
-* [Prevent Common Cybersecurity Threats](/docs/secure/security-guidance/prevent-threats)
-* [Troubleshoot Custom Domains](/docs/troubleshoot/integration-extensibility-issues/troubleshoot-custom-domains)

--- a/main/docs/authenticate/passwordless.mdx
+++ b/main/docs/authenticate/passwordless.mdx
@@ -1,7 +1,9 @@
 ---
+title: Passwordless Authentication on Auth0
+sidebarTitle: Passwordless
 description: Learn about the available methods of passwordless authentication supported by Auth0.
-title: Passwordless Authentication
 ---
+
 <Tooltip tip="Passwordless: Form of authentication that does not rely on a password as the first factor." cta="View Glossary" href="/docs/glossary?term=Passwordless">Passwordless</Tooltip> authentication provides users with a seamless and more secure login experience. As technology advances, traditional methods of authentication, such as usernames and passwords, become more prone to cyber attacks (like phishing or keylogging) and potential breaches.
 
 With passwordless authentication, users no longer need to remember or manually enter a password to access an application. Instead, they can use a variety of authentication methods that rely on time-based access links and tokens, stored passkeys, biometrics, or social accounts.
@@ -28,9 +30,7 @@ A passwordless connection is a distinct connection type from database, social, o
 Even though a user from an Auth0 user database or social provider might share the same email address, the identity associated with their passwordless connection is distinct. [Account linking](/docs/manage-users/user-accounts/user-account-linking) can be used to associate passwordless connection identities with other connection identities.
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-
 You cannot create passwordless users from the Auth0 Dashboard. Create them directly from the [Management API](https://auth0.com/docs/api/management/v2/users/post-users) if signup is disabled. In the Connection field, use email for passwordless users using an email address and SMS for passwordless users using a mobile phone number.
-
 </Callout>
 
 ## Social Login
@@ -91,13 +91,11 @@ To learn more about configuring SMS-based passwordless authentication for differ
 * [Passwordless Authentication with Embedded Login](/docs/authenticate/passwordless/implement-login/embedded-login)
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-
 This category of passwordless authentication is currently treated as a unique connection type in your tenant, separate from other database, social, or enterprise connections.
 
 When a user authenticates with this method, their profile is created on the passwordless connection using Auth0 as the Identity Provider (IdP). As you cannot ensure users will log in with the same email or phone number every time, users may end up with multiple user profiles in the Auth0 datastore. If duplicates are created, you can associate multiple user profiles by [linking their accounts](/docs/manage-users/user-accounts/user-account-linking).
 
 In some scenarios, a user profile created through this type of passwordless connection may share an identifier (such as email or phone number) with a profile associated with another type of connection, such as enterprise or social. If this occurs, you can use [account linking](/docs/manage-users/user-accounts/user-account-linking) to associate passwordless profiles with identities from other connections.
-
 </Callout>
 
 ## Email-Based Passwordless Authentication
@@ -108,13 +106,11 @@ Email-based passwordless authentication encompasses two methods:
 * [Magic links](#magic-links)
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-
 This category of passwordless authentication is currently treated as a unique connection type in your tenant, separate from other database, social, or enterprise connections.
 
 When a user authenticates with this method, their profile is created on the passwordless connection using Auth0 as the Identity Provider (IdP). As you cannot ensure users will log in with the same email or phone number every time, users may end up with multiple user profiles in the Auth0 datastore. If duplicates are created, you can associate multiple user profiles by [linking their accounts](/docs/manage-users/user-accounts/user-account-linking).
 
 In some scenarios, a user profile created through this type of passwordless connection may share an identifier (such as email or phone number) with a profile associated with another type of connection, such as enterprise or social. If this occurs, you can use [account linking](/docs/manage-users/user-accounts/user-account-linking) to associate passwordless profiles with identities from other connections.
-
 </Callout>
 
 ### One-time passwords
@@ -154,9 +150,7 @@ Magic links can only be implemented in Classic Login. To learn more, review the 
 Biometrics is a method of passwordless authentication that uses an individual’s physical attributes to verify their identity and grant them access to an application. Auth0 currently supports biometric authentication using fingerprint scans and facial recognition.
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-
 While Auth0 still supports the legacy Identifier First with Biometrics authentication method, it is strongly recommended that you use [passkey-based authentication](/docs/authenticate/passwordless#passkeys) instead.
-
 </Callout>
 
 To implement biometrics for your application, the following configurations are required:
@@ -176,8 +170,3 @@ The general workflow for biometric authentication is as follows:
 After the user enrolls their device, they can use biometrics as their primary method of authentication upon subsequent logins to your application.
 
 To learn more about biometric authentication, review [Configure WebAuthn with Device Biometrics for Passwordless Authentication](/docs/authenticate/login/auth0-universal-login/passwordless-login/webauthn-device-biometrics).
-
-## Learn more
-
-* [Passwordless Connections Best Practices](/docs/authenticate/passwordless/best-practices)
-* [Using Passwordless APIs](/docs/authenticate/passwordless/implement-login/embedded-login/relevant-api-endpoints)

--- a/main/docs/authenticate/passwordless/authentication-methods.mdx
+++ b/main/docs/authenticate/passwordless/authentication-methods.mdx
@@ -1,7 +1,9 @@
 ---
-description: Describes the various authentication methods supported by Auth0 passwordless connections, including email, magic link, and SMS.
-title: Passwordless Authentication Methods
+title: Passwordless Authentication Methods on Auth0
+sidebarTitle: Authentication Methods
+description: Describes authentication methods supported by Auth0 passwordless connections, including email, magic link, and SMS.
 ---
+
 With <Tooltip tip="Passwordless: Form of authentication that does not rely on a password as the first factor." cta="View Glossary" href="/docs/glossary?term=Passwordless">Passwordless</Tooltip> connections, users can log in without a password. Instead, they can use a variety of other authentication methods. Auth0 Passwordless connections support the following authentication methods:
 
 | Factor | Description |

--- a/main/docs/authenticate/passwordless/implement-login.mdx
+++ b/main/docs/authenticate/passwordless/implement-login.mdx
@@ -1,7 +1,9 @@
 ---
-description: Describes the available methods for implementing passwordless login with Auth0.
 title: Implement Login with Passwordless
+sidebarTitle: Implement Login
+description: Describes the available methods for implementing passwordless login with Auth0.
 ---
+
 You can implement <Tooltip tip="Passwordless: Form of authentication that does not rely on a password as the first factor." cta="View Glossary" href="/docs/glossary?term=passwordless">passwordless</Tooltip> login using either [hosted login](/docs/authenticate/passwordless/implement-login/universal-login) or [embedded login](/docs/authenticate/passwordless/implement-login/embedded-login).
 
 To learn more about the differences between these two options, read [Hosted Login vs. Embedded Login](/docs/authenticate/login/universal-vs-embedded-login).

--- a/main/docs/authenticate/passwordless/implement-login/embedded-login.mdx
+++ b/main/docs/authenticate/passwordless/implement-login/embedded-login.mdx
@@ -1,19 +1,14 @@
 ---
-description: Describes how to implement Passwordless authentication with Universal Login.
 title: Passwordless Authentication with Embedded Login
+description: Describes how to implement Passwordless authentication with Universal Login.
 ---
-If you'd like to embed the login user interface in your application, you can do it by using our [Embedded Passwordless API](/docs/authenticate/passwordless/implement-login/embedded-login/relevant-api-endpoints) or our SDKs.
 
-Depending on the kind of application you want to build, you'll need to implement it differently:
+To embed the login user interface in your application, you can use our [Embedded Passwordless API](/docs/authenticate/passwordless/implement-login/embedded-login/relevant-api-endpoints) or our SDKs.
+
+Depending on the kind of application you want to build, you need to implement it differently:
 
 * For Single Page Applications (SPAs) (for example, Angular or React), read [Embedded Passwordless Authentication for Single-page Applications (SPA)](/docs/authenticate/passwordless/implement-login/embedded-login/spa).
 * For Native applications (for example, iOS, Android, or desktop applications), read [Embedded Passwordless Login in Native Applications](/docs/authenticate/passwordless/implement-login/embedded-login/native).
 * For Regular Web Applications (for example, NodeJS, Java, Rails, or .NET), read [Embedded Passwordless Login in Regular Web Applications](/docs/authenticate/passwordless/implement-login/embedded-login/webapps).
 
 Embedded login in regular web applications and SPAs require configuration of cross-origin authentication. To learn more, read [Cross-Origin Authentication](/docs/authenticate/login/cross-origin-authentication).
-
-## Learn more
-
-* [Passwordless Authentication](/docs/authenticate/passwordless)
-* [Passwordless Connections Best Practices](/docs/authenticate/passwordless/best-practices)
-* [Using Passwordless APIs](/docs/authenticate/passwordless/implement-login/embedded-login/relevant-api-endpoints)

--- a/main/docs/authenticate/protocols.mdx
+++ b/main/docs/authenticate/protocols.mdx
@@ -1,8 +1,9 @@
 ---
-description: Describes which authorization protocols Auth0 supports and how they work.
-sidebarTitle: Overview
-title: Protocols
+title: Authentication and Authorization Protocols at Auth0
+sidebarTitle: Protocols
+description: Learn about the industry standard specification and protocols Auth0 uses for authentication and authorization.
 ---
+
 There are a set of open specifications and protocols that specify how to design an authentication and authorization system. They specify how you should manage identity, move personal data securely, and decide who can access applications and data.
 
 The identity industry standards that we use at Auth0 are:

--- a/main/docs/authenticate/protocols/saml.mdx
+++ b/main/docs/authenticate/protocols/saml.mdx
@@ -1,8 +1,9 @@
 ---
+title: SAML Support on Auth0
+sidebarTitle: SAML
 description: Learn about the Security Assertion Markup Language (SAML) protocol, which is an open-standard, XML-based framework for authentication and authorization between two entities without a password.
-sidebarTitle: Overview
-title: SAML
 ---
+
 The <Tooltip tip="Security Assertion Markup Language (SAML): Standardized protocol allowing two parties to exchange authentication information without a password." cta="View Glossary" href="/docs/glossary?term=Security+Assertion+Markup+Language">Security Assertion Markup Language</Tooltip> (SAML) protocol is an open-standard, XML-based framework for authentication and authorization between two entities without a password:
 
 * **Service provider** (SP) agrees to trust the <Tooltip tip="Security Assertion Markup Language (SAML): Standardized protocol allowing two parties to exchange authentication information without a password." cta="View Glossary" href="/docs/glossary?term=identity+provider">identity provider</Tooltip> to authenticate users.

--- a/main/docs/authenticate/protocols/saml/saml-configuration.mdx
+++ b/main/docs/authenticate/protocols/saml/saml-configuration.mdx
@@ -1,8 +1,8 @@
 ---
-description: Describes how Auth0 works with Security Assertion Markup Language (SAML) protocol.
-sidebarTitle: Overview
 title: SAML Configuration
+description: Describes how Auth0 works with Security Assertion Markup Language (SAML) protocol.
 ---
+
 ## SAML service providers
 
 Applications, especially custom ones, can authenticate users against an external <Tooltip tip="Identity Provider (IdP): Service that stores and manages digital identities." cta="View Glossary" href="/docs/glossary?term=IdP">IdP</Tooltip> using protocols such as <Tooltip tip="OpenID: Open standard for authentication that allows applications to verify users' identities without collecting and storing login information." cta="View Glossary" href="/docs/glossary?term=OpenID">OpenID</Tooltip> Connect (OIDC) or <Tooltip tip="OpenID: Open standard for authentication that allows applications to verify users' identities without collecting and storing login information." cta="View Glossary" href="/docs/glossary?term=OAuth+2.0">OAuth 2.0</Tooltip>. However, you might want to leverage an enterprise <Tooltip tip="Security Assertion Markup Language (SAML): Standardized protocol allowing two parties to exchange authentication information without a password." cta="View Glossary" href="/docs/glossary?term=SAML">SAML</Tooltip> provider for authentication, even if you wrote your application to use either protocol.
@@ -39,15 +39,7 @@ Here is a list of IdP services known to support the SAML protocol. There may be 
 * Ubisecure SSO
 * WSO2 Identity Server
 
-Auth0 provides specific instructions to configure the following SAML identity providers with Auth0:
-
-* [ADFS](/docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider/configure-adfs-saml-connections)
-* [Okta](/docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider/configure-okta-as-saml-identity-provider)
-* [OneLogin](/docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider/configure-onelogin-as-saml-identity-provider)
-* [PingFederate 7](/docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider/configure-pingfederate-as-saml-identity-provider)
-* [Salesforce](/docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider/configure-salesforce-as-saml-identity-provider)
-* [SiteMinder](/docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider/configure-siteminder-as-saml-identity-provider)
-* [SSOCircle](/docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider/configure-ssocircle-as-saml-identity-provider)
+You can also view step-by-step instructions on how to [configure many SAML identity providers with Auth0](/docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider).
 
 ## Auth0 as service provider
 
@@ -75,18 +67,3 @@ If your application is written to retrieve user profile information from a local
 * An out-of-band process creating user profiles in the application;
 * An Auth0 rule that executes on first login that calls an application API to create the user profile in the application;
 * Modifying the application to create user profiles dynamically, based on information in the SAML assertion.
-
-## Test SAML SSO using Auth0 as service and identity provider
-
-You can use Auth0 as both the SAML service provider and the SAML identity provider for testing purposes.
-
-<Frame>![Protocols Auth0 as SAML SP and IdP Diagram](/docs/images/cdy7uua7fh8z/7Ds9dLC3HaxGBLsG3ry7B9/0c08d51b6d6bb57ef6eff3796ca4cd21/saml-case3.png)</Frame>
-
-## Learn more
-
-* [SAML Single Sign-On Integrations](/docs/authenticate/protocols/saml/saml-sso-integrations)
-* [Configure Auth0 as SAML Service Provider](/docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider)
-* [Configure Auth0 as SAML Identity Provider](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider)
-* [Test SAML SSO with Auth0 as Service Provider and Identity Provider](/docs/authenticate/protocols/saml/saml-configuration/configure-auth0-as-service-and-identity-provider)
-* [SAML Identity Provider Configuration Settings](/docs/authenticate/protocols/saml/saml-identity-provider-configuration-settings)
-* [Customize SAML Assertions](/docs/authenticate/protocols/saml/saml-configuration/customize-saml-assertions)

--- a/main/docs/authenticate/protocols/saml/saml-sso-integrations.mdx
+++ b/main/docs/authenticate/protocols/saml/saml-sso-integrations.mdx
@@ -1,70 +1,16 @@
 ---
-description: Describes the Security Assertion Markup Language (SAML) for single sign-on (SSO) integration options.
-sidebarTitle: Overview
 title: SAML Single Sign-On Integrations
+description: Describes the Security Assertion Markup Language (SAML) for single sign-on (SSO) integration options.
 ---
+
 When you implement <Tooltip tip="Security Assertion Markup Language (SAML): Standardized protocol allowing two parties to exchange authentication information without a password." cta="View Glossary" href="/docs/glossary?term=SAML">SAML</Tooltip> <Tooltip tip="Security Assertion Markup Language (SAML): Standardized protocol allowing two parties to exchange authentication information without a password." cta="View Glossary" href="/docs/glossary?term=single+sign-on">single sign-on</Tooltip> (SSO), it's important to consider:
 
 * Which system(s) will serve as the authoritative source for user profile information if there's ever a conflict between two or more sources.
 * What user profile attributes each application needs.
 * How user profile information will be distributed to the systems that need it.
 
-## Identity provider-initiated SSO
-
 You typically set up a SAML federation by configuring SSO initiated by the service provider. The service provider returns a browser redirect so that the user authenticates using the <Tooltip tip="Identity Provider (IdP): Service that stores and manages digital identities." cta="View Glossary" href="/docs/glossary?term=IdP">IdP</Tooltip>. After authentication, the browser redirects the user back to the service provider with a SAML assertion containing information about the authentication status. This is commonly used for consumer-facing scenarios.
 
-You can also configure the IdP to initiate SSO instead of the service provider. In this scenario, the user invokes a URL on the IdP and is prompted to authenticate, then is redirected to the service provider with a SAML assertion. This is commonly used in enterprise scenarios. To learn more, read [Configure SAML Identity Provider-Initiated Single Sign-On](/docs/authenticate/protocols/saml/saml-sso-integrations/identity-provider-initiated-single-sign-on).
+You can also configure the IdP to initiate SSO instead of the service provider. In this scenario, the user invokes a URL on the IdP and is prompted to authenticate, then is redirected to the service provider with a SAML assertion. This is commonly used in enterprise scenarios.
 
-## Auth0 as identity provider for SAML SSO integrations
-
-Some of the following integrations make use of the Auth0 SAML2 Web App addon.
-
-* [Amazon Web Services](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-saml2-web-app-addon-for-aws)
-* [Atlassian](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-auth0-as-identity-provider-for-atlassian)
-* [Cisco-WebEx](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-auth0-as-identity-provider-for-cisco-webex)
-* [DataDog](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-auth0-as-identity-provider-for-datadog)
-* [Egencia](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-auth0-as-identity-provider-for-egencia)
-* [Freshdesk](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-auth0-as-identity-provider-for-freshdesk)
-* [GitHub Enterprise Cloud](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-saml2-web-app-addon-for-github-enterprise-server)
-* [GitHub Enterprise Server](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-saml2-web-app-addon-for-github-enterprise-server)
-* [Google Workspace](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-auth0-as-idp-for-google-g-suite)
-* [Heroku](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-saml2-web-app-addon-for-heroku)
-* [Hosted Graphite](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-auth0-as-identity-provider-for-hosted-graphite)
-* [Litmos](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-auth0-as-identity-provider-for-litmos)
-* [Oracle Eloqua Marketing Cloud](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-saml2-addon-eloqua)
-* [PluralSight](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-auth0-as-identity-provider-for-pluralsight)
-* [Sprout Video](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-auth0-as-identity-provider-for-sprout-video)
-* [Tableau Online](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-auth0-as-identity-provider-for-tableau-online)
-* [Tableau Server](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-auth0-as-identity-provider-for-tableau-server)
-* [Workday](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-auth0-as-identity-provider-for-workday)
-* [Workpath](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-auth0-as-identity-provider-for-workpath)
-
-To learn more, read [Enable SAML2 Web App Addon](/docs/authenticate/protocols/saml/saml-sso-integrations/enable-saml2-web-app-addon).
-
-## Other SAML identity provider SSO integrations
-
-Auth0 provides SSO integrations for using the following services as identity providers:
-
-* [ADFS](/docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider/configure-adfs-saml-connections)
-* [Okta](/docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider/configure-okta-as-saml-identity-provider)
-* [OneLogin](/docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider/configure-onelogin-as-saml-identity-provider)
-* [PingFederate](/docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider/configure-pingfederate-as-saml-identity-provider)
-* [Salesforce](/docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider/configure-salesforce-as-saml-identity-provider)
-* [SiteMinder](/docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider/configure-siteminder-as-saml-identity-provider)
-* [SSOCircle](/docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider/configure-ssocircle-as-saml-identity-provider)
-
-## Special scenarios
-
-Once you've set up a basic SAML integration, there are a number of additional requirements you might need to implement so that your integration reflects your needs and requirements.
-
-You have set up a connection or an application and that you're altering specific settings for an existing SAML integration, not configuring an integration from scratch.
-
-To learn more about special scenarios, read [Configure Identity Provider-Initiated Single Sign-On](/docs/authenticate/protocols/saml/saml-sso-integrations/identity-provider-initiated-single-sign-on) and [Sign and Encrypt SAML Requests](/docs/authenticate/protocols/saml/saml-sso-integrations/sign-and-encrypt-saml-requests).
-
-## Learn more
-
-* [SAML Identity Provider Configuration Settings](/docs/authenticate/protocols/saml/saml-identity-provider-configuration-settings)
-* [Customize SAML Assertions](/docs/authenticate/protocols/saml/saml-configuration/customize-saml-assertions)
-* [Configure SAML Identity Provider-Initiated Single Sign-On](/docs/authenticate/protocols/saml/saml-sso-integrations/identity-provider-initiated-single-sign-on)
-* [Sign and Encrypt SAML Requests](/docs/authenticate/protocols/saml/saml-sso-integrations/sign-and-encrypt-saml-requests)
-* [Troubleshoot SAML Configurations](/docs/troubleshoot/authentication-issues/troubleshoot-saml-configurations)
+We have many [SSO integrations that use Auth0 as the IdP](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider). We also provide [SSO integrations for other IdPs](/docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider).

--- a/main/docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider.mdx
+++ b/main/docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider.mdx
@@ -1,8 +1,8 @@
 ---
-description: Describes how to configure Auth0 to serve as a service provider in a SAML federation.
-sidebarTitle: Overview
-title: Configure Auth0 as SAML Service Provider
+title: Configure Auth0 as a SAML Service Provider
+description: Learn how to configure Auth0 to serve as a service provider in a SAML federation.
 ---
+
 To configure Auth0 as the service provider (SP) in a <Tooltip tip="Security Assertion Markup Language (SAML): Standardized protocol allowing two parties to exchange authentication information without a password." cta="View Glossary" href="/docs/glossary?term=SAML">SAML</Tooltip> federation, you will need to create an Enterprise connection in Auth0 and then update your SAML <Tooltip tip="Security Assertion Markup Language (SAML): Standardized protocol allowing two parties to exchange authentication information without a password." cta="View Glossary" href="/docs/glossary?term=identity+provider">identity provider</Tooltip> (IdP) with the connection's metadata.
 
 Auth0 supports using Auth0 as the SP in configurations that conform to the SAML 1.1 or SAML 2.0 protocol.
@@ -100,13 +100,8 @@ The Auth0 Management API [Create a Connection](https://auth0.com/docs/api/manage
 	}
 }
 ```
-
-
-
-
-
-
-</Tab></Tabs>
+</Tab>
+</Tabs>
 
 ### Configure SAML connection for proxy gateways
 
@@ -152,15 +147,7 @@ Variables can be placed into the `AuthnRequest` template using the `@@VariableNa
 
 Go to [SAML Identity Provider Configuration Settings](/docs/authenticate/protocols/saml/saml-identity-provider-configuration-settings) to find the metadata you'll need to provide to the IdP.
 
-Auth0 supports all SAML IdPs that conform to the SAML 1.1 or SAML 2.0 protocol. We have detailed instructions for configuring specific providers:
-
-* [ADFS](/docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider/configure-adfs-saml-connections)
-* [Okta](/docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider/configure-okta-as-saml-identity-provider)
-* [OneLogin](/docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider/configure-onelogin-as-saml-identity-provider)
-* [Ping](/docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider/configure-pingfederate-as-saml-identity-provider)
-* [Salesforce](/docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider/configure-salesforce-as-saml-identity-provider)
-* [SiteMinder](/docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider/configure-siteminder-as-saml-identity-provider)
-* [SSOCircle](/docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider/configure-ssocircle-as-saml-identity-provider)
+Auth0 supports all SAML IdPs that conform to the SAML 1.1 or SAML 2.0 protocol. We have detailed instructions for configuring specific providers below.
 
 ## Test connection
 
@@ -180,10 +167,3 @@ If your connection is not working as expected, try the following steps:
 * Clear your browser history, cookies, and cache before each test. If you do not, the browser may not pick up the latest configuration information, or it may have stale cookies that affect execution.
 * Ensure that your browser allows cookies and has JavaScript enabled.
 * [Capture a HAR file](/docs/troubleshoot/troubleshooting-tools/generate-and-analyze-har-files) of the transaction, and then use the [Auth0 SAML Tool](http://samltool.io/) to decode the SAML assertion and inspect its contents.
-
-## Learn more
-
-* [Customize SAML Assertions](/docs/authenticate/protocols/saml/saml-configuration/customize-saml-assertions)
-* [Sign and Encrypt SAML Requests](/docs/authenticate/protocols/saml/saml-sso-integrations/sign-and-encrypt-saml-requests)
-* [Troubleshoot SAML Configurations](/docs/troubleshoot/authentication-issues/troubleshoot-saml-configurations)
-* [Troubleshoot SAML Errors](/docs/troubleshoot/authentication-issues/saml-errors)

--- a/main/docs/authenticate/protocols/scim.mdx
+++ b/main/docs/authenticate/protocols/scim.mdx
@@ -1,13 +1,13 @@
 ---
-description: Describes using System for Cross-domain Identity Management (SCIM) schema in identity management
-sidebarTitle: Overview
 title: System for Cross-domain Identity Management (SCIM)
+description: Describes using System for Cross-domain Identity Management (SCIM) schema in identity management
 ---
+
 SCIM (System for Cross-domain Identity Management) is a set of application-level protocols to securely manage and communicate user data across multiple domains. SCIM clients can be integrated to manage CRUD (create, replace, update, delete) operations, apply queries and filters, and create user groups within your organization. SCIM allows you to automate user lifecycles and maintain user accounts across platforms.
 
 To read the SCIM specification, read [System for Cross-domain Identity Management: Core Schema](https://datatracker.ietf.org/doc/rfc7643/).
 
-### SCIM with Auth0
+## SCIM with Auth0
 
 Auth0 supplies an extensible, flexible directory designed to support CIAM use cases and focuses on simplifying identity for direct-to-consumer and software-as-a-service applications.
 

--- a/main/docs/authenticate/single-sign-on.mdx
+++ b/main/docs/authenticate/single-sign-on.mdx
@@ -1,8 +1,8 @@
 ---
-description: Learn what Single Sign-on (SSO) is and how it works.
-sidebarTitle: Overview
 title: Single Sign-On
+description: Learn what Single Sign-on (SSO) is and how it works.
 ---
+
 <Tooltip tip="Single Sign-On (SSO): Service that, after a user logs into one applicaton, automatically logs that user in to other applications." cta="View Glossary" href="/docs/glossary?term=Single+Sign-on">Single Sign-on</Tooltip> (SSO) occurs when a user logs in to one application and is then signed in to other applications automatically, regardless of the platform, technology, or domain the user is using. The user signs in only one time, hence the name of the feature (Single Sign-on).
 
 For example, if you log in to a Google service such as Gmail, you are automatically authenticated to YouTube, AdSense, Google Analytics, and other Google apps. Likewise, if you log out of your Gmail or other Google apps, you are automatically logged out of all the apps; this is known as Single Logout.
@@ -33,9 +33,7 @@ If you cannot use Universal Login with your application, review the following fo
 * [Auth0.js](/docs/libraries/auth0js)
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-
 If you are using [Passwordless](/docs/authenticate/passwordless/passwordless-with-universal-login) with Single Sign-On, connection parameters `sms` and `email` do not utilize the existing Auth0 session, and the user will be prompted to log in.
-
 </Callout>
 
 ### SSO on first login
@@ -129,11 +127,3 @@ For Business to Business (B2B) scenarios, SSO can simplify packaging your applic
 For Business to Consumer (B2C) or Customer Identity Access Management (CIAM) scenarios, SSO can provide frictionless access to your applications or services. You can let customers authenticate through popular social identity providers, such as Google, Facebook, LinkedIn, X, and Microsoft, instead of requiring them to make another account.
 
 * [Case Study: Giving Compass](https://auth0.com/case-studies/giving-compass)
-
-## Learn more
-
-* [Service-Provider-Initiated Single Sign-On](/docs/authenticate/single-sign-on/inbound-single-sign-on)
-* [Identity-Provider-Initiated Single Sign-On](/docs/authenticate/single-sign-on/outbound-single-sign-on)
-* [API Endpoints for Single Sign-On](/docs/authenticate/single-sign-on/api-endpoints-for-single-sign-on)
-* [Troubleshoot SAML Configurations](/docs/troubleshoot/authentication-issues/troubleshoot-saml-configurations)
-* [Verify Connections](/docs/troubleshoot/basic-issues/verify-connections)

--- a/main/docs/authenticate/single-sign-on/native-to-web.mdx
+++ b/main/docs/authenticate/single-sign-on/native-to-web.mdx
@@ -1,7 +1,6 @@
 ---
-description: Understand how Native to Web SSO transitions authenticated users from native to web applications.
-sidebarTitle: Overview
 title: Native to Web SSO
+description: Understand how Native to Web SSO transitions authenticated users from native to web applications.
 validatedOn: 2026-02-24
 ---
 

--- a/main/docs/authenticate/single-sign-on/outbound-single-sign-on.mdx
+++ b/main/docs/authenticate/single-sign-on/outbound-single-sign-on.mdx
@@ -1,24 +1,17 @@
 ---
-description: Overview of Single Sign-on (SSO) initiated by Identity Providers (IdPs).
-sidebarTitle: Overview
 title: Identity-Provider-Initiated Single Sign-On
+description: Overview of Single Sign-on (SSO) initiated by Identity Providers (IdPs).
 ---
+
 For Identity-Provider-Initiated <Tooltip tip="Single Sign-On (SSO): Service that, after a user logs into one applicaton, automatically logs that user in to other applications." cta="View Glossary" href="/docs/glossary?term=Single+Sign-On">Single Sign-On</Tooltip> (SSO), a third-party <Tooltip tip="Single Sign-On (SSO): Service that, after a user logs into one applicaton, automatically logs that user in to other applications." cta="View Glossary" href="/docs/glossary?term=Identity+Provider">Identity Provider</Tooltip> (IdP) is the SSO provider. When a user logs in to an application:
 
 1. The application redirects the user to an identity provider.
 2. The third-party identity provider performs authentication and authorization.
 3. Upon successful authentication, the user is returned to the application.
 
-## Pre-defined integrations
-
 Auth0 provides IdP-initiated [SSO Integrations](/docs/customize/integrations/sso-integrations) for various services, like [Dropbox](https://marketplace.auth0.com/integrations/dropbox-sso), [Slack](https://marketplace.auth0.com/integrations/slack-sso), or [Zoom](https://marketplace.auth0.com/integrations/zoom-sso). To see the full list, explore [Auth0 Marketplace: SSO Integrations](https://marketplace.auth0.com/features/sso-integrations).
 
-## Build your own implementations
-
-## SAML
+You can also build your own implementation with SAML or OIDC:
 
 * [SAML Identity Provider Configuration Settings](/docs/authenticate/protocols/saml/saml-identity-provider-configuration-settings)
-
-## OIDC
-
 * [Configure Applications with OIDC Discovery](/docs/get-started/applications/configure-applications-with-oidc-discovery)

--- a/main/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider.mdx
+++ b/main/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider.mdx
@@ -1,8 +1,8 @@
 ---
+title: Configure Auth0 as a SAML Identity Provider
 description: Describes how to configure Auth0 to serve as a SAML identity provider in a SAML federation.
-sidebarTitle: Overview
-title: Configure Auth0 as SAML Identity Provider
 ---
+
 You can use Auth0 as the <Tooltip tip="Identity Provider (IdP): Service that stores and manages digital identities." cta="View Glossary" href="/docs/glossary?term=identity+provider">identity provider</Tooltip> in <Tooltip tip="Identity Provider (IdP): Service that stores and manages digital identities." cta="View Glossary" href="/docs/glossary?term=SAML">SAML</Tooltip> configurations with SAML 2.0.
 
 ## SSO integrations with built-in Auth0 support
@@ -13,27 +13,7 @@ You can use Auth0 as the <Tooltip tip="Identity Provider (IdP): Service that sto
 
 On the Tutorial view, you will see additional configuration instructions that are specific to the integration you have chosen.
 
-Some of the following integrations make use of the [SAML2 Web App addon](/docs/authenticate/protocols/saml/saml-sso-integrations/enable-saml2-web-app-addon).
-
-* [Amazon Web Services](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-saml2-web-app-addon-for-aws)
-* [Atlassian](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-auth0-as-identity-provider-for-atlassian)
-* [Cisco-WebEx](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-auth0-as-identity-provider-for-cisco-webex)
-* [DataDog](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-auth0-as-identity-provider-for-datadog)
-* [Egencia](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-auth0-as-identity-provider-for-egencia)
-* [Oracle Eloqua Marketing Cloud](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-saml2-addon-eloqua)
-* [Freshdesk](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-auth0-as-identity-provider-for-freshdesk)
-* [GitHub Enterprise Cloud](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-saml2-web-app-addon-for-github-enterprise-server)
-* [GitHub Enterprise Server](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-saml2-web-app-addon-for-github-enterprise-server)
-* [Google Workspace](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-auth0-as-idp-for-google-g-suite)
-* [Heroku](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-saml2-web-app-addon-for-heroku)
-* [Hosted Graphite](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-auth0-as-identity-provider-for-hosted-graphite)
-* [Litmos](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-auth0-as-identity-provider-for-litmos)
-* [PluralSight](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-auth0-as-identity-provider-for-pluralsight)
-* [Sprout Video](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-auth0-as-identity-provider-for-sprout-video)
-* [Tableau Online](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-auth0-as-identity-provider-for-tableau-online)
-* [Tableau Server](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-auth0-as-identity-provider-for-tableau-server)
-* [Workday](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-auth0-as-identity-provider-for-workday)
-* [Workpath](/docs/authenticate/single-sign-on/outbound-single-sign-on/configure-auth0-saml-identity-provider/configure-auth0-as-identity-provider-for-workpath)
+Some SSO integrations make use of the [SAML2 Web App addon](/docs/authenticate/protocols/saml/saml-sso-integrations/enable-saml2-web-app-addon).
 
 ## Manually configure SSO integrations
 
@@ -56,20 +36,16 @@ Obtain the URL to which the SAML Authentication Assertion should be sent from th
 6. Enable the **SAML2 Web App** toggle.
 
    <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-
    Enabling both SAML and WS-Fed addons for a single client is not supported and may lead to inconsistent behavior. Use a separate client for each addon.
-
    </Callout>
 7. On the **Settings** tab, enter the **Application Callback URL** from the service provider (or application) to which the SAML assertions should be sent after Auth0 has authenticated the user. This is the Assertion Consumer Service (ACS) URL.
 
    <Frame>![Dashboard Applications Applications Addons Tab SAML2 Web App Settings Tab](/docs/images/cdy7uua7fh8z/6dJgYkcOgMZ73HVTkAWt1x/fe9dbbf306e6c587cb3326c00a3b4e1f/2025-02-27_13-59-00.png)</Frame>
 
    <Warning>
-
    Adding an allowed callback URL to the SAML2 add-on also adds that URL as the first item in the application's allowed callback list. This will impact functionality that relies on the first URL of this list as the default.
 
    Additionally, if the first URL in the application's allowed callback list is later updated or changed, this will be reflected in the SAML2 add-on which may break its functionality.
-
    </Warning>
 8. Scroll to the bottom of the tab and click **Enable**.
 9. If your service provider sends multiple ACS URLs in the SAML request, you will need to add them to the allow list by navigating to your application's **Settings** tab, locating **Allowed Callback URLs**, and adding them.


### PR DESCRIPTION
## Description

implements group root pages and [directory listings](https://www.mintlify.com/docs/organize/navigation#directory-listings) for the authenticate section.

this removes the manual "overview" pages, which were a workaround from before mintlify supported group roots.

this also removes the maintenance hell of manual lists or tables of child pages in a section. it also exposes the navigation of the site more, which is good, even though it reveals existing weaknesses in our content organization. :)

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
