### PR TITLE
feat: add On-Behalf-Of Token Exchange API documentation

### DIFF
--- a/main/config/navigation/api.authentication.en.json
+++ b/main/config/navigation/api.authentication.en.json
@@ -107,6 +107,10 @@
       "pages": ["docs/api/authentication/custom-token-exchange/get-token"]
     },
     {
+      "group": "On-Behalf-Of Token Exchange",
+      "pages": ["docs/api/authentication/on-behalf-of-token-exchange/get-token"]
+    },
+    {
       "group": "Resource Owner Password Flow",
       "pages": [
         "docs/api/authentication/resource-owner-password-flow/get-token"

--- a/main/config/navigation/api.authentication.fr-ca.json
+++ b/main/config/navigation/api.authentication.fr-ca.json
@@ -109,6 +109,10 @@
       "pages": ["docs/fr-ca/api/authentication/custom-token-exchange/get-token"]
     },
     {
+      "group": "On-Behalf-Of Token Exchange",
+      "pages": ["docs/api/authentication/on-behalf-of-token-exchange/get-token"]
+    },
+    {
       "group": "Resource Owner Password Flow",
       "pages": [
         "docs/fr-ca/api/authentication/resource-owner-password-flow/get-token"

--- a/main/config/navigation/api.authentication.ja-jp.json
+++ b/main/config/navigation/api.authentication.ja-jp.json
@@ -109,6 +109,10 @@
       "pages": ["docs/ja-jp/api/authentication/custom-token-exchange/get-token"]
     },
     {
+      "group": "On-Behalf-Of Token Exchange",
+      "pages": ["docs/api/authentication/on-behalf-of-token-exchange/get-token"]
+    },
+    {
       "group": "Resource Owner Password Flow",
       "pages": [
         "docs/ja-jp/api/authentication/resource-owner-password-flow/get-token"

--- a/main/docs/api/authentication/on-behalf-of-token-exchange/get-token.mdx
+++ b/main/docs/api/authentication/on-behalf-of-token-exchange/get-token.mdx
@@ -5,21 +5,21 @@ description: "The On-Behalf-Of (OBO) Token Exchange enables a middle-tier servic
 
 `POST /oauth/token`
 
-The On-Behalf-Of (OBO) Token Exchange ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)) enables middle-tier services to to exchange a user-scoped token for a new token to call downstream services.
+The On-Behalf-Of (OBO) Token Exchange ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)) enables middle-tier services to exchange a user-scoped token for a new token to call downstream services.
 
 The new token maintains the original user's identity and permissions while being scoped specifically for the downstream service, enabling that service to make authorization decisions based on the end user. The delegation chain is tracked in the `act` (actor) claim, with each level representing a service in the call chain. To learn more, read the [On-Behalf-Of Token Exchange documentation](https://auth0.com/docs/secure/call-apis-on-users-behalf/on-behalf-of-token-exchange).
 
-### Remarks
+## Remarks
 
 - Only Custom API clients associated with a resource server can use the OBO token exchange. A Custom API client has the following requirements:
   - Set `app_type` to `resource_server`.
-  - Set `resource_server_identifier` to the valid resource server, i.e., https://my-api.example.com. Auth0 uses the resource server identifier as the audience parameter in authorization calls.
+  - Set `resource_server_identifier` to the valid resource server, i.e. `https://my-api.example.com`. Auth0 uses the resource server identifier as the audience parameter in authorization calls.
 
 - The scopes issued to the application may differ from the scopes requested. In this case, a `scope` parameter will be included in the response JSON. Scopes are based on the user's [Role-Based Access Control (RBAC) policies](/docs/manage-users/access-control/rbac).
 
 - OBO token exchanges trigger the [`post-login` Action trigger](/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger), where `event.transaction.protocol` is set to `oauth2-token-exchange` and `event.transaction.actor` tracks the complete delegation chain.
 
-- The delegation chain is limited to five nested levels. The OBO token exchange will fail if the subject token already has five nested `act` levels.
+- The delegation chain is limited to five nested levels. The OBO token exchange fails if the subject token already has five nested `act` levels.
 
 - Cache access tokens for the lifetime of the token instead of requesting a new token for each API call. Access tokens are reusable until they expire; repeated token exchanges waste resources, increase latency, and may trigger rate limits.
 
@@ -30,7 +30,7 @@ The new token maintains the original user's identity and permissions while being
 </ParamField>
 
 <ParamField header="auth0-forwarded-for" type="string">
