### PR TITLE
Changing actions cache default ttl

### DIFF
--- a/main/docs/customize/actions/explore-triggers/event-stream-triggers/event-stream-api-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/event-stream-triggers/event-stream-api-object.mdx
@@ -5,7 +5,7 @@
 #
 description: Learn about the event-stream Action trigger's API object.
 title: 'Actions Triggers: event-stream - API Object'
-validatedOn: 2026-02-26
+validatedOn: 2026-05-22
 ---
 
 The API object for the event-stream Actions trigger includes:
@@ -43,7 +43,7 @@ are set. They are subject to the [Actions Cache Limits](https://auth0.com/docs/c
 
 Values stored in this way will have lifetimes of _up to_ the specified
 `ttl` or `expires_at` values. If no lifetime is specified, a default of
-lifetime of 24 hours will be used. Lifetimes may not exceed the maximum
+lifetime of 15 minutes will be used. Lifetimes may not exceed the maximum
 duration listed at [Actions Cache Limits](https://auth0.com/docs/customize/actions/limitations).
 
 **Important**: This cache is designed for short-lived, ephemeral data. Items may not be

--- a/main/docs/customize/actions/explore-triggers/machine-to-machine-trigger/credentials-exchange-api-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/machine-to-machine-trigger/credentials-exchange-api-object.mdx
@@ -5,7 +5,7 @@
 #
 description: Learn about the credentials-exchange Action trigger's API object.
 title: 'Actions Triggers: credentials-exchange - API Object'
-validatedOn: 2026-02-26
+validatedOn: 2026-05-22
 ---
 
 The API object for the credentials-exchange Actions trigger includes:
@@ -34,7 +34,7 @@ Request changes to the access token being issued.
 
 ### `api.accessToken.setCustomClaim(key, value)`
 
-Set a custom claim on the Access Token that will be issed.
+Set a custom claim on the Access Token that will be issued.
 
 <ResponseField name="key" type="string">
   Name of the claim (note that this may need to be a fully-qualified url).
@@ -75,7 +75,7 @@ are set. They are subject to the [Actions Cache Limits](https://auth0.com/docs/c
 
 Values stored in this way will have lifetimes of _up to_ the specified
 `ttl` or `expires_at` values. If no lifetime is specified, a default of
-lifetime of 24 hours will be used. Lifetimes may not exceed the maximum
+lifetime of 15 minutes will be used. Lifetimes may not exceed the maximum
 duration listed at [Actions Cache Limits](https://auth0.com/docs/customize/actions/limitations).
 
 **Important**: This cache is designed for short-lived, ephemeral data. Items may not be

--- a/main/docs/customize/actions/explore-triggers/mfa-notifications-trigger/send-phone-message-api-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/mfa-notifications-trigger/send-phone-message-api-object.mdx
@@ -5,7 +5,7 @@
 #
 description: Learn about the send-phone-message Action trigger's API object.
 title: 'Actions Triggers: send-phone-message - API Object'
-validatedOn: 2026-02-26
+validatedOn: 2026-05-22
 ---
 
 The API object for the send-phone-message Actions trigger includes:
@@ -42,7 +42,7 @@ are set. They are subject to the [Actions Cache Limits](https://auth0.com/docs/c
 
 Values stored in this way will have lifetimes of _up to_ the specified
 `ttl` or `expires_at` values. If no lifetime is specified, a default of
-lifetime of 24 hours will be used. Lifetimes may not exceed the maximum
+lifetime of 15 minutes will be used. Lifetimes may not exceed the maximum
 duration listed at [Actions Cache Limits](https://auth0.com/docs/customize/actions/limitations).
 
 **Important**: This cache is designed for short-lived, ephemeral data. Items may not be

--- a/main/docs/customize/actions/explore-triggers/password-reset-triggers/post-challenge-trigger/post-challenge-api-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/password-reset-triggers/post-challenge-trigger/post-challenge-api-object.mdx
@@ -5,7 +5,7 @@
 #
 description: Learn about the password-reset-post-challenge Action trigger's API object.
 title: 'Actions Triggers: password-reset-post-challenge - API Object'
-validatedOn: 2026-02-26
+validatedOn: 2026-05-22
 ---
 
 The API object for the password-reset-post-challenge Actions trigger includes:
@@ -57,13 +57,11 @@ select another factor if they choose to.
   An object describing the type of factor its options that should be used for the initial challenge.
   <Expandable title="factor properties" defaultOpen>
     <ResponseField name="type" type="string">
-      A type of authentication factor such as `push-notification`, `phone`, `email`, `otp`, `webauthn-roaming`, `webauthn-platform`, and `recovery-code`.
 
 
       Allowed values: `otp`, `email`, `webauthn-platform`, `webauthn-roaming`, `recovery-code`
     </ResponseField>
     <ResponseField name="options" type="dictionary" post={["optional"]}>
-      Additional options for configuring a factor of a given type.
     </ResponseField>
   </Expandable>
 </ResponseField>
@@ -202,7 +200,7 @@ are set. They are subject to the [Actions Cache Limits](https://auth0.com/docs/c
 
 Values stored in this way will have lifetimes of _up to_ the specified
 `ttl` or `expires_at` values. If no lifetime is specified, a default of
-lifetime of 24 hours will be used. Lifetimes may not exceed the maximum
+lifetime of 15 minutes will be used. Lifetimes may not exceed the maximum
 duration listed at [Actions Cache Limits](https://auth0.com/docs/customize/actions/limitations).
 
 **Important**: This cache is designed for short-lived, ephemeral data. Items may not be

--- a/main/docs/customize/actions/explore-triggers/password-reset-triggers/post-change-password-trigger/post-change-password-api-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/password-reset-triggers/post-change-password-trigger/post-change-password-api-object.mdx
@@ -5,7 +5,7 @@
 #
 description: Learn about the post-change-password Action trigger's API object.
 title: 'Actions Triggers: post-change-password - API Object'
-validatedOn: 2026-02-26
+validatedOn: 2026-05-22
 ---
 
 The API object for the post-change-password Actions trigger includes:
@@ -42,7 +42,7 @@ are set. They are subject to the [Actions Cache Limits](https://auth0.com/docs/c
 
 Values stored in this way will have lifetimes of _up to_ the specified
 `ttl` or `expires_at` values. If no lifetime is specified, a default of
-lifetime of 24 hours will be used. Lifetimes may not exceed the maximum
+lifetime of 15 minutes will be used. Lifetimes may not exceed the maximum
 duration listed at [Actions Cache Limits](https://auth0.com/docs/customize/actions/limitations).
 
 **Important**: This cache is designed for short-lived, ephemeral data. Items may not be

--- a/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/custom-token-exchange-trigger/custom-token-exchange-api-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/custom-token-exchange-trigger/custom-token-exchange-api-object.mdx
@@ -5,7 +5,7 @@
 #
 description: Learn about the custom-token-exchange Action trigger's API object.
 title: 'Actions Triggers: custom-token-exchange - API Object'
-validatedOn: 2026-02-26
+validatedOn: 2026-05-22
 ---
 
 The API object for the custom-token-exchange Actions trigger includes:
@@ -390,7 +390,7 @@ are set. They are subject to the [Actions Cache Limits](https://auth0.com/docs/c
 
 Values stored in this way will have lifetimes of _up to_ the specified
 `ttl` or `expires_at` values. If no lifetime is specified, a default of
-lifetime of 24 hours will be used. Lifetimes may not exceed the maximum
+lifetime of 15 minutes will be used. Lifetimes may not exceed the maximum
 duration listed at [Actions Cache Limits](https://auth0.com/docs/customize/actions/limitations).
 
 **Important**: This cache is designed for short-lived, ephemeral data. Items may not be

--- a/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-api-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-api-object.mdx
@@ -5,7 +5,7 @@
 #
 description: Learn about the post-login Action trigger's API object.
 title: 'Actions Triggers: post-login - API Object'
-validatedOn: 2026-04-28
+validatedOn: 2026-05-22
 ---
 
 The API object for the post-login Actions trigger includes:
@@ -463,7 +463,7 @@ are set. They are subject to the [Actions Cache Limits](https://auth0.com/docs/c
 
 Values stored in this way will have lifetimes of _up to_ the specified
 `ttl` or `expires_at` values. If no lifetime is specified, a default of
-lifetime of 24 hours will be used. Lifetimes may not exceed the maximum
+lifetime of 15 minutes will be used. Lifetimes may not exceed the maximum
 duration listed at [Actions Cache Limits](https://auth0.com/docs/customize/actions/limitations).
 
 **Important**: This cache is designed for short-lived, ephemeral data. Items may not be

--- a/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/post-user-registration-trigger/post-user-registration-api-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/post-user-registration-trigger/post-user-registration-api-object.mdx
@@ -5,7 +5,7 @@
 #
 description: Learn about the post-user-registration Action trigger's API object.
 title: 'Actions Triggers: post-user-registration - API Object'
-validatedOn: 2026-02-26
+validatedOn: 2026-05-22
 ---
 
 The API object for the post-user-registration Actions trigger includes:
@@ -42,7 +42,7 @@ are set. They are subject to the [Actions Cache Limits](https://auth0.com/docs/c
 
 Values stored in this way will have lifetimes of _up to_ the specified
 `ttl` or `expires_at` values. If no lifetime is specified, a default of
-lifetime of 24 hours will be used. Lifetimes may not exceed the maximum
+lifetime of 15 minutes will be used. Lifetimes may not exceed the maximum
 duration listed at [Actions Cache Limits](https://auth0.com/docs/customize/actions/limitations).
 
 **Important**: This cache is designed for short-lived, ephemeral data. Items may not be

--- a/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/pre-user-registration-trigger/pre-user-registration-api-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/pre-user-registration-trigger/pre-user-registration-api-object.mdx
@@ -5,7 +5,7 @@
 #
 description: Learn about the pre-user-registration Action trigger's API object.
 title: 'Actions Triggers: pre-user-registration - API Object'
-validatedOn: 2026-04-06
+validatedOn: 2026-05-22
 ---
 
 The API object for the pre-user-registration Actions trigger includes:
@@ -96,7 +96,7 @@ are set. They are subject to the [Actions Cache Limits](https://auth0.com/docs/c
 
 Values stored in this way will have lifetimes of _up to_ the specified
 `ttl` or `expires_at` values. If no lifetime is specified, a default of
-lifetime of 24 hours will be used. Lifetimes may not exceed the maximum
+lifetime of 15 minutes will be used. Lifetimes may not exceed the maximum
 duration listed at [Actions Cache Limits](https://auth0.com/docs/customize/actions/limitations).
 
 **Important**: This cache is designed for short-lived, ephemeral data. Items may not be

--- a/main/docs/customize/email/smtp-email-providers/custom/action-triggers-custom-email-provider-api-object.mdx
+++ b/main/docs/customize/email/smtp-email-providers/custom/action-triggers-custom-email-provider-api-object.mdx
@@ -5,7 +5,7 @@
 #
 description: Learn about the custom-email-provider Action trigger's API object.
 title: 'Actions Triggers: custom-email-provider - API Object'
-validatedOn: 2026-02-26
+validatedOn: 2026-05-22
 ---
 
 The API object for the custom-email-provider Actions trigger includes:
@@ -42,7 +42,7 @@ are set. They are subject to the [Actions Cache Limits](https://auth0.com/docs/c
 
 Values stored in this way will have lifetimes of _up to_ the specified
 `ttl` or `expires_at` values. If no lifetime is specified, a default of
-lifetime of 24 hours will be used. Lifetimes may not exceed the maximum
+lifetime of 15 minutes will be used. Lifetimes may not exceed the maximum
 duration listed at [Actions Cache Limits](https://auth0.com/docs/customize/actions/limitations).
 
 **Important**: This cache is designed for short-lived, ephemeral data. Items may not be
@@ -90,7 +90,7 @@ When called, the notification event is considered failed without recovery:
 We will log an error for this event, but won't be sending it again to the action in the future.
 If you need this notification event to be retried, consider calling retry instead.
 
-<ResponseField name="reason" type="string" post={["optional"]}>
+<ResponseField name="reason" type="string">
   this reason will be part of the log entry, this will help you analyze the error further. Please note that this field is limited to 1024 characters and will be truncated if larger.
 </ResponseField>
 
@@ -100,6 +100,6 @@ When called, the notification event is considered failed, but recoverable:
 We will log an error for this event, but we will retry it up to 5 times in the next minutes.
 If you consider that this notification event should not be retried, consider calling drop instead.
 
-<ResponseField name="reason" type="string" post={["optional"]}>
+<ResponseField name="reason" type="string">
   this reason will be part of the log entry, this will help you analyze the error further. Please note that this field is limited to 1024 characters and will be truncated if larger.
 </ResponseField>

--- a/main/docs/customize/phone-messages/configure-phone-messaging-providers/configure-a-custom-phone-provider/action-triggers-custom-phone-provider-api-object.mdx
+++ b/main/docs/customize/phone-messages/configure-phone-messaging-providers/configure-a-custom-phone-provider/action-triggers-custom-phone-provider-api-object.mdx
@@ -5,7 +5,7 @@
 #
 description: Learn about the custom-phone-provider Action trigger's API object.
 title: 'Actions Triggers: custom-phone-provider - API Object'
-validatedOn: 2026-02-26
+validatedOn: 2026-05-22
 ---
 
 The API object for the custom-phone-provider Actions trigger includes:
@@ -42,7 +42,7 @@ are set. They are subject to the [Actions Cache Limits](https://auth0.com/docs/c
 
 Values stored in this way will have lifetimes of _up to_ the specified
 `ttl` or `expires_at` values. If no lifetime is specified, a default of
-lifetime of 24 hours will be used. Lifetimes may not exceed the maximum
+lifetime of 15 minutes will be used. Lifetimes may not exceed the maximum
 duration listed at [Actions Cache Limits](https://auth0.com/docs/customize/actions/limitations).
 
 **Important**: This cache is designed for short-lived, ephemeral data. Items may not be
@@ -90,7 +90,7 @@ When called, the notification event is considered failed without recovery:
 We will log an error for this event, but won't be sending it again to the action in the future.
 If you need this notification event to be retried, consider calling retry instead.
 
-<ResponseField name="reason" type="string" post={["optional"]}>
+<ResponseField name="reason" type="string">
   this reason will be part of the log entry, this will help you analyze the error further. Please note that this field is limited to 1024 characters and will be truncated if larger.
 </ResponseField>
 
@@ -100,6 +100,6 @@ When called, the notification event is considered failed, but recoverable:
 We will log an error for this event, but we will retry it up to 5 times in the next minutes.
 If you consider that this notification event should not be retried, consider calling drop instead.
 
-<ResponseField name="reason" type="string" post={["optional"]}>
+<ResponseField name="reason" type="string">
   this reason will be part of the log entry, this will help you analyze the error further. Please note that this field is limited to 1024 characters and will be truncated if larger.
 </ResponseField>


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

We are updating the default TTL of the Actions Cache to 15 minutes in the docs, because it was mentioning 24 hours instead.

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

- https://auth0team.atlassian.net/browse/ACTIONS-2136

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
