### PR TITLE
fix: declutter nav tabs - remove icons

### DIFF
--- a/main/config/nav.en.json
+++ b/main/config/nav.en.json
@@ -9,61 +9,49 @@
     },
     {
       "tab": "Get Started",
-      "icon": "play",
       "$ref": "./navigation/get-started.json"
     },
     {
       "tab": "Authenticate",
-      "icon": "/icons/authenticate.svg",
       "$ref": "./navigation/authenticate.json"
     },
     {
       "tab": "Manage Users",
-      "icon": "/icons/manage-users.svg",
       "$ref": "./navigation/manage-users.json"
     },
     {
       "tab": "Customize",
-      "icon": "/icons/customize.svg",
       "$ref": "./navigation/customize.json"
     },
     {
       "tab": "Secure",
-      "icon": "shield-check",
       "$ref": "./navigation/secure.json"
     },
     {
       "tab": "Deploy & Monitor",
-      "icon": "chart-simple",
       "$ref": "./navigation/deploy-and-monitor.json"
     },
     {
       "tab": "Auth0 AI",
-      "icon": "/icons/auth0-ai.svg",
       "$ref": "./navigation/ai.json"
     },
     {
       "tab": "Platform",
-      "icon": "/icons/platform.svg",
       "$ref": "./navigation/platform.json"
     },
     {
       "tab": "Dev Tools",
-      "icon": "/icons/dev-tools.svg",
       "menu": [
         {
           "item": "APIs",
-          "icon": "/icons/apis.svg",
           "$ref": "./navigation/apis.json"
         },
         {
           "item": "SDKs",
-          "icon": "/icons/sdks.svg",
           "$ref": "./navigation/sdk-libraries.json"
         },
         {
           "item": "Events Catalog",
-          "icon": "/icons/events-catalog.svg",
           "pages": [
             "/docs/events",
             {
@@ -74,7 +62,6 @@
         },
         {
           "item": "Universal Components",
-          "icon": "/icons/universal-components.svg",
           "$ref": "./navigation/universal-components.json"
         }
       ]

--- a/main/ui/css/styles.css
+++ b/main/ui/css/styles.css
@@ -901,6 +901,23 @@ html[style*="color-scheme: dark"] {
   gap: 1rem;
 }
 
+/* The active tab gets Tailwind's `font-medium` (500) which overrides the
+   base `.nav-tabs-item` weight. Force semibold on the selected tab so it
+   stands out from the inactive tabs. `.text-primary` (rather than
+   `[data-active]`) also covers the Dev Tools <button> dropdown when one
+   of its sub-pages is the current page. */
+.nav-tabs-item.text-primary {
+  font-weight: 600;
+}
+
+/* The Dev Tools dropdown is a <button> whose inner content <div> has its own
+   `text-gray-800` class. When the button is selected the outer <button> gets
+   `text-primary`, but the inner div's gray override kept the label black.
+   Force the inner content div to inherit the accent color too. */
+button.nav-tabs-item.text-primary > div {
+  color: var(--accent);
+}
+
 .nav-tabs-item {
   position: relative;
   padding: 0.25rem 0.75rem;
@@ -923,7 +940,8 @@ html[style*="color-scheme: dark"] {
   transition: all 0.15s ease-out;
 }
 
-.nav-tabs a > div.absolute.bottom-0 {
+.nav-tabs a > div.absolute.bottom-0,
+.nav-tabs button > div.absolute.bottom-0 {
   display: none;
 }
 


### PR DESCRIPTION
Removed icons from all top-level navigation tabs (and Dev Tools menu items). The icons were originally added as visual indicators but in practice took up space and looked cluttered with multiple number of tabs. Tabs are now text-only.
Updated font-weight: 600 on .nav-tabs-item.text-primary so the selected tab is visibly heavier than the inactive ones.

Before
<img width="1728" height="996" alt="Screenshot 2026-05-21 at 23 22 59" src="https://github.com/user-attachments/assets/fe28610e-14d4-4ce6-9eac-31bb81d5fdff" />


After
<img width="1728" height="997" alt="Screenshot 2026-05-21 at 23 23 15" src="https://github.com/user-attachments/assets/b0a3833c-6f37-4a1c-bf77-a1b544b76fd7" />
