### PR TITLE
feat: add AI accordion to Flutter (native) quickstart

### DIFF
--- a/main/docs/quickstart/native/flutter.mdx
+++ b/main/docs/quickstart/native/flutter.mdx
@@ -7,6 +7,26 @@ mode: wide
 'twitter:title': 'Auth0 Flutter SDK Quickstarts: Add Login to Your Flutter Application'
 ---
 
+<Accordion title="Use AI to integrate Auth0" icon="microchip-ai" iconType="solid" defaultOpen>
+
+If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, you can add Auth0 authentication automatically in minutes using [agent skills](https://agentskills.io/home).
+
+**Install:**
+
+```bash
+npx skills add auth0/agent-skills --skill auth0-quickstart --skill auth0-flutter-native
+```
+
+**Then ask your AI assistant:**
+
+```text
+Add Auth0 authentication to my Flutter app
+```
+
+Your AI assistant will automatically create your Auth0 application, fetch credentials, add the auth0_flutter SDK dependency, configure the Android and iOS callback URLs, and implement Web Auth login/logout with secure credential storage. [Full agent skills documentation →](/quickstart/agent-skills)
+
+</Accordion>
+
 This guide demonstrates how to integrate Auth0 with a Flutter application using the [Auth0 Flutter SDK](https://github.com/auth0/auth0-flutter). This guide covers setup for **Android**, **iOS**, and **macOS** platforms.
 
 <Info>


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

Adds the "Use AI to integrate Auth0" agent skills accordion to the Flutter native (iOS/Android) quickstart page (main/docs/quickstart/native/flutter.mdx).

This mirrors the accordion already added to the Flutter Web quickstart (#1293), giving developers a quick path to set up Auth0 via an AI coding assistant (Claude Code, Cursor, GitHub Copilot). The accordion provides the npx skills add install command (auth0-quickstart + auth0-flutter-native), an example prompt, and a link to the full agent skills docs.

The copy is tailored to mobile — it references Web Auth login/logout, Android/iOS callback URLs, and secure credential storage, matching what the auth0-flutter-native skill actually does. Additive change only; no existing content is modified.

### References

SDK-8020

### Testing

- Confirmed the --skill auth0-flutter-native name matches the skill being added to the agent-skills repo.
- Diff is a single 20-line addition immediately after the frontmatter; no other content changed.

**Environment:** macOS, Mintlify/MDX docs.

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
