### PR TITLE
Add workflow to auto-update SDK versions

### DIFF
--- a/.github/workflows/update-sdk-versions.yml
+++ b/.github/workflows/update-sdk-versions.yml
@@ -123,9 +123,6 @@ jobs:
           update_sdk          "Auth0.Android"         "auth0/Auth0.Android"
           update_sdk_prefixed "auth0-oidc-client-net" "auth0/auth0-oidc-client-net" "ios-" "false"
 
-          # --- ACUL SDKs ---
-          update_sdk_prefixed "universal-login" "auth0/universal-login" "auth0-acul-js-v" "true"
-
           # --- Management API SDKs ---
           update_sdk "auth0.net"  "auth0/auth0.net"
           update_sdk "go-auth0"   "auth0/go-auth0"

--- a/.github/workflows/update-sdk-versions.yml
+++ b/.github/workflows/update-sdk-versions.yml
@@ -1,0 +1,177 @@
+name: Update SDK library versions
+
+on:
+  schedule:
+    - cron: '17 6 * * *' # Daily at 6:17 UTC
+  workflow_dispatch:
+
+jobs:
+  update-versions:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch latest SDK releases and update libraries.mdx
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          FILE="main/docs/libraries.mdx"
+
+          # Fetches releases/latest for a repo and updates badge + date for a subtext.
+          # Falls back to tags if no formal releases exist.
+          update_sdk() {
+            local subtext="$1"
+            local repo="$2"
+            local tag pub_date release
+
+            release=$(gh api "repos/${repo}/releases/latest" 2>/dev/null)
+
+            if [ -n "$release" ]; then
+              tag=$(echo "$release" | jq -r '.tag_name')
+              pub_date=$(echo "$release" | jq -r '.published_at')
+            else
+              local tags sha
+              tags=$(gh api "repos/${repo}/tags" 2>/dev/null)
+              tag=$(echo "$tags" | jq -r '.[0].name // empty')
+              sha=$(echo "$tags" | jq -r '.[0].commit.sha // empty')
+              if [ -z "$tag" ]; then
+                echo "  No release or tag found for ${repo} — skipping"
+                return
+              fi
+              pub_date=$(gh api "repos/${repo}/commits/${sha}" 2>/dev/null | jq -r '.commit.committer.date // empty')
+              pub_date="${pub_date:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+            fi
+
+            local fmt_date
+            fmt_date=$(date -d "$pub_date" '+%b %-d, %Y')
+            echo "  ${subtext}: ${tag}  (${fmt_date})"
+
+            sed -i "/subtext: \"${subtext}\"/,/}}\/>/{
+              s|badge: \"[^\"]*\"|badge: \"${tag}\"|
+              s|date: \"[^\"]*\"|date: \"${fmt_date}\"|
+            }" "$FILE"
+          }
+
+          # Fetches releases filtered by a tag prefix (for monorepos).
+          # strip_prefix="true" removes the prefix from the displayed badge value.
+          update_sdk_prefixed() {
+            local subtext="$1"
+            local repo="$2"
+            local prefix="$3"
+            local strip_prefix="${4:-false}"
+            local releases tag pub_date display_tag fmt_date
+
+            releases=$(gh api "repos/${repo}/releases?per_page=20")
+            tag=$(echo "$releases" | jq -r --arg p "$prefix" \
+              '[.[] | select(.tag_name | startswith($p))][0].tag_name // empty')
+            pub_date=$(echo "$releases" | jq -r --arg p "$prefix" \
+              '[.[] | select(.tag_name | startswith($p))][0].published_at // empty')
+
+            if [ -z "$tag" ]; then
+              echo "  No release with prefix '${prefix}' for ${repo} — skipping"
+              return
+            fi
+
+            display_tag="$tag"
+            if [ "$strip_prefix" = "true" ]; then
+              display_tag="${tag#${prefix}}"
+            fi
+
+            fmt_date=$(date -d "$pub_date" '+%b %-d, %Y')
+            echo "  ${subtext}: ${display_tag}  (${fmt_date})"
+
+            sed -i "/subtext: \"${subtext}\"/,/}}\/>/{
+              s|badge: \"[^\"]*\"|badge: \"${display_tag}\"|
+              s|date: \"[^\"]*\"|date: \"${fmt_date}\"|
+            }" "$FILE"
+          }
+
+          # --- SPA SDKs ---
+          update_sdk          "auth0-react"   "auth0/auth0-react"
+          update_sdk          "auth0-vue"     "auth0/auth0-vue"
+          update_sdk          "auth0-angular" "auth0/auth0-angular"
+          update_sdk          "auth0-spa-js"  "auth0/auth0-spa-js"
+          update_sdk_prefixed "auth0-flutter" "auth0/auth0-flutter" "af-v" "false"
+
+          # --- Regular Web App SDKs ---
+          update_sdk          "nextjs-auth0"                    "auth0/nextjs-auth0"
+          update_sdk          "express-openid-connect"          "auth0/express-openid-connect"
+          update_sdk_prefixed "auth0-fastify"                   "auth0/auth0-fastify" "auth0-fastify-v" "true"
+          update_sdk_prefixed "auth0-nuxt"                      "auth0/auth0-nuxt" "auth0-nuxt-v" "true"
+          update_sdk          "auth0-aspnetcore-authentication" "auth0/auth0-aspnetcore-authentication"
+          update_sdk          "laravel-auth0"                   "auth0/laravel-auth0"
+          update_sdk          "okta-spring-boot"                "auth0/auth0-auth-java"
+          update_sdk          "auth0-python"                    "auth0/auth0-python"
+          update_sdk          "auth0-php"                       "auth0/auth0-php"
+          update_sdk          "omniauth-auth0"                  "auth0/omniauth-auth0"
+          update_sdk          "auth0-java-mvc-common"           "auth0/auth0-java-mvc-common"
+          update_sdk          "auth0-hono"                      "auth0-lab/auth0-hono"
+
+          # --- Backend / API SDKs ---
+          update_sdk          "node-oauth2-jwt-bearer" "auth0/node-oauth2-jwt-bearer"
+          update_sdk_prefixed "auth0-fastify-api"      "auth0/auth0-fastify" "auth0-fastify-api-v" "true"
+          update_sdk          "go-jwt-middleware"      "auth0/go-jwt-middleware"
+          update_sdk          "auth0-PHP"              "auth0/auth0-php"
+
+          # --- Native / Mobile SDKs ---
+          update_sdk          "react-native-auth0"    "auth0/react-native-auth0"
+          update_sdk          "Auth0.swift"           "auth0/Auth0.swift"
+          update_sdk          "Auth0.Android"         "auth0/Auth0.Android"
+          update_sdk_prefixed "auth0-oidc-client-net" "auth0/auth0-oidc-client-net" "ios-" "false"
+
+          # --- ACUL SDKs ---
+          update_sdk_prefixed "universal-login" "auth0/universal-login" "auth0-acul-js-v" "true"
+
+          # --- Management API SDKs ---
+          update_sdk "auth0.net"  "auth0/auth0.net"
+          update_sdk "go-auth0"   "auth0/go-auth0"
+          update_sdk "auth0-java" "auth0/auth0-java"
+          update_sdk "node-auth0" "auth0/node-auth0"
+          update_sdk "ruby-auth0" "auth0/ruby-auth0"
+
+          # --- Lock SDKs ---
+          update_sdk "Lock.Android" "auth0/Lock.Android"
+          update_sdk "Lock.swift"   "auth0/Lock.swift"
+          update_sdk "lock"         "auth0/lock"
+
+          echo "--- Done ---"
+
+      - name: Open PR if versions changed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git add main/docs/libraries.mdx
+          if git diff --cached --quiet; then
+            echo "All SDK versions are already up to date — nothing to do."
+            exit 0
+          fi
+
+          BRANCH="chore/sdk-version-update-$(date +%Y%m%d)"
+
+          if gh pr list --head "$BRANCH" --state open --json number --jq 'length' | grep -qv '^0$'; then
+            echo "Open PR already exists for ${BRANCH} — skipping."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git checkout -b "$BRANCH"
+          git commit -m "chore: update SDK library versions $(date +%Y-%m-%d)"
+          git push origin "$BRANCH"
+
+          gh pr create \
+            --title "chore: update SDK library versions" \
+            --body "Automated daily sync of SDK version badges and release dates in \`main/docs/libraries.mdx\`.
+
+          Each \`badge\` and \`date\` was updated by fetching the latest GitHub release for the corresponding SDK repository.
+
+          ---
+          Auto-generated by [update-sdk-versions]($(gh repo view --json url -q .url)/blob/main/.github/workflows/update-sdk-versions.yml). Approve to deploy." \
+            --head "$BRANCH" \
+            --base main \
+            --label "sdk-version-autoupdate"


### PR DESCRIPTION
## Description
Adds .github/workflows/update-sdk-versions.yml: a scheduled GitHub Actions workflow that keeps SDK version badges and release dates in main/docs/libraries.mdx up to date automatically.

The workflow runs daily at 6:17 UTC (and supports manual dispatch). For each of the 34 SDK entries in the libraries page it fetches the latest release from GitHub and updates two fields in the corresponding SectionCard component:

- badge: the version tag (e.g. v2.3.0)
- date: the formatted release date (e.g. Jan 23, 2024)

Two fetch strategies are used depending on the repo:

- Standard: releases/latest, with a tag fallback for repos that have no formal releases
- Prefixed: filters releases by tag prefix for monorepos where multiple packages share a repo (e.g. auth0/auth0-fastify, auth0/universal-login, auth0/auth0-oidc-client-net)

If any values changed, the workflow creates a branch chore/sdk-version-update-YYYYMMDD and opens a PR targeting main labeled sdk-version-autoupdate. 

### References
n/a

### Testing

1. After merging, go to Actions → Update SDK library versions → Run workflow to trigger a manual run
2. Verify a PR is opened with updated badge and date values in main/docs/libraries.mdx
3. Confirm no duplicate PR is created if the workflow is triggered again on the same day

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
