### PR TITLE
feat: add HowTo JSON-LD schema to quickstart guides

### DIFF
--- a/main/docs/quickstart/backend/aspnet-core-webapi/index.mdx
+++ b/main/docs/quickstart/backend/aspnet-core-webapi/index.mdx
@@ -2,6 +2,53 @@
 title: 'ASP.NET Core Web API'
 description: 'Add Auth0 JWT authentication to an ASP.NET Core Web API with protected endpoints'
 ---
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "ASP.NET Core Web API",
+  "description": "Add Auth0 JWT authentication to an ASP.NET Core Web API with protected endpoints",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create a new project",
+      "text": "Create a new project"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Install the Auth0 SDK",
+      "text": "Install the Auth0 SDK"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Setup your Auth0 API",
+      "text": "Setup your Auth0 API"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Configure authentication",
+      "text": "Configure authentication"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Create public and protected endpoints",
+      "text": "Create public and protected endpoints"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Run your API",
+      "text": "Run your API"
+    }
+  ]
+}} />
+
 <Callout icon="pencil" color="#FFC107" iconType="solid">
   This Quickstart is currently in **Beta**. We'd love to hear your feedback!
 </Callout>

--- a/main/docs/quickstart/backend/fastapi/index.mdx
+++ b/main/docs/quickstart/backend/fastapi/index.mdx
@@ -4,6 +4,59 @@ description: 'Add Auth0 JWT authentication to an FastAPI with protected endpoint
 sidebarTitle: FastAPI API
 title: 'FastAPI API'
 ---
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "FastAPI API",
+  "description": "Add Auth0 JWT authentication to an FastAPI with protected endpoints",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create a new FastAPI project",
+      "text": "Create a new FastAPI project"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Install dependencies",
+      "text": "Install dependencies"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Setup your Auth0 API",
+      "text": "Setup your Auth0 API"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Define API permissions",
+      "text": "Define API permissions"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Configure the Auth0 client",
+      "text": "Configure the Auth0 client"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Create protected routes",
+      "text": "Create protected routes"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 7,
+      "name": "Run your API",
+      "text": "Run your API"
+    }
+  ]
+}} />
+
 <Accordion title="AI Prompt" defaultOpen icon="microchip-ai" iconType="sharp-solid">
   **Using AI to integrate Auth0?** Add this prompt to Cursor, Windsurf, Copilot, Claude Code or your favourite AI-powered IDE to speed up development.
 

