### PR TITLE
fix: update SDK version badges and release dates in libraries page

### DIFF
--- a/main/docs/libraries.mdx
+++ b/main/docs/libraries.mdx
@@ -15,8 +15,8 @@ Need to protect a JavaScript application that runs entirely in a browser? Choose
     name: "React",
     subtext: "auth0-react",
     logo: "react.svg",
-    date: "Jan 23, 2024",
-    badge: "v2.3.0",
+    date: "May 22, 2026",
+    badge: "v2.17.0",
     links: [
       { label: "Github", url: "https://github.com/auth0/auth0-react" },
       {
@@ -30,8 +30,8 @@ Need to protect a JavaScript application that runs entirely in a browser? Choose
     name: "Vue",
     subtext: "auth0-vue",
     logo: "vuejs.svg",
-    date: "Jan 27, 2024",
-    badge: "v2.4.0",
+    date: "May 8, 2026",
+    badge: "v2.7.0",
     links: [
       { label: "Github", url: "https://github.com/auth0/auth0-vue" },
       {
@@ -45,8 +45,8 @@ Need to protect a JavaScript application that runs entirely in a browser? Choose
     name: "Angular",
     subtext: "auth0-angular",
     logo: "angular.svg",
-    date: "Jan 16, 2024",
-    badge: "v2.2.3",
+    date: "Apr 28, 2026",
+    badge: "v2.9.0",
     links: [
       { label: "Github", url: "https://github.com/auth0/auth0-angular" },
       {
@@ -60,8 +60,8 @@ Need to protect a JavaScript application that runs entirely in a browser? Choose
     name: "JavaScript",
     subtext: "auth0-spa-js",
     logo: "javascript.svg",
-    date: "May 29, 2024",
-    badge: "v2.2.0",
+    date: "May 22, 2026",
+    badge: "v2.20.0",
     links: [
       { label: "Github", url: "https://github.com/auth0/auth0-spa-js" },
       {
@@ -75,8 +75,8 @@ Need to protect a JavaScript application that runs entirely in a browser? Choose
     name: "Flutter (Web)",
     subtext: "auth0-flutter",
     logo: "flutter.svg",
-    date: "Jul 10, 2024",
-    badge: "v2.2.3",
+    date: "May 21, 2026",
+    badge: "af-v2.1.0",
     links: [
       { label: "Github", url: "https://github.com/auth0/auth0-flutter" },
       {
@@ -98,8 +98,8 @@ Have a traditional web application that runs on a server? Auth0 maintains these 
     name: "Next.js",
     subtext: "nextjs-auth0",
     logo: "nextjs.svg",
-    date: "Jul 1, 2024",
-    badge: "v4.8.0",
+    date: "May 22, 2026",
+    badge: "v4.21.0",
     links: [
       { label: "Github", url: "https://github.com/auth0/nextjs-auth0/" },
       {
@@ -114,8 +114,8 @@ Have a traditional web application that runs on a server? Auth0 maintains these 
     name: "Express",
     subtext: "express-openid-connect",
     logo: "nodejs.svg",
-    date: "May 6, 2024",
-    badge: "v2.18.1",
+    date: "May 15, 2026",
+    badge: "v3.0.0",
     links: [
       { label: "Github", url: "https://github.com/auth0/express-openid-connect" },
       {
@@ -130,8 +130,8 @@ Have a traditional web application that runs on a server? Auth0 maintains these 
     name: "Fastify",
     subtext: "auth0-fastify",
     logo: "nodejs.svg",
-    date: "Oct 2, 2025",
-    badge: "v1.2.0",
+    date: "Apr 9, 2026",
+    badge: "v1.3.0",
     links: [
       { label: "Github", url: "https://github.com/auth0/auth0-fastify" },
       {
@@ -146,8 +146,8 @@ Have a traditional web application that runs on a server? Auth0 maintains these 
     name: "Nuxt",
     subtext: "auth0-nuxt",
     logo: "nuxt.svg",
-    date: "Nov 15, 2024",
-    badge: "v0.3.3",
+    date: "Apr 13, 2026",
+    badge: "v1.1.0",
     links: [
       { label: "Github", url: "https://github.com/auth0/auth0-nuxt" },
       {
@@ -162,8 +162,8 @@ Have a traditional web application that runs on a server? Auth0 maintains these 
     name: "ASP.NET Core MVC",
     subtext: "auth0-aspnetcore-authentication",
     logo: "dotnet-platform.svg",
-    date: "Jul 10, 2025",
-    badge: "1.4.1",
+    date: "Apr 9, 2026",
+    badge: "1.7.0",
     links: [
       { label: "Github", url: "https://github.com/auth0/auth0-aspnetcore-authentication" },
       {
@@ -178,8 +178,8 @@ Have a traditional web application that runs on a server? Auth0 maintains these 
     name: "ASP.NET Core Blazor",
     subtext: "auth0-aspnetcore-authentication",
     logo: "dotnet.svg",
-    date: "Jan 25, 2024",
-    badge: "1.4.1",
+    date: "Apr 9, 2026",
+    badge: "1.7.0",
     links: [
       { label: "Github", url: "https://github.com/auth0/auth0-aspnetcore-authentication" },
       {
@@ -194,8 +194,8 @@ Have a traditional web application that runs on a server? Auth0 maintains these 
     name: "Laravel",
     subtext: "laravel-auth0",
     logo: "laravel.svg",
-    date: "May 16, 2024",
-    badge: "7.17.0",
+    date: "Apr 8, 2026",
+    badge: "7.22.0",
     links: [
       { label: "Github", url: "https://github.com/auth0/laravel-auth0" },
       {
@@ -210,8 +210,8 @@ Have a traditional web application that runs on a server? Auth0 maintains these 
     name: "Java Spring Boot",
     subtext: "okta-spring-boot",
     logo: "spring.svg",
-    date: "Jun 21, 2024",
-    badge: "3.0.7",
+    date: "Feb 24, 2026",
+    badge: "3.1.0",
     links: [
       { label: "Github", url: "https://github.com/okta/okta-spring-boot/" },
       {
@@ -226,8 +226,8 @@ Have a traditional web application that runs on a server? Auth0 maintains these 
     name: "Python",
     subtext: "auth0-python",
     logo: "python.svg",
-    date: "Jun 6, 2024",
-    badge: "4.10.0",
+    date: "May 20, 2026",
+    badge: "5.5.0",
     links: [
       { label: "Github", url: "https://github.com/auth0/auth0-python" },
       {
@@ -242,8 +242,8 @@ Have a traditional web application that runs on a server? Auth0 maintains these 
     name: "Go",
     subtext: "go-auth0",
     logo: "golang.svg",
-    date: "Apr 30, 2026",
-    badge: "v2.10.0",
+    date: "May 14, 2026",
+    badge: "v2.11.0",
     links: [
       { label: "Github", url: "https://github.com/auth0/go-auth0" },
       {
@@ -258,8 +258,8 @@ Have a traditional web application that runs on a server? Auth0 maintains these 
     name: "PHP",
     subtext: "auth0-php",
     logo: "php.svg",
-    date: "May 30, 2024",
-    badge: "8.15.0",
+    date: "Apr 1, 2026",
+    badge: "8.19.0",
     links: [
       { label: "Github", url: "https://github.com/auth0/auth0-php" },
       {
@@ -290,8 +290,8 @@ Have a traditional web application that runs on a server? Auth0 maintains these 
     name: "Java",
     subtext: "auth0-java-mvc-common",
     logo: "java.svg",
-    date: "Dec 19, 2023",
-    badge: "1.11.0",
+    date: "Apr 9, 2026",
+    badge: "1.12.0",
     links: [
       { label: "Github", url: "https://github.com/auth0/auth0-java-mvc-common" },
       {
@@ -306,8 +306,8 @@ Have a traditional web application that runs on a server? Auth0 maintains these 
     name: "Java EE",
     subtext: "auth0-java-mvc-common",
     logo: "java.svg",
-    date: "Dec 19, 2023",
-    badge: "1.11.0",
+    date: "Apr 9, 2026",
+    badge: "1.12.0",
     links: [
       { label: "Github", url: "https://github.com/auth0/auth0-java-mvc-common" },
       {
@@ -345,8 +345,8 @@ Does your API or service need authentication? Auth0 has SDKs for common API and 
   name: "Node (Express) API",
   subtext: "node-oauth2-jwt-bearer",
   logo: "nodejs.svg",
-  date: "Mar 14, 2024",
-  badge: "v1.6.1",
+  date: "May 20, 2026",
+  badge: "v1.9.0",
   links: [
     {
       label: "Github",
@@ -364,8 +364,8 @@ Does your API or service need authentication? Auth0 has SDKs for common API and 
   name: "Fastify API",
   subtext: "auth0-fastify-api",
   logo: "nodejs.svg",
-  date: "Oct 2, 2025",
-  badge: "v1.2.0",
+  date: "May 18, 2026",
+  badge: "v1.3.0",
   links: [
     { label: "Github", url: "https://github.com/auth0/auth0-fastify" },
     {
@@ -396,8 +396,8 @@ Does your API or service need authentication? Auth0 has SDKs for common API and 
   name: "Go API",
   subtext: "go-jwt-middleware",
   logo: "golang.svg",
-  date: "Apr 9, 2026",
-  badge: "v3.1.0",
+  date: "May 15, 2026",
+  badge: "v3.2.0",
   links: [
     { label: "Github", url: "https://github.com/auth0/go-jwt-middleware" },
     {
@@ -428,8 +428,8 @@ Does your API or service need authentication? Auth0 has SDKs for common API and 
   name: "Laravel API",
   subtext: "laravel-auth0",
   logo: "laravel.svg",
-  date: "May 16, 2024",
-  badge: "7.17.0",
+  date: "Apr 8, 2026",
+  badge: "7.22.0",
   links: [
     { label: "Github", url: "https://github.com/auth0/laravel-auth0" },
     { label: "Sample App", url: "https://github.com/auth0-samples/laravel/tree/7.x/sample" },
@@ -441,8 +441,8 @@ Does your API or service need authentication? Auth0 has SDKs for common API and 
   name: "Python API",
   subtext: "auth0-python",
   logo: "python.svg",
-  date: "Jun 6, 2024",
-  badge: "4.10.0",
+  date: "May 20, 2026",
+  badge: "5.5.0",
   links: [
     { label: "Github", url: "https://github.com/auth0/auth0-python" },
     {
@@ -457,8 +457,8 @@ Does your API or service need authentication? Auth0 has SDKs for common API and 
   name: "PHP API",
   subtext: "auth0-PHP",
   logo: "php.svg",
-  date: "May 30, 2024",
-  badge: "8.15.0",
+  date: "Apr 1, 2026",
+  badge: "8.19.0",
   links: [
     { label: "Github", url: "https://github.com/auth0/auth0-php" },
     {
@@ -495,8 +495,8 @@ Mobile or Desktop app that runs natively on a device
   name: "React Native",
   subtext: "react-native-auth0",
   logo: "react.svg",
-  date: "May 2, 2024",
-  badge: "v4.6.0",
+  date: "May 14, 2026",
+  badge: "v5.6.0",
   links: [
     { label: "Github", url: "https://github.com/auth0/react-native-auth0" },
     {
@@ -511,8 +511,8 @@ Mobile or Desktop app that runs natively on a device
   name: "Flutter",
   subtext: "auth0-flutter",
   logo: "flutter.svg",
-  date: "Jul 10, 2024",
-  badge: "af-v1.12.0",
+  date: "May 21, 2026",
+  badge: "af-v2.1.0",
   links: [
     { label: "Github", url: "https://www.github.com/auth0/auth0-flutter/" },
     {
@@ -527,8 +527,8 @@ Mobile or Desktop app that runs natively on a device
   name: "iOS / macOS",
   subtext: "Auth0.swift",
   logo: "apple.svg",
-  date: "May 30, 2024",
-  badge: "2.13.0",
+  date: "May 21, 2026",
+  badge: "2.20.0",
   links: [
     { label: "Github", url: "https://github.com/auth0/Auth0.swift" },
     {
@@ -543,8 +543,8 @@ Mobile or Desktop app that runs natively on a device
   name: "Android",
   subtext: "Auth0.Android",
   logo: "android.svg",
-  date: "Jun 4, 2024",
-  badge: "3.8.0",
+  date: "May 21, 2026",
+  badge: "3.17.0",
   links: [
     { label: "Github", url: "https://github.com/auth0/Auth0.Android" },
     {
@@ -559,8 +559,8 @@ Mobile or Desktop app that runs natively on a device
   name: "Expo",
   subtext: "react-native-auth0",
   logo: "expo.svg",
-  date: "May 2, 2024",
-  badge: "v4.6.0",
+  date: "May 14, 2026",
+  badge: "v5.6.0",
   links: [
     { label: "Github", url: "https://github.com/auth0/react-native-auth0" },
     {
@@ -575,8 +575,8 @@ Mobile or Desktop app that runs natively on a device
   name: ".NET (OIDC Client)",
   subtext: "auth0-oidc-client-net",
   logo: "dotnet-platform.svg",
-  date: "Apr 16, 2024",
-  badge: "ios-4.3.0",
+  date: "Jul 22, 2025",
+  badge: "ios-4.4.0",
   links: [
     { label: "Github", url: "https://github.com/auth0/auth0-oidc-client-net" },
     {
@@ -591,8 +591,8 @@ Mobile or Desktop app that runs natively on a device
   name: "MAUI",
   subtext: "auth0-oidc-client-net",
   logo: "dotnet.svg",
-  date: "Apr 16, 2024",
-  badge: "ios-4.3.0",
+  date: "Jul 22, 2025",
+  badge: "maui-1.4.0",
   links: [
     { label: "Github", url: "https://github.com/auth0/auth0-oidc-client-net" },
     {
@@ -660,8 +660,8 @@ Need to programmatically perform Auth0 administrative tasks? Choose from one of 
     name: ".NET",
     subtext: "auth0.net",
     logo: "dotnet-platform.svg",
-    date: "Jan 16, 2024",
-    badge: "v7.28.0",
+    date: "May 13, 2026",
+    badge: "7.46.0",
     links: [
       { label: "Github", url: "https://github.com/auth0/auth0.net" }
     ],
@@ -670,8 +670,8 @@ Need to programmatically perform Auth0 administrative tasks? Choose from one of 
     name: "Go",
     subtext: "go-auth0",
     logo: "golang.svg",
-    date: "Dec 11, 2025",
-    badge: "v2.3.0",
+    date: "May 14, 2026",
+    badge: "v2.11.0",
     links: [
       { label: "Github", url: "https://github.com/auth0/go-auth0" }
     ],
@@ -680,8 +680,8 @@ Need to programmatically perform Auth0 administrative tasks? Choose from one of 
     name: "Go JWT Middleware",
     subtext: "go-jwt-middleware",
     logo: "golang.svg",
-    date: "Apr 9, 2026",
-    badge: "v3.1.0",
+    date: "May 15, 2026",
+    badge: "v3.2.0",
     links: [
       { label: "Github", url: "https://github.com/auth0/go-jwt-middleware" }
     ],
@@ -690,8 +690,8 @@ Need to programmatically perform Auth0 administrative tasks? Choose from one of 
     name: "Java",
     subtext: "auth0-java",
     logo: "java.svg",
-    date: "Dec 19, 2023",
-    badge: "2.12.0",
+    date: "May 22, 2026",
+    badge: "3.6.0",
     links: [
       { label: "Github", url: "https://github.com/auth0/auth0-java" }
     ],
@@ -700,8 +700,8 @@ Need to programmatically perform Auth0 administrative tasks? Choose from one of 
     name: "Node",
     subtext: "node-auth0",
     logo: "nodejs.svg",
-    date: "Nov 21, 2024",
-    badge: "v4.11.0",
+    date: "May 13, 2026",
+    badge: "v5.10.0",
     links: [
       { label: "Github", url: "https://github.com/auth0/node-auth0" }
     ],
@@ -710,8 +710,8 @@ Need to programmatically perform Auth0 administrative tasks? Choose from one of 
     name: "Node JWT Bearer",
     subtext: "node-oauth2-jwt-bearer",
     logo: "nodejs.svg",
-    date: "Mar 14, 2024",
-    badge: "v1.6.1",
+    date: "May 20, 2026",
+    badge: "v1.9.0",
     links: [
       { label: "Github", url: "https://github.com/auth0/node-oauth2-jwt-bearer" }
     ],
@@ -720,8 +720,8 @@ Need to programmatically perform Auth0 administrative tasks? Choose from one of 
     name: "PHP",
     subtext: "auth0-php",
     logo: "php.svg",
-    date: "May 30, 2024",
-    badge: "8.15.0",
+    date: "Apr 1, 2026",
+    badge: "8.19.0",
     links: [
       { label: "Github", url: "https://github.com/auth0/auth0-php" }
     ],
@@ -730,8 +730,8 @@ Need to programmatically perform Auth0 administrative tasks? Choose from one of 
     name: "Python",
     subtext: "auth0-python",
     logo: "python.svg",
-    date: "Jun 6, 2024",
-    badge: "4.10.0",
+    date: "May 20, 2026",
+    badge: "5.5.0",
     links: [
       { label: "Github", url: "https://github.com/auth0/auth0-python" }
     ],
@@ -740,8 +740,8 @@ Need to programmatically perform Auth0 administrative tasks? Choose from one of 
     name: "Ruby",
     subtext: "ruby-auth0",
     logo: "ruby.svg",
-    date: "Dec 3, 2024",
-    badge: "v5.18.0",
+    date: "May 8, 2026",
+    badge: "v5.19.0",
     links: [
       { label: "Github", url: "https://github.com/auth0/ruby-auth0" }
     ],
@@ -758,7 +758,7 @@ Do you use Lock, Auth0's legacy self-hosted login experience? You can still rely
     name: "Lock for Android",
     subtext: "Lock.Android",
     logo: "android.svg",
-    date: "on Jan 11, 2023",
+    date: "Jan 11, 2023",
     badge: "3.2.2",
     links: [
       { label: "Github", url: "https://github.com/auth0/Lock.Android" },
@@ -769,7 +769,7 @@ Do you use Lock, Auth0's legacy self-hosted login experience? You can still rely
     name: "Lock for iOS",
     subtext: "Lock.swift",
     logo: "apple.svg",
-    date: "on Nov 30, 2021",
+    date: "Nov 30, 2021",
     badge: "2.24.1",
     links: [
       { label: "Github", url: "https://github.com/auth0/Lock.swift" },
@@ -780,8 +780,8 @@ Do you use Lock, Auth0's legacy self-hosted login experience? You can still rely
     name: "Lock for Web",
     subtext: "lock",
     logo: "auth0.svg",
-    date: "on Jun 2",
-    badge: "v14.0.0",
+    date: "Apr 6, 2026",
+    badge: "v14.3.0",
     links: [
       { label: "Github", url: "https://github.com/auth0/lock" },
       { label: "Get started", url: "/docs/libraries/lock" }


### PR DESCRIPTION
Fix: update SDK version badges and release dates in libraries page
## Description
Bumped versions and release dates for all outdated SDK cards across SPA, Web App, Backend, Mobile, Management, and Lock sections. Also fixed malformed date formats on Lock for Android/iOS ("on Jan 11" style), corrected the missing year on Lock for Web, and fixed the MAUI badge which was incorrectly showing an iOS platform tag (ios-4.3.0) instead of its own (maui-1.4.0).

Notable major version bumps included: Express v2→v3, Nuxt v0→v1, Python v4→v5, React Native v4→v5, Flutter native v1→v2, auth0-java v2→v3, node-auth0 v4→v5.


### References

N/A

### Testing

- Verified all badge and date values against the latest GitHub releases for each SDK repository.
- No structural or component changes — date and badge prop values only.

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
