### PR TITLE
fix: update section headings to align with v1 documentation

### DIFF
--- a/main/docs/api/authentication/account-linking-legacy/link.mdx
+++ b/main/docs/api/authentication/account-linking-legacy/link.mdx
@@ -7,9 +7,9 @@ description: "This endpoint is **deprecated** for account linking. The [POST /ap
 
 `GET /authorize`
 
-<Note>
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 This endpoint is **deprecated** for account linking. The [POST /api/v2/users/{id}/identities](/api/management/v2/users/post-identities) should be used instead. For more information refer to the [Migration Notice](/migrations/past-migrations#account-linking-removal).
-</Note>
+</Callout>
 
 Call this endpoint when a user wants to link a second authentication method (for example, a user/password database connection, with Facebook).
 

--- a/main/docs/api/authentication/account-linking-legacy/link.mdx
+++ b/main/docs/api/authentication/account-linking-legacy/link.mdx
@@ -3,6 +3,8 @@ title: "Link"
 description: "This endpoint is **deprecated** for account linking. The [POST /api/v2/users/{id}/identities](/api/management/v2#!/Users/post_identities) should be used..."
 ---
 
+## Endpoint
+
 `GET /authorize`
 
 <Note>
@@ -22,8 +24,7 @@ This endpoint will trigger the login flow to link an existing account with a new
 - [Link User Accounts Initiated by Users Scenario](http://auth0.com/docs/users/references/link-accounts-user-initiated-scenario)
 - [Link User Accounts Server-Side Scenario](https://auth0.com/docs/ja-jp/manage-users/user-accounts/user-account-linking/suggested-account-linking-server-side-implementation)
 
-## Parameters
-
+## Query Parameters
 <ParamField query="response_type" type="string" required>
   Use `code` for server side flows, `token` for client side flows.
 </ParamField>
@@ -44,8 +45,7 @@ This endpoint will trigger the login flow to link an existing account with a new
   The logged-in user's Access Token.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 302 | Redirect to connection for linking accounts |

--- a/main/docs/api/authentication/account-linking-legacy/link.mdx
+++ b/main/docs/api/authentication/account-linking-legacy/link.mdx
@@ -8,7 +8,7 @@ description: "This endpoint is **deprecated** for account linking. The [POST /ap
 `GET /authorize`
 
 <Note>
-This endpoint is **deprecated** for account linking. The [POST /api/v2/users/{id}/identities](/api/management/v2#!/Users/post_identities) should be used instead. For more information refer to the [Migration Notice](/migrations/past-migrations#account-linking-removal).
+This endpoint is **deprecated** for account linking. The [POST /api/v2/users/{id}/identities](/api/management/v2/users/post-identities) should be used instead. For more information refer to the [Migration Notice](/migrations/past-migrations#account-linking-removal).
 </Note>
 
 Call this endpoint when a user wants to link a second authentication method (for example, a user/password database connection, with Facebook).

--- a/main/docs/api/authentication/account-linking-legacy/unlink.mdx
+++ b/main/docs/api/authentication/account-linking-legacy/unlink.mdx
@@ -8,7 +8,7 @@ description: "This endpoint is **deprecated**. The [DELETE /api/v2/users/{id}/id
 `POST /login/unlink`
 
 <Note>
-This endpoint is **deprecated**. The [DELETE /api/v2/users/{id}/identities/{provider}/{user_id}](/api/management/v2#!/Users/delete_user_identity_by_user_id) should be used instead.
+This endpoint is **deprecated**. The [DELETE /api/v2/users/{id}/identities/{provider}/{user_id}](/api/management/v2/users/delete-user-identity-by-user-id) should be used instead.
 </Note>
 
 Given a logged-in user's `access_token` and `user_id`, this endpoint will unlink a user's account from the identity provider.

--- a/main/docs/api/authentication/account-linking-legacy/unlink.mdx
+++ b/main/docs/api/authentication/account-linking-legacy/unlink.mdx
@@ -3,6 +3,8 @@ title: "Unlink"
 description: "This endpoint is **deprecated**. The [DELETE /api/v2/users/{id}/identities/{provider}/{user_id}](/api/management/v2#!/Users/delete_user_identity_by_user_id)..."
 ---
 
+## Endpoint
+
 `POST /login/unlink`
 
 <Note>
@@ -14,8 +16,7 @@ Given a logged-in user's `access_token` and `user_id`, this endpoint will unlink
 ### Learn More
 - [Unlink User Accounts](https://auth0.com/docs/manage-users/user-accounts/user-account-linking/unlink-user-accounts)
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | Successfully unlinked user account |

--- a/main/docs/api/authentication/authorization-code-flow-with-enhanced-privacy-protection/authorize.mdx
+++ b/main/docs/api/authentication/authorization-code-flow-with-enhanced-privacy-protection/authorize.mdx
@@ -3,6 +3,8 @@ title: "Authorize"
 description: "After calling the `/oauth/par` endpoint, redirect the end user to the `/authorize` endpoint using a `GET` call."
 ---
 
+## Endpoint
+
 `GET /authorize`
 
 After calling the `/oauth/par` endpoint, redirect the end user to the `/authorize` endpoint using a `GET` call.
@@ -11,8 +13,7 @@ After calling the `/oauth/par` endpoint, redirect the end user to the `/authoriz
 The `/authorize` endpoint will respond based on the parameters passed to the `/oauth/par` endpoint. If you request a `response_type`, you should receive an authorization code to use at the `/oauth/token` endpoint.
 </Note>
 
-## Parameters
-
+## Query Parameters
 <ParamField query="client_id" type="string" required>
   The `client_id` of your application. Required.
 </ParamField>
@@ -21,8 +22,7 @@ The `/authorize` endpoint will respond based on the parameters passed to the `/o
   The `request_uri` value received from the `/oauth/par` endpoint. Required.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 302 | Redirects to the specified redirect URI. |

--- a/main/docs/api/authentication/authorization-code-flow-with-enhanced-privacy-protection/exchange-authorization-code-for-token.mdx
+++ b/main/docs/api/authentication/authorization-code-flow-with-enhanced-privacy-protection/exchange-authorization-code-for-token.mdx
@@ -3,6 +3,9 @@ title: "Exchange Authorization Code for Token"
 description: "When users are redirected back to your callback, you need to make a `POST` call to the `oauth/token` endpoint to exchange an authorization code for an access..."
 ---
 
+import { ResponseSchema } from '/snippets/ResponseSchema.jsx';
+
+
 ## Endpoint
 
 `POST /oauth/token`
@@ -41,6 +44,30 @@ To make a call to the `/oauth/token` endpoint, you must:
 <ParamField body="code_verifier" type="string">
   Cryptographically random key used to generate the `code_challenge`. Recommended if `code_challenge` was provided.
 </ParamField>
+
+## Response Schema
+
+<ResponseSchema>
+<ResponseField name="access_token" type="string">
+  The access token to access protected resources.
+</ResponseField>
+
+<ResponseField name="refresh_token" type="string">
+  Token used to obtain new access tokens.
+</ResponseField>
+
+<ResponseField name="id_token" type="string">
+  The ID token.
+</ResponseField>
+
+<ResponseField name="token_type" type="string">
+  The type of token. Usually `Bearer`.
+</ResponseField>
+
+<ResponseField name="expires_in" type="integer">
+  The lifetime in seconds of the access token.
+</ResponseField>
+</ResponseSchema>
 
 ## Response Messages
 | Status | Description |

--- a/main/docs/api/authentication/authorization-code-flow-with-enhanced-privacy-protection/exchange-authorization-code-for-token.mdx
+++ b/main/docs/api/authentication/authorization-code-flow-with-enhanced-privacy-protection/exchange-authorization-code-for-token.mdx
@@ -65,7 +65,7 @@ To make a call to the `/oauth/token` endpoint, you must:
 </ResponseField>
 
 <ResponseField name="expires_in" type="integer">
-  The lifetime in seconds of the access token.
+  The access token lifetime in seconds.
 </ResponseField>
 </ResponseSchema>
 

--- a/main/docs/api/authentication/authorization-code-flow-with-enhanced-privacy-protection/exchange-authorization-code-for-token.mdx
+++ b/main/docs/api/authentication/authorization-code-flow-with-enhanced-privacy-protection/exchange-authorization-code-for-token.mdx
@@ -3,6 +3,8 @@ title: "Exchange Authorization Code for Token"
 description: "When users are redirected back to your callback, you need to make a `POST` call to the `oauth/token` endpoint to exchange an authorization code for an access..."
 ---
 
+## Endpoint
+
 `POST /oauth/token`
 
 When users are redirected back to your callback, you need to make a `POST` call to the `oauth/token` endpoint to exchange an authorization code for an access and/or an ID token.
@@ -14,14 +16,12 @@ To make a call to the `/oauth/token` endpoint, you must:
 - Use `strings` for all passed parameters
 - Include an additional parameter for application authentication in the request (e.g. `client_secret`, or `client_assertion` and `client_assertion_type` for JSON Web Token Client Authentication, or pass a `client-certificate` and `client-certificate-ca-verified` header when using Mutual TLS).
 
-## Parameters
-
+## Headers
 <ParamField header="DPoP" type="string">
   A DPoP proof for the request. This is optional and only required if your application uses Demonstrating Proof-of-Possession.
 </ParamField>
 
-## Request Body
-
+## Body Parameters
 <ParamField body="grant_type" type="string" required>
   Denotes the flow; use `authorization_code` with a valid authorization code.
 </ParamField>
@@ -42,8 +42,7 @@ To make a call to the `/oauth/token` endpoint, you must:
   Cryptographically random key used to generate the `code_challenge`. Recommended if `code_challenge` was provided.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | Successful response containing the tokens. |

--- a/main/docs/api/authentication/authorization-code-flow-with-enhanced-privacy-protection/push-authorization-requests.mdx
+++ b/main/docs/api/authentication/authorization-code-flow-with-enhanced-privacy-protection/push-authorization-requests.mdx
@@ -3,6 +3,8 @@ title: "Push Authorization Requests (PAR)"
 description: "To use Highly Regulated Identity features, you must have an Enterprise Plan with the Highly Regulated Identity add-on. Refer to [Auth0..."
 ---
 
+## Endpoint
+
 `POST /oauth/par`
 
 <Note>
@@ -21,14 +23,12 @@ Assuming the call to the `/oauth/par` endpoint is valid, Auth0 will respond with
   - Include an additional parameter for application authentication in the request (e.g. `client_secret`, or `client_assertion` and `client_assertion_type` for JSON Web Token Client Authentication, or pass a `client-certificate` and `client-certificate-ca-verified` header when using Mutual TLS).
 - Use the `authorization_details` parameter to request permission for each resource. For example, you can specify an array of JSON objects to convey fine-grained information on the authorization. Each JSON object must contain a `type` attribute. The rest is up to you to define.
 
-## Parameters
-
+## Headers
 <ParamField header="DPoP" type="string">
   A DPoP proof for the request. This is optional and only required if your application uses Demonstrating Proof-of-Possession.
 </ParamField>
 
-## Request Body
-
+## Body Parameters
 <ParamField body="authorization_details" type="string">
   Requested permissions for each resource, similar to scopes.
 </ParamField>
@@ -89,8 +89,7 @@ Assuming the call to the `/oauth/par` endpoint is valid, Auth0 will respond with
   The JWK Thumbprint [RFC7638](https://www.rfc-editor.org/rfc/rfc7638.html) of the proof-of-possession public key using the SHA-256 hash function. Only when using Demonstrating Proof-of-Possession (DPoP).
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 201 | Request successful; returns the request URI and expiration time. |

--- a/main/docs/api/authentication/authorization-code-flow-with-enhanced-privacy-protection/push-authorization-requests.mdx
+++ b/main/docs/api/authentication/authorization-code-flow-with-enhanced-privacy-protection/push-authorization-requests.mdx
@@ -3,6 +3,9 @@ title: "Push Authorization Requests (PAR)"
 description: "To use Highly Regulated Identity features, you must have an Enterprise Plan with the Highly Regulated Identity add-on. Refer to [Auth0..."
 ---
 
+import { ResponseSchema } from '/snippets/ResponseSchema.jsx';
+
+
 ## Endpoint
 
 `POST /oauth/par`
@@ -88,6 +91,18 @@ Assuming the call to the `/oauth/par` endpoint is valid, Auth0 will respond with
 <ParamField body="dpop_jkt" type="string">
   The JWK Thumbprint [RFC7638](https://www.rfc-editor.org/rfc/rfc7638.html) of the proof-of-possession public key using the SHA-256 hash function. Only when using Demonstrating Proof-of-Possession (DPoP).
 </ParamField>
+
+## Response Schema
+
+<ResponseSchema>
+<ResponseField name="request_uri" type="string">
+  The URI to use at the authorization endpoint.
+</ResponseField>
+
+<ResponseField name="expires_in" type="integer">
+  Number of seconds the `request_uri` is valid.
+</ResponseField>
+</ResponseSchema>
 
 ## Response Messages
 | Status | Description |

--- a/main/docs/api/authentication/authorization-code-flow-with-pkce/authorize-with-pkce.mdx
+++ b/main/docs/api/authentication/authorization-code-flow-with-pkce/authorize-with-pkce.mdx
@@ -3,6 +3,9 @@ title: "Authorize"
 description: "This is the OAuth 2.0 grant that mobile apps utilize in order to access an API. Before starting with this flow, you need to generate and store a..."
 ---
 
+import { ResponseSchema } from '/snippets/ResponseSchema.jsx';
+
+
 ## Endpoint
 
 `GET /authorize`
@@ -69,6 +72,19 @@ This is the OAuth 2.0 grant that mobile apps utilize in order to access an API. 
 <ParamField query="dpop_jkt" type="string">
   The JWK Thumbprint [RFC7638](https://www.rfc-editor.org/rfc/rfc7638.html) of the proof-of-possession public key using the SHA-256 hash function.
 </ParamField>
+
+## Response Schema
+
+<ResponseSchema statusCode="default error">
+
+<ResponseField name="error" type="string">
+  Error code.
+</ResponseField>
+
+<ResponseField name="error_description" type="string">
+  Description of the error.
+</ResponseField>
+</ResponseSchema>
 
 ## Response Messages
 | Status | Description |

--- a/main/docs/api/authentication/authorization-code-flow-with-pkce/authorize-with-pkce.mdx
+++ b/main/docs/api/authentication/authorization-code-flow-with-pkce/authorize-with-pkce.mdx
@@ -3,12 +3,13 @@ title: "Authorize"
 description: "This is the OAuth 2.0 grant that mobile apps utilize in order to access an API. Before starting with this flow, you need to generate and store a..."
 ---
 
+## Endpoint
+
 `GET /authorize`
 
 This is the OAuth 2.0 grant that mobile apps utilize in order to access an API. Before starting with this flow, you need to generate and store a `code_verifier`, and using that, generate a `code_challenge` that will be sent in the authorization request.
 
-## Parameters
-
+## Query Parameters
 <ParamField query="audience" type="string" required>
   The unique identifier of the target API you want to access.
 </ParamField>
@@ -69,8 +70,7 @@ This is the OAuth 2.0 grant that mobile apps utilize in order to access an API. 
   The JWK Thumbprint [RFC7638](https://www.rfc-editor.org/rfc/rfc7638.html) of the proof-of-possession public key using the SHA-256 hash function.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 302 | Redirect to the specified redirect_uri after authorization. |

--- a/main/docs/api/authentication/authorization-code-flow-with-pkce/authorize-with-pkce.mdx
+++ b/main/docs/api/authentication/authorization-code-flow-with-pkce/authorize-with-pkce.mdx
@@ -82,7 +82,7 @@ This is the OAuth 2.0 grant that mobile apps utilize in order to access an API. 
 </ResponseField>
 
 <ResponseField name="error_description" type="string">
-  Description of the error.
+  Error description.
 </ResponseField>
 </ResponseSchema>
 

--- a/main/docs/api/authentication/authorization-code-flow-with-pkce/get-token-pkce.mdx
+++ b/main/docs/api/authentication/authorization-code-flow-with-pkce/get-token-pkce.mdx
@@ -3,6 +3,9 @@ title: "Get Token"
 description: "This is the flow that mobile apps use to access an API. Use this endpoint to exchange an Authorization Code for a token."
 ---
 
+import { ResponseSchema } from '/snippets/ResponseSchema.jsx';
+
+
 ## Endpoint
 
 `POST /oauth/token`
@@ -47,6 +50,42 @@ This is the flow that mobile apps use to access an API. Use this endpoint to exc
 <ParamField body="redirect_uri" type="string">
   This is required only if it was set at the `GET` `/authorize` endpoint.
 </ParamField>
+
+## Response Schema
+
+<ResponseSchema statusCode="200">
+
+<ResponseField name="access_token" type="string">
+  The access token.
+</ResponseField>
+
+<ResponseField name="refresh_token" type="string">
+  The refresh token used to obtain new access tokens.
+</ResponseField>
+
+<ResponseField name="id_token" type="string">
+  The ID token.
+</ResponseField>
+
+<ResponseField name="token_type" type="string">
+  The type of token. Usually `Bearer`.
+</ResponseField>
+
+<ResponseField name="expires_in" type="integer">
+  The lifetime in seconds of the access token.
+</ResponseField>
+</ResponseSchema>
+
+<ResponseSchema statusCode="default error">
+
+<ResponseField name="error" type="string">
+  Error code.
+</ResponseField>
+
+<ResponseField name="error_description" type="string">
+  Description of the error.
+</ResponseField>
+</ResponseSchema>
 
 ## Response Messages
 | Status | Description |

--- a/main/docs/api/authentication/authorization-code-flow-with-pkce/get-token-pkce.mdx
+++ b/main/docs/api/authentication/authorization-code-flow-with-pkce/get-token-pkce.mdx
@@ -3,6 +3,8 @@ title: "Get Token"
 description: "This is the flow that mobile apps use to access an API. Use this endpoint to exchange an Authorization Code for a token."
 ---
 
+## Endpoint
+
 `POST /oauth/token`
 
 This is the flow that mobile apps use to access an API. Use this endpoint to exchange an Authorization Code for a token.
@@ -18,14 +20,12 @@ This is the flow that mobile apps use to access an API. Use this endpoint to exc
 - [Call API Using the Authorization Code Flow with PKCE](https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow-with-pkce/call-your-api-using-the-authorization-code-flow-with-pkce)
 - [Silent Authentication](https://auth0.com/docs/authenticate/login/configure-silent-authentication)
 
-## Parameters
-
+## Headers
 <ParamField header="DPoP" type="string">
   A DPoP proof for the request. This is optional and only required if your application uses Demonstrating Proof-of-Possession.
 </ParamField>
 
-## Request Body
-
+## Body Parameters
 <ParamField body="grant_type" type="string" required>
   Denotes the flow you are using. For Authorization Code (PKCE) use `authorization_code`.
 
@@ -48,8 +48,7 @@ This is the flow that mobile apps use to access an API. Use this endpoint to exc
   This is required only if it was set at the `GET` `/authorize` endpoint.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | Successful token exchange. |

--- a/main/docs/api/authentication/authorization-code-flow-with-pkce/get-token-pkce.mdx
+++ b/main/docs/api/authentication/authorization-code-flow-with-pkce/get-token-pkce.mdx
@@ -72,7 +72,7 @@ This is the flow that mobile apps use to access an API. Use this endpoint to exc
 </ResponseField>
 
 <ResponseField name="expires_in" type="integer">
-  The lifetime in seconds of the access token.
+  The access token lifetime in seconds.
 </ResponseField>
 </ResponseSchema>
 
@@ -83,7 +83,7 @@ This is the flow that mobile apps use to access an API. Use this endpoint to exc
 </ResponseField>
 
 <ResponseField name="error_description" type="string">
-  Description of the error.
+  Error description.
 </ResponseField>
 </ResponseSchema>
 

--- a/main/docs/api/authentication/authorization-code-flow/authorize-application.mdx
+++ b/main/docs/api/authentication/authorization-code-flow/authorize-application.mdx
@@ -3,6 +3,8 @@ title: "Authorize Application"
 description: "Begin an OAuth 2.0 Authorization flow by sending the user to the authorization URL to obtain consent and an authorization code."
 ---
 
+## Endpoint
+
 `GET /authorize`
 
 To begin an OAuth 2.0 Authorization flow, your application should first send the user to the authorization URL.
@@ -21,8 +23,7 @@ The [Resource Owner Password Grant](https://auth0.com/docs/get-started/authentic
 
 Based on the OAuth 2.0 flow you are implementing, the parameters slightly change. To determine which flow is best suited for your case, refer to: [Which OAuth 2.0 flow should I use?](https://auth0.com/docs/get-started/authentication-and-authorization-flow/which-oauth-2-0-flow-should-i-use).
 
-## Parameters
-
+## Query Parameters
 <ParamField query="audience" type="string" required>
   The unique identifier of the target API you want to access.
 </ParamField>
@@ -71,8 +72,7 @@ Based on the OAuth 2.0 flow you are implementing, the parameters slightly change
   The JWK Thumbprint [RFC7638] of the proof-of-possession public key using the SHA-256 hash function. Only when using Demonstrating Proof-of-Possession (DPoP).
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 302 | Redirect with authorization code |

--- a/main/docs/api/authentication/authorization-code-flow/get-token.mdx
+++ b/main/docs/api/authentication/authorization-code-flow/get-token.mdx
@@ -3,6 +3,8 @@ title: "Get Token"
 description: "For token-based authentication, use the `oauth/token` endpoint to get an access token for your application to make authenticated calls to a secure API...."
 ---
 
+## Endpoint
+
 `POST /oauth/token`
 
 For token-based authentication, use the `oauth/token` endpoint to get an access token for your application to make authenticated calls to a secure API. Optionally, you can also retrieve an ID Token and a Refresh Token. ID Tokens contains user information in the form of scopes you application can extract to provide a better user experience. Refresh Tokens allow your application to request a new access token once the current token expires without interruping the user experience. To learn more, read [ID Tokens](https://auth0.com/docs/secure/tokens/id-tokens) and [Refresh Tokens](https://auth0.com/docs/secure/tokens/refresh-tokens).
@@ -16,14 +18,12 @@ Note that the only OAuth 2.0 flows that can retrieve a Refresh Token are:
 
 This is the flow that regular web apps use to access an API. Use this endpoint to exchange an Authorization Code for a token.
 
-## Parameters
-
+## Headers
 <ParamField header="DPoP" type="string">
   A DPoP proof for the request. This is optional and only required if your application uses Demonstrating Proof-of-Possession.
 </ParamField>
 
-## Request Body
-
+## Body Parameters
 <ParamField body="grant_type" type="string" required>
   Denotes the flow you are using. For Authorization Code, use `authorization_code`.
 </ParamField>
@@ -44,8 +44,7 @@ This is the flow that regular web apps use to access an API. Use this endpoint t
   This is required only if it was set at the [GET /authorize](#authorization-code-grant) endpoint. The values from `/authorize` must match the value you set at `/oauth/token`.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | Successful token retrieval |

--- a/main/docs/api/authentication/authorization-code-flow/get-token.mdx
+++ b/main/docs/api/authentication/authorization-code-flow/get-token.mdx
@@ -10,7 +10,7 @@ import { ResponseSchema } from '/snippets/ResponseSchema.jsx';
 
 `POST /oauth/token`
 
-For token-based authentication, use the `oauth/token` endpoint to get an access token for your application to make authenticated calls to a secure API. Optionally, you can also retrieve an ID Token and a Refresh Token. ID Tokens contains user information in the form of scopes you application can extract to provide a better user experience. Refresh Tokens allow your application to request a new access token once the current token expires without interruping the user experience. To learn more, read [ID Tokens](https://auth0.com/docs/secure/tokens/id-tokens) and [Refresh Tokens](https://auth0.com/docs/secure/tokens/refresh-tokens).
+For token-based authentication, use the `oauth/token` endpoint to get an access token for your application to make authenticated calls to a secure API. Optionally, you can also retrieve an ID Token and a Refresh Token. ID Tokens contain user information in the form of scopes you application can extract to provide a better user experience. Refresh Tokens allow your application to request a new access token once the current token expires without interruping the user experience. To learn more, read [ID Tokens](https://auth0.com/docs/secure/tokens/id-tokens) and [Refresh Tokens](https://auth0.com/docs/secure/tokens/refresh-tokens).
 
 Note that the only OAuth 2.0 flows that can retrieve a Refresh Token are:
 - [Authorization Code Flow (Authorization Code)](https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow)
@@ -67,7 +67,7 @@ This is the flow that regular web apps use to access an API. Use this endpoint t
 </ResponseField>
 
 <ResponseField name="expires_in" type="integer">
-  The lifetime in seconds of the access token.
+  The access token lifetime in seconds.
 </ResponseField>
 </ResponseSchema>
 

--- a/main/docs/api/authentication/authorization-code-flow/get-token.mdx
+++ b/main/docs/api/authentication/authorization-code-flow/get-token.mdx
@@ -3,6 +3,9 @@ title: "Get Token"
 description: "For token-based authentication, use the `oauth/token` endpoint to get an access token for your application to make authenticated calls to a secure API...."
 ---
 
+import { ResponseSchema } from '/snippets/ResponseSchema.jsx';
+
+
 ## Endpoint
 
 `POST /oauth/token`
@@ -43,6 +46,30 @@ This is the flow that regular web apps use to access an API. Use this endpoint t
 <ParamField body="redirect_uri" type="string">
   This is required only if it was set at the [GET /authorize](#authorization-code-grant) endpoint. The values from `/authorize` must match the value you set at `/oauth/token`.
 </ParamField>
+
+## Response Schema
+
+<ResponseSchema>
+<ResponseField name="access_token" type="string">
+  The access token.
+</ResponseField>
+
+<ResponseField name="refresh_token" type="string">
+  The refresh token used to obtain new access tokens.
+</ResponseField>
+
+<ResponseField name="id_token" type="string">
+  The ID token.
+</ResponseField>
+
+<ResponseField name="token_type" type="string">
+  The type of token. Usually `Bearer`.
+</ResponseField>
+
+<ResponseField name="expires_in" type="integer">
+  The lifetime in seconds of the access token.
+</ResponseField>
+</ResponseSchema>
 
 ## Response Messages
 | Status | Description |

--- a/main/docs/api/authentication/change-password/change-password.mdx
+++ b/main/docs/api/authentication/change-password/change-password.mdx
@@ -3,6 +3,9 @@ title: "Change Password"
 description: "Send a change password email to the user's provided email address and `connection`."
 ---
 
+import { ResponseSchema } from '/snippets/ResponseSchema.jsx';
+
+
 ## Endpoint
 
 `POST /dbconnections/change_password`
@@ -42,6 +45,12 @@ Optionally, you may provide an Organization ID to support Organization-specific 
 <ParamField body="organization" type="string">
   The `organization_id` of the Organization associated with the user.
 </ParamField>
+
+## Response Schema
+
+The 200 response body is a plain text string.
+
+Example: `"We've just sent you an email to reset your password."`
 
 ## Response Messages
 | Status | Description |

--- a/main/docs/api/authentication/change-password/change-password.mdx
+++ b/main/docs/api/authentication/change-password/change-password.mdx
@@ -3,6 +3,8 @@ title: "Change Password"
 description: "Send a change password email to the user's provided email address and `connection`."
 ---
 
+## Endpoint
+
 `POST /dbconnections/change_password`
 
 Send a change password email to the user's provided email address and `connection`.
@@ -24,8 +26,7 @@ Optionally, you may provide an Organization ID to support Organization-specific 
 - [Password Options in Auth0 Database Connections](https://auth0.com/docs/authenticate/database-connections/password-options)
 - [Auth0 API Rate Limit Policy](https://auth0.com/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations)
 
-## Parameters
-
+## Body Parameters
 <ParamField body="client_id" type="string" required>
   The `client_id` of your client.
 </ParamField>
@@ -42,8 +43,7 @@ Optionally, you may provide an Organization ID to support Organization-specific 
   The `organization_id` of the Organization associated with the user.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | A change password email has been sent. |

--- a/main/docs/api/authentication/change-password/change-password.mdx
+++ b/main/docs/api/authentication/change-password/change-password.mdx
@@ -12,7 +12,7 @@ import { ResponseSchema } from '/snippets/ResponseSchema.jsx';
 
 Send a change password email to the user's provided email address and `connection`.
 
-Optionally, you may provide an Organization ID to support Organization-specific variables in [customized email templates](https://auth0.com/docs/customize/email/email-templates#common-variables) and to include the `organization_id` and `organization_name` parameters in the **Redirect To** URL.
+Optionally, you may provide an Organization ID to support Organization-specific variables in [customized email templates](https://auth0.com/docs/customize/email/email-templates) and to include the `organization_id` and `organization_name` parameters in the **Redirect To** URL.
 
 **Note:** This endpoint only works for database connections.
 
@@ -48,9 +48,13 @@ Optionally, you may provide an Organization ID to support Organization-specific 
 
 ## Response Schema
 
-The 200 response body is a plain text string.
+<ResponseSchema type="string">
 
+The 200 response body is a plain text string.
+<br />
 Example: `"We've just sent you an email to reset your password."`
+
+</ResponseSchema>
 
 ## Response Messages
 | Status | Description |

--- a/main/docs/api/authentication/client-credential-flow/get-token.mdx
+++ b/main/docs/api/authentication/client-credential-flow/get-token.mdx
@@ -3,6 +3,8 @@ title: "Get Token"
 description: "This is the OAuth 2.0 grant that server processes use to access an API. Use this endpoint to directly request an access token by using the application's..."
 ---
 
+## Endpoint
+
 `POST /oauth/token`
 
 This is the OAuth 2.0 grant that server processes use to access an API. Use this endpoint to directly request an access token by using the application's credentials (a Client ID and a Client Secret).
@@ -27,14 +29,12 @@ A successful response will return an access token.
 - [Setting up a Client Grant using the Management Dashboard](https://auth0.com/docs/get-started/applications/update-grant-types)
 - [Asking for Access Tokens for a Client Credentials Grant](https://auth0.com/docs/get-started/authentication-and-authorization-flow/client-credentials-flow/call-your-api-using-the-client-credentials-flow)
 
-## Parameters
-
+## Headers
 <ParamField header="DPoP" type="string">
   A DPoP proof for the request. This is optional and only required if your application uses Demonstrating Proof-of-Possession.
 </ParamField>
 
-## Request Body
-
+## Body Parameters
 <ParamField body="grant_type" type="string" required>
   Denotes the flow you are using. For Client Credentials use `client_credentials`.
 
@@ -61,8 +61,7 @@ A successful response will return an access token.
   [Recommended]The organization or identifier with which you want the request to be associated. To learn more, read [Machine-to-Machine Access for Organizations](https://auth0.com/docs/manage-users/organizations/organizations-for-m2m-applications).
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | Successful response |

--- a/main/docs/api/authentication/client-credential-flow/get-token.mdx
+++ b/main/docs/api/authentication/client-credential-flow/get-token.mdx
@@ -76,7 +76,7 @@ A successful response will return an access token.
 </ResponseField>
 
 <ResponseField name="expires_in" type="integer">
-  The lifetime in seconds of the access token.
+  The access token lifetime in seconds.
 </ResponseField>
 </ResponseSchema>
 

--- a/main/docs/api/authentication/client-credential-flow/get-token.mdx
+++ b/main/docs/api/authentication/client-credential-flow/get-token.mdx
@@ -3,6 +3,9 @@ title: "Get Token"
 description: "This is the OAuth 2.0 grant that server processes use to access an API. Use this endpoint to directly request an access token by using the application's..."
 ---
 
+import { ResponseSchema } from '/snippets/ResponseSchema.jsx';
+
+
 ## Endpoint
 
 `POST /oauth/token`
@@ -60,6 +63,22 @@ A successful response will return an access token.
 <ParamField body="organization" type="string">
   [Recommended]The organization or identifier with which you want the request to be associated. To learn more, read [Machine-to-Machine Access for Organizations](https://auth0.com/docs/manage-users/organizations/organizations-for-m2m-applications).
 </ParamField>
+
+## Response Schema
+
+<ResponseSchema>
+<ResponseField name="access_token" type="string">
+  The access token.
+</ResponseField>
+
+<ResponseField name="token_type" type="string">
+  The type of token. Usually `Bearer`.
+</ResponseField>
+
+<ResponseField name="expires_in" type="integer">
+  The lifetime in seconds of the access token.
+</ResponseField>
+</ResponseSchema>
 
 ## Response Messages
 | Status | Description |

--- a/main/docs/api/authentication/custom-token-exchange/get-token.mdx
+++ b/main/docs/api/authentication/custom-token-exchange/get-token.mdx
@@ -113,7 +113,7 @@ Custom Token Exchange is currently available in Early Access. By using this feat
 </ResponseField>
 
 <ResponseField name="expires_in" type="integer">
-  The lifetime in seconds of the access token.
+  The access token lifetime in seconds.
 </ResponseField>
 </ResponseSchema>
 

--- a/main/docs/api/authentication/custom-token-exchange/get-token.mdx
+++ b/main/docs/api/authentication/custom-token-exchange/get-token.mdx
@@ -3,6 +3,8 @@ title: "Get Token"
 description: "Custom Token Exchange (CTE) provides a mechanism for applications to exchange pre-existing identity tokens for Auth0 tokens by invoking the `/oauth/token`..."
 ---
 
+## Endpoint
+
 `POST /oauth/token`
 
 Custom Token Exchange (CTE) provides a mechanism for applications to exchange pre-existing identity tokens for Auth0 tokens by invoking the `/oauth/token` endpoint, adhering to the specifications of [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693). This functionality is instrumental in addressing advanced integration requirements, such as exchanging existing Auth0 tokens to access another audience on behalf of the same user, facilitating the integration of external identity providers, or enabling seamless user migration into the Auth0 platform. The exchange process is fully governable, as developers can control its details using their custom logic running in a dedicated Auth0 Action for the associated use case.
@@ -28,8 +30,7 @@ Custom Token Exchange is currently available in Early Access. By using this feat
 
  - When the Action calls `setActor()`, issued access tokens and ID tokens include an `act` claim representing the [delegation chain](/docs/secure/call-apis-on-users-behalf/on-behalf-of-token-exchange#the-act-claim). The `act` claim is also included in the userinfo response.
 
-## Parameters
-
+## Headers
 <ParamField header="DPoP" type="string">
   A DPoP proof for the request. This is optional and only required if your application uses Demonstrating Proof-of-Possession.
 </ParamField>
@@ -38,8 +39,7 @@ Custom Token Exchange is currently available in Early Access. By using this feat
   End-user IP as a string value. Set this if you want Suspicious IP Throttling protection to work in server-side scenarios.
 </ParamField>
 
-## Request Body
-
+## Body Parameters
 <ParamField body="grant_type" type="string" required>
   Denotes the flow you are using. For Custom Token Exchange, use `urn:ietf:params:oauth:grant-type:token-exchange`.
 
@@ -86,8 +86,7 @@ Custom Token Exchange is currently available in Early Access. By using this feat
   (Optional) The type of the actor token. Must be provided together with `actor_token`. For Auth0 ID tokens, use `urn:ietf:params:oauth:token-type:id_token` for automatic server-side validation (signature, expiry, issuer, user lookup). For other values, follow the same namespace restrictions as `subject_token_type`.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | Successful response |

--- a/main/docs/api/authentication/custom-token-exchange/get-token.mdx
+++ b/main/docs/api/authentication/custom-token-exchange/get-token.mdx
@@ -3,6 +3,9 @@ title: "Get Token"
 description: "Custom Token Exchange (CTE) provides a mechanism for applications to exchange pre-existing identity tokens for Auth0 tokens by invoking the `/oauth/token`..."
 ---
 
+import { ResponseSchema } from '/snippets/ResponseSchema.jsx';
+
+
 ## Endpoint
 
 `POST /oauth/token`
@@ -85,6 +88,34 @@ Custom Token Exchange is currently available in Early Access. By using this feat
 <ParamField body="actor_token_type" type="string">
   (Optional) The type of the actor token. Must be provided together with `actor_token`. For Auth0 ID tokens, use `urn:ietf:params:oauth:token-type:id_token` for automatic server-side validation (signature, expiry, issuer, user lookup). For other values, follow the same namespace restrictions as `subject_token_type`.
 </ParamField>
+
+## Response Schema
+
+<ResponseSchema>
+<ResponseField name="access_token" type="string">
+  The access token.
+</ResponseField>
+
+<ResponseField name="refresh_token" type="string">
+  The refresh token.
+</ResponseField>
+
+<ResponseField name="id_token" type="string">
+  The ID token.
+</ResponseField>
+
+<ResponseField name="token_type" type="string">
+  The type of token.
+</ResponseField>
+
+<ResponseField name="issued_token_type" type="string">
+  The issued token type.
+</ResponseField>
+
+<ResponseField name="expires_in" type="integer">
+  The lifetime in seconds of the access token.
+</ResponseField>
+</ResponseSchema>
 
 ## Response Messages
 | Status | Description |

--- a/main/docs/api/authentication/delegation-legacy/delegation.mdx
+++ b/main/docs/api/authentication/delegation-legacy/delegation.mdx
@@ -3,6 +3,8 @@ title: "Delegation"
 description: "By default, this feature is disabled for tenants without an add-on in use as of 8 June 2017. Legacy tenants who currently use an add-on that requires..."
 ---
 
+## Endpoint
+
 `POST /delegation`
 
 <Note>
@@ -32,8 +34,7 @@ Given an existing token, this endpoint will generate a new token signed with the
 - [Delegation Tokens](https://auth0.com/docs/secure/tokens/delegation-tokens)
 - [Auth0 API Rate Limit Policy](https://auth0.com/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy)
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | Successful delegation token retrieval |

--- a/main/docs/api/authentication/delegation-legacy/delegation.mdx
+++ b/main/docs/api/authentication/delegation-legacy/delegation.mdx
@@ -21,7 +21,7 @@ Given an existing token, this endpoint will generate a new token signed with the
 
 - The `email` scope value requests access to the `email` and `email_verified` Claims.
 
-- Delegation is __not supported__ in version 8 of [auth0.js](http://auth0.com/libraries/auth0js). For a sample in version 7 of the library, refer to [Delegation Token Request](https://auth0.com/docs/libraries/auth0js#delegation-token-request).
+- Delegation is __not supported__ in version 8 of [auth0.js](https://auth0.com/docs/libraries/auth0js). For a sample in version 7 of the library, refer to the [auth0.js v7 reference guide](https://auth0.com/docs/libraries/auth0js/v7).
 
 - This endpoint limits up to 10 requests per minute from the same IP address with the same `user_id`.
 

--- a/main/docs/api/authentication/device-authorization-flow/authorize-device.mdx
+++ b/main/docs/api/authentication/device-authorization-flow/authorize-device.mdx
@@ -3,6 +3,8 @@ title: "Authorize Device"
 description: "This flow is designed for input-constrained devices to access an API. Use this endpoint to obtain a device code that allows the user to authorize the device."
 ---
 
+## Endpoint
+
 `POST /oauth/device/code`
 
 This flow is designed for input-constrained devices to access an API. Use this endpoint to obtain a device code that allows the user to authorize the device.
@@ -84,8 +86,7 @@ Content-Type: application/json
 - [Call API using the Device Authorization Flow](https://auth0.com/docs/get-started/authentication-and-authorization-flow/device-authorization-flow/call-your-api-using-the-device-authorization-flow)
 - [Setting up a Device Code Grant using the Management Dashboard](https://auth0.com/docs/get-started/applications/update-grant-types)
 
-## Parameters
-
+## Body Parameters
 <ParamField body="client_id" type="string" required>
   Your application's ID.
 </ParamField>
@@ -102,8 +103,7 @@ Content-Type: application/json
   The identifier of the target API (resource server) you want to access. Must match an API Identifier registered in your Auth0 tenant. Used as an alternative to `audience` when the tenant's [Resource Parameter Compatibility Profile](https://auth0.com/docs/get-started/tenant-settings#settings-advanced) is set to `compatibility`.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | Returns device and user codes. |

--- a/main/docs/api/authentication/device-authorization-flow/authorize-device.mdx
+++ b/main/docs/api/authentication/device-authorization-flow/authorize-device.mdx
@@ -3,6 +3,9 @@ title: "Authorize Device"
 description: "This flow is designed for input-constrained devices to access an API. Use this endpoint to obtain a device code that allows the user to authorize the device."
 ---
 
+import { ResponseSchema } from '/snippets/ResponseSchema.jsx';
+
+
 ## Endpoint
 
 `POST /oauth/device/code`
@@ -102,6 +105,34 @@ Content-Type: application/json
 <ParamField body="resource" type="string">
   The identifier of the target API (resource server) you want to access. Must match an API Identifier registered in your Auth0 tenant. Used as an alternative to `audience` when the tenant's [Resource Parameter Compatibility Profile](https://auth0.com/docs/get-started/tenant-settings#settings-advanced) is set to `compatibility`.
 </ParamField>
+
+## Response Schema
+
+<ResponseSchema>
+<ResponseField name="device_code" type="string">
+  The unique code for the device. When the user goes to the `verification_uri` in their browser-based device, this code will be bound to their session.
+</ResponseField>
+
+<ResponseField name="user_code" type="string">
+  The code that the user must input at the `verification_uri`.
+</ResponseField>
+
+<ResponseField name="verification_uri" type="string">
+  The URL the user must visit to authorize the device.
+</ResponseField>
+
+<ResponseField name="verification_uri_complete" type="string">
+  The complete URL the user must visit, including the `user_code`.
+</ResponseField>
+
+<ResponseField name="expires_in" type="integer">
+  The lifetime in seconds of the `device_code` and `user_code`.
+</ResponseField>
+
+<ResponseField name="interval" type="integer">
+  The interval in seconds at which the app should poll for a token.
+</ResponseField>
+</ResponseSchema>
 
 ## Response Messages
 | Status | Description |

--- a/main/docs/api/authentication/device-authorization-flow/authorize-device.mdx
+++ b/main/docs/api/authentication/device-authorization-flow/authorize-device.mdx
@@ -110,7 +110,7 @@ Content-Type: application/json
 
 <ResponseSchema>
 <ResponseField name="device_code" type="string">
-  The unique code for the device. When the user goes to the `verification_uri` in their browser-based device, this code will be bound to their session.
+  The unique code for the device. When the user goes to the `verification_uri` in their browser-based device, this code is bound to their session.
 </ResponseField>
 
 <ResponseField name="user_code" type="string">

--- a/main/docs/api/authentication/dynamic-application-client-registration/dynamic-application-registration.mdx
+++ b/main/docs/api/authentication/dynamic-application-client-registration/dynamic-application-registration.mdx
@@ -3,12 +3,13 @@ title: "Dynamic Application Registration"
 description: "With a name and the necessary callback URL, you can dynamically register a client with Auth0. No token is needed for this request."
 ---
 
+## Endpoint
+
 `POST /oidc/register`
 
 With a name and the necessary callback URL, you can dynamically register a client with Auth0. No token is needed for this request.
 
-## Parameters
-
+## Body Parameters
 <ParamField body="client_name" type="string">
   The name of the Dynamic Client to be created.
 </ParamField>
@@ -25,8 +26,7 @@ With a name and the necessary callback URL, you can dynamically register a clien
   Method used for authentication at the token endpoint.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | Successful response with client details. |

--- a/main/docs/api/authentication/dynamic-application-client-registration/dynamic-application-registration.mdx
+++ b/main/docs/api/authentication/dynamic-application-client-registration/dynamic-application-registration.mdx
@@ -3,6 +3,9 @@ title: "Dynamic Application Registration"
 description: "With a name and the necessary callback URL, you can dynamically register a client with Auth0. No token is needed for this request."
 ---
 
+import { ResponseSchema } from '/snippets/ResponseSchema.jsx';
+
+
 ## Endpoint
 
 `POST /oidc/register`
@@ -25,6 +28,26 @@ With a name and the necessary callback URL, you can dynamically register a clien
 <ParamField body="token_endpoint_auth_method" type="string">
   Method used for authentication at the token endpoint.
 </ParamField>
+
+## Response Schema
+
+<ResponseSchema>
+<ResponseField name="client_name" type="string">
+  The name of the newly registered client.
+</ResponseField>
+
+<ResponseField name="client_id" type="string">
+  The unique identifier of the client.
+</ResponseField>
+
+<ResponseField name="client_secret" type="string">
+  The client secret.
+</ResponseField>
+
+<ResponseField name="client_secret_expires_at" type="integer">
+  The expiration time of the client secret.
+</ResponseField>
+</ResponseSchema>
 
 ## Response Messages
 | Status | Description |

--- a/main/docs/api/authentication/dynamic-application-client-registration/dynamic-application-registration.mdx
+++ b/main/docs/api/authentication/dynamic-application-client-registration/dynamic-application-registration.mdx
@@ -41,11 +41,11 @@ With a name and the necessary callback URL, you can dynamically register a clien
 </ResponseField>
 
 <ResponseField name="client_secret" type="string">
-  The client secret.
+  The Client Secret.
 </ResponseField>
 
 <ResponseField name="client_secret_expires_at" type="integer">
-  The expiration time of the client secret.
+  The expiration time of the Client Secret.
 </ResponseField>
 </ResponseSchema>
 

--- a/main/docs/api/authentication/impersonation-legacy/impersonation.mdx
+++ b/main/docs/api/authentication/impersonation-legacy/impersonation.mdx
@@ -3,6 +3,8 @@ title: "Impersonation"
 description: "Use this endpoint to obtain an impersonation URL to login as another user. Useful for troubleshooting."
 ---
 
+## Endpoint
+
 `POST /users/{user_id}/impersonate`
 
 Use this endpoint to obtain an impersonation URL to login as another user. Useful for troubleshooting.
@@ -13,8 +15,7 @@ Use this endpoint to obtain an impersonation URL to login as another user. Usefu
 - To distinguish between real logins and impersonation logins, the profile of the impersonated user will contain additional impersonated and impersonator properties. For example: `"impersonated": true, "impersonator": {"user_id": "auth0|...", "email": "admin@example.com"}`.
 - For a regular web app, you should set the `additionalParameters`: set the `response_type` to be `code`, the `callback_url` to be the callback URL to which Auth0 will redirect with the authorization code, and the `scope` to be the JWT claims that you want included in the JWT.
 
-## Parameters
-
+## Body Parameters
 <ParamField body="protocol" type="string" required>
   
 </ParamField>
@@ -31,8 +32,7 @@ Use this endpoint to obtain an impersonation URL to login as another user. Usefu
   
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | Successful impersonation URL retrieval |

--- a/main/docs/api/authentication/implicit-flow/authorize.mdx
+++ b/main/docs/api/authentication/implicit-flow/authorize.mdx
@@ -3,6 +3,8 @@ title: "Authorize"
 description: "This is the OAuth 2.0 grant that web apps utilize in order to access an API."
 ---
 
+## Endpoint
+
 `GET /authorize`
 
 This is the OAuth 2.0 grant that web apps utilize in order to access an API.
@@ -32,8 +34,7 @@ Location: ${account.callback}#access_token=TOKEN&state=STATE&token_type=TYPE&exp
 - [Mitigate replay attacks when using the Implicit Grant](https://auth0.com/docs/get-started/authentication-and-authorization-flow/implicit-flow-with-form-post/mitigate-replay-attacks-when-using-the-implicit-flow)
 - [Silent Authentication](https://auth0.com/docs/authenticate/login/configure-silent-authentication)
 
-## Parameters
-
+## Query Parameters
 <ParamField query="audience" type="string">
   The unique identifier of the target API you want to access.
 </ParamField>
@@ -84,8 +85,7 @@ Location: ${account.callback}#access_token=TOKEN&state=STATE&token_type=TYPE&exp
   Ticket ID of the organization invitation.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 302 | Redirects to the specified callback URL with the access token. |

--- a/main/docs/api/authentication/login-legacy/database-ad-lapd-active.mdx
+++ b/main/docs/api/authentication/login-legacy/database-ad-lapd-active.mdx
@@ -3,6 +3,9 @@ title: "Database/AD/LDAP (Active)"
 description: "This endpoint is part of the legacy authentication pipeline and has been replaced in favor of the [Password Grant](#resource-owner-password). For more..."
 ---
 
+import { ResponseSchema } from '/snippets/ResponseSchema.jsx';
+
+
 ## Endpoint
 
 `POST /oauth/ro`
@@ -58,6 +61,34 @@ Use this endpoint for API-based (active) authentication. Given the user credenti
 <ParamField body="id_token" type="string">
   Required when `grant_type` is `urn:ietf:params:oauth:grant-type:jwt-bearer`.
 </ParamField>
+
+## Response Schema
+
+<ResponseSchema statusCode="200">
+
+<ResponseField name="id_token" type="string">
+  The ID token.
+</ResponseField>
+
+<ResponseField name="access_token" type="string">
+  The access token.
+</ResponseField>
+
+<ResponseField name="token_type" type="string">
+  The type of token. Usually `Bearer`.
+</ResponseField>
+</ResponseSchema>
+
+<ResponseSchema statusCode="400">
+
+<ResponseField name="error" type="string">
+  Error code.
+</ResponseField>
+
+<ResponseField name="error_description" type="string">
+  Description of the error.
+</ResponseField>
+</ResponseSchema>
 
 ## Response Messages
 | Status | Description |

--- a/main/docs/api/authentication/login-legacy/database-ad-lapd-active.mdx
+++ b/main/docs/api/authentication/login-legacy/database-ad-lapd-active.mdx
@@ -86,7 +86,7 @@ Use this endpoint for API-based (active) authentication. Given the user credenti
 </ResponseField>
 
 <ResponseField name="error_description" type="string">
-  Description of the error.
+  Error description.
 </ResponseField>
 </ResponseSchema>
 

--- a/main/docs/api/authentication/login-legacy/database-ad-lapd-active.mdx
+++ b/main/docs/api/authentication/login-legacy/database-ad-lapd-active.mdx
@@ -3,6 +3,8 @@ title: "Database/AD/LDAP (Active)"
 description: "This endpoint is part of the legacy authentication pipeline and has been replaced in favor of the [Password Grant](#resource-owner-password). For more..."
 ---
 
+## Endpoint
+
 `POST /oauth/ro`
 
 <Note>
@@ -24,8 +26,7 @@ Use this endpoint for API-based (active) authentication. Given the user credenti
 - [Rate Limits on User/Password Authentication](https://auth0.com/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy)
 - [Active Directory/LDAP Connector](https://auth0.com/docs/authenticate/identity-providers/enterprise-identity-providers/active-directory-ldap/ad-ldap-connector)
 
-## Parameters
-
+## Body Parameters
 <ParamField body="client_id" type="string" required>
   The `client_id` of your application.
 </ParamField>
@@ -58,8 +59,7 @@ Use this endpoint for API-based (active) authentication. Given the user credenti
   Required when `grant_type` is `urn:ietf:params:oauth:grant-type:jwt-bearer`.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | Successful authentication response |

--- a/main/docs/api/authentication/login-legacy/social-with-providers-access-token.mdx
+++ b/main/docs/api/authentication/login-legacy/social-with-providers-access-token.mdx
@@ -70,7 +70,7 @@ Given the social provider's Access Token and the `connection`, this endpoint wil
 </ResponseField>
 
 <ResponseField name="error_description" type="string">
-  Description of the error.
+  Error description.
 </ResponseField>
 </ResponseSchema>
 

--- a/main/docs/api/authentication/login-legacy/social-with-providers-access-token.mdx
+++ b/main/docs/api/authentication/login-legacy/social-with-providers-access-token.mdx
@@ -3,6 +3,8 @@ title: "Social with Provider's Access Token"
 description: "This endpoint is part of the legacy authentication pipeline. We recommend that you open the browser to do social authentication instead, which is what [Google..."
 ---
 
+## Endpoint
+
 `POST /oauth/access_token`
 
 <Note>
@@ -24,8 +26,7 @@ Given the social provider's Access Token and the `connection`, this endpoint wil
 - [Identity Provider Access Tokens](https://auth0.com/docs/secure/tokens/access-tokens/identity-provider-access-tokens)
 - [Add scopes/permissions to call Identity Provider's APIs](https://auth0.com/docs/authenticate/identity-providers/adding-scopes-for-an-external-idp)
 
-## Parameters
-
+## Body Parameters
 <ParamField body="client_id" type="string" required>
   The `client_id` of your application.
 </ParamField>
@@ -42,8 +43,7 @@ Given the social provider's Access Token and the `connection`, this endpoint wil
   Use `openid` to get an ID Token, or `openid profile email` to include user information.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | Successful authentication response |

--- a/main/docs/api/authentication/login-legacy/social-with-providers-access-token.mdx
+++ b/main/docs/api/authentication/login-legacy/social-with-providers-access-token.mdx
@@ -3,6 +3,9 @@ title: "Social with Provider's Access Token"
 description: "This endpoint is part of the legacy authentication pipeline. We recommend that you open the browser to do social authentication instead, which is what [Google..."
 ---
 
+import { ResponseSchema } from '/snippets/ResponseSchema.jsx';
+
+
 ## Endpoint
 
 `POST /oauth/access_token`
@@ -42,6 +45,34 @@ Given the social provider's Access Token and the `connection`, this endpoint wil
 <ParamField body="scope" type="string">
   Use `openid` to get an ID Token, or `openid profile email` to include user information.
 </ParamField>
+
+## Response Schema
+
+<ResponseSchema statusCode="200">
+
+<ResponseField name="id_token" type="string">
+  The ID token.
+</ResponseField>
+
+<ResponseField name="access_token" type="string">
+  The access token.
+</ResponseField>
+
+<ResponseField name="token_type" type="string">
+  The type of token. Usually `Bearer`.
+</ResponseField>
+</ResponseSchema>
+
+<ResponseSchema statusCode="400 / 401 / 403">
+
+<ResponseField name="error" type="string">
+  Error code.
+</ResponseField>
+
+<ResponseField name="error_description" type="string">
+  Description of the error.
+</ResponseField>
+</ResponseSchema>
 
 ## Response Messages
 | Status | Description |

--- a/main/docs/api/authentication/login/authenticate-using-database.mdx
+++ b/main/docs/api/authentication/login/authenticate-using-database.mdx
@@ -24,7 +24,7 @@ Passive authentication occurs through the browser and is initiated from the [Aut
 - [Rate Limits on User/Password Authentication](https://auth0.com/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy)
 - [Active Directory/LDAP Connector](https://auth0.com/docs/authenticate/identity-providers/enterprise-identity-providers/active-directory-ldap/ad-ldap-connector)
 - [State Parameter](https://auth0.com/docs/secure/attack-protection/state-parameters)
-- [Auth0.js /authorize Method Reference](https://auth0.com/docs/libraries/auth0js#webauth-authorize-)
+- [Auth0.js /authorize Method Reference](https://auth0.com/docs/libraries/auth0js#webauth-authorize)
 
 ## Query Parameters
 <ParamField query="response_type" type="string" required>

--- a/main/docs/api/authentication/login/authenticate-using-database.mdx
+++ b/main/docs/api/authentication/login/authenticate-using-database.mdx
@@ -3,6 +3,8 @@ title: "Database/AD/LDAP (Passive)"
 description: "Use the Auth0 user store or your own database to store and manage username and password credentials. If you have your own user database, you can use it as an..."
 ---
 
+## Endpoint
+
 `GET /authorize`
 
 Use the Auth0 user store or your own database to store and manage username and password credentials. If you have your own user database, you can use it as an identity provider in Auth0 to authenticate users. When you make a `GET` call to the `/authorize` endpoint for browser-based (passive) authentication, it returns a `302` redirect to the [Auth0 Login Page](http://manage.auth0.com/login) that will show the Login Widget where the user can log in with email and password.
@@ -24,8 +26,7 @@ Passive authentication occurs through the browser and is initiated from the [Aut
 - [State Parameter](https://auth0.com/docs/secure/attack-protection/state-parameters)
 - [Auth0.js /authorize Method Reference](https://auth0.com/docs/libraries/auth0js#webauth-authorize-)
 
-## Parameters
-
+## Query Parameters
 <ParamField query="response_type" type="string" required>
   Specifies the token type. Use `code` for server side flows and `token` for application side flows.
 
@@ -52,8 +53,7 @@ Passive authentication occurs through the browser and is initiated from the [Aut
   An opaque value the application adds to the initial request that the authorization server includes when redirecting back to the application. This value must be used by the application to prevent CSRF attacks.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 302 | Redirect to the login page |

--- a/main/docs/api/authentication/login/check-back-channel-login-status.mdx
+++ b/main/docs/api/authentication/login/check-back-channel-login-status.mdx
@@ -3,6 +3,8 @@ title: "Back-Channel Login flow - Status Check"
 description: "To check on the status of a Back-Channel Login flow, poll the `/oauth/token` endpoint at regular intervals by passing the following:"
 ---
 
+## Endpoint
+
 `POST /oauth/token`
 
 To check on the status of a Back-Channel Login flow, poll the `/oauth/token` endpoint at regular intervals by passing the following:
@@ -63,8 +65,7 @@ Include an optional parameter for application authentication in the request:
 - Private Key JWT, where the `client_id`, `client_assertion`, and `client_assertion` type are required.
 - mTLS, where the `client_id` parameter is required and the `client-certificate` and `client-certificate-ca-verified` headers are required.
 
-## Parameters
-
+## Body Parameters
 <ParamField body="client_id" type="string" required>
   The `client_id` of your application.
 </ParamField>
@@ -77,8 +78,7 @@ Include an optional parameter for application authentication in the request:
   Must be set to `urn:openid:params:grant-type:ciba`.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | Authentication status returned. |

--- a/main/docs/api/authentication/login/enterprise-saml-and-others.mdx
+++ b/main/docs/api/authentication/login/enterprise-saml-and-others.mdx
@@ -21,7 +21,7 @@ Make a `GET` call to the `/authorize` endpoint for passive authentication. It re
 - [SAML](https://auth0.com/docs/authenticate/protocols/saml/saml-configuration)
 - [Obtain a Client Id and Client Secret for Microsoft Azure Active Directory](https://auth0.com/docs/authenticate/identity-providers/enterprise-identity-providers/azure-active-directory/v2)
 - [State Parameter](https://auth0.com/docs/secure/attack-protection/state-parameters)
-- [Auth0.js /authorize Method Reference](https://auth0.com/docs/libraries/auth0js#webauth-authorize-)
+- [Auth0.js /authorize Method Reference](https://auth0.com/docs/libraries/auth0js#webauth-authorize)
 
 ## Query Parameters
 <ParamField query="response_type" type="string" required>

--- a/main/docs/api/authentication/login/enterprise-saml-and-others.mdx
+++ b/main/docs/api/authentication/login/enterprise-saml-and-others.mdx
@@ -3,6 +3,8 @@ title: "Enterprise (SAML and Others)"
 description: "You can connect your Auth0 service to an enterprise identity provider and allow your users to log in to your application via Microsoft Azure Active Directory,..."
 ---
 
+## Endpoint
+
 `GET /authorize`
 
 You can connect your Auth0 service to an enterprise identity provider and allow your users to log in to your application via Microsoft Azure Active Directory, Google Workspace, Okta Workforce, or other supported providers. To learn more about supported providers, visit [Auth0 Marketplace](https://marketplace.auth0.com/features/enterprise-connections).
@@ -21,8 +23,7 @@ Make a `GET` call to the `/authorize` endpoint for passive authentication. It re
 - [State Parameter](https://auth0.com/docs/secure/attack-protection/state-parameters)
 - [Auth0.js /authorize Method Reference](https://auth0.com/docs/libraries/auth0js#webauth-authorize-)
 
-## Parameters
-
+## Query Parameters
 <ParamField query="response_type" type="string" required>
   Specifies the token type. Use `code` for server-side flows and `token` for client-side flows.
 
@@ -45,8 +46,7 @@ Make a `GET` call to the `/authorize` endpoint for passive authentication. It re
   [Recommended] An opaque value the application adds to the initial request that the authorization server includes when redirecting back to the application. This value must be used by the application to prevent CSRF attacks.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 302 | Redirect to the authentication provider. |

--- a/main/docs/api/authentication/login/index.mdx
+++ b/main/docs/api/authentication/login/index.mdx
@@ -4,6 +4,8 @@ sidebarTitle: "Social"
 description: "You can connect your Auth0 service to a social identity provider and allow your users to log in to your application via Facebook, Google, Apple, or other..."
 ---
 
+## Endpoint
+
 `GET /authorize`
 
 ## Social
@@ -29,8 +31,7 @@ Social connections only support browser-based (passive) authentication because m
 - [State Parameter](https://auth0.com/docs/secure/attack-protection/state-parameters)
 - [Auth0.js /authorize Method Reference](https://auth0.com/docs/libraries/auth0js#webauth-authorize-)
 
-## Parameters
-
+## Query Parameters
 <ParamField query="response_type" type="string" required>
   Specifies the token type (code or token)
 
@@ -53,8 +54,7 @@ Social connections only support browser-based (passive) authentication because m
   Opaque value to prevent CSRF attacks
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 302 | Redirect to the social identity provider |

--- a/main/docs/api/authentication/login/index.mdx
+++ b/main/docs/api/authentication/login/index.mdx
@@ -29,7 +29,7 @@ Social connections only support browser-based (passive) authentication because m
 - [Supported Social Identity Providers](https://marketplace.auth0.com/features/social-connections)
 - [Custom Social Connections](https://auth0.com/docs/authenticate/identity-providers/social-identity-providers/oauth2)
 - [State Parameter](https://auth0.com/docs/secure/attack-protection/state-parameters)
-- [Auth0.js /authorize Method Reference](https://auth0.com/docs/libraries/auth0js#webauth-authorize-)
+- [Auth0.js /authorize Method Reference](https://auth0.com/docs/libraries/auth0js#webauth-authorize)
 
 ## Query Parameters
 <ParamField query="response_type" type="string" required>

--- a/main/docs/api/authentication/login/start-back-channel-login.mdx
+++ b/main/docs/api/authentication/login/start-back-channel-login.mdx
@@ -3,6 +3,8 @@ title: "Back-Channel Login"
 description: "The Back-Channel Login endpoint enables applications to send an authentication request to a user’s phone, or the authentication device, provided they have an..."
 ---
 
+## Endpoint
+
 `POST /bc-authorize`
 
 The Back-Channel Login endpoint enables applications to send an authentication request to a user’s phone, or the authentication device, provided they have an app installed and are enrolled for [push notifications using the Guardian SDK](https://auth0.com/docs/secure/multi-factor-authentication/auth0-guardian#enroll-in-push-notifications).
@@ -43,8 +45,7 @@ The request should be approved or rejected on the user’s authentication device
 
 - Authentication can use Client Secret (via HTTP Basic Auth or Post), Private Key JWT, or mTLS. Please refer to the detailed examples above.
 
-## Parameters
-
+## Body Parameters
 <ParamField body="client_id" type="string" required>
   The `client_id` of your application.
 </ParamField>
@@ -77,8 +78,7 @@ The request should be approved or rejected on the user’s authentication device
   An optional JSON array of objects that describe the permissions to be authorized. Each object’s `type` value should be previously registered on the resource server using the Resource Server’s `authorization_details` parameter. To learn more, read the [Update a resource server](https://auth0.com/docs/api/management/v2/resource-servers/patch-resource-servers-by-id#body-parameters) Management API documentation.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | Authentication request successfully initiated. |

--- a/main/docs/api/authentication/logout/auth-0-logout.mdx
+++ b/main/docs/api/authentication/logout/auth-0-logout.mdx
@@ -3,6 +3,8 @@ title: "Auth0 Logout"
 description: "Use this endpoint to logout a user. If you want to navigate the user to a specific URL after the logout, set that URL at the `returnTo` parameter. The URL..."
 ---
 
+## Endpoint
+
 `GET /v2/logout`
 
 Use this endpoint to logout a user. If you want to navigate the user to a specific URL after the logout, set that URL at the `returnTo` parameter. The URL should be included in the appropriate `Allowed Logout URLs` list:
@@ -20,8 +22,7 @@ Use this endpoint to logout a user. If you want to navigate the user to a specif
 
 - [Logout](https://auth0.com/docs/authenticate/login/logout)
 
-## Parameters
-
+## Query Parameters
 <ParamField query="client_id" type="string">
   The `client_id` of your application.
 </ParamField>
@@ -34,8 +35,7 @@ Use this endpoint to logout a user. If you want to navigate the user to a specif
   Add this query string parameter to the logout URL, to log the user out of their identity provider.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | Successfully logged out |

--- a/main/docs/api/authentication/logout/global-token-revocation.mdx
+++ b/main/docs/api/authentication/logout/global-token-revocation.mdx
@@ -3,18 +3,18 @@ title: "Global Token Revocation"
 description: "Use this endpoint with the [Okta Workforce Identity Cloud Universal Logout](https://developer.okta.com/docs/guides/oin-universal-logout-overview/) to log..."
 ---
 
+## Endpoint
+
 `POST /oauth/global-token-revocation/connection/{connection_name}`
 
 Use this endpoint with the [Okta Workforce Identity Cloud Universal Logout](https://developer.okta.com/docs/guides/oin-universal-logout-overview/) to log users out of your applications. A request to this endpoint revokes session cookies and refresh tokens, but not access tokens. To learn more, read [Universal Logout](https://auth0.com/docs/authenticate/login/logout/universal-logout). The request must be authenticated before revoking user sessions. Review [Endpoint Authentication](https://developer.okta.com/docs/guides/oin-universal-logout-overview/#endpoint-authentication).
 
-## Parameters
-
+## Path Parameters
 <ParamField path="connection_name" type="string" required>
   The name of the connection for which you want to revoke the user's session.
 </ParamField>
 
-## Request Body
-
+## Body Parameters
 <ParamField body="subject" type="object">
   
 
@@ -33,8 +33,7 @@ Use this endpoint with the [Okta Workforce Identity Cloud Universal Logout](http
   </Expandable>
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | Successfully revoked session cookies and refresh tokens. |

--- a/main/docs/api/authentication/logout/oidc-logout.mdx
+++ b/main/docs/api/authentication/logout/oidc-logout.mdx
@@ -3,6 +3,8 @@ title: "OIDC Logout"
 description: "Use this endpoint to logout a user. If you want to navigate the user to a specific URL after the logout, set that URL at the `post_logout_redirect_uri`..."
 ---
 
+## Endpoint
+
 `GET /oidc/logout`
 
 Use this endpoint to logout a user. If you want to navigate the user to a specific URL after the logout, set that URL at the `post_logout_redirect_uri` parameter. The URL should be included in the appropriate `Allowed Logout URLs` list:
@@ -32,8 +34,7 @@ To learn more, read [Log Users Out of Auth0 with OIDC Endpoint](https://auth0.co
 - [Use the OIDC Endpoint to Log Users Out of Auth0](https://auth0.com/docs/authenticate/login/logout/log-users-out-of-auth0)
 - [OIDC RP-initiated Logout Specification](https://openid.net/specs/openid-connect-rpinitiated-1_0.html)
 
-## Parameters
-
+## Query Parameters
 <ParamField query="id_token_hint" type="string">
   [Recommended] Previously issued ID Token for the user. This is used to indicate which user to log out.
 </ParamField>
@@ -62,8 +63,7 @@ To learn more, read [Log Users Out of Auth0 with OIDC Endpoint](https://auth0.co
   Space-delimited list of locales used to constrain the language list for the request. The first locale on the list must match the enabled locale in your tenant.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | Successfully logged out |

--- a/main/docs/api/authentication/logout/saml-logout.mdx
+++ b/main/docs/api/authentication/logout/saml-logout.mdx
@@ -3,6 +3,8 @@ title: "SAML Logout"
 description: "Use this endpoint to log out a user from an Auth0 tenant configured as a SAML identity provider (IdP). Logout behavior is determined by the configuration of..."
 ---
 
+## Endpoint
+
 `POST /samlp/{client_id}/logout`
 
 Use this endpoint to log out a user from an Auth0 tenant configured as a SAML identity provider (IdP). Logout behavior is determined by the configuration of the SAML2 Web App addon for the application on the Auth0 tenant acting as the SAML IdP. To learn more, read [Log Users Out of SAML Identity Providers](https://auth0.com/docs/authenticate/login/logout/log-users-out-of-saml-idps#configure-slo-when-auth0-is-the-saml-idp).
@@ -16,14 +18,12 @@ Use this endpoint to log out a user from an Auth0 tenant configured as a SAML id
 - [Logout](https://auth0.com/docs/authenticate/login/logout)
 - [Log Users Out of SAML Identity Providers](https://auth0.com/docs/authenticate/login/logout/log-users-out-of-saml-idps)
 
-## Parameters
-
+## Path Parameters
 <ParamField path="client_id" type="string" required>
   Client ID of your application configured with the [SAML2 Web App addon](https://auth0.com/docs/authenticate/protocols/saml/saml-sso-integrations/enable-saml2-web-app-addon).
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | Successfully logged out |

--- a/main/docs/api/authentication/multi-factor-authentication/add-an-authenticator.mdx
+++ b/main/docs/api/authentication/multi-factor-authentication/add-an-authenticator.mdx
@@ -3,6 +3,8 @@ title: "Add an Authenticator"
 description: "Associates or adds a new authenticator for multi-factor authentication (MFA)."
 ---
 
+## Endpoint
+
 `POST /mfa/associate`
 
 Associates or adds a new authenticator for multi-factor authentication (MFA).
@@ -19,8 +21,7 @@ To access this endpoint, you must set an Access Token at the Authorization heade
 - `scope`: `enroll`
 - `audience`: `https://{yourDomain}/mfa/`
 
-## Parameters
-
+## Body Parameters
 <ParamField body="client_id" type="string" required>
   Your application's Client ID.
 </ParamField>
@@ -49,8 +50,7 @@ To access this endpoint, you must set an Access Token at the Authorization heade
   The phone number to use for SMS or Voice. Required if `oob_channels` includes `sms` or `voice`.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | Successful response for adding an authenticator. |

--- a/main/docs/api/authentication/multi-factor-authentication/add-an-authenticator.mdx
+++ b/main/docs/api/authentication/multi-factor-authentication/add-an-authenticator.mdx
@@ -3,6 +3,9 @@ title: "Add an Authenticator"
 description: "Associates or adds a new authenticator for multi-factor authentication (MFA)."
 ---
 
+import { ResponseSchema } from '/snippets/ResponseSchema.jsx';
+
+
 ## Endpoint
 
 `POST /mfa/associate`
@@ -49,6 +52,30 @@ To access this endpoint, you must set an Access Token at the Authorization heade
 <ParamField body="phone_number" type="string">
   The phone number to use for SMS or Voice. Required if `oob_channels` includes `sms` or `voice`.
 </ParamField>
+
+## Response Schema
+
+<ResponseSchema>
+<ResponseField name="oob_code" type="string">
+  The code used for out-of-band authentication.
+</ResponseField>
+
+<ResponseField name="binding_method" type="string">
+  Indicates the binding method used.
+</ResponseField>
+
+<ResponseField name="authenticator_type" type="string">
+  The type of authenticator added.
+</ResponseField>
+
+<ResponseField name="oob_channels" type="string">
+  The OOB channels used.
+</ResponseField>
+
+<ResponseField name="recovery_codes" type="array">
+  An array of recovery codes generated for the user. Included only the first time an authenticator is added.
+</ResponseField>
+</ResponseSchema>
 
 ## Response Messages
 | Status | Description |

--- a/main/docs/api/authentication/multi-factor-authentication/add-an-authenticator.mdx
+++ b/main/docs/api/authentication/multi-factor-authentication/add-an-authenticator.mdx
@@ -57,23 +57,23 @@ To access this endpoint, you must set an Access Token at the Authorization heade
 
 <ResponseSchema>
 <ResponseField name="oob_code" type="string">
-  The code used for out-of-band authentication.
+  The code for out-of-band authentication.
 </ResponseField>
 
 <ResponseField name="binding_method" type="string">
-  Indicates the binding method used.
+  Indicates the binding method.
 </ResponseField>
 
 <ResponseField name="authenticator_type" type="string">
-  The type of authenticator added.
+  The authenticator type.
 </ResponseField>
 
 <ResponseField name="oob_channels" type="string">
-  The OOB channels used.
+  The OOB channels the authenticator uses.
 </ResponseField>
 
 <ResponseField name="recovery_codes" type="array">
-  An array of recovery codes generated for the user. Included only the first time an authenticator is added.
+  An array of recovery codes Auth0 generates for the user. When a user adds an authenticator, recovery codes display only once.
 </ResponseField>
 </ResponseSchema>
 

--- a/main/docs/api/authentication/multi-factor-authentication/delete-authenticator.mdx
+++ b/main/docs/api/authentication/multi-factor-authentication/delete-authenticator.mdx
@@ -3,6 +3,8 @@ title: "Delete an Authenticator"
 description: "Deletes an associated authenticator using its ID. You can get authenticator IDs by listing the authenticators."
 ---
 
+## Endpoint
+
 `DELETE /mfa/authenticators/{AUTHENTICATOR_ID}`
 
 Deletes an associated authenticator using its ID. You can get authenticator IDs by listing the authenticators.
@@ -11,17 +13,19 @@ To access this endpoint, you must set an Access Token in the Authorization heade
 - `scope`: `remove:authenticators`
 - `audience`: `https://{yourDomain}/mfa/`
 
-## Parameters
+## Path Parameters
 
 <ParamField path="AUTHENTICATOR_ID" type="string" required>
   The ID of the authenticator to delete.
 </ParamField>
 
+## Headers
+
 <ParamField header="Authorization" type="string" required>
   The Access Token obtained during login.
 </ParamField>
 
-## Response
+## Response Messages
 
 | Status | Description |
 |--------|-------------|

--- a/main/docs/api/authentication/multi-factor-authentication/list-authenticators.mdx
+++ b/main/docs/api/authentication/multi-factor-authentication/list-authenticators.mdx
@@ -3,6 +3,9 @@ title: "List Authenticators"
 description: "Returns a list of authenticators associated with your application."
 ---
 
+import { ResponseSchema } from '/snippets/ResponseSchema.jsx';
+
+
 ## Endpoint
 
 `GET /mfa/authenticators`
@@ -17,6 +20,32 @@ To access this endpoint, you must set an Access Token at the Authorization heade
 <ParamField header="Authorization" type="string" required>
   Bearer ACCESS_TOKEN
 </ParamField>
+
+## Response Schema
+
+<ResponseSchema>
+The response is an array of authenticator objects.
+
+<ResponseField name="id" type="string" required>
+  The authenticator ID.
+</ResponseField>
+
+<ResponseField name="authenticator_type" type="string" required>
+  The type of authenticator.
+</ResponseField>
+
+<ResponseField name="active" type="boolean" required>
+  Whether the authenticator is active.
+</ResponseField>
+
+<ResponseField name="oob_channels" type="string">
+  The OOB channels configured for this authenticator.
+</ResponseField>
+
+<ResponseField name="name" type="string">
+  The name of the authenticator.
+</ResponseField>
+</ResponseSchema>
 
 ## Response Messages
 | Status | Description |

--- a/main/docs/api/authentication/multi-factor-authentication/list-authenticators.mdx
+++ b/main/docs/api/authentication/multi-factor-authentication/list-authenticators.mdx
@@ -3,6 +3,8 @@ title: "List Authenticators"
 description: "Returns a list of authenticators associated with your application."
 ---
 
+## Endpoint
+
 `GET /mfa/authenticators`
 
 Returns a list of authenticators associated with your application.
@@ -11,14 +13,12 @@ To access this endpoint, you must set an Access Token at the Authorization heade
 - `scope`: `read:authenticators`
 - `audience`: `https://{yourDomain}/mfa/`
 
-## Parameters
-
+## Headers
 <ParamField header="Authorization" type="string" required>
   Bearer ACCESS_TOKEN
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | A list of authenticators. |

--- a/main/docs/api/authentication/multi-factor-authentication/list-authenticators.mdx
+++ b/main/docs/api/authentication/multi-factor-authentication/list-authenticators.mdx
@@ -35,11 +35,11 @@ The response is an array of authenticator objects.
 </ResponseField>
 
 <ResponseField name="active" type="boolean" required>
-  Whether the authenticator is active.
+  Indicates whether the authenticator is active.
 </ResponseField>
 
 <ResponseField name="oob_channels" type="string">
-  The OOB channels configured for this authenticator.
+The OOB channels this authenticator supports.
 </ResponseField>
 
 <ResponseField name="name" type="string">

--- a/main/docs/api/authentication/multi-factor-authentication/request-mfa-challenge.mdx
+++ b/main/docs/api/authentication/multi-factor-authentication/request-mfa-challenge.mdx
@@ -78,7 +78,7 @@ If OTP is supported by the user and you don't want to request a different factor
 <ResponseSchema statusCode="200">
 
 <ResponseField name="challenge_type" type="string">
-  The type of challenge issued. Possible values: `otp`, `oob`.
+  The type of challenge this authenticator issues. Possible values: `otp`, `oob`.
 </ResponseField>
 
 <ResponseField name="oob_code" type="string">

--- a/main/docs/api/authentication/multi-factor-authentication/request-mfa-challenge.mdx
+++ b/main/docs/api/authentication/multi-factor-authentication/request-mfa-challenge.mdx
@@ -3,6 +3,9 @@ title: "Challenge Request"
 description: "The Multi-factor Authentication (MFA) API endpoints allow you to enforce MFA when users interact with [the Token endpoints](#get-token), as well as enroll and..."
 ---
 
+import { ResponseSchema } from '/snippets/ResponseSchema.jsx';
+
+
 ## Endpoint
 
 `POST /mfa/challenge`
@@ -69,6 +72,34 @@ If OTP is supported by the user and you don't want to request a different factor
 <ParamField body="authenticator_id" type="string">
   The ID of the authenticator to challenge.
 </ParamField>
+
+## Response Schema
+
+<ResponseSchema statusCode="200">
+
+<ResponseField name="challenge_type" type="string">
+  The type of challenge issued. Possible values: `otp`, `oob`.
+</ResponseField>
+
+<ResponseField name="oob_code" type="string">
+  The code for the out-of-band challenge. Only present when `challenge_type` is `oob`.
+</ResponseField>
+
+<ResponseField name="binding_method" type="string">
+  The method used for binding. Only present when applicable. Possible values: `prompt`.
+</ResponseField>
+</ResponseSchema>
+
+<ResponseSchema statusCode="400">
+
+<ResponseField name="error" type="string">
+  Error code.
+</ResponseField>
+
+<ResponseField name="error_description" type="string">
+  Detailed error description.
+</ResponseField>
+</ResponseSchema>
 
 ## Response Messages
 | Status | Description |

--- a/main/docs/api/authentication/multi-factor-authentication/request-mfa-challenge.mdx
+++ b/main/docs/api/authentication/multi-factor-authentication/request-mfa-challenge.mdx
@@ -3,6 +3,8 @@ title: "Challenge Request"
 description: "The Multi-factor Authentication (MFA) API endpoints allow you to enforce MFA when users interact with [the Token endpoints](#get-token), as well as enroll and..."
 ---
 
+## Endpoint
+
 `POST /mfa/challenge`
 
 The Multi-factor Authentication (MFA) API endpoints allow you to enforce MFA when users interact with [the Token endpoints](#get-token), as well as enroll and manage user authenticators.
@@ -37,8 +39,7 @@ If OTP is supported by the user and you don't want to request a different factor
 * [Authenticate With Resource Owner Password Grant and MFA](https://auth0.com/docs/secure/multi-factor-authentication/authenticate-using-ropg-flow-with-mfa)
 * [Manage Authenticator Factors using the MFA API](https://auth0.com/docs/secure/multi-factor-authentication/manage-mfa-auth0-apis/manage-authenticator-factors-mfa-api)
 
-## Parameters
-
+## Body Parameters
 <ParamField body="mfa_token" type="string" required>
   The token received from mfa_required error.
 </ParamField>
@@ -69,8 +70,7 @@ If OTP is supported by the user and you don't want to request a different factor
   The ID of the authenticator to challenge.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | Challenge request successful |

--- a/main/docs/api/authentication/multi-factor-authentication/verify-mfa-with-otp.mdx
+++ b/main/docs/api/authentication/multi-factor-authentication/verify-mfa-with-otp.mdx
@@ -3,6 +3,9 @@ title: "Verify multi-factor authentication with one-time password (OTP)"
 description: "Verifies multi-factor authentication (MFA) using a one-time password (OTP). To verify MFA with an OTP, prompt the user to get the OTP code, then make a..."
 ---
 
+import { ResponseSchema } from '/snippets/ResponseSchema.jsx';
+
+
 ## Endpoint
 
 `POST /oauth/token`
@@ -46,6 +49,22 @@ Verifies multi-factor authentication (MFA) using a one-time password (OTP). To v
 <ParamField body="client_assertion_type" type="string">
   The value is `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`.
 </ParamField>
+
+## Response Schema
+
+<ResponseSchema>
+<ResponseField name="access_token" type="string">
+  The access token for the authenticated session.
+</ResponseField>
+
+<ResponseField name="token_type" type="string">
+  The type of token issued.
+</ResponseField>
+
+<ResponseField name="expires_in" type="integer">
+  The lifetime in seconds of the access token.
+</ResponseField>
+</ResponseSchema>
 
 ## Response Messages
 | Status | Description |

--- a/main/docs/api/authentication/multi-factor-authentication/verify-mfa-with-otp.mdx
+++ b/main/docs/api/authentication/multi-factor-authentication/verify-mfa-with-otp.mdx
@@ -3,6 +3,8 @@ title: "Verify multi-factor authentication with one-time password (OTP)"
 description: "Verifies multi-factor authentication (MFA) using a one-time password (OTP). To verify MFA with an OTP, prompt the user to get the OTP code, then make a..."
 ---
 
+## Endpoint
+
 `POST /oauth/token`
 
 Verifies multi-factor authentication (MFA) using a one-time password (OTP). To verify MFA with an OTP, prompt the user to get the OTP code, then make a request to the /oauth/token endpoint. The request must have the OTP code, the mfa_token you received (from the mfa_required error), and the grant_type set to http://auth0.com/oauth/grant-type/mfa-otp. The response is the same as responses for password or http://auth0.com/oauth/grant-type/password-realm grant types. Learn more at [Associate OTP Authenticators](/mfa/guides/mfa-api/otp).
@@ -11,14 +13,12 @@ Verifies multi-factor authentication (MFA) using a one-time password (OTP). To v
 
 - [Associate OTP Authenticators](https://auth0.com/docs/mfa/guides/mfa-api/otp)
 
-## Parameters
-
+## Headers
 <ParamField header="DPoP" type="string">
   A DPoP proof for the request. This is optional and only required if your application uses Demonstrating Proof-of-Possession.
 </ParamField>
 
-## Request Body
-
+## Body Parameters
 <ParamField body="grant_type" type="string" required>
   Denotes the flow you are using. For OTP MFA use `http://auth0.com/oauth/grant-type/mfa-otp`.
 </ParamField>
@@ -47,8 +47,7 @@ Verifies multi-factor authentication (MFA) using a one-time password (OTP). To v
   The value is `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | OTP verification successful. |

--- a/main/docs/api/authentication/multi-factor-authentication/verify-mfa-with-otp.mdx
+++ b/main/docs/api/authentication/multi-factor-authentication/verify-mfa-with-otp.mdx
@@ -62,7 +62,7 @@ Verifies multi-factor authentication (MFA) using a one-time password (OTP). To v
 </ResponseField>
 
 <ResponseField name="expires_in" type="integer">
-  The lifetime in seconds of the access token.
+  The access token lifetime in seconds.
 </ResponseField>
 </ResponseSchema>
 

--- a/main/docs/api/authentication/multi-factor-authentication/verify-with-out-of-band.mdx
+++ b/main/docs/api/authentication/multi-factor-authentication/verify-with-out-of-band.mdx
@@ -3,6 +3,9 @@ title: "Verify with Out-of-Band (OOB)"
 description: "Verifies multi-factor authentication (MFA) using an out-of-band (OOB) challenge (either Push notification, SMS, or Voice). To verify MFA using an OOB..."
 ---
 
+import { ResponseSchema } from '/snippets/ResponseSchema.jsx';
+
+
 ## Endpoint
 
 `POST /oauth/token`
@@ -61,6 +64,30 @@ When the challenge response includes a `binding_method: prompt`, your app needs 
 <ParamField body="binding_code" type="string">
   A code used to bind the side channel with the main channel you are using to authenticate.
 </ParamField>
+
+## Response Schema
+
+<ResponseSchema>
+<ResponseField name="access_token" type="string">
+  The access token returned upon successful verification.
+</ResponseField>
+
+<ResponseField name="token_type" type="string">
+  The type of token issued.
+</ResponseField>
+
+<ResponseField name="expires_in" type="integer">
+  The lifetime in seconds of the access token.
+</ResponseField>
+
+<ResponseField name="error" type="string">
+  Error code returned when verification is pending or has failed.
+</ResponseField>
+
+<ResponseField name="error_description" type="string">
+  Description of the error.
+</ResponseField>
+</ResponseSchema>
 
 ## Response Messages
 | Status | Description |

--- a/main/docs/api/authentication/multi-factor-authentication/verify-with-out-of-band.mdx
+++ b/main/docs/api/authentication/multi-factor-authentication/verify-with-out-of-band.mdx
@@ -77,7 +77,7 @@ When the challenge response includes a `binding_method: prompt`, your app needs 
 </ResponseField>
 
 <ResponseField name="expires_in" type="integer">
-  The lifetime in seconds of the access token.
+  The access token lifetime in seconds.
 </ResponseField>
 
 <ResponseField name="error" type="string">
@@ -85,7 +85,7 @@ When the challenge response includes a `binding_method: prompt`, your app needs 
 </ResponseField>
 
 <ResponseField name="error_description" type="string">
-  Description of the error.
+  Error description.
 </ResponseField>
 </ResponseSchema>
 

--- a/main/docs/api/authentication/multi-factor-authentication/verify-with-out-of-band.mdx
+++ b/main/docs/api/authentication/multi-factor-authentication/verify-with-out-of-band.mdx
@@ -3,6 +3,8 @@ title: "Verify with Out-of-Band (OOB)"
 description: "Verifies multi-factor authentication (MFA) using an out-of-band (OOB) challenge (either Push notification, SMS, or Voice). To verify MFA using an OOB..."
 ---
 
+## Endpoint
+
 `POST /oauth/token`
 
 Verifies multi-factor authentication (MFA) using an out-of-band (OOB) challenge (either Push notification, SMS, or Voice). To verify MFA using an OOB challenge, your application must make a request to `/oauth/token` with `grant_type=http://auth0.com/oauth/grant-type/mfa-oob`. Include the `oob_code` you received from the challenge response, as well as the `mfa_token` you received as part of `mfa_required` error.
@@ -18,14 +20,12 @@ When the challenge response includes a `binding_method: prompt`, your app needs 
 
 - [Associate Out-of-Band Authenticators](https://auth0.com/docs/secure/multi-factor-authentication/authenticate-using-ropg-flow-with-mfa/enroll-challenge-sms-voice-authenticators)
 
-## Parameters
-
+## Headers
 <ParamField header="DPoP" type="string">
   A DPoP proof for the request. This is optional and only required if your application uses Demonstrating Proof-of-Possession.
 </ParamField>
 
-## Request Body
-
+## Body Parameters
 <ParamField body="grant_type" type="string" required>
   Denotes the flow you are using. For OTP MFA, use `http://auth0.com/oauth/grant-type/mfa-oob`.
 
@@ -62,8 +62,7 @@ When the challenge response includes a `binding_method: prompt`, your app needs 
   A code used to bind the side channel with the main channel you are using to authenticate.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | Successful response for OOB verification. |

--- a/main/docs/api/authentication/multi-factor-authentication/verify-with-recovery-code.mdx
+++ b/main/docs/api/authentication/multi-factor-authentication/verify-with-recovery-code.mdx
@@ -56,7 +56,7 @@ To verify MFA using a recovery code your app must prompt the user for the recove
 
 <ResponseSchema>
 <ResponseField name="access_token" type="string">
-  The access token returned upon successful verification.
+  The access token from a successful verification.
 </ResponseField>
 
 <ResponseField name="token_type" type="string">
@@ -64,7 +64,7 @@ To verify MFA using a recovery code your app must prompt the user for the recove
 </ResponseField>
 
 <ResponseField name="expires_in" type="integer">
-  The lifetime in seconds of the access token.
+  The access token lifetime in seconds.
 </ResponseField>
 
 <ResponseField name="recovery_code" type="string">

--- a/main/docs/api/authentication/multi-factor-authentication/verify-with-recovery-code.mdx
+++ b/main/docs/api/authentication/multi-factor-authentication/verify-with-recovery-code.mdx
@@ -3,20 +3,20 @@ title: "Verify with Recovery Code"
 description: "Verifies multi-factor authentication (MFA) using a recovery code. Some multi-factor authentication (MFA) providers (such as Guardian) support using a recovery..."
 ---
 
+## Endpoint
+
 `POST /oauth/token`
 
 Verifies multi-factor authentication (MFA) using a recovery code. Some multi-factor authentication (MFA) providers (such as Guardian) support using a recovery code to login. Use this method to authenticate when the user's enrolled device is unavailable, or the user cannot receive the challenge or accept it due to connectivity issues.
 
 To verify MFA using a recovery code your app must prompt the user for the recovery code, and then make a request to `/oauth/token` with `grant_type=http://auth0.com/oauth/grant-type/mfa-recovery-code`. Include the collected recovery code and the `mfa_token` from the `mfa_required` error. If the recovery code is accepted, the response will be the same as for `password` or `http://auth0.com/oauth/grant-type/password-realm` grant types. It might also include a `recovery_code` field, which the application must display to the end-user to be stored securely for future use.
 
-## Parameters
-
+## Headers
 <ParamField header="DPoP" type="string">
   A DPoP proof for the request. This is optional and only required if your application uses Demonstrating Proof-of-Possession.
 </ParamField>
 
-## Request Body
-
+## Body Parameters
 <ParamField body="grant_type" type="string" required>
   Denotes the flow you are using. For recovery code use `http://auth0.com/oauth/grant-type/mfa-recovery-code`.
 
@@ -49,8 +49,7 @@ To verify MFA using a recovery code your app must prompt the user for the recove
   Recovery code provided by the end-user.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | Successful response for recovery code verification. |

--- a/main/docs/api/authentication/multi-factor-authentication/verify-with-recovery-code.mdx
+++ b/main/docs/api/authentication/multi-factor-authentication/verify-with-recovery-code.mdx
@@ -3,6 +3,9 @@ title: "Verify with Recovery Code"
 description: "Verifies multi-factor authentication (MFA) using a recovery code. Some multi-factor authentication (MFA) providers (such as Guardian) support using a recovery..."
 ---
 
+import { ResponseSchema } from '/snippets/ResponseSchema.jsx';
+
+
 ## Endpoint
 
 `POST /oauth/token`
@@ -48,6 +51,26 @@ To verify MFA using a recovery code your app must prompt the user for the recove
 <ParamField body="recovery_code" type="string" required>
   Recovery code provided by the end-user.
 </ParamField>
+
+## Response Schema
+
+<ResponseSchema>
+<ResponseField name="access_token" type="string">
+  The access token returned upon successful verification.
+</ResponseField>
+
+<ResponseField name="token_type" type="string">
+  The type of token issued.
+</ResponseField>
+
+<ResponseField name="expires_in" type="integer">
+  The lifetime in seconds of the access token.
+</ResponseField>
+
+<ResponseField name="recovery_code" type="string">
+  A new recovery code to be stored securely for future use.
+</ResponseField>
+</ResponseSchema>
 
 ## Response Messages
 | Status | Description |

--- a/main/docs/api/authentication/passwordless/authenticate-user.mdx
+++ b/main/docs/api/authentication/passwordless/authenticate-user.mdx
@@ -3,6 +3,8 @@ title: "Authenticate User"
 description: "Once you have a verification code, use this endpoint to login the user with their phone number/email and verification code."
 ---
 
+## Endpoint
+
 `POST /oauth/token`
 
 Once you have a verification code, use this endpoint to login the user with their phone number/email and verification code.
@@ -20,14 +22,12 @@ Once you have a verification code, use this endpoint to login the user with thei
 
 - [Passwordless Authentication](https://auth0.com/docs/authenticate/passwordless)
 
-## Parameters
-
+## Headers
 <ParamField header="DPoP" type="string">
   A DPoP proof for the request. This is optional and only required if your application uses Demonstrating Proof-of-Possession.
 </ParamField>
 
-## Request Body
-
+## Body Parameters
 <ParamField body="grant_type" type="string" required>
   Should be http://auth0.com/oauth/grant-type/passwordless/otp.
 </ParamField>
@@ -70,8 +70,7 @@ Once you have a verification code, use this endpoint to login the user with thei
   A callback URL that has been registered with your application's Allowed Callback URLs.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | User authenticated successfully. |

--- a/main/docs/api/authentication/passwordless/get-code-or-link.mdx
+++ b/main/docs/api/authentication/passwordless/get-code-or-link.mdx
@@ -3,6 +3,8 @@ title: "Get Code or Link"
 description: "Passwordless connections do not require the user to remember a password. Instead, another mechanism is used to prove identity, such as a one-time code sent..."
 ---
 
+## Endpoint
+
 `POST /passwordless/start`
 
 Passwordless connections do not require the user to remember a password. Instead, another mechanism is used to prove identity, such as a one-time code sent through email or SMS, every time the user logs in.
@@ -28,8 +30,7 @@ For the complete error code reference for this endpoint refer to [Errors > POST 
 - [Passwordless Authentication](https://auth0.com/docs/authenticate/passwordless)
 - [Passwordless Best Practices](https://auth0.com/docs/authenticate/passwordless/best-practices)
 
-## Parameters
-
+## Body Parameters
 <ParamField body="client_id" type="string" required>
   The `client_id` of your application.
 </ParamField>
@@ -80,8 +81,7 @@ For the complete error code reference for this endpoint refer to [Errors > POST 
   </Expandable>
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | Code or link sent successfully. |

--- a/main/docs/api/authentication/passwordless/verify.mdx
+++ b/main/docs/api/authentication/passwordless/verify.mdx
@@ -3,6 +3,8 @@ title: "Verify"
 description: "This feature is disabled by default for new tenants as of 8 June 2017. Please see [Application Grant Types](/applications/concepts/application-grant-types)..."
 ---
 
+## Endpoint
+
 `POST /passwordless/verify`
 
 <Note>
@@ -21,8 +23,7 @@ Once you have a verification code, use this endpoint to login the user with thei
 
 - [Passwordless Best Practices](/connections/passwordless/best-practices)
 
-## Parameters
-
+## Body Parameters
 <ParamField body="grant_type" type="string" required>
   Grant type, must be `password`.
 </ParamField>
@@ -53,8 +54,7 @@ Once you have a verification code, use this endpoint to login the user with thei
   Callback URL registered with your application's Allowed Callback URLs.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | User authenticated successfully. |

--- a/main/docs/api/authentication/refresh-token/refresh-token.mdx
+++ b/main/docs/api/authentication/refresh-token/refresh-token.mdx
@@ -3,6 +3,8 @@ title: "Refresh Access Token"
 description: "Use this endpoint to refresh an Access Token using the Refresh Token you got during authorization."
 ---
 
+## Endpoint
+
 `POST /oauth/token`
 
 Use this endpoint to refresh an Access Token using the Refresh Token you got during authorization.
@@ -11,14 +13,12 @@ Use this endpoint to refresh an Access Token using the Refresh Token you got dur
 
 - [Refresh Tokens](https://auth0.com/docs/secure/tokens/refresh-tokens)
 
-## Parameters
-
+## Headers
 <ParamField header="DPoP" type="string">
   A DPoP proof for the request. This is optional and only required if your application uses Demonstrating Proof-of-Possession.
 </ParamField>
 
-## Request Body
-
+## Body Parameters
 <ParamField body="grant_type" type="string" required>
   Specifies the flow being used. For refreshing an access token, this must be set to `refresh_token`.
 
@@ -41,8 +41,7 @@ Use this endpoint to refresh an Access Token using the Refresh Token you got dur
   A space-delimited list of requested scope permissions. If omitted, the original scopes will be used; otherwise, you can request a reduced set of scopes. Note that this must be URL encoded.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | Access token successfully refreshed. |

--- a/main/docs/api/authentication/refresh-token/refresh-token.mdx
+++ b/main/docs/api/authentication/refresh-token/refresh-token.mdx
@@ -64,11 +64,11 @@ Use this endpoint to refresh an Access Token using the Refresh Token you got dur
 </ResponseField>
 
 <ResponseField name="expires_in" type="integer">
-  The lifetime in seconds of the access token.
+  The access token lifetime in seconds.
 </ResponseField>
 
 <ResponseField name="scope" type="string">
-  The scopes granted to the access token.
+  Access token scopes.
 </ResponseField>
 </ResponseSchema>
 

--- a/main/docs/api/authentication/refresh-token/refresh-token.mdx
+++ b/main/docs/api/authentication/refresh-token/refresh-token.mdx
@@ -3,6 +3,9 @@ title: "Refresh Access Token"
 description: "Use this endpoint to refresh an Access Token using the Refresh Token you got during authorization."
 ---
 
+import { ResponseSchema } from '/snippets/ResponseSchema.jsx';
+
+
 ## Endpoint
 
 `POST /oauth/token`
@@ -40,6 +43,34 @@ Use this endpoint to refresh an Access Token using the Refresh Token you got dur
 <ParamField body="scope" type="string">
   A space-delimited list of requested scope permissions. If omitted, the original scopes will be used; otherwise, you can request a reduced set of scopes. Note that this must be URL encoded.
 </ParamField>
+
+## Response Schema
+
+<ResponseSchema>
+<ResponseField name="access_token" type="string">
+  The newly issued access token.
+</ResponseField>
+
+<ResponseField name="refresh_token" type="string">
+  The refresh token.
+</ResponseField>
+
+<ResponseField name="id_token" type="string">
+  The ID token, if applicable.
+</ResponseField>
+
+<ResponseField name="token_type" type="string">
+  The type of token. Usually `Bearer`.
+</ResponseField>
+
+<ResponseField name="expires_in" type="integer">
+  The lifetime in seconds of the access token.
+</ResponseField>
+
+<ResponseField name="scope" type="string">
+  The scopes granted to the access token.
+</ResponseField>
+</ResponseSchema>
 
 ## Response Messages
 | Status | Description |

--- a/main/docs/api/authentication/resource-owner-legacy/resource-owner-password-grant.mdx
+++ b/main/docs/api/authentication/resource-owner-legacy/resource-owner-password-grant.mdx
@@ -3,6 +3,8 @@ title: "Resource Owner Password Grant"
 description: "Given the user's credentials, this endpoint will authenticate the user with the provider and return a JSON object with the Access Token and an ID Token."
 ---
 
+## Endpoint
+
 `POST /oauth/ro`
 
 Given the user's credentials, this endpoint will authenticate the user with the provider and return a JSON object with the Access Token and an ID Token.
@@ -21,8 +23,7 @@ This endpoint is part of the legacy authentication pipeline and has been replace
 
 - [Calling APIs from Highly Trusted Applications](https://auth0.com/docs/get-started/authentication-and-authorization-flow/resource-owner-password-flow)
 
-## Parameters
-
+## Body Parameters
 <ParamField body="client_id" type="string" required>
   
 </ParamField>
@@ -57,8 +58,7 @@ This endpoint is part of the legacy authentication pipeline and has been replace
   
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | Successful authentication |

--- a/main/docs/api/authentication/resource-owner-password-flow/get-token.mdx
+++ b/main/docs/api/authentication/resource-owner-password-flow/get-token.mdx
@@ -3,6 +3,9 @@ title: "Get Token"
 description: "This flow should only be used from highly-trusted applications that **cannot do redirects**. If you can use redirect-based flows from your app, we recommend..."
 ---
 
+import { ResponseSchema } from '/snippets/ResponseSchema.jsx';
+
+
 ## Endpoint
 
 `POST /oauth/token`
@@ -88,6 +91,22 @@ Content-Type: application/json
 <ParamField body="realm" type="string">
   String value of the realm the user belongs.
 </ParamField>
+
+## Response Schema
+
+<ResponseSchema>
+<ResponseField name="access_token" type="string">
+  The access token.
+</ResponseField>
+
+<ResponseField name="token_type" type="string">
+  The type of token. Usually `Bearer`.
+</ResponseField>
+
+<ResponseField name="expires_in" type="integer">
+  The lifetime in seconds of the access token.
+</ResponseField>
+</ResponseSchema>
 
 ## Response Messages
 | Status | Description |

--- a/main/docs/api/authentication/resource-owner-password-flow/get-token.mdx
+++ b/main/docs/api/authentication/resource-owner-password-flow/get-token.mdx
@@ -104,7 +104,7 @@ Content-Type: application/json
 </ResponseField>
 
 <ResponseField name="expires_in" type="integer">
-  The lifetime in seconds of the access token.
+  The access token lifetime in seconds.
 </ResponseField>
 </ResponseSchema>
 

--- a/main/docs/api/authentication/resource-owner-password-flow/get-token.mdx
+++ b/main/docs/api/authentication/resource-owner-password-flow/get-token.mdx
@@ -3,6 +3,8 @@ title: "Get Token"
 description: "This flow should only be used from highly-trusted applications that **cannot do redirects**. If you can use redirect-based flows from your app, we recommend..."
 ---
 
+## Endpoint
+
 `POST /oauth/token`
 
 <Note>
@@ -45,14 +47,12 @@ Content-Type: application/json
 - [Executing the Resource Owner Password Grant](https://auth0.com/docs/get-started/authentication-and-authorization-flow/resource-owner-password-flow/call-your-api-using-resource-owner-password-flow)
 - [Multi-factor Authentication and Resource Owner Password](https://auth0.com/docs/secure/multi-factor-authentication/authenticate-using-ropg-flow-with-mfa)
 
-## Parameters
-
+## Headers
 <ParamField header="DPoP" type="string">
   A DPoP proof for the request. This is optional and only required if your application uses Demonstrating Proof-of-Possession.
 </ParamField>
 
-## Request Body
-
+## Body Parameters
 <ParamField body="grant_type" type="string" required>
   Denotes the flow you are using. For Resource Owner Password use `password`.
 </ParamField>
@@ -89,8 +89,7 @@ Content-Type: application/json
   String value of the realm the user belongs.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | Returns the access token. |

--- a/main/docs/api/authentication/revoke-refresh-token/revoke-refresh-token.mdx
+++ b/main/docs/api/authentication/revoke-refresh-token/revoke-refresh-token.mdx
@@ -3,6 +3,9 @@ title: "Revoke a Refresh Token"
 description: "Use this endpoint to invalidate a Refresh Token if it has been compromised."
 ---
 
+import { ResponseSchema } from '/snippets/ResponseSchema.jsx';
+
+
 ## Endpoint
 
 `POST /oauth/revoke`
@@ -41,6 +44,20 @@ If this toggle is disabled, then only the refresh token is revoked, while the gr
 <ParamField body="token" type="string" required>
   The Refresh Token you want to revoke.
 </ParamField>
+
+## Response Schema
+
+<ResponseSchema>
+A successful 200 response has no body. Error responses use this shape:
+
+<ResponseField name="error" type="string">
+  Error code.
+</ResponseField>
+
+<ResponseField name="error_description" type="string">
+  Description of the error.
+</ResponseField>
+</ResponseSchema>
 
 ## Response Messages
 | Status | Description |

--- a/main/docs/api/authentication/revoke-refresh-token/revoke-refresh-token.mdx
+++ b/main/docs/api/authentication/revoke-refresh-token/revoke-refresh-token.mdx
@@ -55,7 +55,7 @@ A successful 200 response has no body. Error responses use this shape:
 </ResponseField>
 
 <ResponseField name="error_description" type="string">
-  Description of the error.
+  Error description.
 </ResponseField>
 </ResponseSchema>
 

--- a/main/docs/api/authentication/revoke-refresh-token/revoke-refresh-token.mdx
+++ b/main/docs/api/authentication/revoke-refresh-token/revoke-refresh-token.mdx
@@ -3,6 +3,8 @@ title: "Revoke a Refresh Token"
 description: "Use this endpoint to invalidate a Refresh Token if it has been compromised."
 ---
 
+## Endpoint
+
 `POST /oauth/revoke`
 
 Use this endpoint to invalidate a Refresh Token if it has been compromised.
@@ -19,8 +21,7 @@ If this toggle is disabled, then only the refresh token is revoked, while the gr
 
 - [Refresh Tokens](https://auth0.com/docs/ja-jp/secure/tokens/refresh-tokens)
 
-## Parameters
-
+## Body Parameters
 <ParamField body="client_id" type="string" required>
   The `client_id` of your application.
 </ParamField>
@@ -41,8 +42,7 @@ If this toggle is disabled, then only the refresh token is revoked, while the gr
   The Refresh Token you want to revoke.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | (empty-response-body) |

--- a/main/docs/api/authentication/revoke-refresh-token/revoke-refresh-token.mdx
+++ b/main/docs/api/authentication/revoke-refresh-token/revoke-refresh-token.mdx
@@ -12,7 +12,7 @@ import { ResponseSchema } from '/snippets/ResponseSchema.jsx';
 
 Use this endpoint to invalidate a Refresh Token if it has been compromised.
 
-The behaviour of this endpoint depends on the state of the [Refresh Token Revocation Deletes Grant](https://auth0.com/docs/tokens/refresh-tokens/revoke-refresh-tokens#refresh-tokens-and-grants) toggle.
+The behaviour of this endpoint depends on the state of the [Refresh Token Revocation Deletes Grant](https://auth0.com/docs/secure/tokens/refresh-tokens/revoke-refresh-tokens#choose-whether-token-revocation-deletes-grants) toggle.
 If this toggle is enabled, then each revocation request invalidates not only the specific token, but all other tokens based on the same authorization grant. This means that **all Refresh Tokens that have been issued for the same user, application, and audience will be revoked**.
 If this toggle is disabled, then only the refresh token is revoked, while the grant is left intact.
 

--- a/main/docs/api/authentication/saml/accept-saml-request.mdx
+++ b/main/docs/api/authentication/saml/accept-saml-request.mdx
@@ -3,6 +3,8 @@ title: "Accept Request"
 description: "Use this endpoint to accept a SAML request to initiate a login."
 ---
 
+## Endpoint
+
 `GET /samlp/{clientId}`
 
 Use this endpoint to accept a SAML request to initiate a login.
@@ -11,14 +13,12 @@ Optionally, you can include a `connection` parameter to log in with a specific p
 
 Optionally, SP-initiated login requests can include an `organization` parameter to authenticate users in the context of an organization. To learn more, see [Organizations](https://auth0.com/docs/manage-users/organizations).
 
-## Parameters
-
+## Path Parameters
 <ParamField path="clientId" type="string" required>
   Client ID of your application.
 </ParamField>
 
-## Request Body
-
+## Body Parameters
 <ParamField body="connection" type="string">
   Connection to use during login.
 </ParamField>
@@ -27,8 +27,7 @@ Optionally, SP-initiated login requests can include an `organization` parameter 
   Organization ID, if authenticating in the context of an organization.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | Successful SAML request acceptance. |

--- a/main/docs/api/authentication/saml/get-saml-metadata.mdx
+++ b/main/docs/api/authentication/saml/get-saml-metadata.mdx
@@ -3,6 +3,8 @@ title: "Get Metadata"
 description: "This endpoint returns the SAML 2.0 metadata."
 ---
 
+## Endpoint
+
 `GET /samlp/metadata/{clientId}`
 
 This endpoint returns the SAML 2.0 metadata.
@@ -10,14 +12,12 @@ This endpoint returns the SAML 2.0 metadata.
 ### Learn More
 - [SAML](https://auth0.com/docs/authenticate/protocols/saml/saml-configuration)
 
-## Parameters
-
+## Path Parameters
 <ParamField path="clientId" type="string" required>
   The client_id of your application.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | Successful retrieval of SAML metadata. |

--- a/main/docs/api/authentication/saml/idp-initiated-sso.mdx
+++ b/main/docs/api/authentication/saml/idp-initiated-sso.mdx
@@ -3,6 +3,8 @@ title: "IdP-Initiated Single Sign-On (SSO) Flow"
 description: "This endpoint accepts an IdP-Initiated Sign On SAMLResponse from a SAML Identity Provider. The connection corresponding to the identity provider is specified..."
 ---
 
+## Endpoint
+
 `POST /login/callback`
 
 This endpoint accepts an IdP-Initiated Sign On SAMLResponse from a SAML Identity Provider. The connection corresponding to the identity provider is specified in the query string. The user will be redirected to the application that is specified in the SAML Provider IdP-Initiated Sign On section.
@@ -10,8 +12,7 @@ This endpoint accepts an IdP-Initiated Sign On SAMLResponse from a SAML Identity
 ### Learn More
 - [SAML](https://auth0.com/docs/authenticate/protocols/saml/saml-configuration)
 
-## Parameters
-
+## Body Parameters
 <ParamField body="connection" type="string" required>
   The name of an identity provider configured to your application.
 </ParamField>

--- a/main/docs/api/authentication/signup/create-a-new-user.mdx
+++ b/main/docs/api/authentication/signup/create-a-new-user.mdx
@@ -3,6 +3,9 @@ title: "Create a new user"
 description: "Given a user's credentials and a `connection`, this endpoint creates a new user."
 ---
 
+import { ResponseSchema } from '/snippets/ResponseSchema.jsx';
+
+
 ## Endpoint
 
 `POST /dbconnections/signup`
@@ -68,6 +71,46 @@ This endpoint only works for database connections.
 <ParamField body="user_metadata" type="object">
   The user metadata to be associated with the user. If set, the field must be an object containing no more than ten properties. Property names can have a maximum of 100 characters, and property values must be strings of no more than 500 characters.
 </ParamField>
+
+## Response Schema
+
+<ResponseSchema>
+<ResponseField name="_id" type="string">
+  The user's unique identifier.
+</ResponseField>
+
+<ResponseField name="email_verified" type="boolean">
+  Whether the user's email address has been verified.
+</ResponseField>
+
+<ResponseField name="email" type="string">
+  The user's email address.
+</ResponseField>
+
+<ResponseField name="username" type="string">
+  The user's username.
+</ResponseField>
+
+<ResponseField name="given_name" type="string">
+  The user's given name.
+</ResponseField>
+
+<ResponseField name="family_name" type="string">
+  The user's family name.
+</ResponseField>
+
+<ResponseField name="name" type="string">
+  The user's full name.
+</ResponseField>
+
+<ResponseField name="nickname" type="string">
+  The user's nickname.
+</ResponseField>
+
+<ResponseField name="picture" type="string">
+  A URI pointing to the user's picture.
+</ResponseField>
+</ResponseSchema>
 
 ## Response Messages
 | Status | Description |

--- a/main/docs/api/authentication/signup/create-a-new-user.mdx
+++ b/main/docs/api/authentication/signup/create-a-new-user.mdx
@@ -3,6 +3,8 @@ title: "Create a new user"
 description: "Given a user's credentials and a `connection`, this endpoint creates a new user."
 ---
 
+## Endpoint
+
 `POST /dbconnections/signup`
 
 Given a user's credentials and a `connection`, this endpoint creates a new user.
@@ -18,8 +20,7 @@ This endpoint only works for database connections.
 - [Adding Username for Database Connections](https://auth0.com/docs/authenticate/database-connections/require-username)
 - [Metadata Overview](https://auth0.com/docs/manage-users/user-accounts/metadata)
 
-## Parameters
-
+## Body Parameters
 <ParamField body="client_id" type="string" required>
   The `client_id` of your client.
 </ParamField>
@@ -68,8 +69,7 @@ This endpoint only works for database connections.
   The user metadata to be associated with the user. If set, the field must be an object containing no more than ten properties. Property names can have a maximum of 100 characters, and property values must be strings of no more than 500 characters.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | User successfully created |

--- a/main/docs/api/authentication/signup/create-a-new-user.mdx
+++ b/main/docs/api/authentication/signup/create-a-new-user.mdx
@@ -80,7 +80,7 @@ This endpoint only works for database connections.
 </ResponseField>
 
 <ResponseField name="email_verified" type="boolean">
-  Whether the user's email address has been verified.
+  Indicates whether the user's email address is verified.
 </ResponseField>
 
 <ResponseField name="email" type="string">

--- a/main/docs/api/authentication/token-exchange-for-native-social/token-exchange-native-social.mdx
+++ b/main/docs/api/authentication/token-exchange-for-native-social/token-exchange-native-social.mdx
@@ -3,6 +3,9 @@ title: "Token Exchange for Native Social"
 description: "This flow is intended for use with native social interactions **only**. Use of this flow outside of a native social setting is highly discouraged."
 ---
 
+import { ResponseSchema } from '/snippets/ResponseSchema.jsx';
+
+
 ## Endpoint
 
 `POST /oauth/token`
@@ -71,6 +74,42 @@ Artifacts returned by this flow (and the contents thereof) will be determined by
     </ParamField>
   </Expandable>
 </ParamField>
+
+## Response Schema
+
+<ResponseSchema statusCode="200">
+
+<ResponseField name="access_token" type="string">
+  The issued access token.
+</ResponseField>
+
+<ResponseField name="id_token" type="string">
+  The issued ID token.
+</ResponseField>
+
+<ResponseField name="refresh_token" type="string">
+  The issued refresh token.
+</ResponseField>
+
+<ResponseField name="token_type" type="string">
+  The type of token issued.
+</ResponseField>
+
+<ResponseField name="expires_in" type="integer">
+  The lifetime in seconds of the access token.
+</ResponseField>
+</ResponseSchema>
+
+<ResponseSchema statusCode="default error">
+
+<ResponseField name="error" type="string">
+  Error code.
+</ResponseField>
+
+<ResponseField name="error_description" type="string">
+  Description of the error.
+</ResponseField>
+</ResponseSchema>
 
 ## Response Messages
 | Status | Description |

--- a/main/docs/api/authentication/token-exchange-for-native-social/token-exchange-native-social.mdx
+++ b/main/docs/api/authentication/token-exchange-for-native-social/token-exchange-native-social.mdx
@@ -96,7 +96,7 @@ Artifacts returned by this flow (and the contents thereof) will be determined by
 </ResponseField>
 
 <ResponseField name="expires_in" type="integer">
-  The lifetime in seconds of the access token.
+  The access token lifetime in seconds.
 </ResponseField>
 </ResponseSchema>
 
@@ -107,7 +107,7 @@ Artifacts returned by this flow (and the contents thereof) will be determined by
 </ResponseField>
 
 <ResponseField name="error_description" type="string">
-  Description of the error.
+  Error description.
 </ResponseField>
 </ResponseSchema>
 

--- a/main/docs/api/authentication/token-exchange-for-native-social/token-exchange-native-social.mdx
+++ b/main/docs/api/authentication/token-exchange-for-native-social/token-exchange-native-social.mdx
@@ -3,6 +3,8 @@ title: "Token Exchange for Native Social"
 description: "This flow is intended for use with native social interactions **only**. Use of this flow outside of a native social setting is highly discouraged."
 ---
 
+## Endpoint
+
 `POST /oauth/token`
 
 <Note>
@@ -22,14 +24,12 @@ Artifacts returned by this flow (and the contents thereof) will be determined by
 - [Add Sign In with Apple to Native iOS Apps](https://auth0.com/docs/authenticate/identity-providers/social-identity-providers/apple-native)
 - [iOS Swift - Sign In with Apple Quickstart](https://auth0.com/docs/quickstart/native/ios-swift)
 
-## Parameters
-
+## Headers
 <ParamField header="DPoP" type="string">
   A DPoP proof for the request. This is optional and only required if your application uses Demonstrating Proof-of-Possession.
 </ParamField>
 
-## Request Body
-
+## Body Parameters
 <ParamField body="auth0-forwarded-for" type="string">
   End user IP as a string value. Set this if you want brute-force protection to work in server-side scenarios. To learn more about how and when to use this header, read [Using resource owner password from server-side](/api-auth/tutorials/using-resource-owner-password-from-server-side).
 </ParamField>
@@ -72,8 +72,7 @@ Artifacts returned by this flow (and the contents thereof) will be determined by
   </Expandable>
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | Successful response |

--- a/main/docs/api/authentication/user-profile-legacy/get-token-info.mdx
+++ b/main/docs/api/authentication/user-profile-legacy/get-token-info.mdx
@@ -3,6 +3,9 @@ title: "Get Token Info"
 description: "This endpoint is part of the legacy authentication pipeline and will be disabled for those who use our latest, OIDC conformant, pipeline. We encourage using..."
 ---
 
+import { ResponseSchema } from '/snippets/ResponseSchema.jsx';
+
+
 ## Endpoint
 
 `POST /tokeninfo`
@@ -23,6 +26,62 @@ This endpoint validates a JSON Web Token (JWT) (signature and expiration) and re
 ### Learn More
 - [User Profile Struture](https://auth0.com/docs/manage-users/user-accounts/user-profiles/user-profile-structure)
 - [Auth0 API Rate Limit Policy](https://auth0.com/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy)
+
+## Response Schema
+
+<ResponseSchema>
+<ResponseField name="email_verified" type="boolean">
+  Whether the user's email address has been verified.
+</ResponseField>
+
+<ResponseField name="email" type="string">
+  The user's email address.
+</ResponseField>
+
+<ResponseField name="clientID" type="string">
+  The client ID associated with the token.
+</ResponseField>
+
+<ResponseField name="updated_at" type="string">
+  Time the user's information was last updated.
+</ResponseField>
+
+<ResponseField name="name" type="string">
+  The user's full name.
+</ResponseField>
+
+<ResponseField name="picture" type="string">
+  URL of the user's profile picture.
+</ResponseField>
+
+<ResponseField name="user_id" type="string">
+  The user's unique identifier.
+</ResponseField>
+
+<ResponseField name="nickname" type="string">
+  The user's nickname.
+</ResponseField>
+
+<ResponseField name="provider" type="string">
+  The identity provider for the user.
+</ResponseField>
+
+<ResponseField name="connection" type="string">
+  The connection used to authenticate the user.
+</ResponseField>
+
+<ResponseField name="isSocial" type="boolean">
+  Whether the user authenticated via a social provider.
+</ResponseField>
+
+<ResponseField name="created_at" type="string">
+  Time the user was created.
+</ResponseField>
+
+<ResponseField name="global_client_id" type="string">
+  The global client ID.
+</ResponseField>
+</ResponseSchema>
 
 ## Response Messages
 | Status | Description |

--- a/main/docs/api/authentication/user-profile-legacy/get-token-info.mdx
+++ b/main/docs/api/authentication/user-profile-legacy/get-token-info.mdx
@@ -3,6 +3,8 @@ title: "Get Token Info"
 description: "This endpoint is part of the legacy authentication pipeline and will be disabled for those who use our latest, OIDC conformant, pipeline. We encourage using..."
 ---
 
+## Endpoint
+
 `POST /tokeninfo`
 
 <Note>
@@ -22,8 +24,7 @@ This endpoint validates a JSON Web Token (JWT) (signature and expiration) and re
 - [User Profile Struture](https://auth0.com/docs/manage-users/user-accounts/user-profiles/user-profile-structure)
 - [Auth0 API Rate Limit Policy](https://auth0.com/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy)
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | Successful response with user information |

--- a/main/docs/api/authentication/user-profile-legacy/get-token-info.mdx
+++ b/main/docs/api/authentication/user-profile-legacy/get-token-info.mdx
@@ -31,7 +31,7 @@ This endpoint validates a JSON Web Token (JWT) (signature and expiration) and re
 
 <ResponseSchema>
 <ResponseField name="email_verified" type="boolean">
-  Whether the user's email address has been verified.
+  Indicates whether the user's email address has been verified.
 </ResponseField>
 
 <ResponseField name="email" type="string">

--- a/main/docs/api/authentication/user-profile/get-user-info.mdx
+++ b/main/docs/api/authentication/user-profile/get-user-info.mdx
@@ -3,6 +3,9 @@ title: "Get User Info"
 description: "Given the Auth0 Access Token obtained during login, this endpoint returns a user's profile. This endpoint will work only if `openid` was granted as a scope..."
 ---
 
+import { ResponseSchema } from '/snippets/ResponseSchema.jsx';
+
+
 ## Endpoint
 
 `GET /userinfo`
@@ -35,6 +38,90 @@ Given the Auth0 Access Token obtained during login, this endpoint returns a user
 <ParamField header="DPoP" type="string">
   A DPoP proof for the request. This is optional and only required if your application uses Demonstrating Proof-of-Possession.
 </ParamField>
+
+## Response Schema
+
+<ResponseSchema>
+<ResponseField name="sub" type="string">
+  The user's unique identifier.
+</ResponseField>
+
+<ResponseField name="name" type="string">
+  The user's full name.
+</ResponseField>
+
+<ResponseField name="given_name" type="string">
+  The user's given name.
+</ResponseField>
+
+<ResponseField name="family_name" type="string">
+  The user's family name.
+</ResponseField>
+
+<ResponseField name="middle_name" type="string">
+  The user's middle name.
+</ResponseField>
+
+<ResponseField name="nickname" type="string">
+  The user's nickname.
+</ResponseField>
+
+<ResponseField name="preferred_username" type="string">
+  The user's preferred username.
+</ResponseField>
+
+<ResponseField name="profile" type="string">
+  URL of the user's profile page.
+</ResponseField>
+
+<ResponseField name="picture" type="string">
+  URL of the user's profile picture.
+</ResponseField>
+
+<ResponseField name="website" type="string">
+  URL of the user's website.
+</ResponseField>
+
+<ResponseField name="email" type="string">
+  The user's email address.
+</ResponseField>
+
+<ResponseField name="email_verified" type="boolean">
+  Whether the user's email address has been verified.
+</ResponseField>
+
+<ResponseField name="gender" type="string">
+  The user's gender.
+</ResponseField>
+
+<ResponseField name="birthdate" type="string">
+  The user's date of birth.
+</ResponseField>
+
+<ResponseField name="zoneinfo" type="string">
+  The user's time zone.
+</ResponseField>
+
+<ResponseField name="locale" type="string">
+  The user's locale.
+</ResponseField>
+
+<ResponseField name="phone_number" type="string">
+  The user's phone number.
+</ResponseField>
+
+<ResponseField name="phone_number_verified" type="boolean">
+  Whether the user's phone number has been verified.
+</ResponseField>
+
+<ResponseField name="address" type="object">
+  The user's address.
+</ResponseField>
+
+<ResponseField name="updated_at" type="integer">
+  Time the user's information was last updated, in Unix time.
+</ResponseField>
+</ResponseSchema>
 
 ## Response Messages
 | Status | Description |

--- a/main/docs/api/authentication/user-profile/get-user-info.mdx
+++ b/main/docs/api/authentication/user-profile/get-user-info.mdx
@@ -111,7 +111,7 @@ Given the Auth0 Access Token obtained during login, this endpoint returns a user
 </ResponseField>
 
 <ResponseField name="phone_number_verified" type="boolean">
-  Whether the user's phone number has been verified.
+  Indicates whether the user's phone number has been verified.
 </ResponseField>
 
 <ResponseField name="address" type="object">
@@ -119,7 +119,7 @@ Given the Auth0 Access Token obtained during login, this endpoint returns a user
 </ResponseField>
 
 <ResponseField name="updated_at" type="integer">
-  Time the user's information was last updated, in Unix time.
+  The time of the user's last information update, in Unix time.
 </ResponseField>
 </ResponseSchema>
 

--- a/main/docs/api/authentication/user-profile/get-user-info.mdx
+++ b/main/docs/api/authentication/user-profile/get-user-info.mdx
@@ -3,6 +3,8 @@ title: "Get User Info"
 description: "Given the Auth0 Access Token obtained during login, this endpoint returns a user's profile. This endpoint will work only if `openid` was granted as a scope..."
 ---
 
+## Endpoint
+
 `GET /userinfo`
 
 Given the Auth0 Access Token obtained during login, this endpoint returns a user's profile. This endpoint will work only if `openid` was granted as a scope for the Access Token. The user profile information included in the response depends on the scopes requested. For example, a scope of just `openid` may return less information than a scope of `openid profile email`.
@@ -25,8 +27,7 @@ Given the Auth0 Access Token obtained during login, this endpoint returns a user
 - [Auth0.js v8 Reference: Extract the authResult and get user info](https://auth0.com/docs/libraries/auth0js#extract-the-authresult-and-get-user-info)
 - [Auth0 API Rate Limit Policy](https://auth0.com/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy)
 
-## Parameters
-
+## Headers
 <ParamField header="access_token" type="string" required>
   
 </ParamField>
@@ -35,8 +36,7 @@ Given the Auth0 Access Token obtained during login, this endpoint returns a user
   A DPoP proof for the request. This is optional and only required if your application uses Demonstrating Proof-of-Possession.
 </ParamField>
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | User profile retrieved successfully. |

--- a/main/docs/api/authentication/ws-federation/accept-ws-federation-request.mdx
+++ b/main/docs/api/authentication/ws-federation/accept-ws-federation-request.mdx
@@ -3,6 +3,8 @@ title: "Accept WS-Federation Request"
 description: "This endpoint accepts a WS-Federation request to initiate a login."
 ---
 
+## Endpoint
+
 `GET /wsfed/{clientId}`
 
 This endpoint accepts a WS-Federation request to initiate a login.
@@ -17,11 +19,13 @@ This endpoint accepts a WS-Federation request to initiate a login.
 ### Learn More
 - [WS-Federation](https://auth0.com/docs/authenticate/protocols/ws-fed-protocol)
 
-## Parameters
+## Path Parameters
 
 <ParamField path="client-id" type="string" required>
   The `client-id` of your application.
 </ParamField>
+
+## Query Parameters
 
 <ParamField query="wtrealm" type="string">
   Can be used in place of `client-id`.
@@ -39,7 +43,7 @@ This endpoint accepts a WS-Federation request to initiate a login.
   The callback URL.
 </ParamField>
 
-## Response
+## Response Messages
 
 | Status | Description |
 |--------|-------------|

--- a/main/docs/api/authentication/ws-federation/get-ws-federation-metadata.mdx
+++ b/main/docs/api/authentication/ws-federation/get-ws-federation-metadata.mdx
@@ -3,6 +3,8 @@ title: "Get WS-Federation Metadata"
 description: "This endpoint returns the WS-Federation metadata."
 ---
 
+## Endpoint
+
 `GET /wsfed/FederationMetadata/2007-06/FederationMetadata.xml`
 
 This endpoint returns the WS-Federation metadata.
@@ -10,8 +12,7 @@ This endpoint returns the WS-Federation metadata.
 ### Learn More
 - [WS-Federation](https://auth0.com/docs/authenticate/protocols/ws-fed-protocol)
 
-## Response
-
+## Response Messages
 | Status | Description |
 |--------|-------------|
 | 200 | Successful response with WS-Federation metadata. |

--- a/main/snippets/ResponseSchema.jsx
+++ b/main/snippets/ResponseSchema.jsx
@@ -1,0 +1,90 @@
+export const ResponseSchema = ({ statusCode, children }) => {
+  const [open, setOpen] = useState(false);
+
+  const isSuccess =
+    statusCode &&
+    (statusCode.startsWith("2") || statusCode === "default success");
+  const isError =
+    statusCode &&
+    (statusCode.startsWith("4") ||
+      statusCode.startsWith("5") ||
+      statusCode === "default error");
+
+  const badgeStyle = {
+    display: "inline-flex",
+    alignItems: "center",
+    padding: "2px 8px",
+    borderRadius: "4px",
+    fontSize: "12px",
+    fontWeight: 600,
+    fontFamily: "monospace",
+    backgroundColor: isSuccess
+      ? "var(--color-success-light, #dcfce7)"
+      : isError
+        ? "var(--color-error-light, #fee2e2)"
+        : "var(--color-gray-light, #f3f4f6)",
+    color: isSuccess
+      ? "var(--color-success, #166534)"
+      : isError
+        ? "var(--color-error, #991b1b)"
+        : "var(--color-gray, #374151)",
+  };
+
+  const containerStyle = {
+    border: "1px solid var(--border-color, #e5e7eb)",
+    borderRadius: "8px",
+    marginBottom: "12px",
+    overflow: "hidden",
+  };
+
+  const headerStyle = {
+    display: "flex",
+    alignItems: "center",
+    gap: "10px",
+    padding: "10px 16px",
+    cursor: "pointer",
+    userSelect: "none",
+    backgroundColor: open
+      ? "var(--bg-subtle, #f9fafb)"
+      : "transparent",
+  };
+
+  const chevronStyle = {
+    marginLeft: "auto",
+    transition: "transform 0.2s",
+    transform: open ? "rotate(180deg)" : "rotate(0deg)",
+    opacity: 0.5,
+  };
+
+  const bodyStyle = {
+    padding: "4px 16px 12px",
+    borderTop: "1px solid var(--border-color, #e5e7eb)",
+  };
+
+  return (
+    <div style={containerStyle}>
+      <div style={headerStyle} onClick={() => setOpen(!open)}>
+        {statusCode && <span style={badgeStyle}>{statusCode}</span>}
+        <span style={{ fontSize: "13px", color: "var(--text-muted, #6b7280)" }}>
+          {open ? "Hide fields" : "Show fields"}
+        </span>
+        <svg
+          style={chevronStyle}
+          width="16"
+          height="16"
+          viewBox="0 0 16 16"
+          fill="none"
+        >
+          <path
+            d="M4 6l4 4 4-4"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </div>
+      {open && <div style={bodyStyle}>{children}</div>}
+    </div>
+  );
+};

--- a/main/snippets/ResponseSchema.jsx
+++ b/main/snippets/ResponseSchema.jsx
@@ -19,19 +19,19 @@ export const ResponseSchema = ({ statusCode, children }) => {
     fontWeight: 600,
     fontFamily: "monospace",
     backgroundColor: isSuccess
-      ? "var(--color-success-light, #dcfce7)"
+      ? "light-dark(#dcfce7, #14532d)"
       : isError
-        ? "var(--color-error-light, #fee2e2)"
-        : "var(--color-gray-light, #f3f4f6)",
+        ? "light-dark(#fee2e2, #450a0a)"
+        : "light-dark(#f3f4f6, #1f2937)",
     color: isSuccess
-      ? "var(--color-success, #166534)"
+      ? "light-dark(#166534, #86efac)"
       : isError
-        ? "var(--color-error, #991b1b)"
-        : "var(--color-gray, #374151)",
+        ? "light-dark(#991b1b, #fca5a5)"
+        : "light-dark(#374151, #d1d5db)",
   };
 
   const containerStyle = {
-    border: "1px solid var(--border-color, #e5e7eb)",
+    border: "1px solid light-dark(#e5e7eb, #374151)",
     borderRadius: "8px",
     marginBottom: "12px",
     overflow: "hidden",
@@ -45,7 +45,7 @@ export const ResponseSchema = ({ statusCode, children }) => {
     cursor: "pointer",
     userSelect: "none",
     backgroundColor: open
-      ? "var(--bg-subtle, #f9fafb)"
+      ? "light-dark(#f9fafb, #1f2937)"
       : "transparent",
   };
 
@@ -58,14 +58,14 @@ export const ResponseSchema = ({ statusCode, children }) => {
 
   const bodyStyle = {
     padding: "4px 16px 12px",
-    borderTop: "1px solid var(--border-color, #e5e7eb)",
+    borderTop: "1px solid light-dark(#e5e7eb, #374151)",
   };
 
   return (
     <div style={containerStyle}>
       <div style={headerStyle} onClick={() => setOpen(!open)}>
         {statusCode && <span style={badgeStyle}>{statusCode}</span>}
-        <span style={{ fontSize: "13px", color: "var(--text-muted, #6b7280)" }}>
+        <span style={{ fontSize: "13px", color: "light-dark(#6b7280, #9ca3af)" }}>
           {open ? "Hide fields" : "Show fields"}
         </span>
         <svg

--- a/main/snippets/ResponseSchema.jsx
+++ b/main/snippets/ResponseSchema.jsx
@@ -1,75 +1,29 @@
-export const ResponseSchema = ({ statusCode, children }) => {
+export const ResponseSchema = ({ statusCode, type = "{}", children }) => {
   const [open, setOpen] = useState(false);
 
-  const isSuccess =
-    statusCode &&
-    (statusCode.startsWith("2") || statusCode === "default success");
-  const isError =
-    statusCode &&
-    (statusCode.startsWith("4") ||
-      statusCode.startsWith("5") ||
-      statusCode === "default error");
-
-  const badgeStyle = {
-    display: "inline-flex",
-    alignItems: "center",
-    padding: "2px 8px",
-    borderRadius: "4px",
-    fontSize: "12px",
-    fontWeight: 600,
-    fontFamily: "monospace",
-    backgroundColor: isSuccess
-      ? "light-dark(#dcfce7, #14532d)"
-      : isError
-        ? "light-dark(#fee2e2, #450a0a)"
-        : "light-dark(#f3f4f6, #1f2937)",
-    color: isSuccess
-      ? "light-dark(#166534, #86efac)"
-      : isError
-        ? "light-dark(#991b1b, #fca5a5)"
-        : "light-dark(#374151, #d1d5db)",
-  };
-
-  const containerStyle = {
-    border: "1px solid light-dark(#e5e7eb, #374151)",
-    borderRadius: "8px",
-    marginBottom: "12px",
-    overflow: "hidden",
-  };
-
-  const headerStyle = {
-    display: "flex",
-    alignItems: "center",
-    gap: "10px",
-    padding: "10px 16px",
-    cursor: "pointer",
-    userSelect: "none",
-    backgroundColor: open
-      ? "light-dark(#f9fafb, #1f2937)"
-      : "transparent",
-  };
-
-  const chevronStyle = {
-    marginLeft: "auto",
-    transition: "transform 0.2s",
-    transform: open ? "rotate(180deg)" : "rotate(0deg)",
-    opacity: 0.5,
-  };
-
-  const bodyStyle = {
-    padding: "4px 16px 12px",
-    borderTop: "1px solid light-dark(#e5e7eb, #374151)",
-  };
-
   return (
-    <div style={containerStyle}>
-      <div style={headerStyle} onClick={() => setOpen(!open)}>
-        {statusCode && <span style={badgeStyle}>{statusCode}</span>}
-        <span style={{ fontSize: "13px", color: "light-dark(#6b7280, #9ca3af)" }}>
-          {open ? "Hide fields" : "Show fields"}
+    <div className="border border-gray-100 dark:border-gray-800 rounded-lg mb-3 overflow-hidden">
+      <div
+        className={`flex items-center gap-2.5 px-4 py-2.5 cursor-pointer select-none ${
+          open ? "bg-gray-50 dark:bg-gray-800" : ""
+        }`}
+        onClick={() => setOpen(!open)}
+      >
+        {statusCode && (
+          <span className="border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 font-mono text-xs px-1.5 py-0.5 rounded">
+            {statusCode.startsWith("default") ? "default" : statusCode}
+          </span>
+        )}
+        <span className="text-gray-500 dark:text-gray-400 text-sm font-mono">
+          {type}
+        </span>
+        <span className="text-gray-400 dark:text-gray-500 text-sm italic">
+          application/json
         </span>
         <svg
-          style={chevronStyle}
+          className={`ml-auto opacity-50 transition-transform duration-200 ${
+            open ? "rotate-180" : ""
+          }`}
           width="16"
           height="16"
           viewBox="0 0 16 16"
@@ -84,7 +38,11 @@ export const ResponseSchema = ({ statusCode, children }) => {
           />
         </svg>
       </div>
-      {open && <div style={bodyStyle}>{children}</div>}
+      {open && (
+        <div className="px-4 pt-1 pb-3 border-t border-gray-100 dark:border-gray-800">
+          {children}
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

- Updates section headings to reflect v1 version. 
- Adds response schemas where available with new collapsible component to attempt to match existing docs 

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->
Left: TUS - v1
Right: Prod - v2 with current mismatched state
<img width="1678" height="1053" alt="Screenshot 2026-06-04 at 4 06 08 PM" src="https://github.com/user-attachments/assets/83dda7d0-15f0-449b-bbc8-46ac9ca24e44" />


Left: TUS - v1
Right: Localhost - v2 with new Headers and ResponseSchemas added

<img width="1669" height="964" alt="Screenshot 2026-06-05 at 11 41 34 AM" src="https://github.com/user-attachments/assets/3e119bcf-636b-4d15-ad4c-70b05b596f5f" />



Left: TUS - v1 - Change Password
Right: Localhost - v2 - Change Password ("string" response)
<img width="1669" height="963" alt="Screenshot 2026-06-05 at 10 33 43 AM" src="https://github.com/user-attachments/assets/5f9cf8ca-dcad-4274-9419-a5d5f3728edb" />

Left: TUS - v1 - Authorization With PKCE - Dark Mode
Right: Localhost - v2 - Authorization With PKCE - Dark Mode
<img width="1678" height="967" alt="Screenshot 2026-06-05 at 10 34 51 AM" src="https://github.com/user-attachments/assets/30d9241f-1cd2-4895-96ff-8a2b0d35cc7d" />


### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

Local testing with `mint dev`

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
