### PR TITLE
docs: updated the docs command to use the new qs setup flow

### DIFF
--- a/main/docs/quickstart/spa/react/index.mdx
+++ b/main/docs/quickstart/spa/react/index.mdx
@@ -89,7 +89,7 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
           brew tap auth0/auth0-cli && brew install auth0
 
           # Set up Auth0 app and generate .env file
-          auth0 qs setup --type vite -n "My App" -p 5173
+          auth0 qs setup --app --type spa --framework react --build-tool vite --name "My App" --port 5173
           ```
 
           ```powershell Windows
@@ -98,7 +98,7 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
           scoop install auth0
 
           # Set up Auth0 app and generate .env file
-          auth0 qs setup --type vite -n "My App" -p 5173
+          auth0 qs setup --app --type spa --framework react --build-tool vite --name "My App" --port 5173
           ```
         </CodeGroup>
 

--- a/main/docs/quickstart/spa/svelte/index.mdx
+++ b/main/docs/quickstart/spa/svelte/index.mdx
@@ -73,7 +73,7 @@ import {CreateInteractiveApp} from "/snippets/recipe.jsx";
     brew tap auth0/auth0-cli && brew install auth0
 
     # Set up Auth0 app and generate .env file
-    auth0 qs setup --type vite -n "My App" -p 5173
+    auth0 qs setup --app --type spa --framework svelte --build-tool vite --name "My App" --port 5173
 
   If Windows (PowerShell):
     # Install Auth0 CLI if not already installed
@@ -81,7 +81,7 @@ import {CreateInteractiveApp} from "/snippets/recipe.jsx";
     scoop install auth0
 
     # Set up Auth0 app and generate .env file
-    auth0 qs setup --type vite -n "My App" -p 5173
+    auth0 qs setup --app --type spa --framework svelte --build-tool vite --name "My App" --port 5173
 
   This command will automatically:
   - Authenticate you with Auth0 (prompts for login if needed)
@@ -161,7 +161,7 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
           brew tap auth0/auth0-cli && brew install auth0
 
           # Set up Auth0 app and generate .env file
-          auth0 qs setup --type vite -n "My App" -p 5173
+          auth0 qs setup --app --type spa --framework svelte --build-tool vite --name "My App" --port 5173
           ```
 
           ```powershell Windows
@@ -170,7 +170,7 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
           scoop install auth0
 
           # Set up Auth0 app and generate .env file
-          auth0 qs setup --type vite -n "My App" -p 5173
+          auth0 qs setup --app --type spa --framework svelte --build-tool vite --name "My App" --port 5173
           ```
         </CodeGroup>
 

--- a/main/docs/quickstart/spa/vanillajs/index.mdx
+++ b/main/docs/quickstart/spa/vanillajs/index.mdx
@@ -116,7 +116,7 @@ If MacOS:
   brew tap auth0/auth0-cli && brew install auth0
 
   # Set up Auth0 app and generate .env file
-  auth0 qs setup --type vite -n "My App" -p 5173
+  auth0 qs setup --app --type spa --framework vanilla-javascript --build-tool vite --name "My App" --port 5173
 
 If Windows (PowerShell):
   # Install Auth0 CLI if not already installed
@@ -124,7 +124,7 @@ If Windows (PowerShell):
   scoop install auth0
 
   # Set up Auth0 app and generate .env file
-  auth0 qs setup --type vite -n "My App" -p 5173
+  auth0 qs setup --app --type spa --framework vanilla-javascript --build-tool vite --name "My App" --port 5173
 
 This command will automatically:
 - Authenticate you with Auth0 (prompts for login if needed)
@@ -897,7 +897,7 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
           brew tap auth0/auth0-cli && brew install auth0
 
           # Set up Auth0 app and generate .env file
-          auth0 qs setup --type vite -n "My App" -p 5173
+          auth0 qs setup --app --type spa --framework vanilla-javascript --build-tool vite --name "My App" --port 5173
           ```
 
           ```powershell Windows
@@ -906,7 +906,7 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
           scoop install auth0
 
           # Set up Auth0 app and generate .env file
