### PR TITLE
Fixes broken URLs on quickstarts

### DIFF
--- a/main/config/navigation/quickstarts.json
+++ b/main/config/navigation/quickstarts.json
@@ -35,7 +35,8 @@
         "docs/quickstart/webapp/nginx-plus/interactive",
         "docs/quickstart/webapp/apache/interactive",
         "docs/quickstart/webapp/rails/interactive",
-        "docs/quickstart/webapp/hono"
+        "docs/quickstart/webapp/hono",
+        "docs/quickstart/webapp/aspnet-owin"
       ]
     },
     {
@@ -54,7 +55,8 @@
         "docs/quickstart/native/ionic-react",
         "docs/quickstart/native/ionic-vue",
         "docs/quickstart/native/windows-uwp-csharp",
-        "docs/quickstart/native/device/interactive"
+        "docs/quickstart/native/device/interactive",
+        "docs/quickstart/native/wpf-winforms"
       ]
     },
     {

--- a/main/config/redirects.json
+++ b/main/config/redirects.json
@@ -16441,7 +16441,7 @@
   },
   {
     "source": "/docs/quickstart/native/windows-uwp-csharp/interactive",
-    "destination": "/docs/quickstart/native/windows-uwp-csharp/index"
+    "destination": "/docs/quickstart/native/windows-uwp-csharp"
   },
   {
     "source": "/docs/quickstart/spa/javascript/:client?",
@@ -16837,7 +16837,7 @@
   },
   {
     "source": "/docs/quickstart/webapp/aspnet-owin/interactive",
-    "destination": "/docs/quickstart/webapp/aspnet-owin/index"
+    "destination": "/docs/quickstart/webapp/aspnet-owin"
   },
   {
     "source": "/docs/quickstart/webapp/symfony",
@@ -17181,11 +17181,11 @@
   },
   {
     "source": "/docs/quickstart/native/maui/interactive",
-    "destination": "/docs/quickstart/native/maui/index"
+    "destination": "/docs/quickstart/native/maui"
   },
   {
     "source": "/docs/quickstart/native/wpf-winforms/interactive",
-    "destination": "/docs/quickstart/native/wpf-winforms/index"
+    "destination": "/docs/quickstart/native/wpf-winforms"
   },
   {
     "source": "/docs/api/authentication/link",


### PR DESCRIPTION
## Description

- Fixes broken Quickstart URLs

### References
https://auth0.com/docs/quickstart/webapp/aspnet-owin/index
https://auth0.com/docs/quickstart/native/windows-uwp-csharp/index
https://auth0.com/docs/quickstart/native/wpf-winforms/index
https://auth0.com/docs/quickstart/native/wpf-winforms/index

### Testing


## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