--- a/main/docs/quickstart/backend/fastify/index.mdx
+++ b/main/docs/quickstart/backend/fastify/index.mdx
@@ -5,6 +5,59 @@ sidebarTitle: Fastify API
 title: Protect Your Fastify API
 ---
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Protect Your Fastify API",
+  "description": "This guide demonstrates how to protect Fastify API endpoints using JWT access tokens with the Auth0 Fastify API SDK.",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create a new project",
+      "text": "Create a new project"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Install the Auth0 Fastify API SDK",
+      "text": "Install the Auth0 Fastify API SDK"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Setup your Auth0 API",
+      "text": "Setup your Auth0 API"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Configure the Auth0 API plugin",
+      "text": "Configure the Auth0 API plugin"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Create API routes",
+      "text": "Create API routes"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Run your API",
+      "text": "Run your API"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 7,
+      "name": "Test your API",
+      "text": "Test your API"
+    }
+  ]
+}} />
+
 <Accordion title="Use AI to integrate Auth0" icon="microchip-ai" iconType="solid" defaultOpen>
 
 If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, you can add Auth0 API authentication automatically in minutes using [agent skills](https://agentskills.io/home).

--- a/main/docs/quickstart/backend/golang/index.mdx
+++ b/main/docs/quickstart/backend/golang/index.mdx
@@ -6,6 +6,100 @@ title: Protect Your Go API
 ---
 
 import {AuthCodeBlock} from "/snippets/AuthCodeBlock.jsx";
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Go API: Authorization with JWT Middleware",
+  "description": "Secure your Go API with Auth0 using go-jwt-middleware v3",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create an API",
+      "text": "Create an API"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Configure API settings",
+      "text": "Configure API settings"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Understand RS256",
+      "text": "Understand RS256"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Navigate to Permissions",
+      "text": "Navigate to Permissions"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Add permissions",
+      "text": "Add permissions"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Initialize Go module",
+      "text": "Initialize Go module"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 7,
+      "name": "Install Auth0 middleware",
+      "text": "Install Auth0 middleware"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 8,
+      "name": "Download dependencies",
+      "text": "Download dependencies"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 9,
+      "name": "Start the server",
+      "text": "Start the server"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 10,
+      "name": "Get a test token",
+      "text": "Get a test token"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 11,
+      "name": "Test public endpoint",
+      "text": "Test public endpoint"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 12,
+      "name": "Test private endpoint (no token)",
+      "text": "Test private endpoint (no token)"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 13,
+      "name": "Test private endpoint (with token)",
+      "text": "Test private endpoint (with token)"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 14,
+      "name": "Test scoped endpoint",
+      "text": "Test scoped endpoint"
+    }
+  ]
+}} />
 
 export const envSnippet = `# The URL of your Auth0 Tenant Domain.
 # If you're using a Custom Domain, set this to that value instead.

--- a/main/docs/quickstart/backend/golang/index.mdx
+++ b/main/docs/quickstart/backend/golang/index.mdx
@@ -981,7 +981,7 @@ Now that you have a protected API, consider exploring:
 - **[Role-Based Access Control](https://auth0.com/docs/manage-users/access-control/rbac)** — Implement fine-grained permissions
 - **[Access Token Best Practices](https://auth0.com/docs/secure/tokens/access-tokens)** — Learn about token security
 - **[Monitor Your API](https://auth0.com/docs/deploy-monitor/logs)** — Set up logging and monitoring
-- **[Production Checklist](https://auth0.com/docs/deploy-monitor/production-checks)** — Pre-launch security review
+- **[Production Readiness Checks](https://auth0.com/docs/deploy-monitor/pre-deployment-checks/production-checks-best-practices)** — Pre-launch security review
 
 ---
 

--- a/main/docs/quickstart/backend/java-spring-security5/index.mdx
+++ b/main/docs/quickstart/backend/java-spring-security5/index.mdx
@@ -3,6 +3,53 @@ title: "Java Springboot API"
 description: "Add Auth0 JWT authentication to a Spring Boot API with protected endpoints"
 ---
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Java Springboot API",
+  "description": "Add Auth0 JWT authentication to a Spring Boot API with protected endpoints",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create a new project",
+      "text": "Create a new project"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Add the Auth0 SDK",
+      "text": "Add the Auth0 SDK"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Setup your Auth0 API",
+      "text": "Setup your Auth0 API"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Configure authentication",
+      "text": "Configure authentication"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Create public and protected endpoints",
+      "text": "Create public and protected endpoints"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Run your API",
+      "text": "Run your API"
+    }
+  ]
+}} />
+
 <Callout icon="pencil" color="#FFC107" iconType="solid">
   This Quickstart is currently in **Beta**. We'd love to hear your feedback!
 </Callout>

--- a/main/docs/quickstart/backend/python/index.mdx
+++ b/main/docs/quickstart/backend/python/index.mdx
@@ -3,6 +3,59 @@ title: 'Flask API'
 description: 'This guide demonstrates how to integrate Auth0 with any new or existing Python API built with Flask.'
 ---
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Flask API",
+  "description": "This guide demonstrates how to integrate Auth0 with any new or existing Python API built with Flask.",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create a new Flask project",
+      "text": "Create a new Flask project"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Install dependencies",
+      "text": "Install dependencies"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Setup your Auth0 API",
+      "text": "Setup your Auth0 API"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Define API permissions",
+      "text": "Define API permissions"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Configure the Auth0 client",
+      "text": "Configure the Auth0 client"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Create protected routes",
+      "text": "Create protected routes"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 7,
+      "name": "Run your API",
+      "text": "Run your API"
+    }
+  ]
+}} />
+
 <Note>
   **Prerequisites:** Before you begin, ensure you have the following installed:
 

--- a/main/docs/quickstart/native/android-facebook-login/index.mdx
+++ b/main/docs/quickstart/native/android-facebook-login/index.mdx
@@ -4,6 +4,53 @@ sidebarTitle: Android Facebook Login
 title: Add Native Facebook Login to Your Android Application
 ---
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Add Native Facebook Login to Your Android Application",
+  "description": "",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Configure Facebook Login permissions",
+      "text": "Configure Facebook Login permissions"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Install and configure the Auth0 SDK",
+      "text": "Install and configure the Auth0 SDK"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Fetch Facebook session access token",
+      "text": "Fetch Facebook session access token"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Fetch Facebook user profile",
+      "text": "Fetch Facebook user profile"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Exchange tokens for Auth0 credentials",
+      "text": "Exchange tokens for Auth0 credentials"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Put it all together",
+      "text": "Put it all together"
+    }
+  ]
+}} />
+
 ## Before You Start
 
 Complete these prerequisites before following this quickstart:

--- a/main/docs/quickstart/native/android/index.mdx
+++ b/main/docs/quickstart/native/android/index.mdx
@@ -4,6 +4,53 @@ sidebarTitle: Android
 title: Add Login to Your Android Application using the Auth0.Android SDK
 ---
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Add Login to Your Android Application using the Auth0.Android SDK",
+  "description": "",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create a new Android project",
+      "text": "Create a new Android project"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Add Auth0 SDK via Gradle",
+      "text": "Add Auth0 SDK via Gradle"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Setup your Auth0 App",
+      "text": "Setup your Auth0 App"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Initialize the Auth0 SDK",
+      "text": "Initialize the Auth0 SDK"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Implement Login and Logout",
+      "text": "Implement Login and Logout"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Run your app",
+      "text": "Run your app"
+    }
+  ]
+}} />
+
 <Accordion title="Use AI to integrate Auth0" icon="microchip-ai" iconType="solid" defaultOpen>
 
 If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, you can add Auth0 authentication automatically in minutes using [agent skills](https://agentskills.io/home).

--- a/main/docs/quickstart/native/flutter/index.mdx
+++ b/main/docs/quickstart/native/flutter/index.mdx
@@ -7,6 +7,59 @@ mode: wide
 'twitter:title': 'Auth0 Flutter SDK Quickstarts: Add Login to Your Flutter Application'
 ---
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Add Login to Your Flutter Application",
+  "description": "This guide demonstrates how to integrate Auth0 with any Flutter app using the Auth0 Flutter SDK.",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create a new Flutter project",
+      "text": "Create a new Flutter project"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Install the Auth0 Flutter SDK",
+      "text": "Install the Auth0 Flutter SDK"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Setup your Auth0 App",
+      "text": "Setup your Auth0 App"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Configure Your Application",
+      "text": "Configure Your Application"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Implement Login and Logout",
+      "text": "Implement Login and Logout"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Show User Profile Information",
+      "text": "Show User Profile Information"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 7,
+      "name": "Run your app",
+      "text": "Run your app"
+    }
+  ]
+}} />
+
 This guide demonstrates how to integrate Auth0 with a Flutter application using the [Auth0 Flutter SDK](https://github.com/auth0/auth0-flutter). This guide covers setup for **Android**, **iOS**, **macOS**, and **Web** platforms.
 
 ## Get Started

--- a/main/docs/quickstart/native/ionic-angular/index.mdx
+++ b/main/docs/quickstart/native/ionic-angular/index.mdx
@@ -15,6 +15,52 @@ import {AuthCodeGroup} from "/snippets/AuthCodeGroup.jsx";
 import {AuthCodeBlock} from "/snippets/AuthCodeBlock.jsx";
 import {CreateInteractiveApp} from "/snippets/recipe.jsx";
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Add Login to Your Ionic Angular with Capacitor Application",
+  "description": "",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create a new project",
+      "text": "Create a new project"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Install the Auth0 Angular SDK and Capacitor plugins",
+      "text": "Install the Auth0 Angular SDK and Capacitor plugins"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Setup your Auth0 App",
+      "text": "Setup your Auth0 App"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Configure the Auth0 module",
+      "text": "Configure the Auth0 module"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Create Login, Logout and Profile components",
+      "text": "Create Login, Logout and Profile components"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Run your app",
+      "text": "Run your app"
+    }
+  ]
+}} />
 ## Get Started
 
 This quickstart demonstrates how to add Auth0 authentication to an Ionic Angular application with Capacitor. You'll build a mobile-ready app with login, logout, and user profile features using the Auth0 Angular SDK and Capacitor's native browser plugins.

--- a/main/docs/quickstart/native/ionic-react/index.mdx
+++ b/main/docs/quickstart/native/ionic-react/index.mdx
@@ -15,6 +15,52 @@ import {AuthCodeGroup} from "/snippets/AuthCodeGroup.jsx";
 import {AuthCodeBlock} from "/snippets/AuthCodeBlock.jsx";
 import {CreateInteractiveApp} from "/snippets/recipe.jsx";
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Add Login to Your Ionic React with Capacitor Application",
+  "description": "",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create a new project",
+      "text": "Create a new project"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Install the Auth0 React SDK and Capacitor plugins",
+      "text": "Install the Auth0 React SDK and Capacitor plugins"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Setup your Auth0 App",
+      "text": "Setup your Auth0 App"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Configure the Auth0Provider",
+      "text": "Configure the Auth0Provider"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Create Login, Logout, Profile, and Callback Handler",
+      "text": "Create Login, Logout, Profile, and Callback Handler"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Run your app",
+      "text": "Run your app"
+    }
+  ]
+}} />
 ## Get Started
 
 This quickstart demonstrates how to add Auth0 authentication to an Ionic React application with Capacitor. You'll build a mobile-ready app with login, logout, and user profile features using the Auth0 React SDK and Capacitor's native browser integration.

--- a/main/docs/quickstart/native/ionic-vue/index.mdx
+++ b/main/docs/quickstart/native/ionic-vue/index.mdx
@@ -15,6 +15,52 @@ import {AuthCodeGroup} from "/snippets/AuthCodeGroup.jsx";
 import {AuthCodeBlock} from "/snippets/AuthCodeBlock.jsx";
 import {CreateInteractiveApp} from "/snippets/recipe.jsx";
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Add Login to Your Ionic Vue with Capacitor Application",
+  "description": "",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create a new project",
+      "text": "Create a new project"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Install the Auth0 Vue SDK and Capacitor plugins",
+      "text": "Install the Auth0 Vue SDK and Capacitor plugins"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Setup your Auth0 App",
+      "text": "Setup your Auth0 App"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Configure the Auth0 Plugin",
+      "text": "Configure the Auth0 Plugin"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Create Authentication Components",
+      "text": "Create Authentication Components"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Run your app",
+      "text": "Run your app"
+    }
+  ]
+}} />
 ## Get Started
 
 This quickstart demonstrates how to add Auth0 authentication to an Ionic Vue application running on iOS and Android with Capacitor. You'll build a secure mobile app with login, logout, and user profile features using the Auth0 Vue SDK and Capacitor's native browser plugins.

--- a/main/docs/quickstart/native/ios-swift-facebook-login/index.mdx
+++ b/main/docs/quickstart/native/ios-swift-facebook-login/index.mdx
@@ -4,6 +4,53 @@ sidebarTitle: iOS Facebook Login
 title: Add Native Facebook Login to Your iOS Application
 ---
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Add Native Facebook Login to Your iOS Application",
+  "description": "",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Configure Facebook Login permissions",
+      "text": "Configure Facebook Login permissions"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Install and configure the Auth0 SDK",
+      "text": "Install and configure the Auth0 SDK"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Fetch Facebook session access token",
+      "text": "Fetch Facebook session access token"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Fetch Facebook user profile",
+      "text": "Fetch Facebook user profile"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Exchange tokens for Auth0 credentials",
+      "text": "Exchange tokens for Auth0 credentials"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Put it all together",
+      "text": "Put it all together"
+    }
+  ]
+}} />
+
 ## Before You Start
 
 Complete these prerequisites before following this quickstart:

--- a/main/docs/quickstart/native/ios-swift/index.mdx
+++ b/main/docs/quickstart/native/ios-swift/index.mdx
@@ -7,6 +7,58 @@ title: Add Login to Your iOS or macOS Application using the Auth0.swift SDK
 
 import {AuthCodeGroup} from "/snippets/AuthCodeGroup.jsx";
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Add Login to Your iOS or macOS Application using the Auth0.swift SDK",
+  "description": "",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create a new project",
+      "text": "Create a new project"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Add the Auth0 SDK",
+      "text": "Add the Auth0 SDK"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Configure Auth0",
+      "text": "Configure Auth0"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Configure App Credentials",
+      "text": "Configure App Credentials"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Create the Authentication Service",
+      "text": "Create the Authentication Service"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Configure Authentication Flow (Optional)",
+      "text": "Configure Authentication Flow (Optional)"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 7,
+      "name": "Run your app",
+      "text": "Run your app"
+    }
+  ]
+}} />
 ## Get Started  
 
 <Steps>

--- a/main/docs/quickstart/native/maui/index.mdx
+++ b/main/docs/quickstart/native/maui/index.mdx
@@ -6,6 +6,59 @@ description: This guide demonstrates how to integrate Auth0 with a .NET MAUI app
 'twitter:title': 'Auth0 .NET MAUI SDK Quickstart: Add Login to Your .NET MAUI Application'
 ---
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Add login to your .NET MAUI application",
+  "description": "This guide demonstrates how to integrate Auth0 with a .NET MAUI application using the Auth0.OidcClient.MAUI SDK.",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Configure your Auth0 application",
+      "text": "Configure your Auth0 application"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Create your MAUI project",
+      "text": "Create your MAUI project"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Install the Auth0 MAUI SDK",
+      "text": "Install the Auth0 MAUI SDK"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Configure platform-specific callback handling",
+      "text": "Configure platform-specific callback handling"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Add login and logout",
+      "text": "Add login and logout"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Register services and instantiate the Auth0 client",
+      "text": "Register services and instantiate the Auth0 client"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 7,
+      "name": "Run your app",
+      "text": "Run your app"
+    }
+  ]
+}} />
+
 This guide demonstrates how to integrate Auth0 with a .NET MAUI application using the [Auth0.OidcClient.MAUI SDK](https://github.com/auth0/auth0-oidc-client-net). By the end, your app will support login, logout, and displaying user profile information across **Android**, **iOS**, **macOS**, and **Windows** from a single codebase.
 
 This guide uses `Auth0.OidcClient.MAUI` version **1.x**.

--- a/main/docs/quickstart/native/net-android-ios/index.mdx
+++ b/main/docs/quickstart/native/net-android-ios/index.mdx
@@ -4,6 +4,53 @@ sidebarTitle: .NET Android & iOS
 title: Add Login to Your .NET Android & iOS Application
 ---
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Add Login to Your .NET Android & iOS Application",
+  "description": "",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create a new .NET project",
+      "text": "Create a new .NET project"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Install Auth0 SDK",
+      "text": "Install Auth0 SDK"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Setup your Auth0 App",
+      "text": "Setup your Auth0 App"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Initialize the Auth0 Client",
+      "text": "Initialize the Auth0 Client"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Implement Login and Logout",
+      "text": "Implement Login and Logout"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Run your app",
+      "text": "Run your app"
+    }
+  ]
+}} />
+
 ## Get Started
 
 <Steps>

--- a/main/docs/quickstart/native/react-native-expo/index.mdx
+++ b/main/docs/quickstart/native/react-native-expo/index.mdx
@@ -10,6 +10,53 @@ title: Add Login to Your Expo Application
 'twitter:title': 'Auth0 Expo SDK Quickstarts: Add Login to Your Expo Application'
 ---
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Add Login to Your Expo Application",
+  "description": "",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create a new Expo project",
+      "text": "Create a new Expo project"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Install the Auth0 SDK",
+      "text": "Install the Auth0 SDK"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Configure the Expo Plugin",
+      "text": "Configure the Expo Plugin"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Configure your Auth0 Application",
+      "text": "Configure your Auth0 Application"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Setup App Component",
+      "text": "Setup App Component"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Run your app",
+      "text": "Run your app"
+    }
+  ]
+}} />
+
 <Tip>
   This Quickstart is for Expo applications. To integrate Auth0 into your React Native application, refer to the [React Native Quickstart](https://auth0.com/docs/quickstart/native/react-native/interactive).
 </Tip>

--- a/main/docs/quickstart/native/react-native/index.mdx
+++ b/main/docs/quickstart/native/react-native/index.mdx
@@ -12,6 +12,59 @@ title: Add Login to Your React Native Application
 'twitter:title': 'Auth0 React Native SDK Quickstarts: Add Login to Your React Native Application'
 ---
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Add Login to Your React Native Application",
+  "description": "",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create a new React Native project",
+      "text": "Create a new React Native project"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Install the Auth0 SDK",
+      "text": "Install the Auth0 SDK"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Configure your Auth0 Application",
+      "text": "Configure your Auth0 Application"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Configure Native Platforms",
+      "text": "Configure Native Platforms"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Setup App Component",
+      "text": "Setup App Component"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Implement Login and Logout",
+      "text": "Implement Login and Logout"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 7,
+      "name": "Run your app",
+      "text": "Run your app"
+    }
+  ]
+}} />
+
 <Tip>
   This Quickstart is for the React Native framework. To integrate Auth0 into your Expo application, refer to the [Expo Quickstart](https://auth0.com/docs/quickstart/native/react-native-expo/interactive).
 </Tip>

--- a/main/docs/quickstart/native/wpf-winforms/index.mdx
+++ b/main/docs/quickstart/native/wpf-winforms/index.mdx
@@ -4,6 +4,59 @@ description: 'Add Auth0 login, logout, and user profile to a WPF or WinForms app
 sidebarTitle: WPF / WinForms
 ---
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Add Login to Your WPF or WinForms Application",
+  "description": "Add Auth0 login, logout, and user profile to a WPF or WinForms application using the Auth0 OIDC Client for .NET",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create your application",
+      "text": "Create your application"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Configure Auth0",
+      "text": "Configure Auth0"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Install the Auth0 SDK",
+      "text": "Install the Auth0 SDK"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Instantiate the Auth0Client",
+      "text": "Instantiate the Auth0Client"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Add login to your application",
+      "text": "Add login to your application"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Add logout to your application",
+      "text": "Add logout to your application"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 7,
+      "name": "Show user profile information",
+      "text": "Show user profile information"
+    }
+  ]
+}} />
+
 <Note>
   **Prerequisites:** Before you begin, ensure you have the following:
 

--- a/main/docs/quickstart/spa/angular/index.mdx
+++ b/main/docs/quickstart/spa/angular/index.mdx
@@ -10,6 +10,52 @@ import {AuthCodeGroup} from "/snippets/AuthCodeGroup.jsx";
 import {AuthCodeBlock} from "/snippets/AuthCodeBlock.jsx";
 import {CreateInteractiveApp} from "/snippets/recipe.jsx";
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Add Login to Your Angular Application",
+  "description": "This guide demonstrates how to integrate Auth0, add authentication, and display user profile information in any Angular application using the Auth0 Angular SDK.",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create a new project",
+      "text": "Create a new project"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Install the Auth0 Angular SDK",
+      "text": "Install the Auth0 Angular SDK"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Setup your Auth0 App",
+      "text": "Setup your Auth0 App"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Configure the Auth0 module",
+      "text": "Configure the Auth0 module"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Create Login, Logout and Profile Components",
+      "text": "Create Login, Logout and Profile Components"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Run your app",
+      "text": "Run your app"
+    }
+  ]
+}} />
 <Accordion title="Use AI to integrate Auth0" icon="microchip-ai" iconType="solid" defaultOpen>
 
 If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, you can add Auth0 authentication automatically in minutes using [agent skills](https://agentskills.io/home).

--- a/main/docs/quickstart/spa/capn-web/index.mdx
+++ b/main/docs/quickstart/spa/capn-web/index.mdx
@@ -8,6 +8,52 @@ title: Add Login to Your Cap'n Web Application
 
 import {AuthCodeGroup} from "/snippets/AuthCodeGroup.jsx";
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Add Login to Your Cap'n Web Application",
+  "description": "This guide demonstrates how to integrate Auth0, add authentication, and display user profile information in a Single-Page Application (SPA) that uses Cap'n Web RPC, using the Auth0 SPA SDK.",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create a new project",
+      "text": "Create a new project"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Install dependencies",
+      "text": "Install dependencies"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Setup your Auth0 App",
+      "text": "Setup your Auth0 App"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Create the server",
+      "text": "Create the server"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Create the client interface",
+      "text": "Create the client interface"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Run your app",
+      "text": "Run your app"
+    }
+  ]
+}} />
 <Callout icon="pencil" color="#FFC107" iconType="solid">
   This Quickstart is currently in **Beta**. We'd love to hear your feedback!
 </Callout>

--- a/main/docs/quickstart/spa/flutter/index.mdx
+++ b/main/docs/quickstart/spa/flutter/index.mdx
@@ -5,6 +5,53 @@ sidebarTitle: Flutter (Web)
 title: Add Login to Your Flutter Web Application
 ---
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Add Login to Your Flutter Web Application",
+  "description": "This guide demonstrates how to integrate Auth0 with a Flutter Web application using the Auth0 Flutter SDK.",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create a new project",
+      "text": "Create a new project"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Install the Auth0 Flutter SDK",
+      "text": "Install the Auth0 Flutter SDK"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Setup your Auth0 App",
+      "text": "Setup your Auth0 App"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Configure the SDK",
+      "text": "Configure the SDK"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Create the main view",
+      "text": "Create the main view"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Run your app",
+      "text": "Run your app"
+    }
+  ]
+}} />
+
 <Note>
   **Prerequisites:** Before you begin, ensure you have the following installed:
 

--- a/main/docs/quickstart/spa/react/index.mdx
+++ b/main/docs/quickstart/spa/react/index.mdx
@@ -9,6 +9,28 @@ title: Add Login to Your React Application
 import {AuthCodeGroup} from "/snippets/AuthCodeGroup.jsx";
 import {AuthCodeBlock} from "/snippets/AuthCodeBlock.jsx";
 import {CreateInteractiveApp} from "/snippets/recipe.jsx";
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Add Login to Your React Application",
+  "description": "Integrate Auth0, add authentication, and display user profile information in a Single-Page Application (SPA) that uses React, using the Auth0 React SDK.",
+  "totalTime": "PT15M",
+  "tool": [
+    { "@type": "HowToTool", "name": "Node.js 20 LTS or newer" },
+    { "@type": "HowToTool", "name": "npm 10+, yarn 1.22+, or pnpm 8+" },
+    { "@type": "HowToTool", "name": "React 18.x or newer" }
+  ],
+  "step": [
+    { "@type": "HowToStep", "position": 1, "name": "Create a new project", "text": "Create a new Vite React TypeScript project with npm create vite@latest auth0-react -- --template react-ts." },
+    { "@type": "HowToStep", "position": 2, "name": "Install the Auth0 React SDK", "text": "Run npm add @auth0/auth0-react && npm install to install the Auth0 React SDK." },
+    { "@type": "HowToStep", "position": 3, "name": "Setup your Auth0 App", "text": "Create an Auth0 Single Page Application and configure its Allowed Callback URLs, Allowed Logout URLs, and Allowed Web Origins. Use the Quick Setup tool, the Auth0 CLI, or the Auth0 Dashboard to generate a .env file with VITE_AUTH0_DOMAIN and VITE_AUTH0_CLIENT_ID." },
+    { "@type": "HowToStep", "position": 4, "name": "Add the Auth0Provider", "text": "Wrap the application with Auth0Provider in src/main.tsx, supplying domain, clientId, and authorizationParams.redirect_uri." },
+    { "@type": "HowToStep", "position": 5, "name": "Create Login, Logout, and Profile components", "text": "Add React components that call loginWithRedirect, logout, and the useAuth0 hook to display the authenticated user's profile." },
+    { "@type": "HowToStep", "position": 6, "name": "Run the app", "text": "Run npm run dev and open http://localhost:5173 to verify the login flow." }
+  ]
+}} />
 
 <Accordion title="Use AI to integrate Auth0" icon="microchip-ai" iconType="solid" defaultOpen>
 

--- a/main/docs/quickstart/spa/svelte/index.mdx
+++ b/main/docs/quickstart/spa/svelte/index.mdx
@@ -10,6 +10,52 @@ import {AuthCodeGroup} from "/snippets/AuthCodeGroup.jsx";
 import {AuthCodeBlock} from "/snippets/AuthCodeBlock.jsx";
 import {CreateInteractiveApp} from "/snippets/recipe.jsx";
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Add Login to Your Svelte Application",
+  "description": "This guide demonstrates how to integrate Auth0, add authentication, and display user profile information in a Single-Page Application (SPA) that uses Svelte, using the Auth0 SPA JS SDK.",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create a new project",
+      "text": "Create a new project"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Install the Auth0 SPA SDK",
+      "text": "Install the Auth0 SPA SDK"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Setup your Auth0 App",
+      "text": "Setup your Auth0 App"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Create the Auth0 store",
+      "text": "Create the Auth0 store"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Create Login, Logout and Profile Components",
+      "text": "Create Login, Logout and Profile Components"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Run your app",
+      "text": "Run your app"
+    }
+  ]
+}} />
 <Callout icon="pencil" color="#FFC107" iconType="solid">
   This Quickstart is currently in **Beta**. We'd love to hear your feedback!
 </Callout>

--- a/main/docs/quickstart/spa/vanillajs/index.mdx
+++ b/main/docs/quickstart/spa/vanillajs/index.mdx
@@ -9,6 +9,46 @@ import {AuthCodeGroup} from "/snippets/AuthCodeGroup.jsx";
 import {AuthCodeBlock} from "/snippets/AuthCodeBlock.jsx";
 import {CreateInteractiveApp} from "/snippets/recipe.jsx";
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Add Login to Your JavaScript Application",
+  "description": "This guide demonstrates how to integrate Auth0, add authentication, and display user profile information in a Single-Page Application (SPA) that uses plain JavaScript, using the Auth0 SPA SDK.",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create a new project",
+      "text": "Create a new project"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Install the Auth0 SPA JS SDK",
+      "text": "Install the Auth0 SPA JS SDK"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Setup your Auth0 App",
+      "text": "Setup your Auth0 App"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Create the HTML structure and application logic",
+      "text": "Create the HTML structure and application logic"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Run your app",
+      "text": "Run your app"
+    }
+  ]
+}} />
 <Accordion title="AI Prompt" defaultOpen icon="microchip-ai" iconType="sharp-solid">
   **Using AI to integrate Auth0?** Add this prompt to Cursor, Windsurf, Copilot, Claude Code or your favourite AI-powered IDE to speed up development.
 

--- a/main/docs/quickstart/spa/vuejs/index.mdx
+++ b/main/docs/quickstart/spa/vuejs/index.mdx
@@ -10,6 +10,52 @@ import {AuthCodeGroup} from "/snippets/AuthCodeGroup.jsx";
 import {AuthCodeBlock} from "/snippets/AuthCodeBlock.jsx";
 import {CreateInteractiveApp} from "/snippets/recipe.jsx";
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Add Login to Your Vue Application",
+  "description": "This guide demonstrates how to integrate Auth0, add authentication, and display user profile information in any Vue application using the Auth0 Vue SDK.",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create a new project",
+      "text": "Create a new project"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Install the Auth0 Vue SDK",
+      "text": "Install the Auth0 Vue SDK"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Setup your Auth0 App",
+      "text": "Setup your Auth0 App"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Configure the Auth0 Plugin",
+      "text": "Configure the Auth0 Plugin"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Create Authentication Components",
+      "text": "Create Authentication Components"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Run your app",
+      "text": "Run your app"
+    }
+  ]
+}} />
 <Accordion title="Use AI to integrate Auth0" icon="microchip-ai" iconType="solid" defaultOpen>
 
 If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, you can add Auth0 authentication automatically in minutes using [agent skills](https://agentskills.io/home).

--- a/main/docs/quickstart/webapp/aspnet-core-blazor-server/index.mdx
+++ b/main/docs/quickstart/webapp/aspnet-core-blazor-server/index.mdx
@@ -7,6 +7,58 @@ title: Add Login to Your Blazor Server Application
 
 import {AuthCodeGroup} from "/snippets/AuthCodeGroup.jsx";
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Add Login to Your Blazor Server Application",
+  "description": "This guide demonstrates how to integrate Auth0 with any new or existing Blazor Server application using the Auth0.AspNetCore.Authentication SDK.",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create a new project",
+      "text": "Create a new project"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Install the Auth0 SDK",
+      "text": "Install the Auth0 SDK"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Setup your Auth0 Application",
+      "text": "Setup your Auth0 Application"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Configure authentication",
+      "text": "Configure authentication"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Add Login and Logout pages",
+      "text": "Add Login and Logout pages"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Create Profile page and Update Layout",
+      "text": "Create Profile page and Update Layout"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 7,
+      "name": "Run your application",
+      "text": "Run your application"
+    }
+  ]
+}} />
 <Accordion title="AI Prompt" defaultOpen icon="microchip-ai" iconType="sharp-solid">
   **Using AI to integrate Auth0?** Add this prompt to Cursor, Windsurf, Copilot, Claude Code or your favourite AI-powered IDE to speed up development.
 

--- a/main/docs/quickstart/webapp/aspnet-core/index.mdx
+++ b/main/docs/quickstart/webapp/aspnet-core/index.mdx
@@ -5,6 +5,65 @@ sidebarTitle: ASP.NET Core MVC
 title: Add Login to Your ASP.NET MVC Application
 ---
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Add Login to Your ASP.NET MVC Application",
+  "description": "This guide demonstrates how to integrate Auth0 with any new or existing ASP.NET MVC application using the Auth0.AspNetCore.Authentication SDK.",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create a new project",
+      "text": "Create a new project"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Install the Auth0 SDK",
+      "text": "Install the Auth0 SDK"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Setup your Auth0 Application",
+      "text": "Setup your Auth0 Application"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Configure authentication",
+      "text": "Configure authentication"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Add Login and Logout functionality",
+      "text": "Add Login and Logout functionality"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Create Profile view",
+      "text": "Create Profile view"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 7,
+      "name": "Update your layout",
+      "text": "Update your layout"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 8,
+      "name": "Run your application",
+      "text": "Run your application"
+    }
+  ]
+}} />
+
 <Accordion title="AI Prompt" defaultOpen icon="microchip-ai" iconType="sharp-solid">
   **Using AI to integrate Auth0?** Add this prompt to Cursor, Windsurf, Copilot, Claude Code or your favourite AI-powered IDE to speed up development.
 

--- a/main/docs/quickstart/webapp/aspnet-owin/index.mdx
+++ b/main/docs/quickstart/webapp/aspnet-owin/index.mdx
@@ -4,6 +4,53 @@ description: This guide demonstrates how to integrate Auth0 with any new or exis
 sidebarTitle: ASP.NET OWIN
 ---
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Add Login to Your ASP.NET OWIN Application",
+  "description": "This guide demonstrates how to integrate Auth0 with any new or existing ASP.NET OWIN application using the Microsoft.Owin.Security.OpenIdConnect NuGet package.",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Configure your Auth0 application",
+      "text": "Configure your Auth0 application"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Install NuGet packages",
+      "text": "Install NuGet packages"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Configure OWIN middleware",
+      "text": "Configure OWIN middleware"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Add login, logout, and profile actions",
+      "text": "Add login, logout, and profile actions"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Add a profile view",
+      "text": "Add a profile view"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Add login and logout links to your layout",
+      "text": "Add login and logout links to your layout"
+    }
+  ]
+}} />
+
 Auth0 allows you to add authentication to your ASP.NET OWIN application in minutes. This guide walks you through adding login, logout, and user profile display to a classic ASP.NET OWIN application.
 
 By the end of this guide, your application will:

--- a/main/docs/quickstart/webapp/express/index.mdx
+++ b/main/docs/quickstart/webapp/express/index.mdx
@@ -7,6 +7,52 @@ title: Add Login to Your Express Application
 
 import {CreateInteractiveApp} from "/snippets/recipe.jsx";
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Add Login to Your Express Application",
+  "description": "This guide demonstrates how to integrate Auth0, add authentication, and display user profile information in an Express.js web application using the express-openid-connect SDK.",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create a new project",
+      "text": "Create a new project"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Install the Auth0 Express SDK",
+      "text": "Install the Auth0 Express SDK"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Setup your Auth0 App",
+      "text": "Setup your Auth0 App"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Configure the middleware",
+      "text": "Configure the middleware"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Create login, logout, and profile routes",
+      "text": "Create login, logout, and profile routes"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Run your app",
+      "text": "Run your app"
+    }
+  ]
+}} />
 <Accordion title="Use AI to integrate Auth0" icon="microchip-ai" iconType="solid" defaultOpen>
 
 If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, you can add Auth0 authentication automatically in minutes using [agent skills](https://agentskills.io/home).

--- a/main/docs/quickstart/webapp/express/index.mdx
+++ b/main/docs/quickstart/webapp/express/index.mdx
@@ -726,8 +726,8 @@ console.log('Config check:', {
 
 Now that you have authentication working, consider exploring:
 
-- **[Add Authorization](https://auth0.com/docs/quickstart/webapp/express/02-user-profile)** - Implement role-based access control
-- **[Call Protected APIs](https://auth0.com/docs/quickstart/webapp/express/03-authorization)** - Use access tokens to call your backend APIs
+- **[Add Authorization](https://auth0.com/docs/manage-users/access-control/rbac)** - Implement role-based access control
+- **[Call Protected APIs](https://auth0.com/docs/secure/tokens/access-tokens/get-access-tokens)** - Use access tokens to call your backend APIs
 - **[Customize Universal Login](https://auth0.com/docs/customize/universal-login-pages)** - Brand your login experience
 - **[Add Social Connections](https://auth0.com/docs/connections/social)** - Enable Google, GitHub, and other social logins
 - **[Implement MFA](https://auth0.com/docs/secure/multi-factor-authentication)** - Add multi-factor authentication

--- a/main/docs/quickstart/webapp/fastapi/index.mdx
+++ b/main/docs/quickstart/webapp/fastapi/index.mdx
@@ -5,6 +5,53 @@ sidebarTitle: FastAPI
 title: Add Login to Your FastAPI Application
 ---
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Add Login to Your FastAPI Application",
+  "description": "This guide demonstrates how to integrate Auth0, add authentication, and display user profile information in a Python application using the Auth0 FastAPI SDK.",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create a new project",
+      "text": "Create a new project"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Install the Auth0 FastAPI SDK",
+      "text": "Install the Auth0 FastAPI SDK"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Setup your Auth0 App",
+      "text": "Setup your Auth0 App"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Configure the Auth0 FastAPI SDK",
+      "text": "Configure the Auth0 FastAPI SDK"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Create Routes and Display User Profile",
+      "text": "Create Routes and Display User Profile"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Run your app",
+      "text": "Run your app"
+    }
+  ]
+}} />
+
 <Accordion title="AI Prompt" defaultOpen icon="microchip-ai" iconType="sharp-solid">
   **Using AI to integrate Auth0?** Add this prompt to Cursor, Windsurf, Copilot, Claude Code or your favourite AI-powered IDE to speed up development.
 

--- a/main/docs/quickstart/webapp/fastify/index.mdx
+++ b/main/docs/quickstart/webapp/fastify/index.mdx
@@ -8,6 +8,58 @@ title: Add Login to Your Fastify Application
 import {CreateInteractiveApp} from "/snippets/recipe.jsx";
 import {AuthCodeBlock} from "/snippets/AuthCodeBlock.jsx";
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Add Login to Your Fastify Application",
+  "description": "This guide demonstrates how to integrate Auth0, add authentication, and display user profile information in a Fastify web application using the Auth0 Fastify SDK.",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create a new project",
+      "text": "Create a new project"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Install the Auth0 Fastify SDK",
+      "text": "Install the Auth0 Fastify SDK"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Setup your Auth0 App",
+      "text": "Setup your Auth0 App"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Configure the Auth0 plugin",
+      "text": "Configure the Auth0 plugin"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Create view templates",
+      "text": "Create view templates"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Create routes",
+      "text": "Create routes"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 7,
+      "name": "Run your app",
+      "text": "Run your app"
+    }
+  ]
+}} />
 export function generateRandomString(length) {
   const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
   return Array.from({length}, () => chars[Math.floor(Math.random() * chars.length)]).join('');

--- a/main/docs/quickstart/webapp/hono/index.mdx
+++ b/main/docs/quickstart/webapp/hono/index.mdx
@@ -7,6 +7,46 @@ description: "This Quickstart demonstrates how to secure your Hono applications 
 
 import {AuthCodeGroup} from "/snippets/AuthCodeGroup.jsx";
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Add Login to Your Hono Application",
+  "description": "This Quickstart demonstrates how to secure your Hono applications using Auth0 authentication. Follow the steps to add login, logout, and protected routes to a Hono app.",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create a new Hono application",
+      "text": "Create a new Hono application"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Install dependencies",
+      "text": "Install dependencies"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Create an Auth0 application",
+      "text": "Create an Auth0 application"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Setup Hono web server with Auth0 middleware",
+      "text": "Setup Hono web server with Auth0 middleware"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Run your app",
+      "text": "Run your app"
+    }
+  ]
+}} />
 <Callout icon="pencil" color="#FFC107" iconType="solid">
   This Quickstart is currently in **Beta**. We'd love to hear your feedback!
 </Callout>

--- a/main/docs/quickstart/webapp/java-ee/index.mdx
+++ b/main/docs/quickstart/webapp/java-ee/index.mdx
@@ -7,6 +7,64 @@ title: Add Login to Your Java EE Application
 
 import { AuthCodeGroup } from "/snippets/AuthCodeGroup.jsx";
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Add Login to Your Java EE Application",
+  "description": "Add Auth0 login, logout, and user profile to a Java EE 8 web application using the Security API",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create a new project",
+      "text": "Create a new project"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Install the Auth0 SDK",
+      "text": "Install the Auth0 SDK"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Setup your Auth0 Application",
+      "text": "Setup your Auth0 Application"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Configure authentication",
+      "text": "Configure authentication"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Implement Java EE Security",
+      "text": "Implement Java EE Security"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Add login and logout functionality",
+      "text": "Add login and logout functionality"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 7,
+      "name": "Create the user interface",
+      "text": "Create the user interface"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 8,
+      "name": "Run your application",
+      "text": "Run your application"
+    }
+  ]
+}} />
 <Accordion title="Use AI to integrate Auth0" icon="microchip-ai" iconType="solid" defaultOpen>
 
 If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, you can add Auth0 authentication automatically in minutes using [agent skills](https://agentskills.io/home).

--- a/main/docs/quickstart/webapp/java-spring-boot/index.mdx
+++ b/main/docs/quickstart/webapp/java-spring-boot/index.mdx
@@ -5,6 +5,52 @@ description: "Add Auth0 login to a Spring Boot web application using the Okta Sp
 
 import { AuthCodeGroup } from "/snippets/AuthCodeGroup.jsx";
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Java Spring Boot",
+  "description": "Add Auth0 login to a Spring Boot web application using the Okta Spring Boot Starter.",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create a new project",
+      "text": "Create a new project"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Add the Okta Spring Boot Starter",
+      "text": "Add the Okta Spring Boot Starter"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Configure Auth0",
+      "text": "Configure Auth0"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Configure authentication",
+      "text": "Configure authentication"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Create controllers and views",
+      "text": "Create controllers and views"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Run your application",
+      "text": "Run your application"
+    }
+  ]
+}} />
 <Note>
   **Prerequisites:**
   - JDK 17+ ([download](https://adoptium.net/))

--- a/main/docs/quickstart/webapp/java/index.mdx
+++ b/main/docs/quickstart/webapp/java/index.mdx
@@ -7,6 +7,58 @@ title: Add Login to Your Java Servlet Application
 
 import { AuthCodeGroup } from "/snippets/AuthCodeGroup.jsx";
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Add Login to Your Java Servlet Application",
+  "description": "This quickstart demonstrates how to add Auth0 authentication to a Java servlet application. You'll build a secure web application with login, logout, and user profile features using the Auth0 Java MVC Commons SDK.",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create a New Java Web Project",
+      "text": "Create a New Java Web Project"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Install the Auth0 Java MVC Commons SDK",
+      "text": "Install the Auth0 Java MVC Commons SDK"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Setup Your Auth0 Application",
+      "text": "Setup Your Auth0 Application"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Configure the Auth0 SDK",
+      "text": "Configure the Auth0 SDK"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Create Authentication Components and Filter",
+      "text": "Create Authentication Components and Filter"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Create User Interface Pages",
+      "text": "Create User Interface Pages"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 7,
+      "name": "Build and Run Your Application",
+      "text": "Build and Run Your Application"
+    }
+  ]
+}} />
 <Note>
   **Prerequisites:** Before you begin, ensure you have the following installed:
 

--- a/main/docs/quickstart/webapp/java/index.mdx
+++ b/main/docs/quickstart/webapp/java/index.mdx
@@ -740,6 +740,6 @@ You should now have a fully functional Auth0-integrated servlet application runn
 - Check that cookies are enabled in your browser
 - Verify HTTPS is used in production environments
 
-For additional support, visit the [Auth0 Community](https://community.auth0.com/) or check the [Auth0 Support Center](https://support.auth0.com/).
+For additional support, visit the [Auth0 Community](https://community.auth0.com/).
 
 </Accordion>

--- a/main/docs/quickstart/webapp/nextjs/index.mdx
+++ b/main/docs/quickstart/webapp/nextjs/index.mdx
@@ -9,6 +9,82 @@ import {AuthCodeGroup} from "/snippets/AuthCodeGroup.jsx";
 import {AuthCodeBlock} from "/snippets/AuthCodeBlock.jsx";
 import {CreateInteractiveApp} from "/snippets/recipe.jsx";
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Add Login to Your Next.js Application",
+  "description": "This guide demonstrates how to integrate Auth0 with any new or existing Next.js application using the Auth0 Next.js v4 SDK.",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create a new project",
+      "text": "Create a new project"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Install the Auth0 Next.js SDK",
+      "text": "Install the Auth0 Next.js SDK"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Create project files",
+      "text": "Create project files"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Setup your Auth0 App",
+      "text": "Setup your Auth0 App"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Create the Auth0 configuration",
+      "text": "Create the Auth0 configuration"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Add Proxy",
+      "text": "Add Proxy"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 7,
+      "name": "Create Login, Logout and Profile Components",
+      "text": "Create Login, Logout and Profile Components"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 8,
+      "name": "Update your main page",
+      "text": "Update your main page"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 9,
+      "name": "Update layout with Auth0Provider",
+      "text": "Update layout with Auth0Provider"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 10,
+      "name": "Configure Tailwind CSS",
+      "text": "Configure Tailwind CSS"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 11,
+      "name": "Run your app",
+      "text": "Run your app"
+    }
+  ]
+}} />
 <Accordion title="Use AI to integrate Auth0" icon="microchip-ai" iconType="solid" defaultOpen>
   If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, you can add Auth0 authentication automatically in minutes using [agent skills](https://agentskills.io/home).
 

--- a/main/docs/quickstart/webapp/nuxt/index.mdx
+++ b/main/docs/quickstart/webapp/nuxt/index.mdx
@@ -5,6 +5,53 @@ sidebarTitle: Nuxt.js
 title: Add Login to Your Nuxt.js Application
 ---
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Add Login to Your Nuxt.js Application",
+  "description": "This guide demonstrates how to integrate Auth0, add authentication, and display user profile information in a Single-Page Application (SPA) that uses Nuxt.js, using the Auth0 Nuxt.js SDK.",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Create a new project",
+      "text": "Create a new project"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Install the Auth0 Nuxt SDK",
+      "text": "Install the Auth0 Nuxt SDK"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Setup your Auth0 App",
+      "text": "Setup your Auth0 App"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Configure the Auth0 Nuxt module",
+      "text": "Configure the Auth0 Nuxt module"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Create Login, Logout and Profile Components",
+      "text": "Create Login, Logout and Profile Components"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 6,
+      "name": "Run your app",
+      "text": "Run your app"
+    }
+  ]
+}} />
+
 <Callout icon="pencil" color="#FFC107" iconType="solid">
   This Quickstart is currently in **Beta**. We'd love to hear your feedback!
 </Callout>

--- a/main/docs/quickstart/webapp/python/index.mdx
+++ b/main/docs/quickstart/webapp/python/index.mdx
@@ -7,6 +7,46 @@ title: 'Add Login to Your Flask Application'
 
 import {AuthCodeGroup} from "/snippets/AuthCodeGroup.jsx";
 
+import {JsonLd} from "/snippets/JsonLd.jsx";
+
+<JsonLd data={{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Add Login to Your Flask Application",
+  "description": "Add Auth0 authentication to a Flask web application with login, protected routes, and user profiles",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Set up your environment",
+      "text": "Set up your environment"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Install dependencies",
+      "text": "Install dependencies"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Setup your Auth0 App",
+      "text": "Setup your Auth0 App"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 4,
+      "name": "Create Auth Configuration, Routes, and Templates",
+      "text": "Create Auth Configuration, Routes, and Templates"
+    },
+    {
+      "@type": "HowToStep",
+      "position": 5,
+      "name": "Run your app",
+      "text": "Run your app"
+    }
+  ]
+}} />
 <Note>
   **Prerequisites:** Before you begin, ensure you have the following installed:
 

--- a/main/snippets/JsonLd.jsx
+++ b/main/snippets/JsonLd.jsx
@@ -1,0 +1,6 @@
+export const JsonLd = ({ data }) => (
+  <script
+    type="application/ld+json"
+    dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+  />
+);


### PR DESCRIPTION
## Summary

- Adds `main/snippets/JsonLd.jsx` — a minimal reusable snippet that renders a `<script type="application/ld+json">` tag from a data prop.
- Applies `HowTo` structured data to 39 quickstart `index.mdx` pages across native, SPA, webapp, and backend platforms, exposing each guide's steps as machine-readable `HowToStep` entries.

## Why

Improves discoverability in AI-powered search (ChatGPT, Perplexity, Google AI Overviews, Gemini) and in traditional search rich results. Quickstarts are our highest-intent entry pages — making their step structure machine-readable helps these surfaces cite and summarize them accurately.

## Scope

- Pages touched: 19 native, 7 SPA, 13 webapp — see `main/docs/quickstart/**/index.mdx`
- One new snippet: `main/snippets/JsonLd.jsx`
- No navigation or docs.json changes
- No production JS/CSS bundle rebuild needed — `JsonLd` is an MDX snippet, not a UI library component

## Notes for reviewers

- The Go backend quickstart (`main/docs/quickstart/backend/golang/index.mdx`) had a merge conflict because it was recently reorganized on main. Schema was placed after imports and before `export const envSnippet` to match the pattern used in the other 38 files (see `nextjs/index.mdx` for reference). Step names in that file's schema may need a second pass to align with the new single-file golang structure — flagging for follow-up.
- The `<JsonLd />` component emits a raw `<script>` element via `dangerouslySetInnerHTML`; the JSON is serialized once at render time.

## Test plan

- [ ] `cd main && mint dev` renders without new errors
- [ ] View source on several quickstart pages and confirm one `application/ld+json` block is present with valid JSON
- [ ] Paste rendered JSON into https://validator.schema.org — no errors on a sample of 3-5 pages
- [ ] Spot-check: `/docs/quickstart/webapp/nextjs`, `/docs/quickstart/backend/golang`, `/docs/quickstart/spa/react`, `/docs/quickstart/native/ios-swift`