-  End-user IP as a string value. Set this if you want Suspicious IP Throttling protection to work in server-side scenarios.
+  End-user IP as a string value. Set this if you want [Suspicious IP Throttling](/docs/secure/attack-protection/suspicious-ip-throttling) protection to work in server-side scenarios.
 </ParamField>
 
 ## Request Body
@@ -52,15 +52,15 @@ The new token maintains the original user's identity and permissions while being
 </ParamField>
 
 <ParamField body="client_id" type="string" required>
-  Your Custom API client's Client ID. The Custom API client must be associated with a resource server (same identifier). As for other grant types, you can also pass the client ID in the Authorization header using HTTP Basic Auth.
+  Your Custom API client's Client ID. The Custom API client must be associated with a resource server (same identifier). As for other grant types, you can also pass the Client ID in the Authorization header using HTTP Basic Auth.
 </ParamField>
 
 <ParamField body="client_secret" type="string" required>
-  Your Custom API client's Client Secret. As for other grant types, you can also pass the client secret in the Authorization header using HTTP Basic Auth. Other alternatives are also available as explained in [Auth0 Authentication API reference docs](https://auth0.com/docs/api/authentication#authentication-methods). Note that you cannot set `token_endpoint_auth_method` to `none` for OBO token exchange.
+  Your Custom API client's Client Secret. As for other grant types, you can also pass the Client Secret in the Authorization header using `HTTP` Basic Auth. Review alternatives in [Auth0 Authentication API reference docs](https://auth0.com/docs/api/authentication#authentication-methods). Note that you cannot set `token_endpoint_auth_method` to `none` for OBO token exchange.
 </ParamField>
 
 <ParamField body="audience" type="string" required>
-  The unique identifier of the downstream API you want to access. This is the identifier for the downstream service that will receive and validate the new token.
+  The unique identifier of the downstream API you want to access. This is the identifier for the downstream service that receives and validates the new token.
 </ParamField>
 
 <ParamField body="scope" type="string">
@@ -97,7 +97,7 @@ The new token maintains the original user's identity and permissions while being
 ## Response Fields
 
 <ResponseField name="access_token" type="string">
-  The new Auth0 access token scoped for the downstream API. This JWT contains the same `sub` (user identity) as the subject token, with the `aud` set to the requested downstream API audience. The `act` claim tracks the delegation chain.
+  The new Auth0 access token scoped for the downstream API. This [JSON Web Token (JWT)](/docs/secure/tokens/json-web-tokens#json-web-tokens) contains the same `sub` (user identity) as the subject token, with the `aud` set to the requested downstream API audience. The `act` claim tracks the delegation chain.
 </ResponseField>
 
 <ResponseField name="issued_token_type" type="string">

--- a/main/docs/api/authentication/on-behalf-of-token-exchange/get-token.mdx
+++ b/main/docs/api/authentication/on-behalf-of-token-exchange/get-token.mdx
@@ -1,32 +1,32 @@
 ---
 title: "Get Token"
-description: "The On-Behalf-Of (OBO) Token Exchange enables middle-tier services to preserve user identity and permissions when calling downstream APIs by exchanging an incoming user token for a new token scoped to a downstream service..."
+description: "The On-Behalf-Of (OBO) Token Exchange enables a middle-tier service to exchange an incoming user token for a new token scoped to the downstream service."
 ---
 
 `POST /oauth/token`
 
-The On-Behalf-Of (OBO) Token Exchange enables middle-tier services to preserve user identity and permissions when calling downstream APIs by exchanging an incoming user token for a new token scoped to a downstream service, adhering to the specifications of [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693). When an application receives a user-scoped token, it can exchange it for a new token to call downstream services while preserving the identity and context of the original end user throughout the call chain.
+The On-Behalf-Of (OBO) Token Exchange ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)) enables middle-tier services to to exchange a user-scoped token for a new token to call downstream services.
 
-The new token maintains the original user's identity and permissions while being scoped specifically for the downstream service, enabling that service to make authorization decisions based on the end user. The delegation chain is tracked in the `act` (actor) claim, with each level representing a service in the call chain.
+The new token maintains the original user's identity and permissions while being scoped specifically for the downstream service, enabling that service to make authorization decisions based on the end user. The delegation chain is tracked in the `act` (actor) claim, with each level representing a service in the call chain. To learn more, read the [On-Behalf-Of Token Exchange documentation](https://auth0.com/docs/secure/call-apis-on-users-behalf/on-behalf-of-token-exchange).
 
 ### Remarks
 
