### PR TITLE
fix: remove empty group from events catalog nav

### DIFF
--- a/main/config/nav.en.json
+++ b/main/config/nav.en.json
@@ -64,13 +64,7 @@
         {
           "item": "Events Catalog",
           "icon": "/icons/events-catalog.svg",
-          "pages": [
-            "/docs/events",
-            {
-              "group": " ",
-              "$ref": "./navigation/generated/events-catalog.en.json"
-            }
-          ]
+          "$ref": "./navigation/generated/events-catalog.en.json"
         },
         {
           "item": "Universal Components",


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

☝️ half of the fix for the empty group issue, along with the pipeline PR below

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

### References

https://github.com/atko-cic/docs-content-pipeline/pull/224

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
