### PR TITLE
fix: use signed commits in generated content updates

### DIFF
--- a/.github/workflows/sync-agent-skills.yml
+++ b/.github/workflows/sync-agent-skills.yml
@@ -43,30 +43,12 @@ jobs:
           ls "$SKILLS_DIR"
 
       - name: Open or update PR
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git add main/.mintlify/skills/
-
-          # No changes, so don't update.
-          if git diff --cached --quiet; then
-            exit 0
-          fi
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          BRANCH="automated/mintlify-agent-skills-update"
-          git checkout -b "$BRANCH"
-          git commit -m "chore: sync Mintlify agent skills $(date +%Y-%m-%d)"
-
-          # If there's an existing PR, just update the branch.
-          # Otherwise, open a PR.
-          git push -f origin "$BRANCH"
-          EXISTING_PRS=$(gh pr list --head $BRANCH --json number --jq 'length')
-          if (( $EXISTING_PRS == 0 )); then
-            echo "Creating PR..."
-            gh pr create --head "$BRANCH" --base main \
-              --title "chore: sync Mintlify agent skills" \
-              --body "Automated weekly sync of SKILL.md files from [auth0/agent-skills](https://github.com/auth0/agent-skills). These files are served via Mintlify's skills discovery endpoint at \`auth0.com/docs/.well-known/skills/\`.
-          fi
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
+        with:
+          sign-commits: true
+          title: "chore: sync Mintlify agent skills"
+          commit-message: "chore: sync Mintlify agent skills"
+          branch: automated/mintlify-agent-skills-update
+          body: |
+            Automated weekly sync of SKILL.md files from [auth0/agent-skills](https://github.com/auth0/agent-skills).
+            These files are served via Mintlify's skills discovery endpoint at \`auth0.com/docs/.well-known/skills/\`.

--- a/.github/workflows/update-sdk-versions.yml
+++ b/.github/workflows/update-sdk-versions.yml
@@ -147,30 +147,10 @@ jobs:
           echo "--- Done ---"
 
       - name: Open or update PR
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git add main/docs/libraries.mdx
-
-          # No changes, so don't update.
-          if git diff --cached --quiet; then
-            exit 0
-          fi
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          BRANCH="automated/sdk-version-update"
-          git checkout -b "$BRANCH"
-          git commit -m "chore: update SDK library versions $(date +%Y-%m-%d)"
-
-          # If there's an existing PR, just update the branch.
-          # Otherwise, open a PR.
-          git push -f origin "$BRANCH"
-          EXISTING_PRS=$(gh pr list --head $BRANCH --json number --jq 'length')
-          if (( $EXISTING_PRS == 0 )); then
-            echo "Creating PR..."
-            gh pr create --head "$BRANCH" --base main \
-              --title "chore: update SDK library versions" \
-              --body "Automated daily sync of SDK versions and release dates."
-          fi
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
+        with:
+          sign-commits: true
+          title: "chore: update SDK library versions"
+          commit-message: "chore: update SDK library versions"
+          branch: automated/sdk-version-update
+          body: "Automated daily sync of SDK versions and release dates."


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

switch to using the same github action as the docs management pipelines to enable signed commits.

### Testing

test run: https://github.com/auth0/docs-v2/actions/runs/26777236996

commit from test run updated the existing PR and is signed: https://github.com/auth0/docs-v2/pull/1322/changes/c34b2d47ae42086fface2924f09189d5ddf1feab

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
