### PR TITLE
fix: add X-Forwarded-For header requirement details for self-managed domains

### DIFF
--- a/main/docs/customize/custom-domains/self-managed-certificates.mdx
+++ b/main/docs/customize/custom-domains/self-managed-certificates.mdx
@@ -79,7 +79,7 @@ You can use a service such as [Cloudflare](/docs/customize/custom-domains/self-m
 * [Distribution](#distribution-settings)
 * [Origin authentication headers](#origin-authentication-header-settings)
 * [Origin hostname](#origin-hostname-settings)
-* [Original client ip address](#original-client-ip-address)
+* [Origin client IP address](#origin-client-ip-address)
 * [Default cache behavior](#default-cache-behavior-settings)
 
 ### Distribution settings
@@ -96,7 +96,7 @@ You can use a service such as [Cloudflare](/docs/customize/custom-domains/self-m
 | Setting | Value |
 | --- | --- |
 | Header Name | Set to `cname-api-key`. |
-| Value | Set to the CNAME API Key value that you were given immediately after you verified ownership of your domain name with Auth0. This header is required to be set for Auth0 to accept traffic from your proxy. |
+| Value | Set to the CNAME API Key value that you were given immediately after you verified ownership of your domain name with Auth0. You must set this header for Auth0 to accept traffic from your proxy. |
 
 ### Origin hostname settings
 
@@ -107,15 +107,13 @@ You can use a service such as [Cloudflare](/docs/customize/custom-domains/self-m
 
 For more information on retrieving the details of your custom domain, see [Get custom domain configurations](https://auth0.com/docs/api/management/v2/custom-domains/get-custom-domains).
 
-### Original client ip address
+### Origin client IP address
 
 | Setting | Value |
 | --- | --- |
-| X-Forwarded-For | Have your proxy set this header to the end user's IP address. Auth0 uses this for features such as anomaly detection, rate limiting, and MFA.  Just one ip address is expected. In case it's not possible to set `X-Forwarded-For`, using [Post custom domain configurations](https://auth0.com/docs/api/management/v2/custom-domains/post-custom-domains) the property `custom_client_ip_header` can be set to configure an alternative header name. |
+| Origin IP address | Set the `X-Forwarded-For` (XFF) header to the end user's IP address. Do not specify multiple IP addresses. <br/><br/> You can specify a different header for the user's IP address by using the Management API's [Configure a new custom domain endpoint](/docs/api/management/v2/custom-domains/post-custom-domains) to set the `custom_client_ip_header` property. |
 
-<Info>
-  If your proxy does not forward the end user's IP address, Auth0 will treat your proxy's IP address as the client. This can cause anomaly detection, rate limiting, and MFA to behave incorrectly.
-</Info>
+Auth0 uses the end user's IP address for features such as anomaly detection, rate limiting, and MFA. If your proxy does not forward the end user's IP address, Auth0 treats your proxy's IP address as the client, which may cause these features to behave incorrectly.
 
 ### Default cache behavior settings
 

--- a/main/docs/customize/custom-domains/self-managed-certificates.mdx
+++ b/main/docs/customize/custom-domains/self-managed-certificates.mdx
@@ -77,9 +77,8 @@ You can use a service such as [Cloudflare](/docs/customize/custom-domains/self-m
 3. The way you configure the proxy server will vary depending on the service you use. You will likely need to configure the following types of settings:
 
 * [Distribution](#distribution-settings)
-* [Origin authentication headers](#origin-authentication-header-settings)
 * [Origin hostname](#origin-hostname-settings)
-* [Origin client IP address](#origin-client-ip-address)
+* [Origin HTTP headers](#origin-http-headers)
 * [Default cache behavior](#default-cache-behavior-settings)
 
 ### Distribution settings
@@ -91,27 +90,22 @@ You can use a service such as [Cloudflare](/docs/customize/custom-domains/self-m
 | Origin Protocol Policy | Set to `HTTPS Only`. |
 | Alternate Domain Names (CNAMEs) | Set to your custom domain name (the same one your configured in the Auth0 Dashboard). |
 
-### Origin authentication header settings
-
-| Setting | Value |
-| --- | --- |
-| Header Name | Set to `cname-api-key`. |
-| Value | Set to the CNAME API Key value that you were given immediately after you verified ownership of your domain name with Auth0. You must set this header for Auth0 to accept traffic from your proxy. |
-
 ### Origin hostname settings
 
 | Setting | Value |
 | --- | --- |
-| Origin hostname | Enter `\{yourTenant}-<CUSTOM_DOMAIN_ID>.edge.tenants.us.auth0.com`, making sure to replace `<CUSTOM_DOMAIN_ID>` with the value of the Origin Domain Name (custom domain ID) you received from Auth0 when setting up the new custom domain. If your tenants are not in the US region, use one of the following: <ul><li>EU: `\{yourTenant}-<CUSTOM_DOMAIN_ID>.edge.tenants.eu.auth0.com`</li><li>AU: `\{yourTenant}-<CUSTOM_DOMAIN_ID>.edge.tenants.au.auth0.com`</li><li>JP: `\{yourTenant}-<CUSTOM_DOMAIN_ID>.edge.tenants.jp.auth0.com`</li></ul> For example, if your CUSTOM_DOMAIN_ID is:<br/><br/>`cd_TXIdNgQ07HrAFVmz`<br/><br/>For a US tenant, then the Origin hostname should be:<br/><br/>`US: {yourTenant}-cd-txIdngq07hrafvmz.edge.tenants.us.auth0.com` |
-| Host header | Use the name you provided for the Origin hostname. |
+| Origin hostname | Enter `{yourTenant}-<CUSTOM_DOMAIN_ID>.edge.tenants.us.auth0.com`, making sure to replace `<CUSTOM_DOMAIN_ID>` with the value of the Origin Domain Name (custom domain ID) you received from Auth0 when setting up the new custom domain. If your tenants are not in the US region, use one of the following: <ul><li>EU: `{yourTenant}-<CUSTOM_DOMAIN_ID>.edge.tenants.eu.auth0.com`</li><li>AU: `{yourTenant}-<CUSTOM_DOMAIN_ID>.edge.tenants.au.auth0.com`</li><li>JP: `{yourTenant}-<CUSTOM_DOMAIN_ID>.edge.tenants.jp.auth0.com`</li></ul> For example, if your CUSTOM_DOMAIN_ID is:<br/><br/>`cd_TXIdNgQ07HrAFVmz`<br/><br/>For a US tenant, then the Origin hostname should be:<br/><br/>`US: {yourTenant}-cd-txIdngq07hrafvmz.edge.tenants.us.auth0.com` |
+| Server Name Indication (SNI) | Use the name you provided for the Origin hostname. |
 
 For more information on retrieving the details of your custom domain, see [Get custom domain configurations](https://auth0.com/docs/api/management/v2/custom-domains/get-custom-domains).
 
-### Origin client IP address
+### Origin HTTP headers
 
-| Setting | Value |
+| Header Name | Value |
 | --- | --- |
-| Origin IP address | Set the `X-Forwarded-For` (XFF) header to the end user's IP address. Do not specify multiple IP addresses. <br/><br/> You can specify a different header for the user's IP address by using the Management API's [Configure a new custom domain endpoint](/docs/api/management/v2/custom-domains/post-custom-domains) to set the `custom_client_ip_header` property. |
+| host | Use the name you provided for the Origin hostname. |
+| cname-api-key | Set to the CNAME API Key value that you were given immediately after you verified ownership of your domain name with Auth0. You must set this header for Auth0 to accept traffic from your proxy. |
+| x-forwarded-for | Set to the end user's IP address. Do not specify multiple IP addresses. <br/><br/> You can specify a different header for the user's IP address by using the Management API's [Configure a new custom domain endpoint](/docs/api/management/v2/custom-domains/post-custom-domains) to set the `custom_client_ip_header` property. |
 
 Auth0 uses the end user's IP address for features such as anomaly detection, rate limiting, and MFA. If your proxy does not forward the end user's IP address, Auth0 treats your proxy's IP address as the client, which may cause these features to behave incorrectly.
 

--- a/main/docs/customize/custom-domains/self-managed-certificates.mdx
+++ b/main/docs/customize/custom-domains/self-managed-certificates.mdx
@@ -77,8 +77,9 @@ You can use a service such as [Cloudflare](/docs/customize/custom-domains/self-m
 3. The way you configure the proxy server will vary depending on the service you use. You will likely need to configure the following types of settings:
 
 * [Distribution](#distribution-settings)
-* [Origin custom headers](#origin-custom-header-settings)
+* [Origin authentication headers](#origin-authentication-header-settings)
 * [Origin hostname](#origin-hostname-settings)
+* [Original client ip address](#original-client-ip-address)
 * [Default cache behavior](#default-cache-behavior-settings)
 
 ### Distribution settings
@@ -90,12 +91,12 @@ You can use a service such as [Cloudflare](/docs/customize/custom-domains/self-m
 | Origin Protocol Policy | Set to `HTTPS Only`. |
 | Alternate Domain Names (CNAMEs) | Set to your custom domain name (the same one your configured in the Auth0 Dashboard). |
 
-### Origin custom header settings
+### Origin authentication header settings
 
 | Setting | Value |
 | --- | --- |
 | Header Name | Set to `cname-api-key`. |
-| Value | Set to the CNAME API Key value that you were given immediately after you verified ownership of your domain name with Auth0. |
+| Value | Set to the CNAME API Key value that you were given immediately after you verified ownership of your domain name with Auth0. This header is required to be set for Auth0 to accept traffic from your proxy. |
 
 ### Origin hostname settings
 
@@ -105,6 +106,16 @@ You can use a service such as [Cloudflare](/docs/customize/custom-domains/self-m
 | Host header | Use the name you provided for the Origin hostname. |
 
 For more information on retrieving the details of your custom domain, see [Get custom domain configurations](https://auth0.com/docs/api/management/v2/custom-domains/get-custom-domains).
+
+### Original client ip address
+
+| Setting | Value |
+| --- | --- |
+| X-Forwarded-For | Have your proxy set this header to the end user's IP address. Auth0 uses this for features such as anomaly detection, rate limiting, and MFA.  Just one ip address is expected. In case it's not possible to set `X-Forwarded-For`, using [Post custom domain configurations](https://auth0.com/docs/api/management/v2/custom-domains/post-custom-domains) the property `custom_client_ip_header` can be set to configure an alternative header name. |
+
+<Info>
+  If your proxy does not forward the end user's IP address, Auth0 will treat your proxy's IP address as the client. This can cause anomaly detection, rate limiting, and MFA to behave incorrectly.
+</Info>
 
 ### Default cache behavior settings
 

--- a/main/docs/customize/custom-domains/self-managed-certificates.mdx
+++ b/main/docs/customize/custom-domains/self-managed-certificates.mdx
@@ -78,7 +78,7 @@ You can use a service such as [Cloudflare](/docs/customize/custom-domains/self-m
 
 * [Distribution](#distribution-settings)
 * [Origin hostname](#origin-hostname-settings)
-* [Origin HTTP headers](#origin-http-headers)
+* [HTTP headers](#http-headers)
 * [Default cache behavior](#default-cache-behavior-settings)
 
 ### Distribution settings
@@ -99,7 +99,7 @@ You can use a service such as [Cloudflare](/docs/customize/custom-domains/self-m
 
 For more information on retrieving the details of your custom domain, see [Get custom domain configurations](https://auth0.com/docs/api/management/v2/custom-domains/get-custom-domains).
 
-### Origin HTTP headers
+### HTTP headers
 
 | Header Name | Value |
 | --- | --- |

--- a/main/docs/customize/custom-domains/self-managed-certificates.mdx
+++ b/main/docs/customize/custom-domains/self-managed-certificates.mdx
@@ -103,9 +103,9 @@ For more information on retrieving the details of your custom domain, see [Get c
 
 | Header Name | Value |
 | --- | --- |
-| host | Use the name you provided for the Origin hostname. |
-| cname-api-key | Set to the CNAME API Key value that you were given immediately after you verified ownership of your domain name with Auth0. You must set this header for Auth0 to accept traffic from your proxy. |
-| x-forwarded-for | Set to the end user's IP address. Do not specify multiple IP addresses. <br/><br/> You can specify a different header for the user's IP address by using the Management API's [Configure a new custom domain endpoint](/docs/api/management/v2/custom-domains/post-custom-domains) to set the `custom_client_ip_header` property. |
+| `Host` | The [origin hostname](#origin-hostname-settings). |
+| `cname-api-key` | The CNAME API Key value that you were given immediately after you verified ownership of your domain name with Auth0. You must set this header for Auth0 to accept traffic from your proxy. |
+| `X-Forwarded-For` | The end user's IP address. Do not specify multiple IP addresses. <br/><br/> You can specify a different header for the user's IP address by using the Management API's [Configure a new custom domain endpoint](/docs/api/management/v2/custom-domains/post-custom-domains) to set the `custom_client_ip_header` property. |
 
 Auth0 uses the end user's IP address for features such as anomaly detection, rate limiting, and MFA. If your proxy does not forward the end user's IP address, Auth0 treats your proxy's IP address as the client, which may cause these features to behave incorrectly.
 


### PR DESCRIPTION
## Description

We should encourage customers using self-managed custom domain to set XFF header. Without that production functionality can be impacted and their proxy traffic might get rate limited.

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
