### PR TITLE
Add actor_token params to token exchange requests in Authentication API docs

### DIFF
--- a/main/docs/api/authentication/custom-token-exchange/get-token.mdx
+++ b/main/docs/api/authentication/custom-token-exchange/get-token.mdx
@@ -20,6 +20,14 @@ Custom Token Exchange is currently available in Early Access. By using this feat
 
  - You have to [Enable Custom Token Exchange for your application](https://auth0.com//docs/authenticate/custom-token-exchange/configure-custom-token-exchange#enable-custom-token-exchange-for-your-application). To learn more, read the [Custom Token Exchange documentation](https://auth0.com/docs/authenticate/custom-token-exchange).
 
+ - `actor_token` and `actor_token_type` must both be present or both absent. Providing only one returns a `400` error with code `invalid_request`.
+
+ - When `actor_token` is present, refresh tokens are not issued. The `offline_access` scope is excluded from the response.
+
+ - MFA is not compatible with transactions where an actor is set via `setActor()`. If MFA is required and the Custom Token Exchange Action sets an actor, the request returns a `400` error: `MFA is not supported using actor_token with the requested token exchange profile.`
+
+ - When the Action calls `setActor()`, issued access tokens and ID tokens include an `act` claim representing the [delegation chain](/docs/secure/call-apis-on-users-behalf/on-behalf-of-token-exchange#the-act-claim). The `act` claim is also included in the userinfo response.
+
 ## Parameters
 
 <ParamField header="DPoP" type="string">
@@ -68,6 +76,14 @@ Custom Token Exchange is currently available in Early Access. By using this feat
 
 <ParamField body="organization" type="string">
   (Optional) The organization or identifier with which you want the request to be associated. Alternatively, you can specify an organization name if [Use Organization Names in Authentication API](https://auth0.com/docs/manage-users/organizations/configure-organizations/use-org-name-authentication-api) is specified.
+</ParamField>
+
+<ParamField body="actor_token" type="string">
+  (Optional) A token identifying the actor performing delegation on behalf of the subject user. Must be provided together with `actor_token_type`. When present, refresh tokens will not be issued.
+</ParamField>
+
+<ParamField body="actor_token_type" type="string">
+  (Optional) The type of the actor token. Must be provided together with `actor_token`. For Auth0 ID tokens, use `urn:ietf:params:oauth:token-type:id_token` for automatic server-side validation (signature, expiry, issuer, user lookup). For other values, follow the same namespace restrictions as `subject_token_type`.
 </ParamField>
 
 ## Response


### PR DESCRIPTION

Add actor_token params to token exchange requests in Authentication API docs

This is follow up of https://github.com/auth0/docs-v2/pull/1215