### PR TITLE
Removing Early Access from Event Stream Actions specs

### DIFF
--- a/main/docs/customize/actions/explore-triggers/event-stream-triggers.mdx
+++ b/main/docs/customize/actions/explore-triggers/event-stream-triggers.mdx
@@ -10,14 +10,6 @@ sidebarTitle: Overview
 'twitter:title': Event Stream Triggers
 ---
 
-<Warning>
-
-**Event Stream Actions are currently available in Early Access**.
-
-To learn more about Auth0's product release cycle, review [Product Release Stages](/docs/troubleshoot/product-lifecycle/product-release-stages).
-
-</Warning>
-
 Event Stream Actions are logic-based functions that execute asynchronously when specific events occur within your Auth0 tenant. These are non-blocking actions and won't impact the latency of your user's experience. 
 
 Each Event Stream Action is associated with an Event Stream, and listens for a pre-defined set of Event Types (for example, successful logins, password changes, or user deletions). When a subscribed event occurs, the Action is triggered. Unlike Login or Pre-Registration Actions, Event Stream Actions run in the background and do not affect the primary transaction of the user.

--- a/main/docs/customize/actions/explore-triggers/event-stream-triggers/event-stream-api-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/event-stream-triggers/event-stream-api-object.mdx
@@ -5,14 +5,13 @@
 #
 description: Learn about the event-stream Action trigger's API object.
 title: 'Actions Triggers: event-stream - API Object'
-validatedOn: 2026-05-22
+validatedOn: 2026-05-26
 ---
 
 The API object for the event-stream Actions trigger includes:
 
 ## `api.cache`
 
-[Early Access]
 Store and retrieve data that persists across executions.
 
 ### `api.cache.delete(key)`

--- a/main/docs/customize/actions/explore-triggers/event-stream-triggers/event-stream-event-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/event-stream-triggers/event-stream-event-object.mdx
@@ -5,7 +5,7 @@
 #
 description: Learn about the event-stream Action trigger's event object, which provides contextual information about the trigger execution.
 title: 'Actions Triggers: event-stream - Event Object'
-validatedOn: 2026-02-26
+validatedOn: 2026-05-26
 ---
 
 The `event` object for the event-stream Actions trigger provides contextual information about the trigger execution.
@@ -13,7 +13,7 @@ The `event` object for the event-stream Actions trigger provides contextual info
 ## `event.message`
 
 <ResponseField name="event.message" type="dictionary">
-  [Early Access] The CloudEvent message containing all event properties.
+  The CloudEvent message containing all event properties.
   <Expandable title="message properties" defaultOpen>
     <ResponseField name="id" type="string">
       Identifies the event.


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

- We are removing the Early Access tag for Event Stream Actions specs as they are now GA.

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

- https://auth0team.atlassian.net/browse/ACTIONS-2140

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
