### PR TITLE
Fix/kmsi session expiration clarification

### DIFF
--- a/main/docs/manage-users/sessions/configure-keep-me-signed-in-sessions.mdx
+++ b/main/docs/manage-users/sessions/configure-keep-me-signed-in-sessions.mdx
@@ -213,6 +213,13 @@ Navigate to the [Auth0 Dashboard > Actions > Triggers > Post-Login](https://mana
 <Frame>![Dashboard Actions Triggers Post Login](/docs/images/cdy7uua7fh8z/sessions-use-case/post-login.png)</Frame>
 
 ### Optional - Set session duration for trusted devices
+
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+
+`setCookieMode()` only controls how the session cookie is delivered to the browser. A persistent cookie survives browser restarts while a non-persistent (session) cookie is cleared when the browser closes. It does not change the backend session's expiration time. If you want trusted devices to have a longer session lifetime, you must explicitly set the expiration using `api.session.setExpiresAt()` or `api.session.setIdleExpiresAt()`.
+
+</Callout>
+
 You can use `api.session.setExpiresAt()` or `api.session.setIdleExpiresAt()` methods to further customize session lifetimes.
 
 ```javascript lines

--- a/main/docs/manage-users/sessions/configure-keep-me-signed-in-sessions.mdx
+++ b/main/docs/manage-users/sessions/configure-keep-me-signed-in-sessions.mdx
@@ -172,9 +172,11 @@ exports.onExecutePostLogin = async (event, api) => {
   // Apply the change only when the parameter is available
   if (event.request.body['ulp-remember-me']) {
     api.session.setCookieMode('persistent');
-  } 
+  }
 };
 ```
+
+This Action makes the session cookie persist across browser restarts when the user checks the box. To also extend the session lifetime for trusted devices, see [Set session duration for trusted devices](#set-session-duration-for-trusted-devices) below.
 
 Use Auth0 CLI to create or update your post-login Action using the `set-session-persistence.js` file:
 
@@ -212,7 +214,7 @@ Navigate to the [Auth0 Dashboard > Actions > Triggers > Post-Login](https://mana
 
 <Frame>![Dashboard Actions Triggers Post Login](/docs/images/cdy7uua7fh8z/sessions-use-case/post-login.png)</Frame>
 
-### Optional - Set session duration for trusted devices
+### Set session duration for trusted devices
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 
@@ -220,7 +222,7 @@ Navigate to the [Auth0 Dashboard > Actions > Triggers > Post-Login](https://mana
 
 </Callout>
 
-You can use `api.session.setExpiresAt()` or `api.session.setIdleExpiresAt()` methods to further customize session lifetimes.
+To give trusted devices a longer session lifetime, use `api.session.setExpiresAt()` or `api.session.setIdleExpiresAt()` alongside `setCookieMode()`:
 
 ```javascript lines
 exports.onExecutePostLogin = async (event, api) => {

--- a/main/docs/manage-users/sessions/configure-keep-me-signed-in-sessions.mdx
+++ b/main/docs/manage-users/sessions/configure-keep-me-signed-in-sessions.mdx
@@ -218,7 +218,7 @@ Navigate to the [Auth0 Dashboard > Actions > Triggers > Post-Login](https://mana
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 
-`setCookieMode()` only controls how the session cookie is delivered to the browser. A persistent cookie survives browser restarts while a non-persistent (session) cookie is cleared when the browser closes. It does not change the backend session's expiration time. If you want trusted devices to have a longer session lifetime, you must explicitly set the expiration using `api.session.setExpiresAt()` or `api.session.setIdleExpiresAt()`.
+[`setCookieMode()`](/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-api-object#api-session-setcookiemode-mode) only controls how the session cookie is delivered to the browser. A persistent cookie survives browser restarts while a non-persistent (session) cookie is cleared when the browser closes. It does not change the backend session's expiration time. If you want trusted devices to have a longer session lifetime, you must explicitly set the expiration using `api.session.setExpiresAt()` or `api.session.setIdleExpiresAt()`.
 
 </Callout>
 

--- a/main/docs/manage-users/sessions/configure-keep-me-signed-in-sessions.mdx
+++ b/main/docs/manage-users/sessions/configure-keep-me-signed-in-sessions.mdx
@@ -176,7 +176,7 @@ exports.onExecutePostLogin = async (event, api) => {
 };
 ```
 
-This Action makes the session cookie persist across browser restarts when the user checks the box. To also extend the session lifetime for trusted devices, see [Set session duration for trusted devices](#set-session-duration-for-trusted-devices) below.
+This Action makes the session cookie persist across browser restarts when the user checks the box. To also extend the session lifetime for trusted devices, read [Set session duration for trusted devices](#set-session-duration-for-trusted-devices) below.
 
 Use Auth0 CLI to create or update your post-login Action using the `set-session-persistence.js` file:
 


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

Addresses feedback (& sessions engineering team confirmed) that `setCookieMode('persistent')` alone does not recalculate or extend backend session expiration. Without `setExpiresAt()` or `setIdleExpiresAt()`, users get a cookie that survives browser close but the session still expires at the tenant default, which isn't expected from "Keep Me Signed In."

### References

https://auth0team.atlassian.net/jira/servicedesk/projects/DR/queues/custom/100/DR-2793

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
