### PR TITLE
fix: rename sidebar tab anchors to "Overview" and force 14px

### DIFF
--- a/main/docs/api.mdx
+++ b/main/docs/api.mdx
@@ -1,5 +1,6 @@
 ---
 title: Auth0 APIs
+sidebarTitle: Overview
 mode: wide
 description: Auth0 exposes the following APIs for developers to consume in their applications.
 ---

--- a/main/docs/authenticate.mdx
+++ b/main/docs/authenticate.mdx
@@ -1,6 +1,7 @@
 ---
 description: Learn all about how to authenticate using Auth0.
 title: Authenticate
+sidebarTitle: Overview
 ---
 import {AuthDocsPipeline} from "/snippets/AuthDocsPipeline.mdx";
 

--- a/main/docs/customize.mdx
+++ b/main/docs/customize.mdx
@@ -1,6 +1,7 @@
 ---
 description: Learn how to brand, customize, and localize your login pages, domain names, emails sent to users, and consent prompts.
 title: Customize
+sidebarTitle: Overview
 ---
 import {AuthDocsPipeline} from "/snippets/AuthDocsPipeline.mdx";
 

--- a/main/docs/deploy-monitor.mdx
+++ b/main/docs/deploy-monitor.mdx
@@ -1,6 +1,7 @@
 ---
 description: Learn about Auth0 public and private cloud deployment options, as well as deployment checklists and tools.
 title: Deploy and Monitor
+sidebarTitle: Overview
 ---
 import {AuthDocsPipeline} from "/snippets/AuthDocsPipeline.mdx";
 

--- a/main/docs/get-started.mdx
+++ b/main/docs/get-started.mdx
@@ -1,6 +1,7 @@
 ---
 description: Learn the basics and begin building your authentication solution.
 title: Get Started
+sidebarTitle: Overview
 ---
 import {AuthDocsPipeline} from "/snippets/AuthDocsPipeline.mdx";
 

--- a/main/docs/libraries.mdx
+++ b/main/docs/libraries.mdx
@@ -1,6 +1,7 @@
 ---
 description: Auth0 Libraries and SDKs overview
 title: SDK Libraries
+sidebarTitle: Overview
 ---
 
 import {SectionCard} from "/snippets/SectionsWithCards.jsx";

--- a/main/docs/manage-users.mdx
+++ b/main/docs/manage-users.mdx
@@ -1,6 +1,7 @@
 ---
 description: Learn about working with users, user profiles, and user metadata in Auth0.
 title: Manage Users
+sidebarTitle: Overview
 ---
 import { AuthDocsPipeline } from "/snippets/AuthDocsPipeline.mdx";
 

--- a/main/docs/quickstarts.mdx
+++ b/main/docs/quickstarts.mdx
@@ -1,7 +1,7 @@
 ---
 title: Auth0 Quickstarts
 description: Get started using Auth0. Implement authentication for any kind of application in minutes.
-sidebarTitle: Quickstarts
+sidebarTitle: Overview
 ---
 
 import { QuickstartPage, QuickstartBanner } from "/snippets/QuickstartPage.mdx";

--- a/main/docs/secure.mdx
+++ b/main/docs/secure.mdx
@@ -1,6 +1,7 @@
 ---
 description: Learn about various security-related issues, such as handling tokens, preventing security attacks, AllowListing, data privacy, and Auth0 security bulletins
 title: Secure
+sidebarTitle: Overview
 ---
 import {AuthDocsPipeline} from "/snippets/AuthDocsPipeline.mdx";
 

--- a/main/docs/troubleshoot.mdx
+++ b/main/docs/troubleshoot.mdx
@@ -1,6 +1,7 @@
 ---
 description: Learn how to troubleshoot and solve common issues in Auth0.
 title: Troubleshoot
+sidebarTitle: Overview
 ---
 import {AuthDocsPipeline} from "/snippets/AuthDocsPipeline.mdx";
 

--- a/main/style.css
+++ b/main/style.css
@@ -1,0 +1,5 @@
+/* Sidebar "Overview" anchor links inherit a larger size in Aspen.
+   Match them to the rest of the sidebar nav items at 14px. */
+li[data-title="Overview"] > a {
+  font-size: 14px;
+}


### PR DESCRIPTION
## Summary

The first sidebar item under each top-level documentation tab/dropdown previously duplicated the parent label (e.g., "Get Started" → "Get Started", "API Reference" → "Auth0 APIs", "SDKs" → "SDK Libraries"). This PR renames each of those anchor pages to **Overview** in the sidebar and adds a small CSS rule to normalize their font size to 14px so they match the rest of the navigation items.

## Changes

**Sidebar label rename** — `sidebarTitle: Overview` added to frontmatter on 10 anchor pages:

- `main/docs/get-started.mdx`
- `main/docs/authenticate.mdx`
- `main/docs/manage-users.mdx`
- `main/docs/customize.mdx`
- `main/docs/secure.mdx`
- `main/docs/deploy-monitor.mdx`
- `main/docs/troubleshoot.mdx`
- `main/docs/api.mdx`
- `main/docs/libraries.mdx`
- `main/docs/quickstarts.mdx` (replaced existing `sidebarTitle: Quickstarts`)

Page titles (H1 / browser tab) and URLs are unchanged — only the sidebar label.

**Font-size normalization** — new file `main/style.css`:

```css
li[data-title="Overview"] > a {
  font-size: 14px;
}
```

Targets only sidebar items labeled "Overview" so other navigation entries are untouched. Mintlify auto-loads `style.css` from the project root (same convention as `auth4genai/style.css`).

## Screenshots

Before

<img width="380" height="279" alt="Screenshot 2026-05-20 at 14 07 09" src="https://github.com/user-attachments/assets/3b5b8881-1750-4dd9-a6f5-414d6244d794" />


After 
<img width="379" height="281" alt="Screenshot 2026-05-20 at 14 07 55" src="https://github.com/user-attachments/assets/342c479d-306c-4dd2-8729-f266c28bc4fa" />

