### PR TITLE
fix: add missing step to assign downstream API permissions to roles in OBO quickstart

### DIFF
--- a/auth4genai/mcp/get-started/call-your-apis-on-users-behalf.mdx
+++ b/auth4genai/mcp/get-started/call-your-apis-on-users-behalf.mdx
@@ -16,6 +16,7 @@ import MCPGetStartedCreateRoles from "/snippets/mcp/get-started/config-tenant/ro
 import CreateProfile from "/snippets/mcp/get-started/create-custom-token-exchange-profile.mdx";
 import CreateMCPAPI from "/snippets/mcp/get-started/create-mcp-api.mdx";
 import AssignPermissionsToRoles from "/snippets/mcp/get-started/config-tenant/assign-permissions-to-roles.mdx";
+import AssignDownstreamPermissionsToRoles from "/snippets/mcp/get-started/config-tenant/assign-downstream-permissions-to-roles.mdx";
 import { DownloadQuickstartButton } from "/snippets/download-quickstart/DownloadQuickstartButton.jsx";
 import MCPGetStartedTestingInstructions from "/snippets/mcp/get-started/testing-instructions.mdx";
 import CreateEnvFile from "/snippets/mcp/get-started/call-your-apis/create-env-file.mdx";
@@ -127,6 +128,8 @@ auth0 api post resource-servers --data '{
 ```
 
 Save the API identifier (audience) from the output; you'll configure it in your environment variables as `API_AUTH0_AUDIENCE`.
+
+<AssignDownstreamPermissionsToRoles />
 
 ## Sample app
 <Tabs>

--- a/auth4genai/snippets/mcp/get-started/config-tenant/assign-downstream-permissions-to-roles.mdx
+++ b/auth4genai/snippets/mcp/get-started/config-tenant/assign-downstream-permissions-to-roles.mdx
@@ -1,0 +1,15 @@
+<Accordion title="Assign permissions to roles">
+
+After creating the downstream API and roles, assign the `read:private` permission to the roles.
+
+```shell wrap lines
+# Example for admin role
+auth0 roles permissions add YOUR_ADMIN_ROLE_ID --api-id "http://localhost:8787/" --permissions "read:private"
+
+# Example for user role
+auth0 roles permissions add YOUR_USER_ROLE_ID --api-id "http://localhost:8787/" --permissions "read:private"
+```
+
+Replace `YOUR_ADMIN_ROLE_ID` and `YOUR_USER_ROLE_ID` with the role IDs you saved when creating the roles.
+
+</Accordion>


### PR DESCRIPTION
## Description

The "Call Your API on a User's Behalf" page was missing a step to assign the downstream API's `read:private` scope to the roles created earlier, which would cause the OBO token exchange flow to fail silently for users following the guide.



### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

New section: 
<img width="853" height="649" alt="image" src="https://github.com/user-attachments/assets/db8c3682-08f9-4222-8c13-22fec2ca7d09" />

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