-- Only Custom API clients associated with a resource server can use the OBO token exchange. A Custom API client is linked to a resource server when they share the same identifier.
+- Only Custom API clients associated with a resource server can use the OBO token exchange. A Custom API client has the following requirements:
+  - Set `app_type` to `resource_server`.
+  - Set `resource_server_identifier` to the valid resource server, i.e., https://my-api.example.com. Auth0 uses the resource server identifier as the audience parameter in authorization calls.
 
-- The scopes issued to the application may differ from the scopes requested. In this case, a `scope` parameter will be included in the response JSON. Scopes are based on the user's Role-Based Access Control (RBAC) policies.
+- The scopes issued to the application may differ from the scopes requested. In this case, a `scope` parameter will be included in the response JSON. Scopes are based on the user's [Role-Based Access Control (RBAC) policies](/docs/manage-users/access-control/rbac).
 
-- OBO token exchanges trigger the post-login Action trigger, where `event.transaction.protocol` is set to `oauth2-token-exchange` and `event.transaction.actor` tracks the complete delegation chain.
+- OBO token exchanges trigger the [`post-login` Action trigger](/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger), where `event.transaction.protocol` is set to `oauth2-token-exchange` and `event.transaction.actor` tracks the complete delegation chain.
 
 - The delegation chain is limited to five nested levels. The OBO token exchange will fail if the subject token already has five nested `act` levels.
 
 - Cache access tokens for the lifetime of the token instead of requesting a new token for each API call. Access tokens are reusable until they expire; repeated token exchanges waste resources, increase latency, and may trigger rate limits.
 
