### PR TITLE
Replace okta-spring-boot with auth0-auth-java for Spring Boot API SDK

### DIFF
--- a/main/docs/fr-ca/libraries.mdx
+++ b/main/docs/fr-ca/libraries.mdx
@@ -393,12 +393,12 @@ Est-ce que votre API ou votre service nécessite une authentification? Auth0 dis
 
 <SectionCard item={{
   name: "Spring Boot API",
-  subtext: "okta-spring-boot",
+  subtext: "auth0-springboot-api",
   logo: "spring.svg",
-  date: "Jun 21, 2024",
-  badge: "3.0.7",
+  date: "May 12, 2026",
+  badge: "1.0.0-beta.1",
   links: [
-    { label: "Github", url: "https://github.com/okta/okta-spring-boot/" },
+    { label: "Github", url: "https://github.com/auth0/auth0-auth-java" },
     {
       label: "Sample App",
       url: "https://github.com/auth0-samples/auth0-spring-security5-api-sample/tree/master/01-Authorization-MVC",

--- a/main/docs/ja-jp/libraries.mdx
+++ b/main/docs/ja-jp/libraries.mdx
@@ -392,12 +392,12 @@ APIまたはサービスに認証が必要ですか？Auth0には、一般的な
 
 <SectionCard item={{
   name: "Spring Boot API",
-  subtext: "okta-spring-boot",
+  subtext: "auth0-springboot-api",
   logo: "spring.svg",
-  date: "Jun 21, 2024",
-  badge: "3.0.7",
+  date: "May 12, 2026",
+  badge: "1.0.0-beta.1",
   links: [
-    { label: "Github", url: "https://github.com/okta/okta-spring-boot/" },
+    { label: "Github", url: "https://github.com/auth0/auth0-auth-java" },
     {
       label: "Sample App",
       url: "https://github.com/auth0-samples/auth0-spring-security5-api-sample/tree/master/01-Authorization-MVC",

--- a/main/docs/libraries.mdx
+++ b/main/docs/libraries.mdx
@@ -364,12 +364,12 @@ Does your API or service need authentication? Auth0 has SDKs for common API and 
 
 <SectionCard item={{
   name: "Spring Boot API",
-  subtext: "okta-spring-boot",
+  subtext: "auth0-springboot-api",
   logo: "spring.svg",
-  date: "Jun 21, 2024",
-  badge: "3.0.7",
+  date: "May 12, 2026",
+  badge: "1.0.0-beta.1",
   links: [
-    { label: "Github", url: "https://github.com/okta/okta-spring-boot/" },
+    { label: "Github", url: "https://github.com/auth0/auth0-auth-java" },
     {
       label: "Sample App",
       url: "https://github.com/auth0-samples/auth0-spring-security5-api-sample/tree/master/01-Authorization-MVC",

--- a/main/snippets/sdks/SdkLibraries.mdx
+++ b/main/snippets/sdks/SdkLibraries.mdx
@@ -330,7 +330,7 @@ export const SdkLibrariesPage = () => {
           name: "Spring Boot API",
           logo: "https://cdn2.auth0.com/docs/1.14516.0/img/platforms/spring.svg",
           links: [
-            { label: "Github", url: "https://github.com/okta/okta-spring-boot/" },
+            { label: "Github", url: "https://github.com/auth0/auth0-auth-java" },
             {
               label: "Sample App",
               url: "https://github.com/auth0-samples/auth0-spring-security5-api-sample/tree/master/01-Authorization-MVC",


### PR DESCRIPTION
## Summary

- Replaces the legacy `okta/okta-spring-boot` GitHub link with the newly launched `auth0/auth0-auth-java` repository in the "Spring Boot API" entry under Backend Service and API SDK Libraries
- Updates package name from `okta-spring-boot` to `auth0-springboot-api` and version to `1.0.0-beta.1`
- Applied across all locales (en, fr-ca, ja-jp) and the shared `SdkLibraries.mdx` snippet

## Context

The new Auth0 Spring Boot API SDK (`auth0/auth0-auth-java`) replaces the old Okta Spring Boot starter for API protection. It provides JWT validation with built-in DPoP and Multi-Custom Domain support, purpose-built for Auth0.

## Test plan

- [ ] Verify the libraries page renders correctly at `/docs/libraries`
- [ ] Confirm the GitHub link in the "Spring Boot API" row under "Backend Service and API SDK Libraries" points to https://github.com/auth0/auth0-auth-java
- [ ] Verify fr-ca and ja-jp locale pages also reflect the update