### PR TITLE
docs: update the post-login and cte api docs to match latest

### DIFF
--- a/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/custom-token-exchange-trigger/custom-token-exchange-api-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/custom-token-exchange-trigger/custom-token-exchange-api-object.mdx
@@ -5,7 +5,7 @@
 #
 description: Learn about the custom-token-exchange Action trigger's API object.
 title: 'Actions Triggers: custom-token-exchange - API Object'
-validatedOn: 2026-05-25
+validatedOn: 2026-06-03
 ---
 
 The API object for the custom-token-exchange Actions trigger includes:
@@ -129,7 +129,7 @@ Note: Exactly one of api.authentication.setUserByConnection api.authentication.s
 <ResponseField name="connection_name" type="string">
   Name of the connection the user should be stored in.
 </ResponseField>
-<ResponseField name="user_attributes" type="setuserbyconnectionuserattributes">
+<ResponseField name="user_attributes" type="customtokenexchangesetuserbyconnectionuserattributes">
   The user's profile attributes, including user_id, and optionally other attributes such as email, name, etc.
   
   The user_id field is required, and should be the unique identifier of the user within the connection;
@@ -143,7 +143,7 @@ Note: Exactly one of api.authentication.setUserByConnection api.authentication.s
       The user's email.
     </ResponseField>
     <ResponseField name="email_verified" type="boolean" post={["optional"]}>
-      Whether this email address is verified (true) or unverified (false). User will receive a verification email after creation if email_verified is false or not specified.
+      Whether this email address is verified (true) or unverified (false).
     </ResponseField>
     <ResponseField name="family_name" type="string" post={["optional"]}>
       The user's family name(s).
@@ -173,11 +173,11 @@ Note: Exactly one of api.authentication.setUserByConnection api.authentication.s
       The user's username.
     </ResponseField>
     <ResponseField name="verify_email" type="boolean" post={["optional"]}>
-      Whether the user will receive a verification email after creation (true) or no email (false). Overrides behavior of email_verified parameter.
+      Whether the user will receive a verification email after creation (true) or no email (false).
     </ResponseField>
   </Expandable>
 </ResponseField>
-<ResponseField name="options" type="setuserbyconnectionoptions">
+<ResponseField name="options" type="customtokenexchangesetuserbyconnectionoptions">
   Options to control the behavior of the setUserByConnection command.
   
      - `creationBehavior` - behavior to apply if no user with the specified user_id exists in the connection.
@@ -189,13 +189,13 @@ Note: Exactly one of api.authentication.setUserByConnection api.authentication.s
        user attributes; or 'none' which means the existing user will not be modified.
   <Expandable title="options properties" defaultOpen>
     <ResponseField name="creationBehavior" type="string">
-      Behaviour to apply if no user with the specified user_id exists in the connection. Can be 'create_if_not_exists', which will cause a new user to be created using the supplied user attributes; or 'none', which will result in no user being created and an error being returned if no user exists.
+      Behavior to apply if no user with the specified user_id exists in the connection.
 
 
       Allowed values: `create_if_not_exists`, `none`
     </ResponseField>
     <ResponseField name="updateBehavior" type="string">
-      Behaviour to apply if a user with specified user_id already exists in the connection. Can be 'replace', which results in the existing user's attributes being replaced with the specified user attributes; or 'none' which means the existing user will not be modified.
+      Behavior to apply if a user with specified user_id already exists in the connection.
 
 
       Allowed values: `none`, `replace`

--- a/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-api-object.mdx
+++ b/main/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-api-object.mdx
@@ -5,7 +5,7 @@
 #
 description: Learn about the post-login Action trigger's API object.
 title: 'Actions Triggers: post-login - API Object'
-validatedOn: 2026-05-25
+validatedOn: 2026-06-03
 ---
 
 The API object for the post-login Actions trigger includes:
@@ -956,4 +956,31 @@ Metadata modified using this method is updated in real-time in the
 <ResponseField name="value" type="txmetadatavalue">
   The value of the property. This may be set to `null` to remove the
   metadata property.
+</ResponseField>
+
+## `api.groups`
+
+Get information about user groups membership.
+
+### `api.groups.getUserGroups(params)`
+
+Get the paginated list of the groups the user belongs to.
+
+<ResponseField name="params" type="getusergroupsparams" post={["optional"]}>
+  - An object containing pagination options.
+  <Expandable title="params properties" defaultOpen>
+    <ResponseField name="take" type="number" post={["optional"]}>
+    </ResponseField>
+    <ResponseField name="from" type="string" post={["optional"]}>
+    </ResponseField>
+  </Expandable>
+</ResponseField>
+
+### `api.groups.hasGroupMembership(groups)`
+
+Checks if the user is a member of any of the specified groups and provides details
+about the matching groups if the user is a member.
+
+<ResponseField name="groups" type="array of strings">
+  - An array of group identifiers (IDs or names) to check membership against.
 </ResponseField>


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

Updates the Actions trigger documentation to match the latest published types. Notably, we are releasing documentation for the newly released GroupsAPI on the post-login trigger.

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