-- To learn more, read the [On-Behalf-Of Token Exchange documentation](https://auth0.com/docs/secure/call-apis-on-users-behalf/on-behalf-of-token-exchange).
-
 ## Parameters
 
 <ParamField header="DPoP" type="string">
-  A DPoP proof for the request. This is optional and only required if your application uses Demonstrating Proof-of-Possession.
+  A DPoP proof for the request. This is optional and only required if your application uses [Demonstrating Proof-of-Possession](/docs/secure/sender-constraining/demonstrating-proof-of-possession-dpop).
 </ParamField>
 
 <ParamField header="auth0-forwarded-for" type="string">
@@ -37,14 +37,10 @@ The new token maintains the original user's identity and permissions while being
 
 <ParamField body="grant_type" type="string" required>
   Denotes the flow you are using. For On-Behalf-Of Token Exchange, use `urn:ietf:params:oauth:grant-type:token-exchange`.
-
-  Allowed values: `urn:ietf:params:oauth:grant-type:token-exchange`
 </ParamField>
 
 <ParamField body="subject_token_type" type="string" required>
   The type of the subject token. For On-Behalf-Of Token Exchange, use `urn:ietf:params:oauth:token-type:access_token`.
-
-  Allowed values: `urn:ietf:params:oauth:token-type:access_token`
 </ParamField>
 
 <ParamField body="subject_token" type="string" required>
@@ -53,8 +49,6 @@ The new token maintains the original user's identity and permissions while being
 
 <ParamField body="requested_token_type" type="string" required>
   Indicates what kind of token you want back. For On-Behalf-Of Token Exchange, use `urn:ietf:params:oauth:token-type:access_token`.
-
-  Allowed values: `urn:ietf:params:oauth:token-type:access_token`
 </ParamField>
 
 <ParamField body="client_id" type="string" required>
@@ -71,10 +65,6 @@ The new token maintains the original user's identity and permissions while being
 
 <ParamField body="scope" type="string">
   (Optional) A space-delimited list of specific permissions requested for the downstream call. If not specified, all scopes granted to the user for the target audience will be included based on RBAC policies.
-</ParamField>
-
-<ParamField body="resource" type="string">
-  (Optional) The identifier of the target API (resource server) you want to access. Must match an API Identifier registered in your Auth0 tenant. Used as an alternative to `audience` when the tenant's [Resource Parameter Compatibility Profile](https://auth0.com/docs/get-started/tenant-settings#settings-advanced) is set to `compatibility`.
 </ParamField>
 
 ## Response
@@ -99,7 +89,7 @@ The new token maintains the original user's identity and permissions while being
 ```json 400 Response (Delegation chain limit exceeded)
 {
   "error": "invalid_request",
-  "error_description": "Delegation chain (`act` claim) depth exceeds the maximum allowed limit of 4"
+  "error_description": "Delegation chain (`act` claim) depth exceeds the maximum allowed limit of 5"
 }
 ```
 </ResponseExample>

--- a/main/docs/api/authentication/on-behalf-of-token-exchange/get-token.mdx
+++ b/main/docs/api/authentication/on-behalf-of-token-exchange/get-token.mdx
@@ -1,0 +1,129 @@
+---
+title: "Get Token"
+description: "The On-Behalf-Of (OBO) Token Exchange enables middle-tier services to preserve user identity and permissions when calling downstream APIs by exchanging an incoming user token for a new token scoped to a downstream service..."
+---
+
+`POST /oauth/token`
+
+The On-Behalf-Of (OBO) Token Exchange enables middle-tier services to preserve user identity and permissions when calling downstream APIs by exchanging an incoming user token for a new token scoped to a downstream service, adhering to the specifications of [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693). When an application receives a user-scoped token, it can exchange it for a new token to call downstream services while preserving the identity and context of the original end user throughout the call chain.
+
+The new token maintains the original user's identity and permissions while being scoped specifically for the downstream service, enabling that service to make authorization decisions based on the end user. The delegation chain is tracked in the `act` (actor) claim, with each level representing a service in the call chain.
+
+### Remarks
+
+- Only Custom API clients associated with a resource server can use the OBO token exchange. A Custom API client is linked to a resource server when they share the same identifier.
+
+- The scopes issued to the application may differ from the scopes requested. In this case, a `scope` parameter will be included in the response JSON. Scopes are based on the user's Role-Based Access Control (RBAC) policies.
+
+- OBO token exchanges trigger the post-login Action trigger, where `event.transaction.protocol` is set to `oauth2-token-exchange` and `event.transaction.actor` tracks the complete delegation chain.
+
+- The delegation chain is limited to five nested levels. The OBO token exchange will fail if the subject token already has five nested `act` levels.
+
+- Cache access tokens for the lifetime of the token instead of requesting a new token for each API call. Access tokens are reusable until they expire; repeated token exchanges waste resources, increase latency, and may trigger rate limits.
+
+- To learn more, read the [On-Behalf-Of Token Exchange documentation](https://auth0.com/docs/secure/call-apis-on-users-behalf/on-behalf-of-token-exchange).
+
+## Parameters
+
+<ParamField header="DPoP" type="string">
+  A DPoP proof for the request. This is optional and only required if your application uses Demonstrating Proof-of-Possession.
+</ParamField>
+
+<ParamField header="auth0-forwarded-for" type="string">
+  End-user IP as a string value. Set this if you want Suspicious IP Throttling protection to work in server-side scenarios.
+</ParamField>
+
+## Request Body
+
+<ParamField body="grant_type" type="string" required>
+  Denotes the flow you are using. For On-Behalf-Of Token Exchange, use `urn:ietf:params:oauth:grant-type:token-exchange`.
+
+  Allowed values: `urn:ietf:params:oauth:grant-type:token-exchange`
+</ParamField>
+
+<ParamField body="subject_token_type" type="string" required>
+  The type of the subject token. For On-Behalf-Of Token Exchange, use `urn:ietf:params:oauth:token-type:access_token`.
+
+  Allowed values: `urn:ietf:params:oauth:token-type:access_token`
+</ParamField>
+
+<ParamField body="subject_token" type="string" required>
+  The incoming Auth0 access token from the user or upstream service that the middle-tier service is currently holding.
+</ParamField>
+
+<ParamField body="requested_token_type" type="string" required>
+  Indicates what kind of token you want back. For On-Behalf-Of Token Exchange, use `urn:ietf:params:oauth:token-type:access_token`.
+
+  Allowed values: `urn:ietf:params:oauth:token-type:access_token`
+</ParamField>
+
+<ParamField body="client_id" type="string" required>
+  Your Custom API client's Client ID. The Custom API client must be associated with a resource server (same identifier). As for other grant types, you can also pass the client ID in the Authorization header using HTTP Basic Auth.
+</ParamField>
+
+<ParamField body="client_secret" type="string" required>
+  Your Custom API client's Client Secret. As for other grant types, you can also pass the client secret in the Authorization header using HTTP Basic Auth. Other alternatives are also available as explained in [Auth0 Authentication API reference docs](https://auth0.com/docs/api/authentication#authentication-methods). Note that you cannot set `token_endpoint_auth_method` to `none` for OBO token exchange.
+</ParamField>
+
+<ParamField body="audience" type="string" required>
+  The unique identifier of the downstream API you want to access. This is the identifier for the downstream service that will receive and validate the new token.
+</ParamField>
+
+<ParamField body="scope" type="string">
+  (Optional) A space-delimited list of specific permissions requested for the downstream call. If not specified, all scopes granted to the user for the target audience will be included based on RBAC policies.
+</ParamField>
+
+<ParamField body="resource" type="string">
+  (Optional) The identifier of the target API (resource server) you want to access. Must match an API Identifier registered in your Auth0 tenant. Used as an alternative to `audience` when the tenant's [Resource Parameter Compatibility Profile](https://auth0.com/docs/get-started/tenant-settings#settings-advanced) is set to `compatibility`.
+</ParamField>
+
+## Response
+
+| Status | Description |
+|--------|-------------|
+| 200 | Successful response. Returns an access token for the downstream API with the same user identity preserved. |
+| 400 | Bad request. May occur if the delegation chain depth exceeds the maximum allowed limit of 4 nested levels, or if required parameters are missing. |
+| 401 | Unauthorized. The subject token is invalid, expired, or the client credentials are incorrect. |
+| 403 | Forbidden. The client does not have permission to perform the token exchange, or the user does not have the requested scopes for the target audience. |
+
+<ResponseExample>
+```json 200 Response
+{
+  "access_token": "eyJ...",
+  "expires_in": 86400,
+  "token_type": "Bearer",
+  "issued_token_type": "urn:ietf:params:oauth:token-type:access_token"
+}
+```
+
+```json 400 Response (Delegation chain limit exceeded)
+{
+  "error": "invalid_request",
+  "error_description": "Delegation chain (`act` claim) depth exceeds the maximum allowed limit of 4"
+}
+```
+</ResponseExample>
+
+## Response Fields
+
+<ResponseField name="access_token" type="string">
+  The new Auth0 access token scoped for the downstream API. This JWT contains the same `sub` (user identity) as the subject token, with the `aud` set to the requested downstream API audience. The `act` claim tracks the delegation chain.
+</ResponseField>
+
+<ResponseField name="issued_token_type" type="string">
+  Confirms the format of the token returned. This matches the `requested_token_type` from your request.
+
+  Value: `urn:ietf:params:oauth:token-type:access_token`
+</ResponseField>
+
+<ResponseField name="token_type" type="string">
+  Specifies the authentication scheme to use in the Authorization header. For OBO, this is `Bearer` unless using DPoP, in which case `DPoP` will be used.
+</ResponseField>
+
+<ResponseField name="expires_in" type="number">
+  The lifetime of the token in seconds.
+</ResponseField>
+
+<ResponseField name="scope" type="string">
+  (Optional) Only included if the granted scopes differ from the requested scopes. Space-delimited list of scopes that were actually granted.
+</ResponseField>

--- a/main/docs/fr-ca/api/authentication/on-behalf-of-token-exchange/get-token.mdx
+++ b/main/docs/fr-ca/api/authentication/on-behalf-of-token-exchange/get-token.mdx
@@ -1,0 +1,119 @@
+---
+title: "Get Token"
+description: "The On-Behalf-Of (OBO) Token Exchange enables a middle-tier service to exchange an incoming user token for a new token scoped to the downstream service."
+---
+
+`POST /oauth/token`
+
+The On-Behalf-Of (OBO) Token Exchange ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)) enables middle-tier services to to exchange a user-scoped token for a new token to call downstream services.
+
+The new token maintains the original user's identity and permissions while being scoped specifically for the downstream service, enabling that service to make authorization decisions based on the end user. The delegation chain is tracked in the `act` (actor) claim, with each level representing a service in the call chain. To learn more, read the [On-Behalf-Of Token Exchange documentation](https://auth0.com/docs/secure/call-apis-on-users-behalf/on-behalf-of-token-exchange).
+
+### Remarks
+
+- Only Custom API clients associated with a resource server can use the OBO token exchange. A Custom API client has the following requirements:
+  - Set `app_type` to `resource_server`.
+  - Set `resource_server_identifier` to the valid resource server, i.e., https://my-api.example.com. Auth0 uses the resource server identifier as the audience parameter in authorization calls.
+
+- The scopes issued to the application may differ from the scopes requested. In this case, a `scope` parameter will be included in the response JSON. Scopes are based on the user's [Role-Based Access Control (RBAC) policies](/docs/manage-users/access-control/rbac).
+
+- OBO token exchanges trigger the [`post-login` Action trigger](/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger), where `event.transaction.protocol` is set to `oauth2-token-exchange` and `event.transaction.actor` tracks the complete delegation chain.
+
+- The delegation chain is limited to five nested levels. The OBO token exchange will fail if the subject token already has five nested `act` levels.
+
+- Cache access tokens for the lifetime of the token instead of requesting a new token for each API call. Access tokens are reusable until they expire; repeated token exchanges waste resources, increase latency, and may trigger rate limits.
+
+## Parameters
+
+<ParamField header="DPoP" type="string">
+  A DPoP proof for the request. This is optional and only required if your application uses [Demonstrating Proof-of-Possession](/docs/secure/sender-constraining/demonstrating-proof-of-possession-dpop).
+</ParamField>
+
+<ParamField header="auth0-forwarded-for" type="string">
+  End-user IP as a string value. Set this if you want Suspicious IP Throttling protection to work in server-side scenarios.
+</ParamField>
+
+## Request Body
+
+<ParamField body="grant_type" type="string" required>
+  Denotes the flow you are using. For On-Behalf-Of Token Exchange, use `urn:ietf:params:oauth:grant-type:token-exchange`.
+</ParamField>
+
+<ParamField body="subject_token_type" type="string" required>
+  The type of the subject token. For On-Behalf-Of Token Exchange, use `urn:ietf:params:oauth:token-type:access_token`.
+</ParamField>
+
+<ParamField body="subject_token" type="string" required>
+  The incoming Auth0 access token from the user or upstream service that the middle-tier service is currently holding.
+</ParamField>
+
+<ParamField body="requested_token_type" type="string" required>
+  Indicates what kind of token you want back. For On-Behalf-Of Token Exchange, use `urn:ietf:params:oauth:token-type:access_token`.
+</ParamField>
+
+<ParamField body="client_id" type="string" required>
+  Your Custom API client's Client ID. The Custom API client must be associated with a resource server (same identifier). As for other grant types, you can also pass the client ID in the Authorization header using HTTP Basic Auth.
+</ParamField>
+
+<ParamField body="client_secret" type="string" required>
+  Your Custom API client's Client Secret. As for other grant types, you can also pass the client secret in the Authorization header using HTTP Basic Auth. Other alternatives are also available as explained in [Auth0 Authentication API reference docs](https://auth0.com/docs/api/authentication#authentication-methods). Note that you cannot set `token_endpoint_auth_method` to `none` for OBO token exchange.
+</ParamField>
+
+<ParamField body="audience" type="string" required>
+  The unique identifier of the downstream API you want to access. This is the identifier for the downstream service that will receive and validate the new token.
+</ParamField>
+
+<ParamField body="scope" type="string">
+  (Optional) A space-delimited list of specific permissions requested for the downstream call. If not specified, all scopes granted to the user for the target audience will be included based on RBAC policies.
+</ParamField>
+
+## Response
+
+| Status | Description |
+|--------|-------------|
+| 200 | Successful response. Returns an access token for the downstream API with the same user identity preserved. |
+| 400 | Bad request. May occur if the delegation chain depth exceeds the maximum allowed limit of 4 nested levels, or if required parameters are missing. |
+| 401 | Unauthorized. The subject token is invalid, expired, or the client credentials are incorrect. |
+| 403 | Forbidden. The client does not have permission to perform the token exchange, or the user does not have the requested scopes for the target audience. |
+
+<ResponseExample>
+```json 200 Response
+{
+  "access_token": "eyJ...",
+  "expires_in": 86400,
+  "token_type": "Bearer",
+  "issued_token_type": "urn:ietf:params:oauth:token-type:access_token"
+}
+```
+
+```json 400 Response (Delegation chain limit exceeded)
+{
+  "error": "invalid_request",
+  "error_description": "Delegation chain (`act` claim) depth exceeds the maximum allowed limit of 5"
+}
+```
+</ResponseExample>
+
+## Response Fields
+
+<ResponseField name="access_token" type="string">
+  The new Auth0 access token scoped for the downstream API. This JWT contains the same `sub` (user identity) as the subject token, with the `aud` set to the requested downstream API audience. The `act` claim tracks the delegation chain.
+</ResponseField>
+
+<ResponseField name="issued_token_type" type="string">
+  Confirms the format of the token returned. This matches the `requested_token_type` from your request.
+
+  Value: `urn:ietf:params:oauth:token-type:access_token`
+</ResponseField>
+
+<ResponseField name="token_type" type="string">
+  Specifies the authentication scheme to use in the Authorization header. For OBO, this is `Bearer` unless using DPoP, in which case `DPoP` will be used.
+</ResponseField>
+
+<ResponseField name="expires_in" type="number">
+  The lifetime of the token in seconds.
+</ResponseField>
+
+<ResponseField name="scope" type="string">
+  (Optional) Only included if the granted scopes differ from the requested scopes. Space-delimited list of scopes that were actually granted.
+</ResponseField>

