### PR TITLE
updating clarification post-release

### DIFF
--- a/main/docs/manage-users/user-migration/export-password-hashes-and-mfa-secrets.mdx
+++ b/main/docs/manage-users/user-migration/export-password-hashes-and-mfa-secrets.mdx
@@ -31,7 +31,7 @@ This section uses [GnuPG (`gpg`)](https://gnupg.org/), the standard command-line
   brew install gnupg
   ```
 
-  Requires [Homebrew](https://brew.sh/). For other installation options, see the [GnuPG download page](https://gnupg.org/download/).
+  Requires [Homebrew](https://brew.sh/). For other installation options, read the [GnuPG download page](https://gnupg.org/download/).
 
   </Tab>
 

--- a/main/docs/manage-users/user-migration/export-password-hashes-and-mfa-secrets.mdx
+++ b/main/docs/manage-users/user-migration/export-password-hashes-and-mfa-secrets.mdx
@@ -14,12 +14,81 @@ Before you submit a request, generate a PGP key pair that meets the following re
 | Requirement | Value |
 |---|---|
 | **Key length** | 4096 bits or greater |
-| **Passphrase** | Strong and unique — a randomly generated passphrase is strongly recommended |
+| **Encryption subkey** | The key must include at least one RSA 4096-bit encryption subkey. Auth0 uses this subkey to encrypt your export. Other subkeys may use different parameters; only one needs to meet this requirement. |
+| **Passphrase** | Strong and unique. A randomly generated passphrase is recommended. |
 | **Expiration** | Set an expiration date at least 7 days after the date of generation. To reuse the same key for repeat export requests, adjust the expiration accordingly. |
 
-To generate your key pair, follow the [official GnuPG manual](https://www.gnupg.org/gph/en/manual/c14.html).
+## Generate your PGP key pair
 
-After you generate the key pair, export your **public key** (`.asc` or `.gpg` file). You need the full key block, including the armor headers:
+This section uses [GnuPG (`gpg`)](https://gnupg.org/), the standard command-line tool for OpenPGP. For other tools or advanced options, see the [GnuPG manual](https://www.gnupg.org/gph/en/manual/c14.html).
+
+### Install GnuPG
+
+<Tabs>
+  <Tab title="macOS">
+
+  ```bash
+  brew install gnupg
+  ```
+
+  Requires [Homebrew](https://brew.sh/). For other installation options, see the [GnuPG download page](https://gnupg.org/download/).
+
+  </Tab>
+
+  <Tab title="Linux">
+
+  GnuPG is preinstalled on most distributions. If not:
+
+  ```bash
+  # Debian/Ubuntu
+  sudo apt-get install gnupg
+
+  # RHEL/Fedora
+  sudo dnf install gnupg2
+  ```
+
+  </Tab>
+
+  <Tab title="Windows">
+
+  Install [Gpg4win](https://www.gpg4win.org/), which includes the `gpg` command-line tool. After installation, restart your terminal so the `gpg` command is on your `PATH`.
+
+  </Tab>
+</Tabs>
+
+### Generate the key
+
+Run the key generation command:
+
+```bash
+gpg --full-generate-key
+```
+
+When prompted, provide the following values:
+
+| Prompt | Value |
+|---|---|
+| Please select what kind of key you want | **`1` (RSA and RSA)** |
+| What keysize do you want | **`4096`** |
+| Key is valid for | A duration matching the **Expiration** requirement above (at least 7 days) |
+| Real name / email | Your name and email address |
+| Passphrase | A strong, randomly generated passphrase |
+
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+
+Recent versions of GnuPG default to ECC at the first prompt. **You must explicitly select `1` (RSA and RSA).** ECC and EDDSA keys are not supported by Auth0's export validation.
+
+</Callout>
+
+### Export your public key
+
+After the key is generated, export the public key in ASCII-armored format:
+
+```bash
+gpg --armor --export YOUR_EMAIL > public_key.asc
+```
+
+Replace `YOUR_EMAIL` with the email address you entered during key generation. The output file contains the full key block, including the armor headers:
 
 ```text
 -----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -27,11 +96,11 @@ After you generate the key pair, export your **public key** (`.asc` or `.gpg` fi
 -----END PGP PUBLIC KEY BLOCK-----
 ```
 
-<Warning>
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 
 Do not export or share your private key. Auth0 only needs your public key to encrypt the file.
 
-</Warning>
+</Callout>
 
 ## Request process
 
@@ -41,13 +110,13 @@ Do not export or share your private key. Auth0 only needs your public key to enc
   [Open a support case](https://support.auth0.com) requesting a password hash or MFA secrets export. Include the following in your request:
 
   - The specific **tenant name**.
-  - Your **PGP public key** (the full key block from the prerequisites above).
+  - Your **PGP public key** (the full ASCII-armored block from the previous section).
 
   </Step>
 
   <Step title="Wait for eligibility review">
 
-  The Auth0 team reviews your request to determine eligibility. Not all requests qualify for an export.
+  Auth0 reviews your request to determine eligibility. Not all requests qualify for an export.
 
   Auth0 does not provide ETAs for eligible exports because fulfillment depends on resource and access availability. If you have a required date, note it in your request.
 
@@ -69,18 +138,19 @@ Do not export or share your private key. Auth0 only needs your public key to enc
 
   </Step>
 
-  <Step title="Export preparation">
+  <Step title="Wait for export preparation">
 
-  After Auth0 receives all required documentation, the Auth0 team exports the requested data from your tenant and encrypts it with the PGP public key you provided.
+  After Auth0 receives all required documentation, your tenant data is exported and encrypted with the PGP public key you provided.
 
   </Step>
 
   <Step title="Receive your secure download link">
 
-  You receive an email containing a pre-signed, secure download URL hosted on Amazon S3. This link:
+  You receive an email containing a pre-signed, secure download URL hosted on Amazon S3. The link:
 
-  - Is accessible only to tenant administrators associated with the request.
-  - Expires after **3 days**. Download the file before it expires. After expiration, you must submit a new request.
+  - **Requires authentication** as the user account that opened the support case. Other tenant administrators cannot download the file from this link.
+  - **Requires that user to still hold the tenant administrator role** at the time of download. If they lose the role, the download is blocked and a new request must be submitted.
+  - **Expires after 3 days**. Download the file before it expires. After expiration, you must submit a new request.
 
   </Step>
 
@@ -101,7 +171,7 @@ Do not export or share your private key. Auth0 only needs your public key to enc
 
 - **Never share your private key or passphrase with anyone**, including Auth0 or Okta support staff. Auth0 never asks for them.
 - **Back up your private key and passphrase** securely on an offline device. If lost, you cannot decrypt your export and must submit a new request.
-- **Do not share the download link publicly.** The link is pre-signed and scoped to authorized tenant administrators.
+- **Do not share the download link.** It is pre-signed and only the case creator (authenticated, with an active tenant administrator role) can use it.
 
 ## Learn more
 

--- a/main/docs/manage-users/user-migration/export-password-hashes-and-mfa-secrets.mdx
+++ b/main/docs/manage-users/user-migration/export-password-hashes-and-mfa-secrets.mdx
@@ -158,7 +158,7 @@ Do not export or share your private key. Auth0 only needs your public key to enc
 
   <Step title="Wait for export preparation">
 
-  After Auth0 receives all required documentation, your tenant data is exported and encrypted with the PGP public key you provided.
+  After Auth0 receives all required documentation, we encrypt and export your tenant data with the PGP public key you provided.
 
   </Step>
 

--- a/main/docs/manage-users/user-migration/export-password-hashes-and-mfa-secrets.mdx
+++ b/main/docs/manage-users/user-migration/export-password-hashes-and-mfa-secrets.mdx
@@ -71,8 +71,9 @@ When prompted, provide the following values:
 | Please select what kind of key you want | **`1` (RSA and RSA)** |
 | What keysize do you want | **`4096`** |
 | Key is valid for | A duration matching the **Expiration** requirement above (at least 7 days) |
-| Real name / email | Your name and email address |
-| Passphrase | A strong, randomly generated passphrase |
+| Real name / email | Your name and the exact email address registered for your tenant administrator account. Aliases or different capitalization may cause validation to fail. |
+| Comment | Optional non-sensitive label that helps you identify this key later (for example, *"Auth0 export key"*). |
+| Passphrase | A strong, randomly generated passphrase. |
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 
@@ -82,13 +83,30 @@ Recent versions of GnuPG default to ECC at the first prompt. **You must explicit
 
 ### Export your public key
 
-After the key is generated, export the public key in ASCII-armored format:
+After the key is generated, find its key ID and export the public key. Always reference the key by its key ID (not by email). `gpg` returns the first key matching the identifier you pass, so an email lookup can grab the wrong key if you generated more than one with the same address.
+
+List your keys:
 
 ```bash
-gpg --armor --export YOUR_EMAIL > public_key.asc
+gpg --list-keys
 ```
 
-Replace `YOUR_EMAIL` with the email address you entered during key generation. The output file contains the full key block, including the armor headers:
+The output includes a `pub` line followed by the 16-character key ID:
+
+```text
+pub   rsa4096 2026-06-04 [SC] [expires: 2028-06-04]
+      ABC123451E45G39A
+      uid           [ultimate] Your Name <your.email@example.com>
+sub   rsa4096 2026-06-04 [E]
+```
+
+Export the public key by key ID in ASCII-armored format:
+
+```bash
+gpg --armor --export YOUR_KEY_ID > public_key.asc
+```
+
+Replace `YOUR_KEY_ID` with the alphanumeric string shown under your `pub` line (for example, `ABC123451E45G39A`). The output file contains the full key block, including the armor headers:
 
 ```text
 -----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -146,7 +164,7 @@ Do not export or share your private key. Auth0 only needs your public key to enc
 
   <Step title="Receive your secure download link">
 
-  You receive an email containing a pre-signed, secure download URL hosted on Amazon S3. The link:
+  You receive an email containing a secure download link. The link:
 
   - **Requires authentication** as the user account that opened the support case. Other tenant administrators cannot download the file from this link.
   - **Requires that user to still hold the tenant administrator role** at the time of download. If they lose the role, the download is blocked and a new request must be submitted.
@@ -171,7 +189,7 @@ Do not export or share your private key. Auth0 only needs your public key to enc
 
 - **Never share your private key or passphrase with anyone**, including Auth0 or Okta support staff. Auth0 never asks for them.
 - **Back up your private key and passphrase** securely on an offline device. If lost, you cannot decrypt your export and must submit a new request.
-- **Do not share the download link.** It is pre-signed and only the case creator (authenticated, with an active tenant administrator role) can use it.
+- **Do not share the download link.** Although the download requires the case creator to authenticate with an active tenant administrator role, treat the link as confidential.
 
 ## Learn more
 


### PR DESCRIPTION


## Description

 Updates the [Export Password Hashes and MFA Secrets](https://auth0.com/docs/manage-users/user-migration/export-password-hashes-and-mfa-secrets) doc to reflect new PGP key validation logic and download-flow restrictions, plus addresses gaps that were causing customers to submit invalid PGP keys (notably EDDSA keys, since modern `gpg` defaults to ECC).

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
