### PR TITLE
fix: add branch deletion permissions to 'autoclose superseded PRs' workflow

### DIFF
--- a/.github/workflows/close-superseded-automation-prs.yml
+++ b/.github/workflows/close-superseded-automation-prs.yml
@@ -5,7 +5,8 @@ on:
     types: [opened]
 
 permissions:
-  pull-requests: write
+  pull-requests: write # Required to close PRs
+  contents: write # Required for branch deletion
 
 jobs:
   close-superseded:
@@ -76,6 +77,11 @@ jobs:
             --label "$AUTOUPDATE_LABEL" \
             --json number \
             --jq '.[].number')
+
+          if [[ -z "$OLD_PRS" ]]; then
+            echo "No superseded PRs found. Nothing to close."
+            exit 0
+          fi
 
           for PR_NUMBER in $OLD_PRS; do
             if [[ "$PR_NUMBER" -eq "$CURRENT_PR" ]]; then


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

- The workflow to autoclose superseded automated PRs was lacking `contents: write` permissions, necessary to delete branches
- Additionally, make it log a message if there are no PRs to close

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