--- a/main/docs/ja-jp/api/authentication/on-behalf-of-token-exchange/get-token.mdx
+++ b/main/docs/ja-jp/api/authentication/on-behalf-of-token-exchange/get-token.mdx
@@ -1,0 +1,119 @@
+---
+title: "Get Token"
+description: "The On-Behalf-Of (OBO) Token Exchange enables a middle-tier service to exchange an incoming user token for a new token scoped to the downstream service."
+---
+
+`POST /oauth/token`
+
+The On-Behalf-Of (OBO) Token Exchange ([RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)) enables middle-tier services to to exchange a user-scoped token for a new token to call downstream services.
+
+The new token maintains the original user's identity and permissions while being scoped specifically for the downstream service, enabling that service to make authorization decisions based on the end user. The delegation chain is tracked in the `act` (actor) claim, with each level representing a service in the call chain. To learn more, read the [On-Behalf-Of Token Exchange documentation](https://auth0.com/docs/secure/call-apis-on-users-behalf/on-behalf-of-token-exchange).
+
+### Remarks
+
+- Only Custom API clients associated with a resource server can use the OBO token exchange. A Custom API client has the following requirements:
+  - Set `app_type` to `resource_server`.
+  - Set `resource_server_identifier` to the valid resource server, i.e., https://my-api.example.com. Auth0 uses the resource server identifier as the audience parameter in authorization calls.
+
+- The scopes issued to the application may differ from the scopes requested. In this case, a `scope` parameter will be included in the response JSON. Scopes are based on the user's [Role-Based Access Control (RBAC) policies](/docs/manage-users/access-control/rbac).
+
+- OBO token exchanges trigger the [`post-login` Action trigger](/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger), where `event.transaction.protocol` is set to `oauth2-token-exchange` and `event.transaction.actor` tracks the complete delegation chain.
+
+- The delegation chain is limited to five nested levels. The OBO token exchange will fail if the subject token already has five nested `act` levels.
+
+- Cache access tokens for the lifetime of the token instead of requesting a new token for each API call. Access tokens are reusable until they expire; repeated token exchanges waste resources, increase latency, and may trigger rate limits.
+
+## Parameters
+
+<ParamField header="DPoP" type="string">
+  A DPoP proof for the request. This is optional and only required if your application uses [Demonstrating Proof-of-Possession](/docs/secure/sender-constraining/demonstrating-proof-of-possession-dpop).
+</ParamField>
+
+<ParamField header="auth0-forwarded-for" type="string">
+  End-user IP as a string value. Set this if you want Suspicious IP Throttling protection to work in server-side scenarios.
+</ParamField>
+
+## Request Body
+
+<ParamField body="grant_type" type="string" required>
+  Denotes the flow you are using. For On-Behalf-Of Token Exchange, use `urn:ietf:params:oauth:grant-type:token-exchange`.
+</ParamField>
+
+<ParamField body="subject_token_type" type="string" required>
+  The type of the subject token. For On-Behalf-Of Token Exchange, use `urn:ietf:params:oauth:token-type:access_token`.
+</ParamField>
+
+<ParamField body="subject_token" type="string" required>
+  The incoming Auth0 access token from the user or upstream service that the middle-tier service is currently holding.
+</ParamField>
+
+<ParamField body="requested_token_type" type="string" required>
+  Indicates what kind of token you want back. For On-Behalf-Of Token Exchange, use `urn:ietf:params:oauth:token-type:access_token`.
+</ParamField>
+
+<ParamField body="client_id" type="string" required>
+  Your Custom API client's Client ID. The Custom API client must be associated with a resource server (same identifier). As for other grant types, you can also pass the client ID in the Authorization header using HTTP Basic Auth.
+</ParamField>
+
+<ParamField body="client_secret" type="string" required>
+  Your Custom API client's Client Secret. As for other grant types, you can also pass the client secret in the Authorization header using HTTP Basic Auth. Other alternatives are also available as explained in [Auth0 Authentication API reference docs](https://auth0.com/docs/api/authentication#authentication-methods). Note that you cannot set `token_endpoint_auth_method` to `none` for OBO token exchange.
+</ParamField>
+
+<ParamField body="audience" type="string" required>
+  The unique identifier of the downstream API you want to access. This is the identifier for the downstream service that will receive and validate the new token.
+</ParamField>
+
+<ParamField body="scope" type="string">
+  (Optional) A space-delimited list of specific permissions requested for the downstream call. If not specified, all scopes granted to the user for the target audience will be included based on RBAC policies.
+</ParamField>
+
+## Response
+
+| Status | Description |
+|--------|-------------|
+| 200 | Successful response. Returns an access token for the downstream API with the same user identity preserved. |
+| 400 | Bad request. May occur if the delegation chain depth exceeds the maximum allowed limit of 4 nested levels, or if required parameters are missing. |
+| 401 | Unauthorized. The subject token is invalid, expired, or the client credentials are incorrect. |
+| 403 | Forbidden. The client does not have permission to perform the token exchange, or the user does not have the requested scopes for the target audience. |
+
+<ResponseExample>
+```json 200 Response
+{
+  "access_token": "eyJ...",
+  "expires_in": 86400,
+  "token_type": "Bearer",
+  "issued_token_type": "urn:ietf:params:oauth:token-type:access_token"
+}
+```
+
+```json 400 Response (Delegation chain limit exceeded)
+{
+  "error": "invalid_request",
+  "error_description": "Delegation chain (`act` claim) depth exceeds the maximum allowed limit of 5"
+}
+```
+</ResponseExample>
+
+## Response Fields
+
+<ResponseField name="access_token" type="string">
+  The new Auth0 access token scoped for the downstream API. This JWT contains the same `sub` (user identity) as the subject token, with the `aud` set to the requested downstream API audience. The `act` claim tracks the delegation chain.
+</ResponseField>
+
+<ResponseField name="issued_token_type" type="string">
+  Confirms the format of the token returned. This matches the `requested_token_type` from your request.
+
+  Value: `urn:ietf:params:oauth:token-type:access_token`
+</ResponseField>
+
+<ResponseField name="token_type" type="string">
+  Specifies the authentication scheme to use in the Authorization header. For OBO, this is `Bearer` unless using DPoP, in which case `DPoP` will be used.
+</ResponseField>
+
+<ResponseField name="expires_in" type="number">
+  The lifetime of the token in seconds.
+</ResponseField>
+
+<ResponseField name="scope" type="string">
+  (Optional) Only included if the granted scopes differ from the requested scopes. Space-delimited list of scopes that were actually granted.
+</ResponseField>


