### PR TITLE
Add Terraform migration guide for Unified Phone Experience

### DIFF
--- a/main/config/navigation/customize.json
+++ b/main/config/navigation/customize.json
@@ -153,7 +153,8 @@
               "pages": [
                 "docs/customize/phone-messages/unified-phone/use-auth0s-unified-phone-experience-for-multi-factor-authentication",
                 "docs/customize/phone-messages/unified-phone/unified-phone-experience-passwordless",
-                "docs/customize/phone-messages/unified-phone/configure-unified-phone"
+                "docs/customize/phone-messages/unified-phone/configure-unified-phone",
+                "docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform"
               ]
             },
             {

--- a/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
+++ b/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
@@ -9,7 +9,7 @@ After migration, all [multi-factor authentication (MFA) phone notifications](/do
 
 <Warning>
 
-This migration requires two separate [`terraform apply`](https://developer.hashicorp.com/terraform/cli/commands/apply) operations. 
+This migration requires **two** separate [`terraform apply`](https://developer.hashicorp.com/terraform/cli/commands/apply) operations. 
 
 If you attempt to complete the migration with a single `terraform apply` command, Auth0 APIs return 403 errors because the legacy phone configuration and the Unified Phone Experience flag cannot be active at the same time.
 
@@ -62,7 +62,7 @@ resource "auth0_phone_provider" "default" {
         delivery_methods = ["text", "voice"]
         default_from     = "YOUR_DEFAULT_PHONE_NUMBER"
         sid              = var.twilio_sid
-        mssid            = var.twilio_messaging_service_sid
+        mssid            = var.twilio_messaging_service_sid #Optional
     }
 
     credentials {
@@ -86,7 +86,7 @@ resource "auth0_phone_provider" "default" {
 }
 ```
 
-For custom providers, Auth0 expects a pre-existing Action with the [`custom-phone-provider`](/docs/customize/phone-messages/configure-phone-messaging-providers/configure-a-custom-phone-provider) trigger already deployed. The Action handles the actual delivery logic. Terraform does not manage the Action's existence as part of the `auth0_phone_provider` resource lifecycle.
+For custom providers, Auth0 expects a pre-existing Action with the [`custom-phone-provider`](/docs/customize/phone-messages/configure-phone-messaging-providers/configure-a-custom-phone-provider) trigger already deployed. The Action handles the actual delivery logic.
 
   </Tab>
 </Tabs>
@@ -156,7 +156,7 @@ terraform apply
 
 ## Enable the Unified Phone Experience
 
-Once you've remove the legacy configuration, use the Terraform provider resource to configure the Auth0 Universal Phone Experience. Set [`phone_consolidated_experience`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/tenant#phone_consolidated_experience-2) to `true`. This activates the Unified Phone Experience and routes all MFA phone notifications through the `auth0_phone_provider` you already configured.
+Once you have remove the legacy configuration, use the Terraform provider resource to configure the Auth0 Universal Phone Experience. Set [`phone_consolidated_experience`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/tenant#phone_consolidated_experience-2) to `true`. This activates the Unified Phone Experience and routes all MFA phone notifications through the `auth0_phone_provider` you already configured.
 
 ```hcl wrap lines
 resource "auth0_tenant" "main" {
@@ -179,7 +179,7 @@ After this applies, Auth0 uses the [Unified Phone Experience for MFA phone](/doc
 
 ### 403 Forbidden errors during terraform apply
 
-This typically means `phone_consolidated_experience` was already `true` when trying to manage legacy Guardian phone attributes. Make sure Step 1 applies with `phone_consolidated_experience = false` before Step 2.
+This typically means `phone_consolidated_experience` was already `true` when trying to manage legacy Guardian phone attributes. Make sure [Step 1](/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform#enable-the-terraform-auth0_phone_provider-resource-and-remove-legacy-configuration) applies with `phone_consolidated_experience = false` before [Step 2](/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform#enable-the-unified-phone-experience).
 
 ### Custom provider not delivering messages
 

--- a/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
+++ b/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
@@ -19,7 +19,7 @@ If you attempt to complete the migration with a single `terraform apply` command
 
 
 ## Prerequisites
-
+Before you begin migration, you need:
 - [Auth0 Terraform Provider v1.41.0](https://registry.terraform.io/providers/auth0/auth0/latest) or later.
 
 

--- a/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
+++ b/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
@@ -20,7 +20,7 @@ To enable the Terraform `auth0_phone_provider` resource and clean up legacy conf
 * [Set the `phone_consolidated_experience` flag to true](#set-the-phone_consolidated_experience-flag-to-true)
 * [Add the tenant-level phone provider](#add-the-tenant-level-phone-provider)
 * (Optional) [Add the `auth0_branding_phone_notification_template` resource](#add-the-auth0_branding_phone_notification_template-resource)
-* [Clean up Auth0 Guardian phone block](#clean-up-auth0-guardian-phone-block)
+* [Clean up the `auth0_guardian` resource phone block](#clean-up-auth0_guardian-resource-phone-block)
 * [Plan and apply](#plan-and-apply)
 
 
@@ -90,7 +90,7 @@ resource "auth0_branding_phone_notification_template" "default" {
 }
 ```
 
-### Clean up Auth0 Guardian phone block
+### Clean up `auth0_guardian` resource phone block
 
 Remove all legacy provider specific attributes from the [`auth0_guardian`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/guardian) phone block. After cleanup, the block should contain only `enabled`, `message_types`, and `depends_on` references the `auth0_tenant` and `auth0_phone_provider resources`. This ensures that UPE and phone provider configurations are applied before the legacy guardian phone block. 
 **Before:**

--- a/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
+++ b/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
@@ -16,7 +16,6 @@ If you attempt to complete the migration with a single `terraform apply` command
 </Warning>
 
 
-Follow these steps to Migrate your legacy Guardian phone configuration to the Unified Phone Experince using Auth0 Terraform provider: 
 
 
 ## Prerequisites

--- a/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
+++ b/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
@@ -94,7 +94,9 @@ resource "auth0_branding_phone_notification_template" "default" {
 
 ### Clean up the auth0_guardian resource phone block
 
-Remove all legacy provider-specific attributes from the [`auth0_guardian`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/guardian) phone block. After cleanup, the block should contain only the `enabled` and `message_types` attributes plus a `depends_on` block that references the `auth0_tenant.main` and `auth0_phone_provider.default` resources. This ensures UPE and phone-provider configuration are applied before the legacy Guardian phone block.
+Remove all legacy provider-specific attributes from the [`auth0_guardian`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/guardian) phone block. 
+
+After cleanup, the block should contain only the `enabled` and `message_types` attributes plus a `depends_on` block that references the `auth0_tenant.main` and `auth0_phone_provider.default` resources. This ensures UPE and phone-provider configuration are applied before the legacy Guardian phone block.
 
 **Before:**
 

--- a/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
+++ b/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
@@ -21,7 +21,7 @@ If you attempt to complete the migration with a single `terraform apply` command
 ## Prerequisites
 Before you begin migration, you need:
 - [Auth0 Terraform Provider v1.41.0](https://registry.terraform.io/providers/auth0/auth0/latest) or later.
-
+- If you want to use a custom phone provider, create and deploy an Auth0 Actions [`custom-phone-provider`](/docs/customize/phone-messages/configure-phone-messaging-providers/configure-a-custom-phone-provider) trigger to handle message delivery.
 
 
 ## Enable the Terraform `auth0_phone_provider` resource and remove legacy configuration

--- a/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
+++ b/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
@@ -1,0 +1,174 @@
+---
+description: Learn how to migrate from the legacy Guardian phone configuration to the Unified Phone Experience using the Auth0 Terraform Provider.
+title: Migrate to Unified Phone Experience with Terraform
+---
+
+Migrate your tenant from the legacy Guardian phone configuration to the Unified Phone Experience using the Auth0 Terraform Provider. After migration, all multi-factor authentication (MFA) phone notifications route through a single tenant-level phone provider.
+
+<Warning>
+
+This migration requires two separate `terraform apply` operations. Attempting to complete it in a single apply causes 403 errors from Auth0 APIs because the legacy phone configuration and the Unified Phone Experience flag cannot be active at the same time.
+
+</Warning>
+
+## Prerequisites
+
+- Auth0 Terraform Provider v1.41.0 or later
+
+## Step 1: Add new resources and clean up legacy configuration
+
+In this step, you introduce the `auth0_phone_provider` resource, strip legacy attributes from `auth0_guardian`, and temporarily set `phone_consolidated_experience` to `false` to keep the tenant stable during the apply.
+
+### Set phone_consolidated_experience to false
+
+In your `auth0_tenant` resource, explicitly set the flag to `false`. This ensures the tenant does not route through the Unified Phone Experience while you make changes.
+
+```hcl wrap lines
+resource "auth0_tenant" "main" {
+    # ... other tenant settings ...
+
+    phone_consolidated_experience = false
+}
+```
+
+### Add the auth0_phone_provider resource
+
+Create a tenant-level phone provider. Auth0 supports one phone provider per tenant. This provider handles delivery for all phone-based flows once the Unified Phone Experience is enabled.
+
+<Tabs>
+  <Tab title="Twilio">
+
+```hcl wrap lines
+resource "auth0_phone_provider" "default" {
+    name = "twilio"
+
+    configuration {
+        delivery_methods = ["text", "voice"]
+        default_from     = "YOUR_DEFAULT_PHONE_NUMBER"
+        sid              = var.twilio_sid
+        mssid            = var.twilio_messaging_service_sid
+    }
+
+    credentials {
+        auth_token = var.twilio_auth_token
+    }
+}
+```
+
+To send SMS only, set `delivery_methods` to `["text"]`.
+
+  </Tab>
+  <Tab title="Custom Action-based provider">
+
+```hcl wrap lines
+resource "auth0_phone_provider" "default" {
+    name = "custom"
+
+    configuration {
+        delivery_methods = ["text"]
+    }
+}
+```
+
+For custom providers, Auth0 expects a pre-existing Action with the `custom-phone-provider` trigger already deployed. The Action handles the actual delivery logic. Terraform does not manage the Action's existence as part of the `auth0_phone_provider` resource lifecycle.
+
+  </Tab>
+</Tabs>
+
+### (Optional) Add auth0_branding_phone_notification_template
+
+If you use `enrollment_message` or `verification_message` on the legacy Guardian phone block to customize OTP message text, you can replicate that behavior with the `auth0_branding_phone_notification_template` resource.
+
+```hcl wrap lines
+resource "auth0_branding_phone_notification_template" "default" {
+    # Refer to the Auth0 Terraform Provider docs for available template variables
+}
+```
+
+### Clean up the auth0_guardian phone block
+
+Remove all legacy provider-specific attributes from the `phone` block. After cleanup, the block should contain only `enabled` and `message_types`.
+
+**Before:**
+
+```hcl wrap lines
+resource "auth0_guardian" "default" {
+    phone {
+        enabled       = true
+        provider      = "twilio"
+        message_types = ["sms"]
+
+        options {
+            enrollment_message   = "Your enrollment code is {{code}}"
+            verification_message = "Your verification code is {{code}}"
+        }
+
+        twilio_config {
+            sid                   = var.twilio_sid
+            auth_token            = var.twilio_auth_token
+            from                  = "YOUR_DEFAULT_PHONE_NUMBER"
+            messaging_service_sid = var.twilio_messaging_service_sid
+        }
+    }
+}
+```
+
+**After:**
+
+```hcl wrap lines
+resource "auth0_guardian" "default" {
+    phone {
+        enabled       = true
+        message_types = ["sms"]
+    }
+}
+```
+
+### Plan and apply
+
+Review the plan carefully before applying. You should see:
+
+- `auth0_phone_provider.default` created
+- `auth0_guardian.default` updated (attributes removed)
+- `auth0_tenant.main` updated (`phone_consolidated_experience = false`)
+- `auth0_branding_phone_notification_template.default` created (if added)
+
+```bash wrap lines
+terraform plan
+terraform apply
+```
+
+## Step 2: Enable the Unified Phone Experience
+
+Once Step 1 applies cleanly, set `phone_consolidated_experience` to `true`. This activates the Unified Phone Experience and routes all MFA phone notifications through the `auth0_phone_provider` you configured in Step 1.
+
+```hcl wrap lines
+resource "auth0_tenant" "main" {
+    # ... other tenant settings ...
+
+    phone_consolidated_experience = true
+}
+```
+
+Apply the change:
+
+```bash wrap lines
+terraform plan
+terraform apply
+```
+
+After this applies, Auth0 uses the tenant-level phone provider for all MFA phone factor deliveries. The legacy Guardian phone API endpoints are no longer in use.
+
+## Troubleshooting
+
+### 403 Forbidden errors during terraform apply
+
+This typically means `phone_consolidated_experience` was already `true` when trying to manage legacy Guardian phone attributes. Make sure Step 1 applies with `phone_consolidated_experience = false` before Step 2.
+
+### Custom provider not delivering messages
+
+Verify that the Action with the `custom-phone-provider` trigger exists and is deployed in Auth0 before applying. Terraform does not manage the Action's existence as part of the `auth0_phone_provider` resource lifecycle.
+
+### OTP messages not arriving after migration
+
+Confirm the `auth0_phone_provider` credentials are correct and that `delivery_methods` includes `"text"` for SMS. If you previously used a Messaging Service SID, ensure `mssid` is set on the new provider.

--- a/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
+++ b/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
@@ -15,7 +15,7 @@ Before you begin migration, you need:
 - If you want to configure a custom phone provider, create and deploy a [`custom-phone-provider`](/docs/customize/phone-messages/configure-phone-messaging-providers/configure-a-custom-phone-provider) Auth0 Action to handle message delivery.
 
 
-## Enable the auth0_phone_provider resource and remove legacy configuration
+## Enable the phone provider resource and remove legacy configuration
 
 To enable the Terraform `auth0_phone_provider` resource and clean up legacy configuration:
 

--- a/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
+++ b/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
@@ -29,7 +29,7 @@ Before you begin migration, you need:
 To enable the Terraform `auth0_phone_provider` resource and clean up legacy configuration:
 
 * [Set the `phone_consolidated_experience` flag to false](#set-the-phone_consolidated_experience-flag-to-false)
-* Add the tenant-level phone provider
+* [Add the tenant-level phone provider](#add-the-tenant-level-phone-provider)
 * (Optional) [Add the `auth0_branding_phone_notification_template` resource](#add-the-auth0_branding_phone_notification_template-resource)
 * Clean up the [`auth0_guardian`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/guardian) phone block
 * Plan and apply

--- a/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
+++ b/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
@@ -30,7 +30,7 @@ To enable the Terraform `auth0_phone_provider` resource and clean up legacy conf
 
 * Set the `phone_consolidated_experience` flag to false
 * Add the tenant-level phone provider
-* (Optional) Add the `auth0_branding_phone_notification_template` resource
+* (Optional) [Add the `auth0_branding_phone_notification_template` resource](#add-the-auth0_branding_phone_notification_template-resource)
 * Clean up the [`auth0_guardian`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/guardian) phone block
 * Plan and apply
 

--- a/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
+++ b/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
@@ -1,32 +1,34 @@
 ---
-description: Learn how to migrate from the legacy Guardian phone configuration to the Unified Phone Experience using the Auth0 Terraform Provider.
 title: Migrate to Unified Phone Experience with Terraform
+description: Learn how to migrate from the legacy Guardian phone configuration to the Unified Phone Experience using the Auth0 Terraform Provider.
 ---
 
-Migrate your tenant from the legacy [Auth0 Guardian](/docs/secure/multi-factor-authentication/auth0-guardian) phone configuration to the [Unified Phone Experience (UPE)](/docs/customize/phone-messages/unified-phone/configure-unified-phone) using the Auth0 [Terraform Provider](https://registry.terraform.io/providers/auth0/auth0/latest/docs). 
+Migrate your tenant from the legacy [Auth0 Guardian](/docs/secure/multi-factor-authentication/auth0-guardian) phone configuration to the [Unified Phone Experience (UPE)](/docs/customize/phone-messages/unified-phone/configure-unified-phone) using the Auth0 [Terraform Provider](https://registry.terraform.io/providers/auth0/auth0/latest/docs).
 
 After migration, all [multi-factor authentication (MFA) phone notifications](/docs/customize/phone-messages/unified-phone/use-auth0s-unified-phone-experience-for-multi-factor-authentication) route through a single tenant-level phone provider.
 
 ## Prerequisites
+
 Before you begin migration, you need:
-- [Auth0 Terraform provider v1.49.0](https://registry.terraform.io/providers/auth0/auth0/latest) or later.
+
+- [Auth0 Terraform Provider v1.49.0](https://registry.terraform.io/providers/auth0/auth0/latest) or later.
 - If you want to configure a custom phone provider, create and deploy a [`custom-phone-provider`](/docs/customize/phone-messages/configure-phone-messaging-providers/configure-a-custom-phone-provider) Auth0 Action to handle message delivery.
 
 
-## Enable the Terraform `auth0_phone_provider` resource and remove legacy configuration
+## Enable the auth0_phone_provider resource and remove legacy configuration
 
 To enable the Terraform `auth0_phone_provider` resource and clean up legacy configuration:
 
-* [Set the `phone_consolidated_experience` flag to true](#set-the-phone_consolidated_experience-flag-to-true)
+* [Set the phone_consolidated_experience flag to true](#set-the-phone-consolidated-experience-flag-to-true)
 * [Add the tenant-level phone provider](#add-the-tenant-level-phone-provider)
-* (Optional) [Add the `auth0_branding_phone_notification_template` resource](#add-the-auth0_branding_phone_notification_template-resource)
-* [Clean up the `auth0_guardian` resource phone block](#clean-up-auth0_guardian-resource-phone-block)
+* [Add the auth0_branding_phone_notification_template resource (optional)](#add-the-auth0-branding-phone-notification-template-resource-optional)
+* [Clean up the auth0_guardian resource phone block](#clean-up-the-auth0-guardian-resource-phone-block)
 * [Plan and apply](#plan-and-apply)
 
 
-### Set the `phone_consolidated_experience` flag to false
+### Set the phone_consolidated_experience flag to true
 
-To ensure that your Auth0 tenant enables UPE and routes all MFA phone notifications, edit your [`auth0_tenant`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/tenant) resource and set the `phone_consolidated_experience` flag to `true`.
+To ensure your Auth0 tenant enables UPE and routes all MFA phone notifications through the unified provider, edit your [`auth0_tenant`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/tenant) resource and set the `phone_consolidated_experience` flag to `true`.
 
 ```hcl wrap lines
 resource "auth0_tenant" "main" {
@@ -38,7 +40,7 @@ resource "auth0_tenant" "main" {
 
 ### Add the tenant-level phone provider
 
-Create a tenant-level phone provider using the Terraform [`auth0_phone_provider`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/phone_provider) resource to handle delivery for all phone-based flows once the Unified Phone Experience is enabled.
+Create a tenant-level phone provider using the Terraform [`auth0_phone_provider`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/phone_provider) resource to handle delivery for all phone-based flows under the Unified Phone Experience.
 
 <Tabs>
   <Tab title="Twilio">
@@ -51,7 +53,7 @@ resource "auth0_phone_provider" "default" {
         delivery_methods = ["text", "voice"]
         default_from     = "YOUR_DEFAULT_PHONE_NUMBER"
         sid              = var.twilio_sid
-        mssid            = var.twilio_messaging_service_sid #Optional
+        mssid            = var.twilio_messaging_service_sid # Optional
     }
 
     credentials {
@@ -63,7 +65,7 @@ resource "auth0_phone_provider" "default" {
 To send SMS only, set `delivery_methods` to `["text"]`.
 
   </Tab>
-  <Tab title="Actions custom phone provider">
+  <Tab title="Custom (Actions)">
 
 ```hcl wrap lines
 resource "auth0_phone_provider" "default" {
@@ -75,24 +77,25 @@ resource "auth0_phone_provider" "default" {
 }
 ```
 
-For a [custom phone provider](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/phone_provider), Auth0 expects a pre-existing [`custom-phone-provider`](/docs/customize/phone-messages/configure-phone-messaging-providers/configure-a-custom-phone-provider) Action already deployed. The Action handles the actual delivery logic.
+For a [custom phone provider](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/phone_provider), Auth0 expects the [`custom-phone-provider`](/docs/customize/phone-messages/configure-phone-messaging-providers/configure-a-custom-phone-provider) Action to be deployed before you run `terraform apply`. The Action handles delivery.
 
   </Tab>
 </Tabs>
 
-### (Optional) Add the `auth0_branding_phone_notification_template` resource
+### Add the auth0_branding_phone_notification_template resource (optional)
 
-If you use `enrollment_message` or `verification_message` on the legacy Guardian phone block to customize OTP message text, you can replicate that behavior with the [`auth0_branding_phone_notification_template`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/branding_phone_notification_template) resource.
+If you use `enrollment_message` or `verification_message` on the legacy Guardian phone block to customize one-time passcode (OTP) message text, you can replicate that behavior with the [`auth0_branding_phone_notification_template`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/branding_phone_notification_template) resource.
 
 ```hcl wrap lines
 resource "auth0_branding_phone_notification_template" "default" {
-    # Refer to the Auth0 Terraform Provider docs for available template variables
+    # See the Auth0 Terraform Provider documentation for available template variables.
 }
 ```
 
-### Clean up `auth0_guardian` resource phone block
+### Clean up the auth0_guardian resource phone block
 
-Remove all legacy provider specific attributes from the [`auth0_guardian`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/guardian) phone block. After cleanup, the block should contain only `enabled`, `message_types`, and `depends_on` references the `auth0_tenant` and `auth0_phone_provider resources`. This ensures that UPE and phone provider configurations are applied before the legacy guardian phone block. 
+Remove all legacy provider-specific attributes from the [`auth0_guardian`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/guardian) phone block. After cleanup, the block should contain only the `enabled` and `message_types` attributes plus a `depends_on` block that references the `auth0_tenant.main` and `auth0_phone_provider.default` resources. This ensures UPE and phone-provider configuration are applied before the legacy Guardian phone block.
+
 **Before:**
 
 ```hcl wrap lines
@@ -146,21 +149,21 @@ terraform apply
 
 ## Troubleshooting
 
-### 403 Forbidden errors during `terraform apply` execution
+### 403 Forbidden errors during terraform apply
 
-This typically means that the `phone_consolidated_experience` was already set to `true` when trying to manage legacy Guardian phone attributes. Ensure that [`depends_on`](#clean-up-auth0-guardian-phone-block) references `auth0_tenant.main` and `auth0_phone_provider.default` so that Terraform applies them in the correct order. 
+This error typically means that `phone_consolidated_experience` was already set to `true` when Terraform tried to manage legacy Guardian phone attributes. Ensure that the [`depends_on`](#clean-up-the-auth0-guardian-resource-phone-block) block references `auth0_tenant.main` and `auth0_phone_provider.default` so that Terraform applies them in the correct order.
 
-### 409 Conflict error: Message Type `<sms,voice>` is not supported by the configured phone provider 
+### 409 Conflict error: Message Type is not supported by the configured phone provider
 
-This message means that the `message_types` on the [`auth0_guardian`](#clean-up-auth0-guardian-phone-block) Terraform resource is not supported. Ensure that the provider's `delivery_methods` supports the `messages_types`. The `message_types` for `sms` covers `text` while `voice` covers `voice`.
+This error means the `message_types` value on the [`auth0_guardian`](#clean-up-the-auth0-guardian-resource-phone-block) resource is not supported by the configured provider. Ensure the provider's `delivery_methods` covers the requested `message_types`. Use `message_types: ["sms"]` for `text` delivery, or `message_types: ["voice"]` for `voice` delivery.
 
 ### Terraform apply error: Provider or options cannot be specified
 
-The legacy `auth0_guardian` resource `provider` attribute and/or options block are present while UPE is enabled. Remove `provider` and/or `options` from the [configuration](#clean-up-auth0-guardian-phone-block) so the phone block only contains `enabled` and `message_types` settings.
+The legacy `auth0_guardian` resource still has a `provider` attribute or `options` block while UPE is enabled. Remove `provider` and `options` from the [configuration](#clean-up-the-auth0-guardian-resource-phone-block) so the phone block contains only the `enabled` and `message_types` settings.
 
 ### Custom phone provider not delivering messages
 
-Verify that the Auth0 Action with the [custom-phone-provider](/docs/customize/phone-messages/configure-phone-messaging-providers/configure-a-custom-phone-provider) trigger exists and is deployed in Auth0 before using Terraform `apply`. 
+Verify that the Auth0 Action with the [custom-phone-provider](/docs/customize/phone-messages/configure-phone-messaging-providers/configure-a-custom-phone-provider) trigger exists and is deployed in Auth0 before you run `terraform apply`.
 
 ### OTP messages not arriving after migration
 

--- a/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
+++ b/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
@@ -3,25 +3,30 @@ description: Learn how to migrate from the legacy Guardian phone configuration t
 title: Migrate to Unified Phone Experience with Terraform
 ---
 
-Migrate your tenant from the legacy Guardian phone configuration to the Unified Phone Experience using the Auth0 Terraform Provider. After migration, all multi-factor authentication (MFA) phone notifications route through a single tenant-level phone provider.
+Migrate your tenant from the legacy [Auth0 Guardian](/docs/secure/multi-factor-authentication/auth0-guardian) phone configuration to the [Unified Phone Experience](/docs/customize/phone-messages/unified-phone/configure-unified-phone) using the Auth0 [Terraform Provider](https://registry.terraform.io/providers/auth0/auth0/latest/docs). 
+
+After migration, all [multi-factor authentication (MFA) phone notifications](/docs/customize/phone-messages/unified-phone/use-auth0s-unified-phone-experience-for-multi-factor-authentication) route through a single tenant-level phone provider.
 
 <Warning>
 
-This migration requires two separate `terraform apply` operations. Attempting to complete it in a single apply causes 403 errors from Auth0 APIs because the legacy phone configuration and the Unified Phone Experience flag cannot be active at the same time.
+This migration requires two separate [`terraform apply`](https://developer.hashicorp.com/terraform/cli/commands/apply) operations. 
+
+If you attempt to complete the migration with a single `terraform apply` command causes 403 errors from Auth0 APIs because the legacy phone configuration and the Unified Phone Experience flag cannot be active at the same time.
 
 </Warning>
 
 ## Prerequisites
 
-- Auth0 Terraform Provider v1.41.0 or later
+- [Auth0 Terraform Provider v1.41.0](https://registry.terraform.io/providers/auth0/auth0/latest) or later.
 
-## Step 1: Add new resources and clean up legacy configuration
+Follow these steps to Migrate your legacy Guardian phone configuration to the Unified Phone Experince using Auth0 Terraform provider: 
 
-In this step, you introduce the `auth0_phone_provider` resource, strip legacy attributes from `auth0_guardian`, and temporarily set `phone_consolidated_experience` to `false` to keep the tenant stable during the apply.
+
+## 1. Enable the `auth0_phone_provider` resource and clean up legacy configuration
 
 ### Set phone_consolidated_experience to false
 
-In your `auth0_tenant` resource, explicitly set the flag to `false`. This ensures the tenant does not route through the Unified Phone Experience while you make changes.
+To ensure that your tenant does not route MFA phone notifications through the Unified Phone Experience, edit your [`auth0_tenant`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/tenant) resource and explicitly set the `phone_consolidated_experience` flag to `false`.
 
 ```hcl wrap lines
 resource "auth0_tenant" "main" {
@@ -70,14 +75,14 @@ resource "auth0_phone_provider" "default" {
 }
 ```
 
-For custom providers, Auth0 expects a pre-existing Action with the `custom-phone-provider` trigger already deployed. The Action handles the actual delivery logic. Terraform does not manage the Action's existence as part of the `auth0_phone_provider` resource lifecycle.
+For custom providers, Auth0 expects a pre-existing Action with the [`custom-phone-provider`](/docs/customize/phone-messages/configure-phone-messaging-providers/configure-a-custom-phone-provider) trigger already deployed. The Action handles the actual delivery logic. Terraform does not manage the Action's existence as part of the `auth0_phone_provider` resource lifecycle.
 
   </Tab>
 </Tabs>
 
 ### (Optional) Add auth0_branding_phone_notification_template
 
-If you use `enrollment_message` or `verification_message` on the legacy Guardian phone block to customize OTP message text, you can replicate that behavior with the `auth0_branding_phone_notification_template` resource.
+If you use `enrollment_message` or `verification_message` on the legacy Guardian phone block to customize OTP message text, you can replicate that behavior with the [`auth0_branding_phone_notification_template`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/branding_phone_notification_template) resource.
 
 ```hcl wrap lines
 resource "auth0_branding_phone_notification_template" "default" {
@@ -85,9 +90,9 @@ resource "auth0_branding_phone_notification_template" "default" {
 }
 ```
 
-### Clean up the auth0_guardian phone block
+### Clean up the [`auth0_guardian`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/guardian) phone block
 
-Remove all legacy provider-specific attributes from the `phone` block. After cleanup, the block should contain only `enabled` and `message_types`.
+Remove all legacy provider specific attributes from the `phone` block. After cleanup, the block should contain only `enabled` and `message_types`.
 
 **Before:**
 
@@ -138,9 +143,9 @@ terraform plan
 terraform apply
 ```
 
-## Step 2: Enable the Unified Phone Experience
+## 2. Enable the Unified Phone Experience
 
-Once Step 1 applies cleanly, set `phone_consolidated_experience` to `true`. This activates the Unified Phone Experience and routes all MFA phone notifications through the `auth0_phone_provider` you configured in Step 1.
+Once Step 1 applies cleanly, set [`phone_consolidated_experience`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/tenant#phone_consolidated_experience-2) to `true`. This activates the Unified Phone Experience and routes all MFA phone notifications through the `auth0_phone_provider` you configured in Step 1.
 
 ```hcl wrap lines
 resource "auth0_tenant" "main" {

--- a/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
+++ b/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
@@ -26,7 +26,7 @@ To enable the Terraform `auth0_phone_provider` resource and clean up legacy conf
 * [Plan and apply](#plan-and-apply)
 
 
-### Set the phone_consolidated_experience flag to true
+### Set the consolidated experience flag
 
 To ensure your Auth0 tenant enables UPE and routes all MFA phone notifications through the unified provider, edit your [`auth0_tenant`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/tenant) resource and set the `phone_consolidated_experience` flag to `true`.
 

--- a/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
+++ b/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
@@ -154,7 +154,7 @@ terraform plan
 terraform apply
 ```
 
-## 2. Enable the Unified Phone Experience
+## Enable the Unified Phone Experience
 
 Once Step 1 applies cleanly, set [`phone_consolidated_experience`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/tenant#phone_consolidated_experience-2) to `true`. This activates the Unified Phone Experience and routes all MFA phone notifications through the `auth0_phone_provider` you configured in Step 1.
 

--- a/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
+++ b/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
@@ -101,7 +101,7 @@ resource "auth0_branding_phone_notification_template" "default" {
 }
 ```
 
-### Clean up the [`auth0_guardian`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/guardian) phone block
+### Clean up Auth0 Guardian phone block
 
 Remove all legacy provider specific attributes from the `phone` block. After cleanup, the block should contain only `enabled` and `message_types`.
 

--- a/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
+++ b/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
@@ -103,7 +103,7 @@ resource "auth0_branding_phone_notification_template" "default" {
 
 ### Clean up Auth0 Guardian phone block
 
-Remove all legacy provider specific attributes from the `phone` block. After cleanup, the block should contain only `enabled` and `message_types`.
+Remove all legacy provider specific attributes from the [`auth0_guardian`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/guardian) phone block. After cleanup, the block should contain only `enabled` and `message_types`.
 
 **Before:**
 

--- a/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
+++ b/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
@@ -92,8 +92,7 @@ resource "auth0_branding_phone_notification_template" "default" {
 
 ### Clean up Auth0 Guardian phone block
 
-Remove all legacy provider specific attributes from the [`auth0_guardian`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/guardian) phone block. After cleanup, the block should contain only `enabled` and `message_types`.
-
+Remove all legacy provider specific attributes from the [`auth0_guardian`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/guardian) phone block. After cleanup, the block should contain only `enabled`, `message_types`, and `depends_on` references the `auth0_tenant` and `auth0_phone_provider resources`. This ensures that UPE and phone provider configurations are applied before the legacy guardian phone block. 
 **Before:**
 
 ```hcl wrap lines

--- a/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
+++ b/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
@@ -28,7 +28,7 @@ Before you begin migration, you need:
 
 To enable the Terraform `auth0_phone_provider` resource and clean up legacy configuration:
 
-* Set the `phone_consolidated_experience` flag to false
+* [Set the `phone_consolidated_experience` flag to false](#set-the-phone_consolidated_experience-flag-to-false)
 * Add the tenant-level phone provider
 * (Optional) [Add the `auth0_branding_phone_notification_template` resource](#add-the-auth0_branding_phone_notification_template-resource)
 * Clean up the [`auth0_guardian`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/guardian) phone block

--- a/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
+++ b/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
@@ -156,7 +156,7 @@ terraform apply
 
 ## Enable the Unified Phone Experience
 
-Once Step 1 applies cleanly, set [`phone_consolidated_experience`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/tenant#phone_consolidated_experience-2) to `true`. This activates the Unified Phone Experience and routes all MFA phone notifications through the `auth0_phone_provider` you configured in Step 1.
+Once you've remove the legacy configuration, use the Terraform provider resource to configure the Auth0 Universal Phone Experience. Set [`phone_consolidated_experience`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/tenant#phone_consolidated_experience-2) to `true`. This activates the Unified Phone Experience and routes all MFA phone notifications through the `auth0_phone_provider` you already configured.
 
 ```hcl wrap lines
 resource "auth0_tenant" "main" {

--- a/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
+++ b/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
@@ -92,7 +92,7 @@ resource "auth0_branding_phone_notification_template" "default" {
 }
 ```
 
-### Clean up the auth0_guardian resource phone block
+### Clean up the Auth0 Guardian resource phone block
 
 Remove all legacy provider-specific attributes from the [`auth0_guardian`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/guardian) phone block. 
 

--- a/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
+++ b/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
@@ -24,7 +24,7 @@ Before you begin migration, you need:
 
 
 
-## 1. Enable the Terraform `auth0_phone_provider` resource and remove legacy configuration
+## Enable the Terraform `auth0_phone_provider` resource and remove legacy configuration
 
 To enable the Terraform `auth0_phone_provider` resource and clean up legacy configuration, you need to:
 

--- a/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
+++ b/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
@@ -31,7 +31,7 @@ To enable the Terraform `auth0_phone_provider` resource and clean up legacy conf
 * [Set the `phone_consolidated_experience` flag to false](#set-the-phone_consolidated_experience-flag-to-false)
 * [Add the tenant-level phone provider](#add-the-tenant-level-phone-provider)
 * (Optional) [Add the `auth0_branding_phone_notification_template` resource](#add-the-auth0_branding_phone_notification_template-resource)
-* Clean up the [`auth0_guardian`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/guardian) phone block
+* [Clean up Auth0 Guardian phone block](#clean-up-auth0-guardian-phone-block)
 * [Plan and apply](#plan-and-apply)
 
 

--- a/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
+++ b/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
@@ -32,7 +32,7 @@ To enable the Terraform `auth0_phone_provider` resource and clean up legacy conf
 * [Add the tenant-level phone provider](#add-the-tenant-level-phone-provider)
 * (Optional) [Add the `auth0_branding_phone_notification_template` resource](#add-the-auth0_branding_phone_notification_template-resource)
 * Clean up the [`auth0_guardian`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/guardian) phone block
-* Plan and apply
+* [Plan and apply](#plan-and-apply)
 
 
 ### Set the `phone_consolidated_experience` flag to false

--- a/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
+++ b/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
@@ -3,32 +3,21 @@ description: Learn how to migrate from the legacy Guardian phone configuration t
 title: Migrate to Unified Phone Experience with Terraform
 ---
 
-Migrate your tenant from the legacy [Auth0 Guardian](/docs/secure/multi-factor-authentication/auth0-guardian) phone configuration to the [Unified Phone Experience](/docs/customize/phone-messages/unified-phone/configure-unified-phone) using the Auth0 [Terraform Provider](https://registry.terraform.io/providers/auth0/auth0/latest/docs). 
+Migrate your tenant from the legacy [Auth0 Guardian](/docs/secure/multi-factor-authentication/auth0-guardian) phone configuration to the [Unified Phone Experience (UPE)](/docs/customize/phone-messages/unified-phone/configure-unified-phone) using the Auth0 [Terraform Provider](https://registry.terraform.io/providers/auth0/auth0/latest/docs). 
 
 After migration, all [multi-factor authentication (MFA) phone notifications](/docs/customize/phone-messages/unified-phone/use-auth0s-unified-phone-experience-for-multi-factor-authentication) route through a single tenant-level phone provider.
 
-<Warning>
-
-This migration requires **two** separate [`terraform apply`](https://developer.hashicorp.com/terraform/cli/commands/apply) operations. 
-
-If you attempt to complete the migration with a single `terraform apply` command, Auth0 APIs return 403 errors because the legacy phone configuration and the Unified Phone Experience flag cannot be active at the same time.
-
-</Warning>
-
-
-
-
 ## Prerequisites
 Before you begin migration, you need:
-- [Auth0 Terraform Provider v1.41.0](https://registry.terraform.io/providers/auth0/auth0/latest) or later.
-- If you want to use a custom phone provider, create and deploy an Auth0 Actions [`custom-phone-provider`](/docs/customize/phone-messages/configure-phone-messaging-providers/configure-a-custom-phone-provider) trigger to handle message delivery.
+- [Auth0 Terraform provider v1.49.0](https://registry.terraform.io/providers/auth0/auth0/latest) or later.
+- If you want to configure a custom phone provider, create and deploy a [`custom-phone-provider`](/docs/customize/phone-messages/configure-phone-messaging-providers/configure-a-custom-phone-provider) Auth0 Action to handle message delivery.
 
 
 ## Enable the Terraform `auth0_phone_provider` resource and remove legacy configuration
 
 To enable the Terraform `auth0_phone_provider` resource and clean up legacy configuration:
 
-* [Set the `phone_consolidated_experience` flag to false](#set-the-phone_consolidated_experience-flag-to-false)
+* [Set the `phone_consolidated_experience` flag to true](#set-the-phone_consolidated_experience-flag-to-true)
 * [Add the tenant-level phone provider](#add-the-tenant-level-phone-provider)
 * (Optional) [Add the `auth0_branding_phone_notification_template` resource](#add-the-auth0_branding_phone_notification_template-resource)
 * [Clean up Auth0 Guardian phone block](#clean-up-auth0-guardian-phone-block)
@@ -37,19 +26,19 @@ To enable the Terraform `auth0_phone_provider` resource and clean up legacy conf
 
 ### Set the `phone_consolidated_experience` flag to false
 
-To ensure that your tenant does not route MFA phone notifications using the Unified Phone Experience, edit your [`auth0_tenant`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/tenant) resource and set the `phone_consolidated_experience` flag to `false`.
+To ensure that your Auth0 tenant enables UPE and routes all MFA phone notifications, edit your [`auth0_tenant`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/tenant) resource and set the `phone_consolidated_experience` flag to `true`.
 
 ```hcl wrap lines
 resource "auth0_tenant" "main" {
     # ... other tenant settings ...
 
-    phone_consolidated_experience = false
+    phone_consolidated_experience = true
 }
 ```
 
 ### Add the tenant-level phone provider
 
-Create a tenant-level phone provider using the Terraform [`auth0_phone_provider`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/phone_provider) resource. This provider handles delivery for all phone-based flows once the Unified Phone Experience is enabled.
+Create a tenant-level phone provider using the Terraform [`auth0_phone_provider`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/phone_provider) resource to handle delivery for all phone-based flows once the Unified Phone Experience is enabled.
 
 <Tabs>
   <Tab title="Twilio">
@@ -74,7 +63,7 @@ resource "auth0_phone_provider" "default" {
 To send SMS only, set `delivery_methods` to `["text"]`.
 
   </Tab>
-  <Tab title="Custom Action-based provider">
+  <Tab title="Actions custom phone provider">
 
 ```hcl wrap lines
 resource "auth0_phone_provider" "default" {
@@ -86,7 +75,7 @@ resource "auth0_phone_provider" "default" {
 }
 ```
 
-For custom providers, Auth0 expects a pre-existing Action with the [`custom-phone-provider`](/docs/customize/phone-messages/configure-phone-messaging-providers/configure-a-custom-phone-provider) trigger already deployed. The Action handles the actual delivery logic.
+For a [custom phone provider](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/phone_provider), Auth0 expects a pre-existing [`custom-phone-provider`](/docs/customize/phone-messages/configure-phone-messaging-providers/configure-a-custom-phone-provider) Action already deployed. The Action handles the actual delivery logic.
 
   </Tab>
 </Tabs>
@@ -137,6 +126,7 @@ resource "auth0_guardian" "default" {
         enabled       = true
         message_types = ["sms"]
     }
+    depends_on = [auth0_tenant.main, auth0_phone_provider.default]
 }
 ```
 
@@ -146,7 +136,7 @@ Review the plan carefully before applying. You should see:
 
 - `auth0_phone_provider.default` created
 - `auth0_guardian.default` updated (attributes removed)
-- `auth0_tenant.main` updated (`phone_consolidated_experience = false`)
+- `auth0_tenant.main` updated (`phone_consolidated_experience = true`)
 - `auth0_branding_phone_notification_template.default` created (if added)
 
 ```bash wrap lines
@@ -154,36 +144,24 @@ terraform plan
 terraform apply
 ```
 
-## Enable the Unified Phone Experience
-
-Once you have remove the legacy configuration, use the Terraform provider resource to configure the Auth0 Universal Phone Experience. Set [`phone_consolidated_experience`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/tenant#phone_consolidated_experience-2) to `true`. This activates the Unified Phone Experience and routes all MFA phone notifications through the `auth0_phone_provider` you already configured.
-
-```hcl wrap lines
-resource "auth0_tenant" "main" {
-    # ... other tenant settings ...
-
-    phone_consolidated_experience = true
-}
-```
-
-Apply the change:
-
-```bash wrap lines
-terraform plan
-terraform apply
-```
-
-After this applies, Auth0 uses the [Unified Phone Experience for MFA phone](/docs/customize/phone-messages/unified-phone/use-auth0s-unified-phone-experience-for-multi-factor-authentication) factor deliveries. The legacy Guardian phone API endpoints are no longer in use.
 
 ## Troubleshooting
 
-### 403 Forbidden errors during terraform apply
+### 403 Forbidden errors during `terraform apply` execution
 
-This typically means `phone_consolidated_experience` was already `true` when trying to manage legacy Guardian phone attributes. Make sure [Step 1](/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform#enable-the-terraform-auth0_phone_provider-resource-and-remove-legacy-configuration) applies with `phone_consolidated_experience = false` before [Step 2](/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform#enable-the-unified-phone-experience).
+This typically means that the `phone_consolidated_experience` was already set to `true` when trying to manage legacy Guardian phone attributes. Ensure that [`depends_on`](#clean-up-auth0-guardian-phone-block) references `auth0_tenant.main` and `auth0_phone_provider.default` so that Terraform applies them in the correct order. 
 
-### Custom provider not delivering messages
+### 409 Conflict error: Message Type `<sms,voice>` is not supported by the configured phone provider 
 
-Verify that the Action with the `custom-phone-provider` trigger exists and is deployed in Auth0 before applying. Terraform does not manage the Action's existence as part of the `auth0_phone_provider` resource lifecycle.
+This message means that the `message_types` on the [`auth0_guardian`](#clean-up-auth0-guardian-phone-block) Terraform resource is not supported. Ensure that the provider's `delivery_methods` supports the `messages_types`. The `message_types` for `sms` covers `text` while `voice` covers `voice`.
+
+### Terraform apply error: Provider or options cannot be specified
+
+The legacy `auth0_guardian` resource `provider` attribute and/or options block are present while UPE is enabled. Remove `provider` and/or `options` from the [configuration](#clean-up-auth0-guardian-phone-block) so the phone block only contains `enabled` and `message_types` settings.
+
+### Custom phone provider not delivering messages
+
+Verify that the Auth0 Action with the [custom-phone-provider](/docs/customize/phone-messages/configure-phone-messaging-providers/configure-a-custom-phone-provider) trigger exists and is deployed in Auth0 before using Terraform `apply`. 
 
 ### OTP messages not arriving after migration
 

--- a/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
+++ b/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
@@ -96,7 +96,7 @@ resource "auth0_branding_phone_notification_template" "default" {
 
 Remove all legacy provider-specific attributes from the [`auth0_guardian`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/guardian) phone block. 
 
-After cleanup, the block should contain only the `enabled` and `message_types` attributes plus a `depends_on` block that references the `auth0_tenant.main` and `auth0_phone_provider.default` resources. This ensures UPE and phone-provider configuration are applied before the legacy Guardian phone block.
+After cleanup, the block should contain only the `enabled` and `message_types` attributes plus a `depends_on` block that references the `auth0_tenant.main` and `auth0_phone_provider.default` resources. This applies UPE and phone-provider configuration before the legacy Guardian phone block.
 
 **Before:**
 

--- a/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
+++ b/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
@@ -11,22 +11,34 @@ After migration, all [multi-factor authentication (MFA) phone notifications](/do
 
 This migration requires two separate [`terraform apply`](https://developer.hashicorp.com/terraform/cli/commands/apply) operations. 
 
-If you attempt to complete the migration with a single `terraform apply` command causes 403 errors from Auth0 APIs because the legacy phone configuration and the Unified Phone Experience flag cannot be active at the same time.
+If you attempt to complete the migration with a single `terraform apply` command, Auth0 APIs return 403 errors because the legacy phone configuration and the Unified Phone Experience flag cannot be active at the same time.
 
 </Warning>
+
+
+Follow these steps to Migrate your legacy Guardian phone configuration to the Unified Phone Experince using Auth0 Terraform provider: 
+
 
 ## Prerequisites
 
 - [Auth0 Terraform Provider v1.41.0](https://registry.terraform.io/providers/auth0/auth0/latest) or later.
 
-Follow these steps to Migrate your legacy Guardian phone configuration to the Unified Phone Experince using Auth0 Terraform provider: 
 
 
-## 1. Enable the `auth0_phone_provider` resource and clean up legacy configuration
+## 1. Enable the Terraform `auth0_phone_provider` resource and remove legacy configuration
 
-### Set phone_consolidated_experience to false
+To enable the Terraform `auth0_phone_provider` resource and clean up legacy configuration, you need to:
 
-To ensure that your tenant does not route MFA phone notifications through the Unified Phone Experience, edit your [`auth0_tenant`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/tenant) resource and explicitly set the `phone_consolidated_experience` flag to `false`.
+* Set the `phone_consolidated_experience` flag to false
+* Add the tenant-level phone provider
+* (Optional) Add the `auth0_branding_phone_notification_template` resource
+* Clean up the [`auth0_guardian`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/guardian) phone block
+* Plan and apply
+
+
+### Set the `phone_consolidated_experience` flag to false
+
+To ensure that your tenant does not route MFA phone notifications using the Unified Phone Experience, edit your [`auth0_tenant`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/tenant) resource and set the `phone_consolidated_experience` flag to `false`.
 
 ```hcl wrap lines
 resource "auth0_tenant" "main" {
@@ -36,9 +48,9 @@ resource "auth0_tenant" "main" {
 }
 ```
 
-### Add the auth0_phone_provider resource
+### Add the tenant-level phone provider
 
-Create a tenant-level phone provider. Auth0 supports one phone provider per tenant. This provider handles delivery for all phone-based flows once the Unified Phone Experience is enabled.
+Create a tenant-level phone provider using the Terraform [`auth0_phone_provider`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/phone_provider) resource. This provider handles delivery for all phone-based flows once the Unified Phone Experience is enabled.
 
 <Tabs>
   <Tab title="Twilio">
@@ -80,7 +92,7 @@ For custom providers, Auth0 expects a pre-existing Action with the [`custom-phon
   </Tab>
 </Tabs>
 
-### (Optional) Add auth0_branding_phone_notification_template
+### (Optional) Add the `auth0_branding_phone_notification_template` resource
 
 If you use `enrollment_message` or `verification_message` on the legacy Guardian phone block to customize OTP message text, you can replicate that behavior with the [`auth0_branding_phone_notification_template`](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/branding_phone_notification_template) resource.
 
@@ -162,7 +174,7 @@ terraform plan
 terraform apply
 ```
 
-After this applies, Auth0 uses the tenant-level phone provider for all MFA phone factor deliveries. The legacy Guardian phone API endpoints are no longer in use.
+After this applies, Auth0 uses the [Unified Phone Experience for MFA phone](/docs/customize/phone-messages/unified-phone/use-auth0s-unified-phone-experience-for-multi-factor-authentication) factor deliveries. The legacy Guardian phone API endpoints are no longer in use.
 
 ## Troubleshooting
 

--- a/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
+++ b/main/docs/customize/phone-messages/unified-phone/migrate-to-unified-phone-experience-with-terraform.mdx
@@ -26,7 +26,7 @@ Before you begin migration, you need:
 
 ## Enable the Terraform `auth0_phone_provider` resource and remove legacy configuration
 
-To enable the Terraform `auth0_phone_provider` resource and clean up legacy configuration, you need to:
+To enable the Terraform `auth0_phone_provider` resource and clean up legacy configuration:
 
 * Set the `phone_consolidated_experience` flag to false
 * Add the tenant-level phone provider


### PR DESCRIPTION
## Summary
- Adds new guide: **Migrate to Unified Phone Experience with Terraform** under Customize > Phone Messages > Unified Phone Experience
- Documents the required two-step `terraform apply` process for migrating from legacy Guardian phone config to the new tenant-level phone provider
- Covers Twilio and custom Action-based provider configurations
- Adds navigation entry in `customize.json`

## Test plan
- [ ] Verify page renders correctly in Mintlify preview
- [ ] Confirm navigation link appears under Customize > Phone Messages > Auth0's Unified Phone Experience
- [ ] Validate code blocks render with proper HCL syntax highlighting
- [ ] Check all internal cross-reference links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)