### PR TITLE
chore: limit docs mgmt CODEOWNERS to jsx snippets

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 * @auth0/project-docs-writers-codeowner
 
 # Docs Management ownership for code, config, and related docs
-snippets             @auth0/project-docs-management-codeowner
+snippets/**/*.jsx    @auth0/project-docs-management-codeowner
 ui                   @auth0/project-docs-management-codeowner
 universal-components @auth0/project-docs-management-codeowner
 scripts              @auth0/project-docs-management-codeowner
@@ -11,7 +11,6 @@ scripts              @auth0/project-docs-management-codeowner
 **/CLAUDE.md         @auth0/project-docs-management-codeowner
 
 # Docs Management ownership for generated API & Schema references
-main/docs/api.mdx       @auth0/project-docs-management-codeowner
 main/docs/api           @auth0/project-docs-management-codeowner
 main/docs/fr-ca/api     @auth0/project-docs-management-codeowner
 main/docs/ja-jp/api     @auth0/project-docs-management-codeowner


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

limits docs mgmt CODEOWNERS to jsx snippets, so mdx snippets only require review from writers.

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

### References

https://auth0.slack.com/archives/C09UBR8CWRL/p1779840032874389

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