### PR DESCRIPTION
## Summary
Add comprehensive API documentation for the On-Behalf-Of (OBO) Token Exchange endpoint that enables middle-tier services to preserve user identity and permissions when calling downstream APIs.

## Changes
- Created new API documentation at `/api/authentication/on-behalf-of-token-exchange/get-token`
- Documents the `POST /oauth/token` endpoint with `grant_type: token-exchange` for OBO flows
- Updated navigation config for English, French (fr-ca), and Japanese (ja-jp) locales
- Follows existing authentication API documentation structure and conventions

## Documentation Coverage
- RFC 8693 token exchange for preserving user identity in microservices
- Actor claim delegation chain tracking (up to 5 nested levels)
- Custom API client prerequisites and configuration requirements
- Request parameters: `grant_type`, `subject_token`, `subject_token_type`, `requested_token_type`, `client_id`, `client_secret`, `audience`, `scope`
- Response examples with status codes (200, 400, 401, 403)
- Rate limits and caching best practices
- RBAC-based scope filtering
- Links to main OBO token exchange documentation

## Testing
- ✅ Built and verified locally with `mint dev`
- ✅ Page accessible at `/docs/api/authentication/on-behalf-of-token-exchange/get-token`
- ✅ Navigation entry appears correctly in sidebar
- ✅ All Mintlify components render properly

## Screenshots
Preview available at http://localhost:3000/docs/api/authentication/on-behalf-of-token-exchange/get-token

## Related Documentation
- [On-Behalf-Of Token Exchange Guide](https://auth0.com/docs/secure/call-apis-on-users-behalf/on-behalf-of-token-exchange)

🤖 Generated with [Claude Code](https://claude.com/claude-code)