### PR TITLE
Feat/custom rate limit policies

### DIFF
--- a/main/config/navigation/platform.json
+++ b/main/config/navigation/platform.json
@@ -38,7 +38,7 @@
           "root": "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy",
           "pages": [
             "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-use-cases",
-            "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policy",
+            "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies",
             "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations",
             "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/free-public",
             "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/essentials-professional-b2b",

--- a/main/config/navigation/platform.json
+++ b/main/config/navigation/platform.json
@@ -38,6 +38,7 @@
           "root": "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy",
           "pages": [
             "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-use-cases",
+            "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policy",
             "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations",
             "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/free-public",
             "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/essentials-professional-b2b",

--- a/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
@@ -45,7 +45,7 @@ If one third-party application needs different treatment, assign it a Client ID 
 
 Although CIMD (Client-Initiated Managed Delegation) clients are technically third-party applications, Auth0 places them in a separate group from traditional third-party apps. This means two distinct group buckets exist:
 
-- **Third-party apps** (Client ID prefix: `tpa_`) — Traditional third-party applications, including those created via the Management API or Dynamic Client Registration (DCR).
+- **Third-party apps** (Client ID prefix: `tpa_`):  Traditional third-party applications, including those created via the Management API or Dynamic Client Registration (DCR).
 - **CIMD clients** (Client ID prefix: `https://`) — Applications created through Client-Initiated Managed Delegation.
 
 Each group has its own pooled counter. Traffic from CIMD clients does not count against the third-party apps group limit, and vice versa. You can identify which group an application belongs to by its Client ID prefix.

--- a/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
@@ -43,9 +43,9 @@ If one third-party application needs different treatment, assign it a Client ID 
 
 ### Independent counters (Global / Default policies)
 
-Global policies use independent counters — each application gets its own separate counter evaluated against the same configured ceiling. Applications do not compete with each other for capacity.
+Global policies use independent counters. Each application gets its own separate counter evaluated against the same configured ceiling. Applications do not compete with each other for capacity.
 
-For example, if you set a Global default policy of 50 RPS: Application A can send 50 RPS, Application B can send 50 RPS, and Application C can send 50 RPS — all independently. Application A hitting its limit has no effect on Applications B or C. Each application is throttled only when it individually exceeds 50 RPS.
+For example, if you set a Global default policy of 50 RPS: Application A can send 50 RPS, Application B can send 50 RPS, and Application C can send 50 RPS, all independently. Application A hitting its limit has no effect on Applications B or C. Each application is throttled only when it individually exceeds 50 RPS.
 
 Use Group policies when you need to cap the *aggregate* load from a class of applications (such as third-party integrations whose combined traffic could overwhelm your tenant). Use the Global default when you need a uniform safety ceiling per application without coordination between them.
 
@@ -88,7 +88,7 @@ Because browser-initiated requests are excluded, custom rate limit policies redu
 
 ## Log-only mode
 
-When you enable log-only mode on a policy, Auth0 tracks requests against the configured limit and emits log events (`api_limit` and `api_limit_warning`) as if the policy were enforced — but does not actually return HTTP 429 responses. Traffic continues to flow normally.
+When you enable log-only mode on a policy, Auth0 tracks requests against the configured limit and emits log events (`api_limit` and `api_limit_warning`) as if the policy were enforced, but does not actually return HTTP 429 responses. Traffic continues to flow normally.
 
 Use log-only mode to:
 
@@ -115,7 +115,7 @@ Because you control the application code, you can predict traffic scaling and ad
 
 ### Third-party applications (Group or Global policies)
 
-For applications you do not control — such as partner integrations, customer-built apps, or marketplace connectors — you cannot predict traffic patterns in advance. Set limits based on what your tenant can safely absorb:
+For applications you do not control, such as partner integrations, customer-built apps, or marketplace connectors, you cannot predict traffic patterns in advance. Set limits based on what your tenant can safely absorb:
 
 1. Calculate the maximum RPS your tenant can tolerate from a single source without impacting other applications.
 2. Set the limit at that threshold or below.
@@ -126,7 +126,7 @@ Because you cannot control when third-party applications change their behavior, 
 
 <Tip>
 
-The goal is a ceiling that normal traffic never reaches. If an application routinely approaches its limit, the limit is set too low — raise it and investigate the traffic pattern.
+The goal is a ceiling that normal traffic never reaches. If an application routinely approaches its limit, the limit is set too low. Raise it and investigate the traffic pattern.
 
 </Tip>
 
@@ -284,7 +284,7 @@ Enable log-only mode on new policies to observe their impact without blocking tr
 
 ## Monitor via HTTP response headers
 
-Auth0 includes rate limit headers on all responses to requests evaluated by a custom rate limit policy — both successful and rejected.
+Auth0 includes rate limit headers on all responses to requests evaluated by a custom rate limit policy, both successful and rejected.
 
 Every evaluated response includes the `Auth0-RateLimit` header, which communicates the application's current quota status:
 
@@ -323,7 +323,7 @@ Throttling applies only to the application that exceeded its limit. Other applic
 
 <Note>
 
-On successful responses, the standard `X-RateLimit-*` headers reflect your tenant's global rate limit — not the custom policy limit. Use the `Auth0-RateLimit` header to monitor custom policy quota consumption on successful requests.
+On successful responses, the standard `X-RateLimit-*` headers reflect your tenant's global rate limit, not the custom policy limit. Use the `Auth0-RateLimit` header to monitor custom policy quota consumption on successful requests.
 
 </Note>
 

--- a/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
@@ -1,0 +1,265 @@
+---
+title: Custom Rate Limit Policies
+description: Set per-application rate limit ceilings to protect your tenant from misconfigured or misbehaving applications.
+---
+
+Custom rate limit policies let you set per-application request ceilings on your tenant's Authentication API. When an application calls Auth0 (requesting tokens, starting authorization flows, or refreshing credentials) each request counts toward that application's configured limit. If an application exceeds its ceiling due to a bug, retry loop, or unexpected behavior, Auth0 throttles it before it can consume your tenant's shared rate limit capacity.
+
+You can apply custom rate limit policies to both first-party applications and third-party applications whose behavior you do not directly control.
+
+<Note>
+
+Custom rate limit policies are safety ceilings, not capacity dividers. They don't split your tenant's total rate limit budget across applications. Set them high enough that normal traffic never triggers them, but low enough that a misbehaving application is caught before it affects your tenant.
+
+</Note>
+
+## How custom rate limits relate to tenant rate limits
+
+Your tenant has a [global rate limit](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy) based on your subscription plan. Custom rate limit policies add a *per-application* ceiling below that global limit. The two layers work together:
+
+- Every request that passes the custom rate limit check still counts toward your tenant's global rate limit.
+- If an application exceeds its custom limit, Auth0 returns HTTP 429 to that application. The rejected request does not count toward your tenant's global rate limit.
+- If your tenant's global limit is reached first, all applications are throttled — regardless of whether individual applications are within their custom limits.
+
+Custom rate limits protect your tenant from individual applications consuming a disproportionate share of your global capacity. They do not increase your tenant's total throughput.
+
+## How policy evaluation works
+
+Auth0 evaluates custom rate limit policies in a strict hierarchy, from most specific to most general. The first matching level is enforced and all broader levels are skipped.
+
+1. **Client ID**: A policy targeting a specific application by its Client ID. If a matching policy exists, evaluation stops here.
+2. **Group**: A named profile (such as "Third-Party Clients") that applies a single shared limit to the *combined* traffic from all applications in the group. All applications in the group draw from the same bucket — there is no per-application subdivision within the group. If the application belongs to a group with a policy, evaluation stops here.
+3. **Global / Default**: A fallback policy that applies to any application not covered by a Client ID or Group policy.
+
+This hierarchy protects against both individual misbehaving applications and aggregate surges from entire classes of applications.
+
+For example, if you create a Group policy called "Third-Party Clients" with a limit of 100 RPS, and the group contains five applications. The 100 RPS limit applies to their combined traffic — if one application sends 90 RPS and the others send 5 RPS each, the group has hit its limit (90 + 5 + 5 + 5 + 5 = 110 RPS) and subsequent requests from any application in the group are throttled. There is no guaranteed allocation per application within the group.
+
+If one third-party application needs different treatment, assign it a Client ID policy, which takes precedence over the group limit.
+
+## Requests that count toward custom rate limits
+
+Custom rate limit policies count Authentication API requests that are attributed to an application's `client_id`. Auth0 counts a request when the application controls whether and how often that request occurs — even if the end user's browser is the HTTP client that delivers it.
+
+| Endpoint | Path | Notes |
+| --- | --- | --- |
+| Token requests | `/oauth/token` | Back-channel call from your application server. |
+| Authorization requests | `/authorize` | The application constructs this URL and triggers the redirect. Although the browser executes the request, the application controls the rate. |
+| Device code requests | `/oauth/device/code` | Back-channel call to start device authorization. |
+| Passwordless | `/passwordless/start` | Back-channel call to initiate passwordless login. |
+| Pushed authorization requests | `/oauth/par` | Back-channel call to push authorization parameters. |
+| Token revocation | `/oauth/revoke` | Back-channel call to revoke a token. |
+
+## Requests excluded from custom rate limits
+
+Once Auth0 begins an authentication flow (after `/authorize`), the end user's browser interacts directly with Auth0 to complete login. These subsequent requests — rendering the login page, submitting credentials, completing MFA challenges — are not counted against custom rate limits. The application does not initiate these requests and cannot control their rate or timing.
+
+For example, in a typical login flow:
+
+1. Your application redirects the user to `/authorize` → **counted** (your app initiated this).
+2. Auth0 renders the login page → **not counted** (browser-to-Auth0, outside your app's control).
+3. The user submits their credentials → **not counted**.
+4. The user completes an MFA challenge → **not counted**.
+5. Auth0 redirects back with an authorization code → **not counted**.
+6. Your application exchanges the code at `/oauth/token` → **counted** (your app initiated this).
+
+<Note>
+
+Because browser-initiated requests are excluded, custom rate limit policies reduce but do not eliminate the risk of attacks that exhaust tenant-wide rate limits by triggering complete authentication flows. For protection against those attack patterns, see [Attack Protection](/docs/secure/attack-protection).
+
+</Note>
+
+## Log-only mode
+
+When you enable log-only mode on a policy, Auth0 tracks requests against the configured limit and emits log events (`api_limit` and `api_limit_warning`) as if the policy were enforced — but does not actually return HTTP 429 responses. Traffic continues to flow normally.
+
+Use log-only mode to:
+
+- Validate that a new limit is set appropriately before blocking traffic.
+- Identify applications that would be affected by a policy change.
+- Establish baseline traffic patterns for an application or group.
+
+You can switch a policy between log-only and enforced at any time without recreating it.
+
+## Choose a rate limit value
+
+Set custom rate limits at 2–3x your application's expected peak request rate. For example, if an application peaks at 10 requests per second, set its limit to 20–30 RPS.
+
+To determine an appropriate value:
+
+1. Enable **log-only mode** on the policy.
+2. Observe the application's request patterns for 3–7 days.
+3. Review [`api_limit` log events](/docs/deploy-monitor/logs/log-event-type-codes) to identify peak request rates.
+4. Set the limit above observed peaks but below the level that would impact your tenant.
+
+<Tip>
+
+The goal is a ceiling your application never reaches under normal operation. If an application routinely approaches its limit, the limit is set too low — raise it and investigate the traffic pattern.
+
+</Tip>
+
+## Throttling behavior
+
+When an application exceeds its custom rate limit, Auth0 returns an HTTP `429 Too Many Requests` response. The response includes the following headers:
+
+| Header | Description |
+| --- | --- |
+| `x-ratelimit-limit` | The configured rate limit for this application. |
+| `x-ratelimit-remaining` | Requests remaining before the limit is reached. |
+| `x-ratelimit-reset` | [UNIX timestamp](https://en.wikipedia.org/wiki/Unix_time) (in seconds) when additional request capacity becomes available. |
+
+Throttling applies only to the application that exceeded its limit. Other applications on the same tenant are unaffected.
+
+## Create a custom rate limit policy
+
+<Tabs>
+  <Tab title="Single application">
+
+  Set a rate limit for one specific application by its Client ID. This is the most specific policy level and takes precedence over Group and Global policies.
+
+  <Steps>
+    <Step title="Navigate to rate limit settings">
+
+    Go to **Auth0 Dashboard > Security > Rate Limits > Custom Policies** and select **Create Policy**.
+
+    </Step>
+
+    <Step title="Select policy type">
+
+    Choose **Single Application** and select the target application from the dropdown.
+
+    </Step>
+
+    <Step title="Configure the limit">
+
+    Set the requests-per-second ceiling. Use 2–3x the application's expected peak rate.
+
+    </Step>
+
+    <Step title="Enable log-only mode (recommended)">
+
+    Toggle **Log Only** to observe the policy without enforcing it. Monitor [`api_limit` events](/docs/deploy-monitor/logs/log-event-type-codes) for 3–7 days before switching to enforcement.
+
+    </Step>
+
+    <Step title="Save and activate">
+
+    Save the policy. If log-only mode is disabled, enforcement begins immediately.
+
+    </Step>
+  </Steps>
+
+  </Tab>
+
+  <Tab title="Application group">
+
+  Set a shared rate limit for a named group of applications. The limit applies to the *aggregate* traffic from all applications in the group.
+
+  <Steps>
+    <Step title="Navigate to rate limit settings">
+
+    Go to **Auth0 Dashboard > Security > Rate Limits > Custom Policies** and select **Create Policy**.
+
+    </Step>
+
+    <Step title="Select policy type">
+
+    Choose **Application Group** and either select an existing group or create a new one (for example, "Third-Party Clients").
+
+    </Step>
+
+    <Step title="Add applications to the group">
+
+    Select the applications that belong to this group. Their combined traffic counts toward a single shared bucket.
+
+    </Step>
+
+    <Step title="Configure the limit">
+
+    Set the requests-per-second ceiling for the group's aggregate traffic.
+
+    </Step>
+
+    <Step title="Enable log-only mode (recommended)">
+
+    Toggle **Log Only** to observe without enforcing. Monitor [`api_limit` events](/docs/deploy-monitor/logs/log-event-type-codes) for 3–7 days.
+
+    </Step>
+
+    <Step title="Save and activate">
+
+    Save the policy. If log-only mode is disabled, enforcement begins immediately.
+
+    </Step>
+  </Steps>
+
+  </Tab>
+
+  <Tab title="Global default">
+
+  Set a default rate limit that applies to all applications not covered by a Client ID or Group policy.
+
+  <Steps>
+    <Step title="Navigate to rate limit settings">
+
+    Go to **Auth0 Dashboard > Security > Rate Limits > Custom Policies** and select **Create Policy**.
+
+    </Step>
+
+    <Step title="Select policy type">
+
+    Choose **Global Default**.
+
+    </Step>
+
+    <Step title="Configure the limit">
+
+    Set the requests-per-second ceiling. This acts as a catch-all for any application without a more specific policy.
+
+    </Step>
+
+    <Step title="Enable log-only mode (recommended)">
+
+    Toggle **Log Only** to observe without enforcing. Monitor [`api_limit` events](/docs/deploy-monitor/logs/log-event-type-codes) for 3–7 days.
+
+    </Step>
+
+    <Step title="Save and activate">
+
+    Save the policy. If log-only mode is disabled, enforcement begins immediately.
+
+    </Step>
+  </Steps>
+
+  </Tab>
+</Tabs>
+
+## Monitor policy enforcement
+
+Use tenant logs to observe how custom rate limit policies affect traffic:
+
+| Log event | Description |
+| --- | --- |
+| `api_limit` | Triggered when a rate limit is exceeded. For custom rate limit policies, the log event includes the policy name and the `client_id` of the affected application. |
+| `api_limit_warning` | Triggered when an application reaches 80% of its configured limit. Use this as an early warning to adjust limits before enforcement occurs. |
+
+To view these events, go to **Auth0 Dashboard > Monitoring > Logs** and filter by event type. For details on log event fields, see [Log Event Type Codes](/docs/deploy-monitor/logs/log-event-type-codes).
+
+<Note>
+
+The `api_limit` event type is shared between custom rate limit policies and your tenant's global rate limits. To identify events triggered by a custom policy, check the log event details for the policy name and target `client_id`. Global rate limit events do not include a policy name.
+
+</Note>
+
+<Tip>
+
+Enable log-only mode on new policies to observe their impact without blocking traffic. Review the logs after 3–7 days, then switch to enforcement once you confirm the limit is appropriately set.
+
+</Tip>
+
+## Learn more
+
+- [Rate Limit Policy](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy)
+- [Rate Limit Configurations](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations)
+- [Rate Limit Use Cases](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-use-cases)
+- [Attack Protection](/docs/secure/attack-protection)

--- a/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
@@ -91,7 +91,7 @@ For example, in a typical login flow:
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 
-Because browser-initiated requests are excluded, custom rate limit policies reduce but do not eliminate the risk of attacks that exhaust tenant-wide rate limits by triggering complete authentication flows. For protection against those attack patterns, see [Attack Protection](/docs/secure/attack-protection).
+Because browser-initiated requests are excluded, custom rate limit policies reduce but do not eliminate the risk of attacks that exhaust tenant-wide rate limits by triggering complete authentication flows. For protection against those attack patterns, read [Attack Protection](/docs/secure/attack-protection).
 
 </Callout>
 

--- a/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
@@ -76,7 +76,7 @@ Custom rate limit policies count Authentication API requests that are attributed
 | Passkey challenge | `/passkey/challenge` | Back-channel call to initiate a passkey authentication challenge. |
 | Passkey registration | `/passkey/register` | Back-channel call to register a new passkey. |
 
-## Requests excluded from custom rate limits
+## Custom rate limit exclusions
 
 Once Auth0 begins an authentication flow (after `/authorize`), the end user's browser interacts directly with Auth0 to complete login. These subsequent requests (rendering the login page, submitting credentials, completing MFA challenges) are not counted against custom rate limits. The application does not initiate these requests and cannot control their rate or timing.
 

--- a/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
@@ -37,7 +37,7 @@ This hierarchy protects against both individual misbehaving applications and agg
 
 Group policies use a single, shared counter for all applications in the group. Every request from any group member draws from the same bucket.
 
-For example, if you create a Group policy called "Third-Party Clients" with a limit of 100 RPS, and the group contains five applications, the 100 RPS limit applies to their combined traffic. If one application sends 90 RPS and the others send 5 RPS each, the group has hit its limit (90 + 5 + 5 + 5 + 5 = 110 RPS) and subsequent requests from any application in the group are throttled. There is no guaranteed allocation per application within the group.
+For example, if you create a Group policy called "Third-Party Clients" with a limit of 100 RPS, and the group contains five applications, the 100 RPS limit applies to their combined traffic. If one application sends 90 RPS and the others send 5 RPS each, the group hits its limit (90 + 5 + 5 + 5 + 5 = 110 RPS). Auth0 throttles subsequent requests from any application in the group. There is no guaranteed allocation per application within the group.
 
 If one third-party application needs different treatment, assign it a Client ID policy, which takes precedence over the group limit.
 

--- a/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
@@ -35,7 +35,7 @@ This hierarchy protects against both individual misbehaving applications and agg
 
 ### Pooled counters (Group policies)
 
-Group policies use a single shared counter for all applications in the group. Every request from any group member draws from the same bucket.
+Group policies use a single, shared counter for all applications in the group. Every request from any group member draws from the same bucket.
 
 For example, if you create a Group policy called "Third-Party Clients" with a limit of 100 RPS, and the group contains five applications, the 100 RPS limit applies to their combined traffic. If one application sends 90 RPS and the others send 5 RPS each, the group has hit its limit (90 + 5 + 5 + 5 + 5 = 110 RPS) and subsequent requests from any application in the group are throttled. There is no guaranteed allocation per application within the group.
 

--- a/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
@@ -284,9 +284,7 @@ Enable log-only mode on new policies to observe their impact without blocking tr
 
 ## Monitor via HTTP response headers
 
-Auth0 includes rate limit headers on all responses to requests evaluated by a custom rate limit policy, both successful and rejected.
-
-Every evaluated response includes the `Auth0-RateLimit` header, which communicates the application's current quota status:
+Auth0 returns an `Auth0-RateLimit` response header on all requests evaluated by a custom rate limit policy. This header is specific to custom rate limit policies and communicates the application's current quota status:
 
 ```
 Auth0-RateLimit: client;q=10;t=1;r=9
@@ -299,14 +297,7 @@ Auth0-RateLimit: client;q=10;t=1;r=9
 | `t` | The reset interval in seconds. |
 | `r` | Remaining requests available in the current interval. |
 
-When an application exceeds its custom rate limit, Auth0 returns an HTTP `429 Too Many Requests` response with additional headers:
-
-| Header | Description |
-| --- | --- |
-| `X-RateLimit-Limit` | The configured rate limit for this application. |
-| `X-RateLimit-Remaining` | Requests remaining before the limit is reached (`0` when throttled). |
-| `X-RateLimit-Reset` | [UNIX timestamp](https://en.wikipedia.org/wiki/Unix_time) (in seconds) when additional request capacity becomes available. |
-| `Retry-After` | Number of seconds to wait before retrying the request. |
+When an application exceeds its custom rate limit, Auth0 returns an HTTP `429 Too Many Requests` response with a `Retry-After` header indicating the number of seconds to wait before retrying.
 
 The response body contains a JSON error:
 
@@ -323,7 +314,7 @@ Throttling applies only to the application that exceeded its limit. Other applic
 
 <Note>
 
-On successful responses, the standard `X-RateLimit-*` headers reflect your tenant's global rate limit, not the custom policy limit. Use the `Auth0-RateLimit` header to monitor custom policy quota consumption on successful requests.
+The `X-RateLimit-*` headers (`X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`) reflect your tenant's [global rate limit](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy), not the custom policy limit. These headers appear on both successful and throttled responses but always report tenant-level capacity. Use the `Auth0-RateLimit` header to monitor custom policy quota consumption.
 
 </Note>
 

--- a/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
@@ -313,7 +313,7 @@ The response body contains a JSON error:
 }
 ```
 
-For `/authorize` requests, Auth0 does not return a JSON error response since these requests originate from a browser redirect. Instead, Auth0 presents an error page directly to the user. If you enable the **Redirect** option on the policy, Auth0 redirects the user to a configured URL instead of displaying the error page. This behavior is consistent with how [Tenant ACLs](/docs/secure/tenant-access-control-list) handle blocked requests.
+For `/authorize` requests, Auth0 does not return a JSON error response since these requests originate from a browser redirect. Instead, Auth0 presents an error page directly to the user. If you enable the **Redirect** option on the policy, Auth0 redirects the user to a configured URL instead of displaying the error page.
 
 Throttling applies only to the application that exceeded its limit. Other applications on the same tenant are unaffected.
 

--- a/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
@@ -2,6 +2,18 @@
 title: Custom Rate Limit Policies
 description: Set per-application rate limit ceilings to protect your tenant from misconfigured or misbehaving applications.
 ---
+import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
+
+<ReleaseStageNotice
+    feature="Custom Rate Limit Policies"
+    stage="ea"
+    terms="true"
+    contact="Auth0 Support"
+/>
+
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+Customers with Auth0 v202625.470.0 and operate in Public Cloud Environments prod-jp-1 prod-uk-1 prod-au-1 can now access Custom Rate Limits EA
+</Callout>
 
 Custom rate limit policies let you set per-application request ceilings on your tenant's calls to [Authentication API](https://auth0.com/docs/api/authentication). When an application calls Auth0 (requesting tokens, starting authorization flows, or refreshing credentials) each request counts toward that application's configured limit. If an application exceeds its ceiling due to a bug, retry loop, or unexpected behavior, Auth0 throttles it before it can consume your tenant's shared rate limit capacity.
 

--- a/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
@@ -9,17 +9,17 @@ You can apply custom rate limit policies to both first-party applications and th
 
 <Note>
 
-Custom rate limit policies are safety ceilings, not capacity dividers. They don't split your tenant's total rate limit budget across applications. Set them high enough that normal traffic never triggers them, but low enough that a misbehaving application is caught before it affects your tenant.
+Custom rate limit policies are safety ceilings, not capacity dividers. They aren't intended to split your tenant's total rate limit entitlement evenly across applications. Set them high enough that normal traffic never triggers them, but low enough that a misbehaving application is caught before it affects your tenant.
 
 </Note>
 
 ## How custom rate limits relate to tenant rate limits
 
-Your tenant has a [global rate limit](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy) based on your subscription plan. Custom rate limit policies add a *per-application* ceiling below that global limit. The two layers work together:
+Your tenant has a [global authentication rate limit](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy) based on your subscription plan. Custom rate limit policies add a *per-application* ceiling below that global limit. The two layers work together:
 
 - Every request that passes the custom rate limit check still counts toward your tenant's global rate limit.
 - If an application exceeds its custom limit, Auth0 returns HTTP 429 to that application. The rejected request does not count toward your tenant's global rate limit.
-- If your tenant's global limit is reached first, all applications are throttled — regardless of whether individual applications are within their custom limits.
+- If your tenant's global limit is reached first, all applications are throttled, regardless of whether individual applications are within their custom limits.
 
 Custom rate limits protect your tenant from individual applications consuming a disproportionate share of your global capacity. They do not increase your tenant's total throughput.
 
@@ -28,18 +28,18 @@ Custom rate limits protect your tenant from individual applications consuming a 
 Auth0 evaluates custom rate limit policies in a strict hierarchy, from most specific to most general. The first matching level is enforced and all broader levels are skipped.
 
 1. **Client ID**: A policy targeting a specific application by its Client ID. If a matching policy exists, evaluation stops here.
-2. **Group**: A named profile (such as "Third-Party Clients") that applies a single shared limit to the *combined* traffic from all applications in the group. All applications in the group draw from the same bucket — there is no per-application subdivision within the group. If the application belongs to a group with a policy, evaluation stops here.
-3. **Global / Default**: A fallback policy that applies to any application not covered by a Client ID or Group policy. Each application gets its own independent counter at the configured limit — the limit is shared, but the counters are not. This means each application is evaluated separately against the same ceiling.
+2. **Group**: Grouped profiles (such as third-party applications or CIMD) that apply a single shared limit to the *combined* traffic from all applications in the group. All applications in the group draw from the same policy. There is no per-application subdivision within the group. If the application belongs to a group with a policy, evaluation stops here.
+3. **Global / Default**: A fallback policy that applies to any application not covered by a Client ID or Group policy. Each application gets its own independent policy at the configured limit. The limit is shared, but the policies are not. This means each application is evaluated separately against the same ceiling.
 
 This hierarchy protects against both individual misbehaving applications and aggregate surges from entire classes of applications.
 
-For example, if you create a Group policy called "Third-Party Clients" with a limit of 100 RPS, and the group contains five applications, the 100 RPS limit applies to their combined traffic — if one application sends 90 RPS and the others send 5 RPS each, the group has hit its limit (90 + 5 + 5 + 5 + 5 = 110 RPS) and subsequent requests from any application in the group are throttled. There is no guaranteed allocation per application within the group.
+For example, if you create a Group policy called "Third-Party Clients" with a limit of 100 RPS, and the group contains five applications, the 100 RPS limit applies to their combined traffic. If one application sends 90 RPS and the others send 5 RPS each, the group has hit its limit (90 + 5 + 5 + 5 + 5 = 110 RPS) and subsequent requests from any application in the group are throttled. There is no guaranteed allocation per application within the group.
 
 If one third-party application needs different treatment, assign it a Client ID policy, which takes precedence over the group limit.
 
 ## Requests that count toward custom rate limits
 
-Custom rate limit policies count Authentication API requests that are attributed to an application's `client_id`. Auth0 counts a request when the application controls whether and how often that request occurs — even if the end user's browser is the HTTP client that delivers it.
+Custom rate limit policies count Authentication API requests that are attributed to an application's `client_id`. Auth0 counts a request when the application controls whether and how often that request occurs, even if the end user's browser is the HTTP client that delivers it.
 
 | Endpoint | Path | Notes |
 | --- | --- | --- |
@@ -57,7 +57,7 @@ Custom rate limit policies count Authentication API requests that are attributed
 
 ## Requests excluded from custom rate limits
 
-Once Auth0 begins an authentication flow (after `/authorize`), the end user's browser interacts directly with Auth0 to complete login. These subsequent requests — rendering the login page, submitting credentials, completing MFA challenges — are not counted against custom rate limits. The application does not initiate these requests and cannot control their rate or timing.
+Once Auth0 begins an authentication flow (after `/authorize`), the end user's browser interacts directly with Auth0 to complete login. These subsequent requests (rendering the login page, submitting credentials, completing MFA challenges) are not counted against custom rate limits. The application does not initiate these requests and cannot control their rate or timing.
 
 For example, in a typical login flow:
 
@@ -99,7 +99,7 @@ To determine an appropriate value:
 
 <Tip>
 
-The goal is a ceiling your application never reaches under normal operation. If an application routinely approaches its limit, the limit is set too low — raise it and investigate the traffic pattern.
+The goal is a ceiling your application never reaches under normal operation. If an application routinely approaches its limit, the limit is set too low. You can raise it and investigate the traffic pattern.
 
 </Tip>
 

--- a/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
@@ -7,11 +7,11 @@ Custom rate limit policies let you set per-application request ceilings on your 
 
 You can apply custom rate limit policies to both first-party applications and third-party applications whose behavior you do not directly control.
 
-<Note>
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 
 Custom rate limit policies are safety ceilings, not capacity dividers. They aren't intended to split your tenant's total rate limit entitlement evenly across applications. Set them high enough that normal traffic never triggers them, but low enough that a misbehaving application is caught before it affects your tenant.
 
-</Note>
+</Callout>
 
 ## How custom rate limits relate to tenant rate limits
 
@@ -80,11 +80,11 @@ For example, in a typical login flow:
 5. Auth0 redirects back with an authorization code → **not counted**.
 6. Your application exchanges the code at `/oauth/token` → **counted** (your app initiated this).
 
-<Note>
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 
 Because browser-initiated requests are excluded, custom rate limit policies reduce but do not eliminate the risk of attacks that exhaust tenant-wide rate limits by triggering complete authentication flows. For protection against those attack patterns, see [Attack Protection](/docs/secure/attack-protection).
 
-</Note>
+</Callout>
 
 ## Log-only mode
 
@@ -124,11 +124,11 @@ For applications you do not control, such as partner integrations, customer-buil
 
 Because you cannot control when third-party applications change their behavior, treat these limits as protective ceilings rather than performance targets.
 
-<Tip>
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 
 The goal is a ceiling that normal traffic never reaches. If an application routinely approaches its limit, the limit is set too low. Raise it and investigate the traffic pattern.
 
-</Tip>
+</Callout>
 
 ### Block an application entirely
 
@@ -270,17 +270,13 @@ Auth0 emits these log events at most once per minute per policy and application 
 
 To view these events, go to **Auth0 Dashboard > Monitoring > Logs** and filter by event type. For details on log event fields, see [Log Event Type Codes](/docs/deploy-monitor/logs/log-event-type-codes).
 
-<Note>
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 
 The `api_limit` event type is shared between custom rate limit policies and your tenant's global rate limits. To identify events triggered by a custom policy, check the log event details for the policy name and target `client_id`. Global rate limit events do not include a policy name.
 
-</Note>
-
-<Tip>
-
 Enable log-only mode on new policies to observe their impact without blocking traffic. Review the logs after 3–7 days, then switch to enforcement once you confirm the limit is appropriately set.
 
-</Tip>
+</Callout>
 
 ## Monitor via HTTP response headers
 
@@ -312,11 +308,11 @@ For `/authorize` requests specifically, Auth0 returns an HTTP `302` redirect to 
 
 Throttling applies only to the application that exceeded its limit. Other applications on the same tenant are unaffected.
 
-<Note>
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 
 The `X-RateLimit-*` headers (`X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`) reflect your tenant's [global rate limit](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy), not the custom policy limit. These headers appear on both successful and throttled responses but always report tenant-level capacity. Use the `Auth0-RateLimit` header to monitor custom policy quota consumption.
 
-</Note>
+</Callout>
 
 ## Learn more
 

--- a/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
@@ -3,7 +3,7 @@ title: Custom Rate Limit Policies
 description: Set per-application rate limit ceilings to protect your tenant from misconfigured or misbehaving applications.
 ---
 
-Custom rate limit policies let you set per-application request ceilings on your tenant's Authentication API. When an application calls Auth0 (requesting tokens, starting authorization flows, or refreshing credentials) each request counts toward that application's configured limit. If an application exceeds its ceiling due to a bug, retry loop, or unexpected behavior, Auth0 throttles it before it can consume your tenant's shared rate limit capacity.
+Custom rate limit policies let you set per-application request ceilings on your tenant's calls to [Authentication API](https://auth0.com/docs/api/authentication). When an application calls Auth0 (requesting tokens, starting authorization flows, or refreshing credentials) each request counts toward that application's configured limit. If an application exceeds its ceiling due to a bug, retry loop, or unexpected behavior, Auth0 throttles it before it can consume your tenant's shared rate limit capacity.
 
 You can apply custom rate limit policies to both first-party applications and third-party applications whose behavior you do not directly control.
 

--- a/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
@@ -41,6 +41,15 @@ For example, if you create a Group policy called "Third-Party Clients" with a li
 
 If one third-party application needs different treatment, assign it a Client ID policy, which takes precedence over the group limit.
 
+#### Third-party apps vs. CIMD clients
+
+Although CIMD (Client-Initiated Managed Delegation) clients are technically third-party applications, Auth0 places them in a separate group from traditional third-party apps. This means two distinct group buckets exist:
+
+- **Third-party apps** (Client ID prefix: `tpa_`) — Traditional third-party applications, including those created via the Management API or Dynamic Client Registration (DCR).
+- **CIMD clients** (Client ID prefix: `https://`) — Applications created through Client-Initiated Managed Delegation.
+
+Each group has its own pooled counter. Traffic from CIMD clients does not count against the third-party apps group limit, and vice versa. You can identify which group an application belongs to by its Client ID prefix.
+
 ### Independent counters (Global / Default policies)
 
 Global policies use independent counters. Each application gets its own separate counter evaluated against the same configured ceiling. Applications do not compete with each other for capacity.
@@ -88,7 +97,7 @@ Because browser-initiated requests are excluded, custom rate limit policies redu
 
 ## Log-only mode
 
-When you enable log-only mode on a policy, Auth0 tracks requests against the configured limit and emits log events (`api_limit` and `api_limit_warning`) as if the policy were enforced, but does not actually return HTTP 429 responses. Traffic continues to flow normally.
+When you enable log-only mode on a policy, Auth0 tracks requests against the configured limit and emits `api_limit` log events with `action: log`, but does not actually return HTTP 429 responses. Traffic continues to flow normally.
 
 Use log-only mode to:
 
@@ -304,7 +313,7 @@ The response body contains a JSON error:
 }
 ```
 
-For `/authorize` requests specifically, Auth0 returns an HTTP `302` redirect to the application's `redirect_uri` with error parameters instead of a JSON response, since these requests originate from a browser redirect.
+For `/authorize` requests, Auth0 does not return a JSON error response since these requests originate from a browser redirect. Instead, Auth0 presents an error page directly to the user. If you enable the **Redirect** option on the policy, Auth0 redirects the user to a configured URL instead of displaying the error page. This behavior is consistent with how [Tenant ACLs](/docs/secure/tenant-access-control-list) handle blocked requests.
 
 Throttling applies only to the application that exceeded its limit. Other applications on the same tenant are unaffected.
 

--- a/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
@@ -33,9 +33,21 @@ Auth0 evaluates custom rate limit policies in a strict hierarchy, from most spec
 
 This hierarchy protects against both individual misbehaving applications and aggregate surges from entire classes of applications.
 
+### Pooled counters (Group policies)
+
+Group policies use a single shared counter for all applications in the group. Every request from any group member draws from the same bucket.
+
 For example, if you create a Group policy called "Third-Party Clients" with a limit of 100 RPS, and the group contains five applications, the 100 RPS limit applies to their combined traffic. If one application sends 90 RPS and the others send 5 RPS each, the group has hit its limit (90 + 5 + 5 + 5 + 5 = 110 RPS) and subsequent requests from any application in the group are throttled. There is no guaranteed allocation per application within the group.
 
 If one third-party application needs different treatment, assign it a Client ID policy, which takes precedence over the group limit.
+
+### Independent counters (Global / Default policies)
+
+Global policies use independent counters — each application gets its own separate counter evaluated against the same configured ceiling. Applications do not compete with each other for capacity.
+
+For example, if you set a Global default policy of 50 RPS: Application A can send 50 RPS, Application B can send 50 RPS, and Application C can send 50 RPS — all independently. Application A hitting its limit has no effect on Applications B or C. Each application is throttled only when it individually exceeds 50 RPS.
+
+Use Group policies when you need to cap the *aggregate* load from a class of applications (such as third-party integrations whose combined traffic could overwhelm your tenant). Use the Global default when you need a uniform safety ceiling per application without coordination between them.
 
 ## Requests that count toward custom rate limits
 
@@ -88,18 +100,33 @@ You can switch a policy between log-only and enforced at any time without recrea
 
 ## Choose a rate limit value
 
-Set custom rate limits at 2–3x your application's expected peak request rate. For example, if an application peaks at 10 requests per second, set its limit to 20–30 RPS.
+How you determine an appropriate limit depends on whether you control the application's traffic patterns.
 
-To determine an appropriate value:
+### First-party applications (Client ID policies)
+
+For applications you own and operate, you can measure traffic directly:
 
 1. Enable **log-only mode** on the policy.
 2. Observe the application's request patterns for 3–7 days.
 3. Review [`api_limit` log events](/docs/deploy-monitor/logs/log-event-type-codes) to identify peak request rates.
-4. Set the limit above observed peaks but below the level that would impact your tenant.
+4. Set the limit at 2–3x the observed peak. For example, if an application peaks at 10 RPS, set its limit to 20–30 RPS.
+
+Because you control the application code, you can predict traffic scaling and adjust the limit proactively when deploying changes that increase request volume.
+
+### Third-party applications (Group or Global policies)
+
+For applications you do not control — such as partner integrations, customer-built apps, or marketplace connectors — you cannot predict traffic patterns in advance. Set limits based on what your tenant can safely absorb:
+
+1. Calculate the maximum RPS your tenant can tolerate from a single source without impacting other applications.
+2. Set the limit at that threshold or below.
+3. Enable **log-only mode** to validate the limit against real traffic before enforcement.
+4. Monitor for `api_limit` events and adjust as third-party usage patterns emerge.
+
+Because you cannot control when third-party applications change their behavior, treat these limits as protective ceilings rather than performance targets.
 
 <Tip>
 
-The goal is a ceiling your application never reaches under normal operation. If an application routinely approaches its limit, the limit is set too low. You can raise it and investigate the traffic pattern.
+The goal is a ceiling that normal traffic never reaches. If an application routinely approaches its limit, the limit is set too low — raise it and investigate the traffic pattern.
 
 </Tip>
 
@@ -231,7 +258,7 @@ Setting a custom rate limit to `0` blocks all Authentication API requests from t
   </Tab>
 </Tabs>
 
-## Monitor policy enforcement
+## Monitor via logs
 
 Use tenant logs to observe how custom rate limit policies affect traffic:
 
@@ -255,7 +282,7 @@ Enable log-only mode on new policies to observe their impact without blocking tr
 
 </Tip>
 
-### Rate limit headers
+## Monitor via HTTP response headers
 
 Auth0 includes rate limit headers on all responses to requests evaluated by a custom rate limit policy — both successful and rejected.
 

--- a/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
@@ -46,7 +46,7 @@ If one third-party application needs different treatment, assign it a Client ID 
 Although CIMD (Client-Initiated Managed Delegation) clients are technically third-party applications, Auth0 places them in a separate group from traditional third-party apps. This means two distinct group buckets exist:
 
 - **Third-party apps** (Client ID prefix: `tpa_`):  Traditional third-party applications, including those created via the Management API or Dynamic Client Registration (DCR).
-- **CIMD clients** (Client ID prefix: `https://`) — Applications created through Client-Initiated Managed Delegation.
+- **CIMD clients** (Client ID prefix: `https://`): Applications created through Client-Initiated Managed Delegation.
 
 Each group has its own pooled counter. Traffic from CIMD clients does not count against the third-party apps group limit, and vice versa. You can identify which group an application belongs to by its Client ID prefix.
 

--- a/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
@@ -29,11 +29,11 @@ Auth0 evaluates custom rate limit policies in a strict hierarchy, from most spec
 
 1. **Client ID**: A policy targeting a specific application by its Client ID. If a matching policy exists, evaluation stops here.
 2. **Group**: A named profile (such as "Third-Party Clients") that applies a single shared limit to the *combined* traffic from all applications in the group. All applications in the group draw from the same bucket — there is no per-application subdivision within the group. If the application belongs to a group with a policy, evaluation stops here.
-3. **Global / Default**: A fallback policy that applies to any application not covered by a Client ID or Group policy.
+3. **Global / Default**: A fallback policy that applies to any application not covered by a Client ID or Group policy. Each application gets its own independent counter at the configured limit — the limit is shared, but the counters are not. This means each application is evaluated separately against the same ceiling.
 
 This hierarchy protects against both individual misbehaving applications and aggregate surges from entire classes of applications.
 
-For example, if you create a Group policy called "Third-Party Clients" with a limit of 100 RPS, and the group contains five applications. The 100 RPS limit applies to their combined traffic — if one application sends 90 RPS and the others send 5 RPS each, the group has hit its limit (90 + 5 + 5 + 5 + 5 = 110 RPS) and subsequent requests from any application in the group are throttled. There is no guaranteed allocation per application within the group.
+For example, if you create a Group policy called "Third-Party Clients" with a limit of 100 RPS, and the group contains five applications, the 100 RPS limit applies to their combined traffic — if one application sends 90 RPS and the others send 5 RPS each, the group has hit its limit (90 + 5 + 5 + 5 + 5 = 110 RPS) and subsequent requests from any application in the group are throttled. There is no guaranteed allocation per application within the group.
 
 If one third-party application needs different treatment, assign it a Client ID policy, which takes precedence over the group limit.
 
@@ -46,9 +46,14 @@ Custom rate limit policies count Authentication API requests that are attributed
 | Token requests | `/oauth/token` | Back-channel call from your application server. |
 | Authorization requests | `/authorize` | The application constructs this URL and triggers the redirect. Although the browser executes the request, the application controls the rate. |
 | Device code requests | `/oauth/device/code` | Back-channel call to start device authorization. |
-| Passwordless | `/passwordless/start` | Back-channel call to initiate passwordless login. |
+| Passwordless start | `/passwordless/start` | Back-channel call to initiate passwordless login. |
+| Passwordless verify | `/passwordless/verify` | Back-channel call to verify a passwordless code. |
 | Pushed authorization requests | `/oauth/par` | Back-channel call to push authorization parameters. |
 | Token revocation | `/oauth/revoke` | Back-channel call to revoke a token. |
+| Back-channel authorization (CIBA) | `/bc-authorize` | Back-channel call to initiate a CIBA authorization flow. |
+| Cross-origin authentication | `/co/authenticate` | Back-channel call for cross-origin authentication. |
+| Passkey challenge | `/passkey/challenge` | Back-channel call to initiate a passkey authentication challenge. |
+| Passkey registration | `/passkey/register` | Back-channel call to register a new passkey. |
 
 ## Requests excluded from custom rate limits
 
@@ -98,17 +103,9 @@ The goal is a ceiling your application never reaches under normal operation. If 
 
 </Tip>
 
-## Throttling behavior
+### Block an application entirely
 
-When an application exceeds its custom rate limit, Auth0 returns an HTTP `429 Too Many Requests` response. The response includes the following headers:
-
-| Header | Description |
-| --- | --- |
-| `x-ratelimit-limit` | The configured rate limit for this application. |
-| `x-ratelimit-remaining` | Requests remaining before the limit is reached. |
-| `x-ratelimit-reset` | [UNIX timestamp](https://en.wikipedia.org/wiki/Unix_time) (in seconds) when additional request capacity becomes available. |
-
-Throttling applies only to the application that exceeded its limit. Other applications on the same tenant are unaffected.
+Setting a custom rate limit to `0` blocks all Authentication API requests from that application immediately without consuming any rate limit capacity. Use this to shut down a compromised or severely misbehaving application while you investigate.
 
 ## Create a custom rate limit policy
 
@@ -241,7 +238,8 @@ Use tenant logs to observe how custom rate limit policies affect traffic:
 | Log event | Description |
 | --- | --- |
 | `api_limit` | Triggered when a rate limit is exceeded. For custom rate limit policies, the log event includes the policy name and the `client_id` of the affected application. |
-| `api_limit_warning` | Triggered when an application reaches 80% of its configured limit. Use this as an early warning to adjust limits before enforcement occurs. |
+
+Auth0 emits these log events at most once per minute per policy and application combination. If an application exceeds its limit continuously, you will see one `api_limit` event per minute rather than one per rejected request. This prevents log volume from compounding during sustained overload.
 
 To view these events, go to **Auth0 Dashboard > Monitoring > Logs** and filter by event type. For details on log event fields, see [Log Event Type Codes](/docs/deploy-monitor/logs/log-event-type-codes).
 
@@ -256,6 +254,51 @@ The `api_limit` event type is shared between custom rate limit policies and your
 Enable log-only mode on new policies to observe their impact without blocking traffic. Review the logs after 3–7 days, then switch to enforcement once you confirm the limit is appropriately set.
 
 </Tip>
+
+### Rate limit headers
+
+Auth0 includes rate limit headers on all responses to requests evaluated by a custom rate limit policy — both successful and rejected.
+
+Every evaluated response includes the `Auth0-RateLimit` header, which communicates the application's current quota status:
+
+```
+Auth0-RateLimit: client;q=10;t=1;r=9
+```
+
+| Parameter | Description |
+| --- | --- |
+| `client` | The rate limit entity (the application identified by `client_id`). |
+| `q` | The configured quota (requests per interval). |
+| `t` | The reset interval in seconds. |
+| `r` | Remaining requests available in the current interval. |
+
+When an application exceeds its custom rate limit, Auth0 returns an HTTP `429 Too Many Requests` response with additional headers:
+
+| Header | Description |
+| --- | --- |
+| `X-RateLimit-Limit` | The configured rate limit for this application. |
+| `X-RateLimit-Remaining` | Requests remaining before the limit is reached (`0` when throttled). |
+| `X-RateLimit-Reset` | [UNIX timestamp](https://en.wikipedia.org/wiki/Unix_time) (in seconds) when additional request capacity becomes available. |
+| `Retry-After` | Number of seconds to wait before retrying the request. |
+
+The response body contains a JSON error:
+
+```json
+{
+  "error": "too_many_requests",
+  "error_description": "Rate limit exceeded."
+}
+```
+
+For `/authorize` requests specifically, Auth0 returns an HTTP `302` redirect to the application's `redirect_uri` with error parameters instead of a JSON response, since these requests originate from a browser redirect.
+
+Throttling applies only to the application that exceeded its limit. Other applications on the same tenant are unaffected.
+
+<Note>
+
+On successful responses, the standard `X-RateLimit-*` headers reflect your tenant's global rate limit — not the custom policy limit. Use the `Auth0-RateLimit` header to monitor custom policy quota consumption on successful requests.
+
+</Note>
 
 ## Learn more
 


### PR DESCRIPTION
## Description

 Adds a new documentation page explaining custom rate limit policies, which let customers set per-application request ceilings on the Authentication API to protect tenants from misconfigured or misbehaving applications.

  What's covered

  - How custom rate limits relate to tenant-level rate limits
  - Policy evaluation hierarchy (Client ID → Group → Global/Default)
  - Pooled counters (Group policies) vs independent counters (Global/Default policies)
  - Which Authentication API requests count toward custom limits and which are excluded
  - Log-only mode for validating limits before enforcement
  - Guidance on choosing rate limit values for first-party and third-party applications
  - Step-by-step Dashboard instructions for creating each policy type
  - Monitoring via tenant logs and HTTP response headers (Auth0-RateLimit, X-RateLimit-*)


### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
