### PR TITLE
fix: update sdk cards and remove dot from nav

### DIFF
--- a/main/snippets/SectionsWithCards.jsx
+++ b/main/snippets/SectionsWithCards.jsx
@@ -5,7 +5,7 @@ export const SectionsWithCards = ({ sections }) => {
     .map((s) => ({
       ...s,
       items: s.items.filter((it) =>
-        it.name.toLowerCase().includes(query.toLowerCase())
+        it.name.toLowerCase().includes(query.toLowerCase()),
       ),
     }))
     .filter((s) => s.items.length > 0);
@@ -28,8 +28,8 @@ export const SectionsWithCards = ({ sections }) => {
     const tertiaryLabel = quickstart
       ? "Quickstart"
       : docs
-      ? "Documentation"
-      : "";
+        ? "Documentation"
+        : "";
 
     return (
       <article className="libraries_card rounded-3xl transition-shadow mb-4">
@@ -65,6 +65,7 @@ export const SectionsWithCards = ({ sections }) => {
                     border border-emerald-700 text-emerald-700 bg-emerald-200
                     dark:border-emerald-400 dark:text-emerald-300 dark:bg-emerald-900/30
                   "
+                  style={{ border: "none !important" }}
                 >
                   {badge}
                 </span>
@@ -433,12 +434,12 @@ export const SectionCard = ({ item }) => {
               </>
             )}
 
-            <div className="min-w-0">
+            <div className="min-w-0 truncate">
               <h4 className="text-base md:text-lg font-semibold text-gray-900 dark:text-white truncate !m-0 leading-snug">
                 {title}
               </h4>
               {!!subtext && (
-                <p className="text-xs text-gray-500 dark:text-gray-400 truncate !m-0 leading-tight">
+                <p className="!text-sm text-gray-500 dark:text-gray-400 truncate !m-0 leading-tight">
                   {subtext}
                 </p>
               )}
@@ -447,18 +448,12 @@ export const SectionCard = ({ item }) => {
 
           <div className="flex flex-col items-end gap-0.5 shrink-0">
             {!!badge && (
-              <span
-                className="
-                  inline-flex items-center rounded-full px-1.5 py-[0.5px] text-[10px] font-medium
-                  border border-emerald-700 text-emerald-700 bg-emerald-200
-                  dark:border-emerald-400 dark:text-emerald-300 dark:bg-emerald-900/30
-                "
-              >
+              <span className="inline-flex items-center rounded-full px-1.5 h-5 text-base font-semibold">
                 {badge}
               </span>
             )}
             {!!date && (
-              <span className="mr-[5px] text-[10px] text-gray-500 dark:text-gray-400">
+              <span className="mr-[5px] !text-xs font-medium text-gray-500 dark:text-gray-400">
                 on {date.replace(/^on\s+/i, "")}
               </span>
             )}
@@ -469,55 +464,39 @@ export const SectionCard = ({ item }) => {
       <div className="libraries_card_divider" />
 
       <div className="px-4 md:px-5 pt-3 pb-4">
-        <div className="libraries_cards flex items-center justify-between w-full gap-3">
-          {github && (
-            <a
-              href={github.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="
-                no_external_icon inline-flex items-center gap-1.5 text-xs font-medium
-                !text-black dark:!text-white
-                !no-underline !border-0
-                transition-colors duration-200
-                hover:!text-neutral-700 dark:hover:!text-neutral-200
-              "
-              style={{ borderBottom: "none !important" }}
-            >
-              <Icon icon="github" className="w-3 h-3 shrink-0" />
-              <span className="leading-none">Github</span>
-            </a>
-          )}
+        <div className="flex flex-col gap-3 w-full">
+          <div className="libraries_cards flex items-center w-full gap-5">
+            {github && (
+              <a
+                href={github.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="no_external_icon inline-flex flex-1 items-center gap-1.5 text-sm font-medium !text-black dark:!text-white !no-underline !border-0 transition-colors duration-200 hover:!text-neutral-700 dark:hover:!text-neutral-200 h-6"
+                style={{ borderBottom: "none !important" }}
+              >
+                <Icon icon="github" className="w-3 h-3 shrink-0" />
+                <span className="w-full">Github</span>
+              </a>
+            )}
 
-          {sample && (
-            <a
-              href={sample.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="
-                no_external_icon inline-flex items-center gap-1.5 text-xs font-medium
-                !text-black dark:!text-white
-                !no-underline !border-0
-                transition-colors duration-200
-                hover:!text-neutral-700 dark:hover:!text-neutral-200
-              "
-              style={{ borderBottom: "none !important" }}
-            >
-              <Icon icon="download" className="w-3 h-3 shrink-0" />
-              <span className="leading-none">Sample App</span>
-            </a>
-          )}
+            {sample && (
+              <a
+                href={sample.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="no_external_icon inline-flex flex-1 items-center gap-1.5 text-sm font-medium !text-black dark:!text-white !no-underline !border-0 transition-colors duration-200 hover:!text-neutral-700 dark:hover:!text-neutral-200 h-6"
+                style={{ borderBottom: "none !important" }}
+              >
+                <Icon icon="download" className="w-3 h-3 shrink-0" />
+                <span className="w-full">Sample App</span>
+              </a>
+            )}
+          </div>
 
           {tertiary && (
             <a
               href={tertiary.url}
-              className="
-                no_external_icon inline-flex items-center gap-1.5 text-xs font-medium
-                !text-black dark:!text-white
-                !no-underline !border-0
-                transition-colors duration-200
-                hover:!text-neutral-700 dark:hover:!text-neutral-200
-              "
+              className="no_external_icon inline-flex flex-1 items-center gap-1.5 text-sm font-medium !text-black dark:!text-white !no-underline !border-0 transition-colors duration-200 hover:!text-neutral-700 dark:hover:!text-neutral-200 h-6"
               style={{ borderBottom: "none !important" }}
             >
               {tertiaryLabel === "Quickstart" ? (
@@ -525,7 +504,7 @@ export const SectionCard = ({ item }) => {
               ) : (
                 <Icon icon="file-lines" className="w-3 h-3 shrink-0" />
               )}
-              <span className="leading-none">{tertiaryLabel}</span>
+              <span className="w-full">{tertiaryLabel}</span>
             </a>
           )}
         </div>

--- a/main/ui/css/styles.css
+++ b/main/ui/css/styles.css
@@ -942,13 +942,7 @@ html[style*="color-scheme: dark"] {
 }
 
 .nav-tabs-item > div {
-  bottom: -8px;
-  height: 4px;
-  width: 4px;
-  border-radius: 999px;
-  left: 50%;
-  transform: translateX(-50%);
-  transition: all 0.15s ease-out;
+  display: none;
 }
 
 /* ==========================================================================

--- a/main/ui/css/styles.css
+++ b/main/ui/css/styles.css
@@ -901,10 +901,6 @@ html[style*="color-scheme: dark"] {
   gap: 1rem;
 }
 
-#navbar > div:nth-child(3) > div:nth-child(2) {
-  margin-top: 1rem;
-}
-
 .nav-tabs-item {
   position: relative;
   padding: 0.25rem 0.75rem;
@@ -927,21 +923,7 @@ html[style*="color-scheme: dark"] {
   transition: all 0.15s ease-out;
 }
 
-.nav-tabs-item:hover > div {
-  height: 0px;
-  width: 0px;
-}
-
-.nav-tabs :where(.text-primary):hover > div {
-  height: 4px;
-  width: 4px;
-}
-
-.nav-tabs :where(.text-primary) > div {
-  background-color: oklch(from var(--accent) l c h);
-}
-
-.nav-tabs-item > div {
+.nav-tabs a > div.absolute.bottom-0 {
   display: none;
 }
 

--- a/ui/src/components/nav-actions.tsx
+++ b/ui/src/components/nav-actions.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { observer } from 'mobx-react-lite';
 
 import { cn } from '@/lib/utils';
@@ -14,11 +14,8 @@ const NavActions = observer(({ className }: { className?: string }) => {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const isLgUp = useBreakpoint('lg');
   const user = sessionStore.user;
-  const [isPositioned, setIsPositioned] = useState(false);
 
-  // Use useLayoutEffect to calculate position synchronously before paint
-  // This prevents visible layout shift
-  useLayoutEffect(() => {
+  useEffect(() => {
     const updatePosition = () => {
       const referenceDiv = isLgUp
         ? document.querySelector('.topbar-right-container')
@@ -31,7 +28,6 @@ const NavActions = observer(({ className }: { className?: string }) => {
       if (wrapperRef.current) {
         const iconsWidth = isLgUp ? 30 + 16 : -8; // icon width + margin
         wrapperRef.current.style.right = `${window.innerWidth - right + iconsWidth}px`;
-        setIsPositioned(true);
       }
     };
 
@@ -50,9 +46,6 @@ const NavActions = observer(({ className }: { className?: string }) => {
       ref={wrapperRef}
       className={cn(
         'adu:fixed adu:top-0 adu:z-30 adu:flex adu:h-14 adu:items-center adu:gap-3',
-        // Hide until positioned to prevent layout shift flash
-        !isPositioned && 'adu:opacity-0',
-        isPositioned && 'adu:opacity-100 adu:transition-opacity adu:duration-75',
         className,
       )}
     >


### PR DESCRIPTION
## Description

This PR updates the SDK cards to use more standard sizing and spacing to accommodate the different elements.
Additionally, removes dot indicators from active `nav-tabs`.

### Before
<img width="1394" height="1194" alt="CleanShot 2026-05-15 at 18 12 18@2x" src="https://github.com/user-attachments/assets/ce9ef03b-0403-454f-b78e-f9614bf662db" />

<img width="1478" height="294" alt="CleanShot 2026-05-19 at 20 45 58@2x" src="https://github.com/user-attachments/assets/37abec0a-87ee-4237-837e-b81129a02f84" />

### After
<img width="1378" height="1342" alt="CleanShot 2026-05-15 at 18 12 35@2x" src="https://github.com/user-attachments/assets/3436b913-fecd-4545-a7ca-1cb072e17298" />

<img width="2024" height="246" alt="CleanShot 2026-05-19 at 20 45 33@2x" src="https://github.com/user-attachments/assets/0e53fec9-bb03-49c1-b4e3-4b2cf8d7de35" />



### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

1. Navigate to SDKs
2. Check truncation of text strings + cards

## Checklist

- [X] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [X] I've tested the site build for this change locally.
- [X] I've made appropriate docs updates for any code or config changes.
- [X] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
