### PR TITLE
fix: event catalog overview in pulldown

### DIFF
--- a/main/config/nav.en.json
+++ b/main/config/nav.en.json
@@ -64,7 +64,13 @@
         {
           "item": "Events Catalog",
           "icon": "/icons/events-catalog.svg",
-          "$ref": "./navigation/generated/events-catalog.en.json"
+          "pages": [
+            "/docs/events",
+            {
+              "group": " ",
+              "$ref": "./navigation/generated/events-catalog.en.json"
+            }
+          ]
         },
         {
           "item": "Universal Components",


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

adds the event catalog home page in to the pulldown menu. oversight from the tabs IA boogaloo.

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

### References

found by alison. sorry alison!

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

follow the link in the top nav to the event catalog. it should go to the homepage now.

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
