### PR TITLE
fix: Unified entry points for RWA/SPA updates on docs & formatting issues for mintlify build delegated admin page

### DIFF
--- a/main/docs/get-started/universal-components/my-organization/build-delegated-admin.mdx
+++ b/main/docs/get-started/universal-components/my-organization/build-delegated-admin.mdx
@@ -62,16 +62,16 @@ Before using any My Organization components, you need to configure your Auth0 te
   3. Configure the following settings:
       <br />A. [Connection Profile](/docs/authenticate/enterprise-connections/connection-profile#connection-profile): Select or create a profile with connection attribute mappings.
       <br />B. [User Attribute Profile](/docs/authenticate/enterprise-connections/user-attribute-profile#user-attribute-profile): Select or create a profile with user attribute mappings.
-      <br />B. Supported [Identity Providers](/docs/authenticate/identity-providers): Enable providers your customers can use.
-      <br />C. Connection Deletion Behavior: Choose **Allow** or **Allow if Empty**.
-                  - **Allow**: Users can delete connections, which deletes all users from that connection.
-                  - **Allow if Empty**: Users can only delete connections with no users.
-      <br />D. User Access Authorization: Choose **Unauthorized**, **Authorized**, or **All**.
-                  - **Unauthorized**: No permissions allowed.
-                  - **Authorized**: Select specific permissions.
-                  - **All**: Include all existing and future permissions.
-      <br />E. Client Credential Access Authorization: Choose **Unauthorized**, **Authorized**, or **All**.
-  5. Select **Save**.
+      <br />C. Supported [Identity Providers](/docs/authenticate/identity-providers): Enable providers your customers can use.
+      <br />D. Connection Deletion Behavior: Choose **Allow** or **Allow if Empty**.
+      <br />&nbsp;&nbsp;&nbsp;&nbsp;• **Allow**: Users can delete connections, which deletes all users from that connection.
+      <br />&nbsp;&nbsp;&nbsp;&nbsp;• **Allow if Empty**: Users can only delete connections with no users.
+      <br />E. User Access Authorization: Choose **Unauthorized**, **Authorized**, or **All**.
+      <br />&nbsp;&nbsp;&nbsp;&nbsp;• **Unauthorized**: No permissions allowed.
+      <br />&nbsp;&nbsp;&nbsp;&nbsp;• **Authorized**: Select specific permissions.
+      <br />&nbsp;&nbsp;&nbsp;&nbsp;• **All**: Include all existing and future permissions.
+      <br />F. Client Credential Access Authorization: Choose **Unauthorized**, **Authorized**, or **All**.
+  4. Select **Save**.
 
   ## **Setup Database & User**
 
@@ -172,16 +172,16 @@ User must be authenticated and a member of the Auth0 Organization. Components au
   3. Configure the following settings:
       <br />A. [Connection Profile](/docs/authenticate/enterprise-connections/connection-profile#connection-profile): Select or create a profile with connection attribute mappings.
       <br />B. [User Attribute Profile](/docs/authenticate/enterprise-connections/user-attribute-profile#user-attribute-profile): Select or create a profile with user attribute mappings.
-      <br />B. Supported [Identity Providers](/docs/authenticate/identity-providers): Enable providers your customers can use.
-      <br />C. Connection Deletion Behavior: Choose **Allow** or **Allow if Empty**.
-                  - **Allow**: Users can delete connections, which deletes all users from that connection.
-                  - **Allow if Empty**: Users can only delete connections with no users.
-      <br />D. User Access Authorization: Choose **Unauthorized**, **Authorized**, or **All**.
-                  - **Unauthorized**: No permissions allowed.
-                  - **Authorized**: Select specific permissions.
-                  - **All**: Include all existing and future permissions.
-      <br />E. Client Credential Access Authorization: Choose **Unauthorized**, **Authorized**, or **All**.
-  5. Select **Save**.
+      <br />C. Supported [Identity Providers](/docs/authenticate/identity-providers): Enable providers your customers can use.
+      <br />D. Connection Deletion Behavior: Choose **Allow** or **Allow if Empty**.
+      <br />&nbsp;&nbsp;&nbsp;&nbsp;• **Allow**: Users can delete connections, which deletes all users from that connection.
+      <br />&nbsp;&nbsp;&nbsp;&nbsp;• **Allow if Empty**: Users can only delete connections with no users.
+      <br />E. User Access Authorization: Choose **Unauthorized**, **Authorized**, or **All**.
+      <br />&nbsp;&nbsp;&nbsp;&nbsp;• **Unauthorized**: No permissions allowed.
+      <br />&nbsp;&nbsp;&nbsp;&nbsp;• **Authorized**: Select specific permissions.
+      <br />&nbsp;&nbsp;&nbsp;&nbsp;• **All**: Include all existing and future permissions.
+      <br />F. Client Credential Access Authorization: Choose **Unauthorized**, **Authorized**, or **All**.
+  4. Select **Save**.
 
   ## **Setup Database & User**
 
@@ -288,16 +288,16 @@ User must be authenticated and a member of the Auth0 Organization. Components au
   3. Configure the following settings:
       <br />A. [Connection Profile](/docs/authenticate/enterprise-connections/connection-profile#connection-profile): Select or create a profile with connection attribute mappings.
       <br />B. [User Attribute Profile](/docs/authenticate/enterprise-connections/user-attribute-profile#user-attribute-profile): Select or create a profile with user attribute mappings.
-      <br />B. Supported [Identity Providers](/docs/authenticate/identity-providers): Enable providers your customers can use.
-      <br />C. Connection Deletion Behavior: Choose **Allow** or **Allow if Empty**.
-                  - **Allow**: Users can delete connections, which deletes all users from that connection.
-                  - **Allow if Empty**: Users can only delete connections with no users.
-      <br />D. User Access Authorization: Choose **Unauthorized**, **Authorized**, or **All**.
-                  - **Unauthorized**: No permissions allowed.
-                  - **Authorized**: Select specific permissions.
-                  - **All**: Include all existing and future permissions.
-      <br />E. Client Credential Access Authorization: Choose **Unauthorized**, **Authorized**, or **All**.
-  5. Select **Save**.
+      <br />C. Supported [Identity Providers](/docs/authenticate/identity-providers): Enable providers your customers can use.
+      <br />D. Connection Deletion Behavior: Choose **Allow** or **Allow if Empty**.
+      <br />&nbsp;&nbsp;&nbsp;&nbsp;• **Allow**: Users can delete connections, which deletes all users from that connection.
+      <br />&nbsp;&nbsp;&nbsp;&nbsp;• **Allow if Empty**: Users can only delete connections with no users.
+      <br />E. User Access Authorization: Choose **Unauthorized**, **Authorized**, or **All**.
+      <br />&nbsp;&nbsp;&nbsp;&nbsp;• **Unauthorized**: No permissions allowed.
+      <br />&nbsp;&nbsp;&nbsp;&nbsp;• **Authorized**: Select specific permissions.
+      <br />&nbsp;&nbsp;&nbsp;&nbsp;• **All**: Include all existing and future permissions.
+      <br />F. Client Credential Access Authorization: Choose **Unauthorized**, **Authorized**, or **All**.
+  4. Select **Save**.
 
   ## **Setup Database & User**
 

--- a/main/docs/get-started/universal-components/my-organization/domain-management/configure-org-domains.mdx
+++ b/main/docs/get-started/universal-components/my-organization/domain-management/configure-org-domains.mdx
@@ -46,7 +46,7 @@ npm install @auth0/universal-components-react
 ## Get started
 
 ```tsx React SPA
-import { DomainTable } from "@auth0/universal-components-react/spa";
+import { DomainTable } from "@auth0/universal-components-react";
 
 export function DomainsPage() {
   return <DomainTable />;
@@ -56,7 +56,7 @@ export function DomainsPage() {
 <Accordion title="Full integration example">
 ```tsx
 import React from "react";
-import { DomainTable } from "@auth0/universal-components-react/spa";
+import { DomainTable } from "@auth0/universal-components-react";
 import { Auth0Provider } from "@auth0/auth0-react";
 import { Auth0ComponentProvider } from "@auth0/universal-components-react/spa";
 import { useNavigate } from "react-router-dom";
@@ -536,7 +536,7 @@ pnpm add @auth0/universal-components-react
 ## Get started
 
 ```tsx page.tsx
-import { DomainTable } from "@auth0/universal-components-react/rwa";
+import { DomainTable } from "@auth0/universal-components-react";
 import { useRouter } from "next/navigation";
 
 export function DomainsPage() {
@@ -558,7 +558,7 @@ export function DomainsPage() {
 <Accordion title="Full integration example">
 ```tsx
 import React from "react";
-import { DomainTable } from "@auth0/universal-components-react/rwa";
+import { DomainTable } from "@auth0/universal-components-react";
 import { useRouter } from "next/navigation";
 
 function DomainsManagementPage() {

--- a/main/docs/get-started/universal-components/my-organization/idp-management/sso-provider-create.mdx
+++ b/main/docs/get-started/universal-components/my-organization/idp-management/sso-provider-create.mdx
@@ -46,7 +46,7 @@ npm install @auth0/universal-components-react
 ## Getting Started
 
 ```tsx
-import { SsoProviderCreate } from "@auth0/universal-components-react/spa";
+import { SsoProviderCreate } from "@auth0/universal-components-react";
 import { useNavigate } from "react-router-dom";
 
 export function CreateProviderPage() {
@@ -68,7 +68,7 @@ export function CreateProviderPage() {
 <Accordion title="Full integration example">
 ```tsx
 import React from "react";
-import { SsoProviderCreate } from "@auth0/universal-components-react/spa";
+import { SsoProviderCreate } from "@auth0/universal-components-react";
 import { Auth0Provider } from "@auth0/auth0-react";
 import { Auth0ComponentProvider } from "@auth0/universal-components-react/spa";
 import { useNavigate } from "react-router-dom";
@@ -161,7 +161,7 @@ pnpm add @auth0/universal-components-react
 ## Getting Started
 
 ```tsx page.tsx
-import { SsoProviderCreate } from "@auth0/universal-components-react/rwa";
+import { SsoProviderCreate } from "@auth0/universal-components-react";
 import { useRouter } from "next/navigation";
 
 export function CreateProviderPage() {
@@ -183,7 +183,7 @@ export function CreateProviderPage() {
 <Accordion title="Full integration example">
 ```tsx
 import React from "react";
-import { SsoProviderCreate } from "@auth0/universal-components-react/rwa";
+import { SsoProviderCreate } from "@auth0/universal-components-react";
 import { useRouter } from "next/navigation";
 import { analytics } from "./lib/analytics";
 

--- a/main/docs/get-started/universal-components/my-organization/idp-management/sso-provider-edit.mdx
+++ b/main/docs/get-started/universal-components/my-organization/idp-management/sso-provider-edit.mdx
@@ -46,7 +46,7 @@ npm install @auth0/universal-components-react
 ## Getting Started
 
 ```tsx
-import { SsoProviderEdit } from "@auth0/universal-components-react/spa";
+import { SsoProviderEdit } from "@auth0/universal-components-react";
 import { useNavigate, useParams } from "react-router-dom";
 
 export function EditProviderPage() {
@@ -72,7 +72,7 @@ export function EditProviderPage() {
 <Accordion title="Full integration example">
 ```tsx
 import React from "react";
-import { SsoProviderEdit } from "@auth0/universal-components-react/spa";
+import { SsoProviderEdit } from "@auth0/universal-components-react";
 import { Auth0Provider } from "@auth0/auth0-react";
 import { Auth0ComponentProvider } from "@auth0/universal-components-react/spa";
 import { useNavigate, useParams } from "react-router-dom";
@@ -1080,7 +1080,7 @@ pnpm add @auth0/universal-components-react
 ## Getting Started
 
 ```tsx page.tsx
-import { SsoProviderEdit } from "@auth0/universal-components-react/rwa";
+import { SsoProviderEdit } from "@auth0/universal-components-react";
 import { useRouter } from "next/navigation";
 
 export function EditProviderPage({ providerId }) {
@@ -1105,7 +1105,7 @@ export function EditProviderPage({ providerId }) {
 <Accordion title="Full integration example">
 ```tsx
 import React from "react";
-import { SsoProviderEdit } from "@auth0/universal-components-react/rwa";
+import { SsoProviderEdit } from "@auth0/universal-components-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { analytics } from "./lib/analytics";
 

--- a/main/docs/get-started/universal-components/my-organization/idp-management/sso-provider-table.mdx
+++ b/main/docs/get-started/universal-components/my-organization/idp-management/sso-provider-table.mdx
@@ -46,7 +46,7 @@ npm install @auth0/universal-components-react
 ## Getting Started
 
 ```tsx
-import { SsoProviderTable } from "@auth0/universal-components-react/spa";
+import { SsoProviderTable } from "@auth0/universal-components-react";
 import { useNavigate } from "react-router-dom";
 
 export function ProvidersPage() {
@@ -68,7 +68,7 @@ export function ProvidersPage() {
 <Accordion title="Full integration example">
 ```tsx
 import React from "react";
-import { SsoProviderTable } from "@auth0/universal-components-react/spa";
+import { SsoProviderTable } from "@auth0/universal-components-react";
 import { Auth0Provider } from "@auth0/auth0-react";
 import { Auth0ComponentProvider } from "@auth0/universal-components-react/spa";
 import { useNavigate } from "react-router-dom";
@@ -767,7 +767,7 @@ pnpm add @auth0/universal-components-react
 ## Getting Started
 
 ```tsx page.tsx
-import { SsoProviderTable } from "@auth0/universal-components-react/rwa";
+import { SsoProviderTable } from "@auth0/universal-components-react";
 import { useRouter } from "next/navigation";
 
 export function ProvidersPage() {
@@ -789,7 +789,7 @@ export function ProvidersPage() {
 <Accordion title="Full integration example">
 ```tsx
 import React from "react";
-import { SsoProviderTable } from "@auth0/universal-components-react/rwa";
+import { SsoProviderTable } from "@auth0/universal-components-react";
 import { useRouter } from "next/navigation";
 import { analytics } from "./lib/analytics";
 

--- a/main/docs/get-started/universal-components/my-organization/organization-management/edit-organization-details.mdx
+++ b/main/docs/get-started/universal-components/my-organization/organization-management/edit-organization-details.mdx
@@ -46,7 +46,7 @@ npm install @auth0/universal-components-react
 ## Getting Started
 
 ```tsx
-import { OrganizationDetailsEdit } from "@auth0/universal-components-react/spa";
+import { OrganizationDetailsEdit } from "@auth0/universal-components-react";
 import { useNavigate } from "react-router-dom";
 
 export function OrganizationSettingsPage() {
@@ -68,7 +68,7 @@ export function OrganizationSettingsPage() {
 <Accordion title="Full integration example">
 ```tsx
 import React from "react";
-import { OrganizationDetailsEdit } from "@auth0/universal-components-react/spa";
+import { OrganizationDetailsEdit } from "@auth0/universal-components-react";
 import { Auth0Provider } from "@auth0/auth0-react";
 import { Auth0ComponentProvider } from "@auth0/universal-components-react/spa";
 import { useNavigate } from "react-router-dom";
@@ -632,7 +632,7 @@ pnpm add @auth0/universal-components-react
 ## Getting Started
 
 ```tsx page.tsx
-import { OrganizationDetailsEdit } from "@auth0/universal-components-react/rwa";
+import { OrganizationDetailsEdit } from "@auth0/universal-components-react";
 import { useRouter } from "next/navigation";
 
 export function OrganizationSettingsPage() {
@@ -654,7 +654,7 @@ export function OrganizationSettingsPage() {
 <Accordion title="Full integration example">
 ```tsx
 import React from "react";
-import { OrganizationDetailsEdit } from "@auth0/universal-components-react/rwa";
+import { OrganizationDetailsEdit } from "@auth0/universal-components-react";
 import { useRouter } from "next/navigation";
 import { analytics } from "./lib/analytics";
 

--- a/main/docs/get-started/universal-components/universal-components-overview.mdx
+++ b/main/docs/get-started/universal-components/universal-components-overview.mdx
@@ -91,7 +91,7 @@ function App() {
 
 ```tsx OrganizationManagementPage.tsx
 import { useAuth0 } from "@auth0/auth0-react";
-import { OrganizationDetailsEdit } from "@auth0/universal-components-react/spa";
+import { OrganizationDetailsEdit } from "@auth0/universal-components-react";
 
 function OrganizationManagementPage() {
   const { isAuthenticated, isLoading } = useAuth0();
@@ -191,7 +191,7 @@ export default function RootLayout({ children }) {
 2. Import Universal Components:
 
 ```tsx page.tsx
-import { OrganizationDetailsEdit } from "@auth0/universal-components-react/rwa";
+import { OrganizationDetailsEdit } from "@auth0/universal-components-react";
 
 export default function OrganizationManagementPage() {
   return (


### PR DESCRIPTION
## Description

**1st:** 

Currently, developers need to choose between /rwa or /spa imports for both the components. This delegates implementation details (internal dependencies) to the developer and makes it confusing to understand what to use:

// For SPA
`import { UserMFAMgmt } from '@auth0/universal-components-react/spa';`
// For RWA
`import { UserMFAMgmt } from '@auth0/universal-components-react/rwa';`


// ✅ Unified import for ANY application type
`import { UserMFAMgmt } from '@auth0/universal-components-react';`
<UserMFAMgmt />

**2nd:**

The bullets are marked incorrectly “B” repeats twice.

<img width="971" height="906" alt="image" src="https://github.com/user-attachments/assets/cdc2df4b-f7af-4b9a-b427-507bfcf17917" />


### Testing

<img width="1409" height="961" alt="image" src="https://github.com/user-attachments/assets/cfc3cf26-9644-4921-b3a0-4d20b5dda0d1" />


<img width="1450" height="888" alt="image" src="https://github.com/user-attachments/assets/adc2b2c4-2ab9-4caf-aba9-b90ca89a41f5" />


<img width="1381" height="893" alt="image" src="https://github.com/user-attachments/assets/4dc4b509-4e7e-4b5b-af3e-4a77507618a3" />


## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