-          auth0 qs setup --type vite -n "My App" -p 5173
+          auth0 qs setup --app --type spa --framework vanilla-javascript --build-tool vite --name "My App" --port 5173
           ```
         </CodeGroup>
 

--- a/main/docs/quickstart/spa/vuejs/index.mdx
+++ b/main/docs/quickstart/spa/vuejs/index.mdx
@@ -89,7 +89,7 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
           brew tap auth0/auth0-cli && brew install auth0
 
           # Set up Auth0 app and generate .env file
-          auth0 qs setup --type vite -n "My App" -p 5173
+          auth0 qs setup --app --type spa --framework vue --build-tool vite --name "My App" --port 5173
           ```
 
           ```powershell Windows
@@ -98,7 +98,7 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
           scoop install auth0
 
           # Set up Auth0 app and generate .env file
-          auth0 qs setup --type vite -n "My App" -p 5173
+          auth0 qs setup --app --type spa --framework vue --build-tool vite --name "My App" --port 5173
           ```
         </CodeGroup>
 

--- a/main/docs/quickstart/webapp/fastify/index.mdx
+++ b/main/docs/quickstart/webapp/fastify/index.mdx
@@ -130,7 +130,7 @@ This quickstart demonstrates how to add Auth0 authentication to a Fastify applic
           brew tap auth0/auth0-cli && brew install auth0
 
           # Set up Auth0 app and generate .env file
-          auth0 qs setup --type fastify -n "My Fastify App" -p 3000
+          auth0 qs setup --app --type regular --framework fastify --name "My Fastify App" --port 3000
           ```
 
           ```powershell Windows
@@ -139,7 +139,7 @@ This quickstart demonstrates how to add Auth0 authentication to a Fastify applic
           scoop install auth0
 
           # Set up Auth0 app and generate .env file
-          auth0 qs setup --type fastify -n "My Fastify App" -p 3000
+          auth0 qs setup --app --type regular --framework fastify --name "My Fastify App" --port 3000
           ```
         </CodeGroup>
 

--- a/main/docs/quickstart/webapp/nextjs/index.mdx
+++ b/main/docs/quickstart/webapp/nextjs/index.mdx
@@ -101,15 +101,15 @@ APP_BASE_URL=http://localhost:3000`;
       </Tab>
 
       <Tab title="CLI">
-        Run the following command in your project's root directory to create an Auth0 app and generate a `.env.local` file:
+        Run the following command in your project's root directory to create an Auth0 app and generate a `.env` file:
 
         <CodeGroup>
           ```shellscript Mac
           # Install Auth0 CLI (if not already installed)
           brew tap auth0/auth0-cli && brew install auth0
 
-          # Set up Auth0 app and generate .env.local file
-          auth0 qs setup --type nextjs -n "My App" -p 3000
+          # Set up Auth0 app and generate .env file
+          auth0 qs setup --app --type regular --framework nextjs --name "My App" --port 3000
           ```
 
           ```powershell Windows
@@ -117,8 +117,8 @@ APP_BASE_URL=http://localhost:3000`;
           scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git
           scoop install auth0
 
-          # Set up Auth0 app and generate .env.local file
-          auth0 qs setup --type nextjs -n "My App" -p 3000
+          # Set up Auth0 app and generate .env file
+          auth0 qs setup --app --type regular --framework nextjs --name "My App" --port 3000
           ```
         </CodeGroup>
 

--- a/main/docs/quickstart/webapp/nextjs/index.mdx
+++ b/main/docs/quickstart/webapp/nextjs/index.mdx
@@ -126,7 +126,7 @@ APP_BASE_URL=http://localhost:3000`;
           This command will:
           1. Check if you're authenticated (and prompt for login if needed)
           2. Create an Auth0 Regular Web Application configured for `http://localhost:3000`
-          3. Generate a `.env.local` file with `AUTH0_DOMAIN`, `AUTH0_CLIENT_ID`, `AUTH0_CLIENT_SECRET`, `AUTH0_SECRET`, and `APP_BASE_URL`
+          3. Generate a `.env` file with `AUTH0_DOMAIN`, `AUTH0_CLIENT_ID`, `AUTH0_CLIENT_SECRET`, `AUTH0_SECRET`, and `APP_BASE_URL`
         </Callout>
       </Tab>
 


### PR DESCRIPTION
## Description                                                                                                        
    
  Updates the `auth0 qs setup` CLI command in six quickstart guides to use the new, more explicit flag syntax introduced
   in a recent Auth0 CLI release. The old shorthand flags (`--type <framework>`, `-n`, `-p`) have been replaced with the
   full flags (`--app`, `--type`, `--framework`, `--build-tool`, `--name`, `--port`).

  Also corrects the Next.js quickstart to reference `.env` instead of `.env.local` to match what the updated command
  actually generates.

  Affected quickstarts:
  - SPA: React, Svelte, Vanilla JS, Vue.js
  - Webapp: Fastify, Next.js

  ### References

  - DXCDT-1720

  ### Testing

  Verify the updated commands run correctly with the latest Auth0 CLI version and generate the expected `.env` file.
