### PR TITLE
chore: improve SDK data handling and version updating

### DIFF
--- a/.github/workflows/update-sdk-versions.yml
+++ b/.github/workflows/update-sdk-versions.yml
@@ -2,7 +2,7 @@ name: Update SDK library versions
 
 on:
   schedule:
-    - cron: '17 6 * * *' # Daily at 6:17 UTC
+    - cron: '0 13 * * 1-5' # Mon-Fri at 1pm UTC (9am ET)
   workflow_dispatch:
 
 jobs:
@@ -19,132 +19,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          FILE="main/docs/libraries.mdx"
+          # The first line of the file is a JS variable declaration. The last
+          # line is a semicolon. Everything between is valid JSON.
+          FILE="main/snippets/sdks/versions.mdx"
 
-          # Fetches releases/latest for a repo and updates badge + date for a subtext.
-          # Falls back to tags if no formal releases exist.
-          update_sdk() {
-            local subtext="$1"
-            local repo="$2"
-            local release tag pub_date fmt_date
+          # Remove first and last lines and generate updated JSON:
+          sed '1d;$d' $FILE | python3 scripts/fetch-sdk-versions.py > output.json
 
-            release=$(gh api "repos/${repo}/releases/latest" 2>/dev/null || true)
-            tag=$(echo "$release" | jq -r '.tag_name // empty' 2>/dev/null || true)
-
-            if [ -n "$tag" ]; then
-              pub_date=$(echo "$release" | jq -r '.published_at // empty')
-            else
-              local tags sha
-              tags=$(gh api "repos/${repo}/tags" 2>/dev/null || true)
-              tag=$(echo "$tags" | jq -r '.[0].name // empty' 2>/dev/null || true)
-              sha=$(echo "$tags" | jq -r '.[0].commit.sha // empty' 2>/dev/null || true)
-              if [ -z "$tag" ]; then
-                echo "  No release or tag found for ${repo} — skipping"
-                return
-              fi
-              pub_date=$(gh api "repos/${repo}/commits/${sha}" 2>/dev/null | jq -r '.commit.committer.date // empty' || true)
-              pub_date="${pub_date:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
-            fi
-
-            if [ -z "$pub_date" ]; then
-              echo "  No date found for ${repo} — skipping"
-              return
-            fi
-
-            fmt_date=$(date -d "$pub_date" '+%b %-d, %Y')
-            echo "  ${subtext}: ${tag}  (${fmt_date})"
-
-            sed -i "/subtext: \"${subtext}\"/,/}}\/>/{
-              s|badge: \"[^\"]*\"|badge: \"${tag}\"|
-              s|date: \"[^\"]*\"|date: \"${fmt_date}\"|
-            }" "$FILE"
-          }
-
-          # Fetches releases filtered by a tag prefix (for monorepos).
-          # strip_prefix="true" removes the prefix from the displayed badge value.
-          update_sdk_prefixed() {
-            local subtext="$1"
-            local repo="$2"
-            local prefix="$3"
-            local strip_prefix="${4:-false}"
-            local releases tag pub_date display_tag fmt_date
-
-            releases=$(gh api "repos/${repo}/releases?per_page=20" 2>/dev/null || true)
-            tag=$(echo "$releases" | jq -r --arg p "$prefix" \
-              '[.[] | select(.tag_name | startswith($p))][0].tag_name // empty' 2>/dev/null || true)
-            pub_date=$(echo "$releases" | jq -r --arg p "$prefix" \
-              '[.[] | select(.tag_name | startswith($p))][0].published_at // empty' 2>/dev/null || true)
-
-            if [ -z "$tag" ]; then
-              echo "  No release with prefix '${prefix}' for ${repo} — skipping"
-              return
-            fi
-
-            display_tag="$tag"
-            if [ "$strip_prefix" = "true" ]; then
-              display_tag="${tag#${prefix}}"
-            fi
-
-            if [ -z "$pub_date" ]; then
-              echo "  No date found for ${repo} — skipping"
-              return
-            fi
-
-            fmt_date=$(date -d "$pub_date" '+%b %-d, %Y')
-            echo "  ${subtext}: ${display_tag}  (${fmt_date})"
-
-            sed -i "/subtext: \"${subtext}\"/,/}}\/>/{
-              s|badge: \"[^\"]*\"|badge: \"${display_tag}\"|
-              s|date: \"[^\"]*\"|date: \"${fmt_date}\"|
-            }" "$FILE"
-          }
-
-          # --- SPA SDKs ---
-          update_sdk          "auth0-react"   "auth0/auth0-react"
-          update_sdk          "auth0-vue"     "auth0/auth0-vue"
-          update_sdk          "auth0-angular" "auth0/auth0-angular"
-          update_sdk          "auth0-spa-js"  "auth0/auth0-spa-js"
-          update_sdk_prefixed "auth0-flutter" "auth0/auth0-flutter" "af-v" "false"
-
-          # --- Regular Web App SDKs ---
-          update_sdk          "nextjs-auth0"                    "auth0/nextjs-auth0"
-          update_sdk          "express-openid-connect"          "auth0/express-openid-connect"
-          update_sdk_prefixed "auth0-fastify"                   "auth0/auth0-fastify" "auth0-fastify-v" "true"
-          update_sdk_prefixed "auth0-nuxt"                      "auth0/auth0-nuxt" "auth0-nuxt-v" "true"
-          update_sdk          "auth0-aspnetcore-authentication" "auth0/auth0-aspnetcore-authentication"
-          update_sdk          "laravel-auth0"                   "auth0/laravel-auth0"
-          update_sdk          "okta-spring-boot"                "auth0/auth0-auth-java"
-          update_sdk          "auth0-python"                    "auth0/auth0-python"
-          update_sdk          "auth0-php"                       "auth0/auth0-php"
-          update_sdk          "omniauth-auth0"                  "auth0/omniauth-auth0"
-          update_sdk          "auth0-java-mvc-common"           "auth0/auth0-java-mvc-common"
-          update_sdk          "auth0-hono"                      "auth0-lab/auth0-hono"
-
-          # --- Backend / API SDKs ---
-          update_sdk          "node-oauth2-jwt-bearer" "auth0/node-oauth2-jwt-bearer"
-          update_sdk_prefixed "auth0-fastify-api"      "auth0/auth0-fastify" "auth0-fastify-api-v" "true"
-          update_sdk          "go-jwt-middleware"      "auth0/go-jwt-middleware"
-          update_sdk          "auth0-PHP"              "auth0/auth0-php"
-
-          # --- Native / Mobile SDKs ---
-          update_sdk          "react-native-auth0"    "auth0/react-native-auth0"
-          update_sdk          "Auth0.swift"           "auth0/Auth0.swift"
-          update_sdk          "Auth0.Android"         "auth0/Auth0.Android"
-          update_sdk_prefixed "auth0-oidc-client-net" "auth0/auth0-oidc-client-net" "ios-" "false"
-
-          # --- Management API SDKs ---
-          update_sdk "auth0.net"  "auth0/auth0.net"
-          update_sdk "go-auth0"   "auth0/go-auth0"
-          update_sdk "auth0-java" "auth0/auth0-java"
-          update_sdk "node-auth0" "auth0/node-auth0"
-          update_sdk "ruby-auth0" "auth0/ruby-auth0"
-
-          # --- Lock SDKs ---
-          update_sdk "Lock.Android" "auth0/Lock.Android"
-          update_sdk "Lock.swift"   "auth0/Lock.swift"
-          update_sdk "lock"         "auth0/lock"
-
-          echo "--- Done ---"
+          # Add first/last line back and save to original file:
+          sed '1s;^;export const sdkCardInfo =\n;' output.json | sed '$s;$;\n\;;' > $FILE
+          rm output.json
 
       - name: Open or update PR
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0

--- a/main/docs/libraries.mdx
+++ b/main/docs/libraries.mdx
@@ -36,7 +36,7 @@ Have a traditional web application that runs on a server? Auth0 maintains these 
   <SectionCard item={sdkCardInfo["Go"]} />
   <SectionCard item={sdkCardInfo["PHP"]} />
   <SectionCard item={sdkCardInfo["Ruby on Rails"]} />
-  <SectionCard item={sdkCardInfo["Java"]} />
+  <SectionCard item={sdkCardInfo["Java MVC"]} />
   <SectionCard item={sdkCardInfo["Java EE"]} />
   <SectionCard item={sdkCardInfo["Hono"]} />
 </Columns>

--- a/main/docs/libraries.mdx
+++ b/main/docs/libraries.mdx
@@ -2,6 +2,7 @@
 title: SDK Libraries
 description: Auth0 Libraries and SDKs overview
 ---
+import {sdkCardInfo} from "/snippets/sdks/versions.mdx";
 import {SectionCard} from "/snippets/SectionsWithCards.jsx";
 
 Auth0 SDK libraries make it easy for developers to integrate and interact with Auth0. Explore any library on GitHub, download a sample application, or use a quickstart for customized help.
@@ -11,82 +12,11 @@ Auth0 SDK libraries make it easy for developers to integrate and interact with A
 Need to protect a JavaScript application that runs entirely in a browser? Choose your technology below.
 
 <Columns cols={2}>
-  <SectionCard item={{
-    name: "React",
-    subtext: "auth0-react",
-    logo: "react.svg",
-    date: "May 22, 2026",
-    badge: "v2.17.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-react" },
-      {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-react-samples/tree/master/Sample-01",
-      },
-      { label: "Quickstart", url: "/docs/quickstart/spa/react/interactive" },
-    ],
-  }}/>
-  <SectionCard item={{
-    name: "Vue",
-    subtext: "auth0-vue",
-    logo: "vuejs.svg",
-    date: "May 8, 2026",
-    badge: "v2.7.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-vue" },
-      {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-vue-samples/tree/master/01-Login",
-      },
-      { label: "Quickstart", url: "/docs/quickstart/spa/vuejs/interactive" },
-    ],
-  }}/>
-  <SectionCard item={{
-    name: "Angular",
-    subtext: "auth0-angular",
-    logo: "angular.svg",
-    date: "Apr 28, 2026",
-    badge: "v2.9.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-angular" },
-      {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-angular-samples/tree/main/Standalone",
-      },
-      { label: "Quickstart", url: "/docs/quickstart/spa/angular/interactive" },
-    ],
-  }}/>
-  <SectionCard item={{
-    name: "JavaScript",
-    subtext: "auth0-spa-js",
-    logo: "javascript.svg",
-    date: "Jun 1, 2026",
-    badge: "v2.21.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-spa-js" },
-      {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-javascript-samples/tree/master/01-Login",
-      },
-      { label: "Quickstart", url: "/docs/quickstart/spa/vanillajs/interactive" },
-    ],
-  }}/>
-  <SectionCard item={{
-    name: "Flutter (Web)",
-    subtext: "auth0-flutter",
-    logo: "flutter.svg",
-    date: "May 21, 2026",
-    badge: "af-v2.1.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-flutter" },
-      {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-flutter-samples/tree/main/sample",
-      },
-      { label: "Quickstart", url: "/docs/quickstart/spa/flutter/interactive" },
-    ],
-  }}/>
-
+  <SectionCard item={sdkCardInfo["React"]} />
+  <SectionCard item={sdkCardInfo["Vue"]} />
+  <SectionCard item={sdkCardInfo["Angular"]} />
+  <SectionCard item={sdkCardInfo["JavaScript"]} />
+  <SectionCard item={sdkCardInfo["Flutter (Web)"]} />
 </Columns>
 
 ## Regular Web Application SDK Libraries
@@ -94,246 +24,21 @@ Need to protect a JavaScript application that runs entirely in a browser? Choose
 Have a traditional web application that runs on a server? Auth0 maintains these SDK libraries for the most popular languages and environments.
 
 <Columns cols={2}>
-  <SectionCard item={{
-    name: "Next.js",
-    subtext: "nextjs-auth0",
-    logo: "nextjs.svg",
-    date: "Jun 1, 2026",
-    badge: "v4.22.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/nextjs-auth0/" },
-      {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-nextjs-samples/tree/main/Sample-01",
-      },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/nextjs/interactive" },
-    ],
-  }}/>
-
-  <SectionCard item={{
-    name: "Express",
-    subtext: "express-openid-connect",
-    logo: "nodejs.svg",
-    date: "May 15, 2026",
-    badge: "v3.0.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/express-openid-connect" },
-      {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-express-webapp-sample/tree/master/01-Login",
-      },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/express/interactive" },
-    ],
-  }}/>
-
-  <SectionCard item={{
-    name: "Fastify",
-    subtext: "auth0-fastify",
-    logo: "nodejs.svg",
-    date: "Apr 9, 2026",
-    badge: "1.3.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-fastify" },
-      {
-        label: "Sample App",
-        url: "https://github.com/auth0/auth0-fastify/tree/main/examples",
-      },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/fastify" },
-    ],
-  }}/>
-
-  <SectionCard item={{
-    name: "Nuxt",
-    subtext: "auth0-nuxt",
-    logo: "nuxt.svg",
-    date: "Apr 13, 2026",
-    badge: "1.1.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-nuxt" },
-      {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-nuxt-samples",
-      },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/nuxt" },
-    ],
-  }}/>
-
-  <SectionCard item={{
-    name: "ASP.NET Core MVC",
-    subtext: "auth0-aspnetcore-authentication",
-    logo: "dotnet-platform.svg",
-    date: "Apr 9, 2026",
-    badge: "1.7.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-aspnetcore-authentication" },
-      {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-aspnetcore-mvc-samples/tree/master/Quickstart/Sample",
-      },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/aspnet-core/interactive" },
-    ],
-  }}/>
-
-  <SectionCard item={{
-    name: "ASP.NET Core Blazor",
-    subtext: "auth0-aspnetcore-authentication",
-    logo: "dotnet.svg",
-    date: "Apr 9, 2026",
-    badge: "1.7.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-aspnetcore-authentication" },
-      {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-aspnetcore-blazor-server-samples/tree/main/Quickstart/Sample",
-      },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/aspnet-core-blazor-server/interactive" },
-    ],
-  }}/>
-
-  <SectionCard item={{
-    name: "Laravel",
-    subtext: "laravel-auth0",
-    logo: "laravel.svg",
-    date: "Apr 8, 2026",
-    badge: "7.22.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/laravel-auth0" },
-      {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/laravel/tree/7.x/sample",
-      },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/laravel/interactive" },
-    ],
-  }}/>
-
-  <SectionCard item={{
-    name: "Java Spring Boot",
-    subtext: "okta-spring-boot",
-    logo: "spring.svg",
-    date: "Apr 9, 2026",
-    badge: "1.0.0-beta.1",
-    links: [
-      { label: "Github", url: "https://github.com/okta/okta-spring-boot/" },
-      {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-spring-boot-login-samples/tree/master/mvc-login",
-      },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/java-spring-boot/interactive" },
-    ],
-  }}/>
-
-  <SectionCard item={{
-    name: "Python",
-    subtext: "auth0-python",
-    logo: "python.svg",
-    date: "May 28, 2026",
-    badge: "5.6.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-python" },
-      {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-python-web-app/tree/master/01-Login",
-      },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/python/interactive" },
-    ],
-  }}/>
-
-  <SectionCard item={{
-    name: "Go",
-    subtext: "go-auth0",
-    logo: "golang.svg",
-    date: "May 28, 2026",
-    badge: "v2.12.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/go-auth0" },
-      {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-golang-web-app/tree/master/01-Login-Quickstart",
-      },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/golang" },
-    ],
-  }}/>
-
-  <SectionCard item={{
-    name: "PHP",
-    subtext: "auth0-php",
-    logo: "php.svg",
-    date: "Apr 1, 2026",
-    badge: "8.19.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-php" },
-      {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-php-web-app/tree/main/app",
-      },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/php/interactive" },
-    ],
-  }}/>
-
-  <SectionCard item={{
-    name: "Ruby on Rails",
-    subtext: "omniauth-auth0",
-    logo: "rails.svg",
-    date: "May 28, 2026",
-    badge: "v3.2.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/omniauth-auth0" },
-      {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-rubyonrails-sample/tree/master/sample",
-      },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/rails/interactive" },
-    ],
-  }}/>
-
-  <SectionCard item={{
-    name: "Java",
-    subtext: "auth0-java-mvc-common",
-    logo: "java.svg",
-    date: "Apr 9, 2026",
-    badge: "1.12.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-java-mvc-common" },
-      {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-servlet-sample/tree/master/01-Login",
-      },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/java/interactive" },
-    ],
-  }}/>
-
-  <SectionCard item={{
-    name: "Java EE",
-    subtext: "auth0-java-mvc-common",
-    logo: "java.svg",
-    date: "Apr 9, 2026",
-    badge: "1.12.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-java-mvc-common" },
-      {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-java-ee-sample/tree/master/01-Login",
-      },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/java-ee/interactive" },
-    ],
-  }}/>
-
-  <SectionCard item={{
-    name: "Hono",
-    subtext: "auth0-hono",
-    logo: "hono.svg",
-    date: "Dec 4, 2025",
-    badge: "v1.2.6",
-    links: [
-      { label: "Github", url: "https://github.com/auth0-lab/auth0-hono" },
-      {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-hono-sample/tree/master/01-Login",
-      },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/hono" },
-    ],
-  }}/>
-
+  <SectionCard item={sdkCardInfo["Next.js"]} />
+  <SectionCard item={sdkCardInfo["Express"]} />
+  <SectionCard item={sdkCardInfo["Fastify"]} />
+  <SectionCard item={sdkCardInfo["Nuxt"]} />
+  <SectionCard item={sdkCardInfo["ASP.NET Core MVC"]} />
+  <SectionCard item={sdkCardInfo["ASP.NET Core Blazor"]} />
+  <SectionCard item={sdkCardInfo["Laravel"]} />
+  <SectionCard item={sdkCardInfo["Java Spring Boot"]} />
+  <SectionCard item={sdkCardInfo["Python"]} />
+  <SectionCard item={sdkCardInfo["Go"]} />
+  <SectionCard item={sdkCardInfo["PHP"]} />
+  <SectionCard item={sdkCardInfo["Ruby on Rails"]} />
+  <SectionCard item={sdkCardInfo["Java"]} />
+  <SectionCard item={sdkCardInfo["Java EE"]} />
+  <SectionCard item={sdkCardInfo["Hono"]} />
 </Columns>
 
 ## Backend Service and API SDK Libraries
@@ -341,149 +46,15 @@ Have a traditional web application that runs on a server? Auth0 maintains these 
 Does your API or service need authentication? Auth0 has SDKs for common API and service development tools.
 
 <Columns cols={2}>
-<SectionCard item={{
-  name: "Node (Express) API",
-  subtext: "node-oauth2-jwt-bearer",
-  logo: "nodejs.svg",
-  date: "May 20, 2026",
-  badge: "v1.9.0",
-  links: [
-    {
-      label: "Github",
-      url: "https://github.com/auth0/node-oauth2-jwt-bearer/tree/main/packages/express-oauth2-jwt-bearer",
-    },
-    {
-      label: "Sample App",
-      url: "https://github.com/auth0-samples/auth0-express-api-samples/tree/master/01-Authorization-RS256",
-    },
-    { label: "Quickstart", url: "/docs/quickstart/backend/nodejs/interactive" },
-  ],
-}}/>
-
-<SectionCard item={{
-  name: "Fastify API",
-  subtext: "auth0-fastify-api",
-  logo: "nodejs.svg",
-  date: "May 18, 2026",
-  badge: "1.3.0",
-  links: [
-    { label: "Github", url: "https://github.com/auth0/auth0-fastify" },
-    {
-      label: "Sample App",
-      url: "https://github.com/auth0/auth0-fastify/tree/main/examples/example-fastify-api",
-    },
-    { label: "Quickstart", url: "/docs/quickstart/backend/fastify" },
-  ],
-}}/>
-
-<SectionCard item={{
-  name: "Spring Boot API",
-  subtext: "auth0-springboot-api",
-  logo: "spring.svg",
-  date: "May 12, 2026",
-  badge: "1.0.0-beta.1",
-  links: [
-    { label: "Github", url: "https://github.com/auth0/auth0-auth-java" },
-    {
-      label: "Sample App",
-      url: "https://github.com/auth0-samples/auth0-spring-security5-api-sample/tree/master/01-Authorization-MVC",
-    },
-    { label: "Quickstart", url: "/docs/quickstart/backend/java-spring-security5/interactive" },
-  ],
-}}/>
-
-<SectionCard item={{
-  name: "Go API",
-  subtext: "go-jwt-middleware",
-  logo: "golang.svg",
-  date: "May 15, 2026",
-  badge: "v3.2.0",
-  links: [
-    { label: "Github", url: "https://github.com/auth0/go-jwt-middleware" },
-    {
-      label: "Sample App",
-      url: "https://github.com/auth0-samples/auth0-golang-api-samples/tree/master/01-Quickstart-Go-API",
-    },
-    { label: "Quickstart", url: "/docs/quickstart/backend/golang" },
-  ],
-}}/>
-
-<SectionCard item={{
-  name: "ASP.NET Core Web API",
-  subtext: "aspnetcore-api",
-  logo: "dotnet-platform.svg",
-  date: "Dec 18, 2025",
-  badge: "v1.0.0",
-  links: [
-    { label: "Github", url: "https://github.com/auth0/aspnetcore-api" },
-    {
-      label: "Sample App",
-      url: "https://github.com/auth0-samples/auth0-aspnetcore-webapi-samples/tree/master",
-    },
-    { label: "Quickstart", url: "/docs/quickstart/backend/aspnet-core-webapi" },
-  ],
-}}/>
-
-<SectionCard item={{
-  name: "Laravel API",
-  subtext: "laravel-auth0",
-  logo: "laravel.svg",
-  date: "Apr 8, 2026",
-  badge: "7.22.0",
-  links: [
-    { label: "Github", url: "https://github.com/auth0/laravel-auth0" },
-    { label: "Sample App", url: "https://github.com/auth0-samples/laravel/tree/7.x/sample" },
-    { label: "Quickstart", url: "/docs/quickstart/backend/laravel/interactive" },
-  ],
-}}/>
-
-<SectionCard item={{
-  name: "Python API",
-  subtext: "auth0-python",
-  logo: "python.svg",
-  date: "May 28, 2026",
-  badge: "5.6.0",
-  links: [
-    { label: "Github", url: "https://github.com/auth0/auth0-python" },
-    {
-      label: "Sample App",
-      url: "https://github.com/auth0-samples/auth0-python-api-samples/tree/master/00-Starter-Seed",
-    },
-    { label: "Quickstart", url: "/docs/quickstart/backend/python/interactive" },
-  ],
-}}/>
-
-<SectionCard item={{
-  name: "PHP API",
-  subtext: "auth0-PHP",
-  logo: "php.svg",
-  date: "Apr 1, 2026",
-  badge: "8.19.0",
-  links: [
-    { label: "Github", url: "https://github.com/auth0/auth0-php" },
-    {
-      label: "Sample App",
-      url: "https://github.com/auth0-samples/auth0-php-api-samples/tree/main/app",
-    },
-    { label: "Quickstart", url: "/docs/quickstart/backend/php/interactive" },
-  ],
-}}/>
-
-<SectionCard item={{
-  name: "Ruby On Rails API",
-  subtext: "omniauth-auth0",
-  logo: "rails.svg",
-  date: "May 28, 2026",
-  badge: "v3.2.0",
-  links: [
-    { label: "Github", url: "https://github.com/auth0/omniauth-auth0" },
-    {
-      label: "Sample App",
-      url: "https://github.com/auth0-samples/auth0-rubyonrails-api-samples/tree/master/01-Authentication-RS256",
-    },
-    { label: "Quickstart", url: "/docs/quickstart/backend/rails/interactive" },
-  ],
-}}/>
+  <SectionCard item={sdkCardInfo["Node (Express) API"]} />
+  <SectionCard item={sdkCardInfo["Fastify API"]} />
+  <SectionCard item={sdkCardInfo["Spring Boot API"]} />
+  <SectionCard item={sdkCardInfo["Go API"]} />
+  <SectionCard item={sdkCardInfo["ASP.NET Core Web API"]} />
+  <SectionCard item={sdkCardInfo["Laravel API"]} />
+  <SectionCard item={sdkCardInfo["Python API"]} />
+  <SectionCard item={sdkCardInfo["PHP API"]} />
+  <SectionCard item={sdkCardInfo["Ruby On Rails API"]} />
 </Columns>
 
 ## Native/Mobile App
@@ -491,133 +62,14 @@ Does your API or service need authentication? Auth0 has SDKs for common API and 
 Mobile or Desktop app that runs natively on a device
 
 <Columns cols={2}>
-<SectionCard item={{
-  name: "React Native",
-  subtext: "react-native-auth0",
-  logo: "react.svg",
-  date: "Jun 1, 2026",
-  badge: "v5.7.0",
-  links: [
-    { label: "Github", url: "https://github.com/auth0/react-native-auth0" },
-    {
-      label: "Sample App",
-      url: "https://github.com/auth0-samples/auth0-react-native-sample/tree/master/00-Login-Hooks",
-    },
-    { label: "Quickstart", url: "/docs/quickstart/native/react-native/interactive" },
-  ],
-}}/>
-
-<SectionCard item={{
-  name: "Flutter",
-  subtext: "auth0-flutter",
-  logo: "flutter.svg",
-  date: "May 21, 2026",
-  badge: "af-v2.1.0",
-  links: [
-    { label: "Github", url: "https://www.github.com/auth0/auth0-flutter/" },
-    {
-      label: "Sample App",
-      url: "https://github.com/auth0-samples/auth0-flutter-samples/tree/main/sample",
-    },
-    { label: "Quickstart", url: "/docs/quickstart/native/flutter/interactive" },
-  ],
-}}/>
-
-<SectionCard item={{
-  name: "iOS / macOS",
-  subtext: "Auth0.swift",
-  logo: "apple.svg",
-  date: "May 28, 2026",
-  badge: "2.21.1",
-  links: [
-    { label: "Github", url: "https://github.com/auth0/Auth0.swift" },
-    {
-      label: "Sample App",
-      url: "https://github.com/auth0-samples/auth0-ios-swift-sample/tree/master/Sample-01",
-    },
-    { label: "Quickstart", url: "/docs/quickstart/native/ios-swift/interactive" },
-  ],
-}}/>
-
-<SectionCard item={{
-  name: "Android",
-  subtext: "Auth0.Android",
-  logo: "android.svg",
-  date: "May 26, 2026",
-  badge: "3.18.0",
-  links: [
-    { label: "Github", url: "https://github.com/auth0/Auth0.Android" },
-    {
-      label: "Sample App",
-      url: "https://github.com/auth0-samples/auth0-android-sample/tree/master/00-Login-Kt",
-    },
-    { label: "Quickstart", url: "/docs/quickstart/native/android/interactive" },
-  ],
-}}/>
-
-<SectionCard item={{
-  name: "Expo",
-  subtext: "react-native-auth0",
-  logo: "expo.svg",
-  date: "Jun 1, 2026",
-  badge: "v5.7.0",
-  links: [
-    { label: "Github", url: "https://github.com/auth0/react-native-auth0" },
-    {
-      label: "Sample App",
-      url: "https://github.com/auth0-samples/auth0-react-native-sample/tree/master/00-Login-Expo",
-    },
-    { label: "Quickstart", url: "/docs/quickstart/native/react-native-expo/interactive" },
-  ],
-}}/>
-
-<SectionCard item={{
-  name: ".NET (OIDC Client)",
-  subtext: "auth0-oidc-client-net",
-  logo: "dotnet-platform.svg",
-  date: "Jul 22, 2025",
-  badge: "ios-4.4.0",
-  links: [
-    { label: "Github", url: "https://github.com/auth0/auth0-oidc-client-net" },
-    {
-      label: "Sample App",
-      url: "https://github.com/auth0-samples/auth0-xamarin-oidc-samples/tree/master/Quickstart/01-Login",
-    },
-    { label: "Quickstart", url: "/docs/quickstart/native/net-android-ios/interactive" },
-  ],
-}}/>
-
-<SectionCard item={{
-  name: "MAUI",
-  subtext: "auth0-oidc-client-net",
-  logo: "dotnet.svg",
-  date: "Jul 22, 2025",
-  badge: "ios-4.4.0",
-  links: [
-    { label: "Github", url: "https://github.com/auth0/auth0-oidc-client-net" },
-    {
-      label: "Sample App",
-      url: "https://github.com/auth0-samples/auth0-maui-samples/tree/master/Sample",
-    },
-    { label: "Quickstart", url: "/docs/quickstart/native/maui/interactive" },
-  ],
-}}/>
-
-<SectionCard item={{
-  name: "Xamarin",
-  subtext: "auth0-oidc-client-net",
-  logo: "xamarin.svg",
-  date: "Jul 22, 2025",
-  badge: "ios-4.4.0",
-  links: [
-    { label: "Github", url: "https://github.com/auth0/auth0-oidc-client-net" },
-    {
-      label: "Sample App",
-      url: "https://github.com/auth0-samples/auth0-xamarin-oidc-samples/tree/master/Quickstart/01-Login",
-    },
-    { label: "Quickstart", url: "/docs/quickstart/native/xamarin/interactive" },
-  ],
-}}/>
+  <SectionCard item={sdkCardInfo["React Native"]} />
+  <SectionCard item={sdkCardInfo["Flutter"]} />
+  <SectionCard item={sdkCardInfo["iOS / macOS"]} />
+  <SectionCard item={sdkCardInfo["Android"]} />
+  <SectionCard item={sdkCardInfo["Expo"]} />
+  <SectionCard item={sdkCardInfo[".NET (OIDC Client)"]} />
+  <SectionCard item={sdkCardInfo["MAUI"]} />
+  <SectionCard item={sdkCardInfo["Xamarin"]} />
 </Columns>
 
 ## Advanced Customization for Universal Login (ACUL)
@@ -625,166 +77,32 @@ Mobile or Desktop app that runs natively on a device
 Extend the capabilities of [Universal Login](/docs/authenticate/login/auth0-universal-login/universal-login-vs-classic-login/universal-experience#universal-login-experience) to support multi-branding, complex security configurations, and integration of numerous analytic platforms.
 
 <Columns cols={2}>
-
-  <SectionCard item={{
-    name: "JS SDK",
-    subtext: "universal-login",
-    logo: "auth0.svg",
-    date: "on December 12,2025",
-    badge: "v1.1.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/universal-login/blob/master/packages/auth0-acul-js/README.md" },
-      { label: "Sample App", url: "https://github.com/auth0-samples/auth0-acul-samples" },
-      { label: "Get started", url: "/docs/libraries/acul/js-sdk" }
-    ],
-  }}/>
-  <SectionCard item={{
-    name: "React SDK",
-    subtext: "universal-login",
-    logo: "auth0.svg",
-    date: "on December 12,2025",
-    badge: "v1.1.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/universal-login/blob/master/packages/auth0-acul-react/README.md" },
-      { label: "Sample App", url: "https://github.com/auth0-samples/auth0-acul-samples" },
-      { label: "Get started", url: "/docs/libraries/acul/react-sdk" }
-    ],
-  }}/>
+  <SectionCard item={sdkCardInfo["JS SDK"]} />
+  <SectionCard item={sdkCardInfo["React SDK"]} />
 </Columns>
 
 ## Management API SDK Libraries
 
 Need to programmatically perform Auth0 administrative tasks? Choose from one of these management libraries.
-<Columns cols={2}>
-  <SectionCard item={{
-    name: ".NET",
-    subtext: "auth0.net",
-    logo: "dotnet-platform.svg",
-    date: "May 28, 2026",
-    badge: "mgmt-8.4.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0.net" }
-    ],
-  }}/>
-  <SectionCard item={{
-    name: "Go",
-    subtext: "go-auth0",
-    logo: "golang.svg",
-    date: "May 28, 2026",
-    badge: "v2.12.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/go-auth0" }
-    ],
-  }}/>
-  <SectionCard item={{
-    name: "Go JWT Middleware",
-    subtext: "go-jwt-middleware",
-    logo: "golang.svg",
-    date: "May 15, 2026",
-    badge: "v3.2.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/go-jwt-middleware" }
-    ],
-  }}/>
-  <SectionCard item={{
-    name: "Java",
-    subtext: "auth0-java",
-    logo: "java.svg",
-    date: "May 28, 2026",
-    badge: "3.7.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-java" }
-    ],
-  }}/>
-  <SectionCard item={{
-    name: "Node",
-    subtext: "node-auth0",
-    logo: "nodejs.svg",
-    date: "May 28, 2026",
-    badge: "v5.11.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/node-auth0" }
-    ],
-  }}/>
-  <SectionCard item={{
-    name: "Node JWT Bearer",
-    subtext: "node-oauth2-jwt-bearer",
-    logo: "nodejs.svg",
-    date: "May 20, 2026",
-    badge: "v1.9.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/node-oauth2-jwt-bearer" }
-    ],
-  }}/>
-  <SectionCard item={{
-    name: "PHP",
-    subtext: "auth0-php",
-    logo: "php.svg",
-    date: "Apr 1, 2026",
-    badge: "8.19.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-php" }
-    ],
-  }}/>
-  <SectionCard item={{
-    name: "Python",
-    subtext: "auth0-python",
-    logo: "python.svg",
-    date: "May 28, 2026",
-    badge: "5.6.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-python" }
-    ],
-  }}/>
-  <SectionCard item={{
-    name: "Ruby",
-    subtext: "ruby-auth0",
-    logo: "ruby.svg",
-    date: "May 29, 2026",
-    badge: "v5.20.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/ruby-auth0" }
-    ],
-  }}/>
-</Columns>
 
+<Columns cols={2}>
+  <SectionCard item={sdkCardInfo[".NET"]} />
+  <SectionCard item={sdkCardInfo["Go"]} />
+  <SectionCard item={sdkCardInfo["Go JWT Middleware"]} />
+  <SectionCard item={sdkCardInfo["Java"]} />
+  <SectionCard item={sdkCardInfo["Node"]} />
+  <SectionCard item={sdkCardInfo["Node JWT Bearer"]} />
+  <SectionCard item={sdkCardInfo["PHP"]} />
+  <SectionCard item={sdkCardInfo["Python"]} />
+  <SectionCard item={sdkCardInfo["Ruby"]} />
+</Columns>
 
 ## Lock SDK Libraries
 
 Do you use Lock, Auth0's legacy self-hosted login experience? You can still rely on these libraries for self-hosted login.
+
 <Columns cols={2}>
-  
-  <SectionCard item={{
-    name: "Lock for Android",
-    subtext: "Lock.Android",
-    logo: "android.svg",
-    date: "Jan 11, 2023",
-    badge: "3.2.2",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/Lock.Android" },
-      { label: "Get started", url: "/docs/libraries/lock-android" }
-    ],
-  }}/>
-  <SectionCard item={{
-    name: "Lock for iOS",
-    subtext: "Lock.swift",
-    logo: "apple.svg",
-    date: "Nov 30, 2021",
-    badge: "2.24.1",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/Lock.swift" },
-      { label: "Get started", url: "/docs/libraries/lock-ios" }
-    ],
-  }}/>
-  <SectionCard item={{
-    name: "Lock for Web",
-    subtext: "lock",
-    logo: "auth0.svg",
-    date: "Apr 6, 2026",
-    badge: "v14.3.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/lock" },
-      { label: "Get started", url: "/docs/libraries/lock" }
-    ],
-  }}/>
+  <SectionCard item={sdkCardInfo["Lock for Android"]} />
+  <SectionCard item={sdkCardInfo["Lock for iOS"]} />
+  <SectionCard item={sdkCardInfo["Lock for Web"]} />
 </Columns>

--- a/main/snippets/sdks/versions.mdx
+++ b/main/snippets/sdks/versions.mdx
@@ -1,704 +1,980 @@
-export const sdkCardInfo = {
+export const sdkCardInfo =
+{
   "React": {
-    name: "React",
-    subtext: "auth0-react",
-    logo: "react.svg",
-    date: "May 22, 2026",
-    badge: "v2.17.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-react" },
+    "name": "React",
+    "subtext": "auth0-react",
+    "logo": "react.svg",
+    "date": "May 22, 2026",
+    "badge": "v2.17.0",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-react-samples/tree/master/Sample-01",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/auth0-react"
       },
-      { label: "Quickstart", url: "/docs/quickstart/spa/react/interactive" },
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-react-samples/tree/master/Sample-01"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/spa/react/interactive"
+      }
     ]
   },
   "Vue": {
-    name: "Vue",
-    subtext: "auth0-vue",
-    logo: "vuejs.svg",
-    date: "May 8, 2026",
-    badge: "v2.7.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-vue" },
+    "name": "Vue",
+    "subtext": "auth0-vue",
+    "logo": "vuejs.svg",
+    "date": "May 8, 2026",
+    "badge": "v2.7.0",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-vue-samples/tree/master/01-Login",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/auth0-vue"
       },
-      { label: "Quickstart", url: "/docs/quickstart/spa/vuejs/interactive" },
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-vue-samples/tree/master/01-Login"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/spa/vuejs/interactive"
+      }
     ]
   },
   "Angular": {
-    name: "Angular",
-    subtext: "auth0-angular",
-    logo: "angular.svg",
-    date: "Apr 28, 2026",
-    badge: "v2.9.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-angular" },
+    "name": "Angular",
+    "subtext": "auth0-angular",
+    "logo": "angular.svg",
+    "date": "Apr 28, 2026",
+    "badge": "v2.9.0",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-angular-samples/tree/main/Standalone",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/auth0-angular"
       },
-      { label: "Quickstart", url: "/docs/quickstart/spa/angular/interactive" },
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-angular-samples/tree/main/Standalone"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/spa/angular/interactive"
+      }
     ]
   },
   "JavaScript": {
-    name: "JavaScript",
-    subtext: "auth0-spa-js",
-    logo: "javascript.svg",
-    date: "Jun 1, 2026",
-    badge: "v2.21.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-spa-js" },
+    "name": "JavaScript",
+    "subtext": "auth0-spa-js",
+    "logo": "javascript.svg",
+    "date": "Jun 1, 2026",
+    "badge": "v2.21.0",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-javascript-samples/tree/master/01-Login",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/auth0-spa-js"
       },
-      { label: "Quickstart", url: "/docs/quickstart/spa/vanillajs/interactive" },
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-javascript-samples/tree/master/01-Login"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/spa/vanillajs/interactive"
+      }
     ]
   },
   "Flutter (Web)": {
-    name: "Flutter (Web)",
-    subtext: "auth0-flutter",
-    logo: "flutter.svg",
-    date: "May 21, 2026",
-    badge: "af-v2.1.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-flutter" },
+    "name": "Flutter (Web)",
+    "subtext": "auth0-flutter",
+    "logo": "flutter.svg",
+    "date": "May 21, 2026",
+    "badge": "af-v2.1.0",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-flutter-samples/tree/main/sample",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/auth0-flutter"
       },
-      { label: "Quickstart", url: "/docs/quickstart/spa/flutter/interactive" },
-    ]
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-flutter-samples/tree/main/sample"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/spa/flutter/interactive"
+      }
+    ],
+    "monorepo": {
+      "tagPrefix": "af-v",
+      "stripPrefix": "false"
+    }
   },
   "Next.js": {
-    name: "Next.js",
-    subtext: "nextjs-auth0",
-    logo: "nextjs.svg",
-    date: "Jun 1, 2026",
-    badge: "v4.22.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/nextjs-auth0/" },
+    "name": "Next.js",
+    "subtext": "nextjs-auth0",
+    "logo": "nextjs.svg",
+    "date": "Jun 1, 2026",
+    "badge": "v4.22.0",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-nextjs-samples/tree/main/Sample-01",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/nextjs-auth0/"
       },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/nextjs/interactive" },
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-nextjs-samples/tree/main/Sample-01"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/webapp/nextjs/interactive"
+      }
     ]
   },
   "Express": {
-    name: "Express",
-    subtext: "express-openid-connect",
-    logo: "nodejs.svg",
-    date: "May 15, 2026",
-    badge: "v3.0.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/express-openid-connect" },
+    "name": "Express",
+    "subtext": "express-openid-connect",
+    "logo": "nodejs.svg",
+    "date": "May 15, 2026",
+    "badge": "v3.0.0",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-express-webapp-sample/tree/master/01-Login",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/express-openid-connect"
       },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/express/interactive" },
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-express-webapp-sample/tree/master/01-Login"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/webapp/express/interactive"
+      }
     ]
   },
   "Fastify": {
-    name: "Fastify",
-    subtext: "auth0-fastify",
-    logo: "nodejs.svg",
-    date: "Apr 9, 2026",
-    badge: "1.3.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-fastify" },
+    "name": "Fastify",
+    "subtext": "auth0-fastify",
+    "logo": "nodejs.svg",
+    "date": "Apr 9, 2026",
+    "badge": "1.3.0",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0/auth0-fastify/tree/main/examples",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/auth0-fastify"
       },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/fastify" },
-    ]
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0/auth0-fastify/tree/main/examples"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/webapp/fastify"
+      }
+    ],
+    "monorepo": {
+      "tagPrefix": "auth0-fastify-v",
+      "stripPrefix": "true"
+    }
   },
   "Nuxt": {
-    name: "Nuxt",
-    subtext: "auth0-nuxt",
-    logo: "nuxt.svg",
-    date: "Apr 13, 2026",
-    badge: "1.1.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-nuxt" },
+    "name": "Nuxt",
+    "subtext": "auth0-nuxt",
+    "logo": "nuxt.svg",
+    "date": "Apr 13, 2026",
+    "badge": "1.1.0",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-nuxt-samples",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/auth0-nuxt"
       },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/nuxt" },
-    ]
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-nuxt-samples"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/webapp/nuxt"
+      }
+    ],
+    "monorepo": {
+      "tagPrefix": "auth0-nuxt-v",
+      "stripPrefix": "true"
+    }
   },
   "ASP.NET Core MVC": {
-    name: "ASP.NET Core MVC",
-    subtext: "auth0-aspnetcore-authentication",
-    logo: "dotnet-platform.svg",
-    date: "Apr 9, 2026",
-    badge: "1.7.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-aspnetcore-authentication" },
+    "name": "ASP.NET Core MVC",
+    "subtext": "auth0-aspnetcore-authentication",
+    "logo": "dotnet-platform.svg",
+    "date": "Apr 9, 2026",
+    "badge": "1.7.0",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-aspnetcore-mvc-samples/tree/master/Quickstart/Sample",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/auth0-aspnetcore-authentication"
       },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/aspnet-core/interactive" },
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-aspnetcore-mvc-samples/tree/master/Quickstart/Sample"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/webapp/aspnet-core/interactive"
+      }
     ]
   },
   "ASP.NET Core Blazor": {
-    name: "ASP.NET Core Blazor",
-    subtext: "auth0-aspnetcore-authentication",
-    logo: "dotnet.svg",
-    date: "Apr 9, 2026",
-    badge: "1.7.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-aspnetcore-authentication" },
+    "name": "ASP.NET Core Blazor",
+    "subtext": "auth0-aspnetcore-authentication",
+    "logo": "dotnet.svg",
+    "date": "Apr 9, 2026",
+    "badge": "1.7.0",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-aspnetcore-blazor-server-samples/tree/main/Quickstart/Sample",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/auth0-aspnetcore-authentication"
       },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/aspnet-core-blazor-server/interactive" },
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-aspnetcore-blazor-server-samples/tree/main/Quickstart/Sample"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/webapp/aspnet-core-blazor-server/interactive"
+      }
     ]
   },
   "Laravel": {
-    name: "Laravel",
-    subtext: "laravel-auth0",
-    logo: "laravel.svg",
-    date: "Apr 8, 2026",
-    badge: "7.22.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/laravel-auth0" },
+    "name": "Laravel",
+    "subtext": "laravel-auth0",
+    "logo": "laravel.svg",
+    "date": "Apr 8, 2026",
+    "badge": "7.22.0",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/laravel/tree/7.x/sample",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/laravel-auth0"
       },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/laravel/interactive" },
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/laravel/tree/7.x/sample"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/webapp/laravel/interactive"
+      }
     ]
   },
   "Java Spring Boot": {
-    name: "Java Spring Boot",
-    subtext: "okta-spring-boot",
-    logo: "spring.svg",
-    date: "Apr 9, 2026",
-    badge: "1.0.0-beta.1",
-    links: [
-      { label: "Github", url: "https://github.com/okta/okta-spring-boot/" },
+    "name": "Java Spring Boot",
+    "subtext": "okta-spring-boot",
+    "logo": "spring.svg",
+    "date": "Apr 9, 2026",
+    "badge": "1.0.0-beta.1",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-spring-boot-login-samples/tree/master/mvc-login",
+        "label": "GitHub",
+        "url": "https://github.com/okta/okta-spring-boot/"
       },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/java-spring-boot/interactive" },
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-spring-boot-login-samples/tree/master/mvc-login"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/webapp/java-spring-boot/interactive"
+      }
     ]
   },
   "Python": {
-    name: "Python",
-    subtext: "auth0-python",
-    logo: "python.svg",
-    date: "May 28, 2026",
-    badge: "5.6.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-python" },
+    "name": "Python",
+    "subtext": "auth0-python",
+    "logo": "python.svg",
+    "date": "May 28, 2026",
+    "badge": "5.6.0",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-python-web-app/tree/master/01-Login",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/auth0-python"
       },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/python/interactive" },
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-python-web-app/tree/master/01-Login"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/webapp/python/interactive"
+      }
     ]
   },
   "Go": {
-    name: "Go",
-    subtext: "go-auth0",
-    logo: "golang.svg",
-    date: "May 28, 2026",
-    badge: "v2.12.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/go-auth0" },
+    "name": "Go",
+    "subtext": "go-auth0",
+    "logo": "golang.svg",
+    "date": "May 28, 2026",
+    "badge": "v2.12.0",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-golang-web-app/tree/master/01-Login-Quickstart",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/go-auth0"
       },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/golang" },
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-golang-web-app/tree/master/01-Login-Quickstart"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/webapp/golang"
+      }
     ]
   },
   "PHP": {
-    name: "PHP",
-    subtext: "auth0-php",
-    logo: "php.svg",
-    date: "Apr 1, 2026",
-    badge: "8.19.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-php" },
+    "name": "PHP",
+    "subtext": "auth0-php",
+    "logo": "php.svg",
+    "date": "Apr 1, 2026",
+    "badge": "8.19.0",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-php-web-app/tree/main/app",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/auth0-php"
       },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/php/interactive" },
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-php-web-app/tree/main/app"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/webapp/php/interactive"
+      }
     ]
   },
   "Ruby on Rails": {
-    name: "Ruby on Rails",
-    subtext: "omniauth-auth0",
-    logo: "rails.svg",
-    date: "May 28, 2026",
-    badge: "v3.2.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/omniauth-auth0" },
+    "name": "Ruby on Rails",
+    "subtext": "omniauth-auth0",
+    "logo": "rails.svg",
+    "date": "May 28, 2026",
+    "badge": "v3.2.0",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-rubyonrails-sample/tree/master/sample",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/omniauth-auth0"
       },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/rails/interactive" },
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-rubyonrails-sample/tree/master/sample"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/webapp/rails/interactive"
+      }
     ]
   },
-  "Java": {
-    name: "Java",
-    subtext: "auth0-java-mvc-common",
-    logo: "java.svg",
-    date: "Apr 9, 2026",
-    badge: "1.12.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-java-mvc-common" },
+  "Java MVC": {
+    "name": "Java",
+    "subtext": "auth0-java-mvc-common",
+    "logo": "java.svg",
+    "date": "Apr 9, 2026",
+    "badge": "1.12.0",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-servlet-sample/tree/master/01-Login",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/auth0-java-mvc-common"
       },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/java/interactive" },
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-servlet-sample/tree/master/01-Login"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/webapp/java/interactive"
+      }
     ]
   },
   "Java EE": {
-    name: "Java EE",
-    subtext: "auth0-java-mvc-common",
-    logo: "java.svg",
-    date: "Apr 9, 2026",
-    badge: "1.12.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-java-mvc-common" },
+    "name": "Java EE",
+    "subtext": "auth0-java-mvc-common",
+    "logo": "java.svg",
+    "date": "Apr 9, 2026",
+    "badge": "1.12.0",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-java-ee-sample/tree/master/01-Login",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/auth0-java-mvc-common"
       },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/java-ee/interactive" },
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-java-ee-sample/tree/master/01-Login"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/webapp/java-ee/interactive"
+      }
     ]
   },
   "Hono": {
-    name: "Hono",
-    subtext: "auth0-hono",
-    logo: "hono.svg",
-    date: "Dec 4, 2025",
-    badge: "v1.2.6",
-    links: [
-      { label: "Github", url: "https://github.com/auth0-lab/auth0-hono" },
+    "name": "Hono",
+    "subtext": "auth0-hono",
+    "logo": "hono.svg",
+    "date": "Dec 4, 2025",
+    "badge": "v1.2.6",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-hono-sample/tree/master/01-Login",
+        "label": "GitHub",
+        "url": "https://github.com/auth0-lab/auth0-hono"
       },
-      { label: "Quickstart", url: "/docs/quickstart/webapp/hono" },
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-hono-sample/tree/master/01-Login"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/webapp/hono"
+      }
     ]
   },
   "Node (Express) API": {
-    name: "Node (Express) API",
-    subtext: "node-oauth2-jwt-bearer",
-    logo: "nodejs.svg",
-    date: "May 20, 2026",
-    badge: "v1.9.0",
-    links: [
+    "name": "Node (Express) API",
+    "subtext": "node-oauth2-jwt-bearer",
+    "logo": "nodejs.svg",
+    "date": "May 20, 2026",
+    "badge": "v1.9.0",
+    "links": [
       {
-        label: "Github",
-        url: "https://github.com/auth0/node-oauth2-jwt-bearer/tree/main/packages/express-oauth2-jwt-bearer",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/node-oauth2-jwt-bearer/tree/main/packages/express-oauth2-jwt-bearer"
       },
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-express-api-samples/tree/master/01-Authorization-RS256",
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-express-api-samples/tree/master/01-Authorization-RS256"
       },
-      { label: "Quickstart", url: "/docs/quickstart/backend/nodejs/interactive" },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/backend/nodejs/interactive"
+      }
     ]
   },
   "Fastify API": {
-    name: "Fastify API",
-    subtext: "auth0-fastify-api",
-    logo: "nodejs.svg",
-    date: "May 18, 2026",
-    badge: "1.3.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-fastify" },
+    "name": "Fastify API",
+    "subtext": "auth0-fastify-api",
+    "logo": "nodejs.svg",
+    "date": "May 18, 2026",
+    "badge": "1.3.0",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0/auth0-fastify/tree/main/examples/example-fastify-api",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/auth0-fastify"
       },
-      { label: "Quickstart", url: "/docs/quickstart/backend/fastify" },
-    ]
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0/auth0-fastify/tree/main/examples/example-fastify-api"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/backend/fastify"
+      }
+    ],
+    "monorepo": {
+      "tagPrefix": "auth0-fastify-api-v",
+      "stripPrefix": "true"
+    }
   },
   "Spring Boot API": {
-    name: "Spring Boot API",
-    subtext: "auth0-springboot-api",
-    logo: "spring.svg",
-    date: "May 12, 2026",
-    badge: "1.0.0-beta.1",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-auth-java" },
+    "name": "Spring Boot API",
+    "subtext": "auth0-springboot-api",
+    "logo": "spring.svg",
+    "date": "May 12, 2026",
+    "badge": "1.0.0-beta.1",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-spring-security5-api-sample/tree/master/01-Authorization-MVC",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/auth0-auth-java"
       },
-      { label: "Quickstart", url: "/docs/quickstart/backend/java-spring-security5/interactive" },
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-spring-security5-api-sample/tree/master/01-Authorization-MVC"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/backend/java-spring-security5/interactive"
+      }
     ]
   },
   "Go API": {
-    name: "Go API",
-    subtext: "go-jwt-middleware",
-    logo: "golang.svg",
-    date: "May 15, 2026",
-    badge: "v3.2.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/go-jwt-middleware" },
+    "name": "Go API",
+    "subtext": "go-jwt-middleware",
+    "logo": "golang.svg",
+    "date": "May 15, 2026",
+    "badge": "v3.2.0",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-golang-api-samples/tree/master/01-Quickstart-Go-API",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/go-jwt-middleware"
       },
-      { label: "Quickstart", url: "/docs/quickstart/backend/golang" },
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-golang-api-samples/tree/master/01-Quickstart-Go-API"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/backend/golang"
+      }
     ]
   },
   "ASP.NET Core Web API": {
-    name: "ASP.NET Core Web API",
-    subtext: "aspnetcore-api",
-    logo: "dotnet-platform.svg",
-    date: "Dec 18, 2025",
-    badge: "v1.0.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/aspnetcore-api" },
+    "name": "ASP.NET Core Web API",
+    "subtext": "aspnetcore-api",
+    "logo": "dotnet-platform.svg",
+    "date": "Dec 18, 2025",
+    "badge": "v1.0.0",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-aspnetcore-webapi-samples/tree/master",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/aspnetcore-api"
       },
-      { label: "Quickstart", url: "/docs/quickstart/backend/aspnet-core-webapi" },
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-aspnetcore-webapi-samples/tree/master"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/backend/aspnet-core-webapi"
+      }
     ]
   },
   "Laravel API": {
-    name: "Laravel API",
-    subtext: "laravel-auth0",
-    logo: "laravel.svg",
-    date: "Apr 8, 2026",
-    badge: "7.22.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/laravel-auth0" },
-      { label: "Sample App", url: "https://github.com/auth0-samples/laravel/tree/7.x/sample" },
-      { label: "Quickstart", url: "/docs/quickstart/backend/laravel/interactive" },
+    "name": "Laravel API",
+    "subtext": "laravel-auth0",
+    "logo": "laravel.svg",
+    "date": "Apr 8, 2026",
+    "badge": "7.22.0",
+    "links": [
+      {
+        "label": "GitHub",
+        "url": "https://github.com/auth0/laravel-auth0"
+      },
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/laravel/tree/7.x/sample"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/backend/laravel/interactive"
+      }
     ]
   },
   "Python API": {
-    name: "Python API",
-    subtext: "auth0-python",
-    logo: "python.svg",
-    date: "May 28, 2026",
-    badge: "5.6.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-python" },
+    "name": "Python API",
+    "subtext": "auth0-python",
+    "logo": "python.svg",
+    "date": "May 28, 2026",
+    "badge": "5.6.0",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-python-api-samples/tree/master/00-Starter-Seed",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/auth0-python"
       },
-      { label: "Quickstart", url: "/docs/quickstart/backend/python/interactive" },
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-python-api-samples/tree/master/00-Starter-Seed"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/backend/python/interactive"
+      }
     ]
   },
   "PHP API": {
-    name: "PHP API",
-    subtext: "auth0-PHP",
-    logo: "php.svg",
-    date: "Apr 1, 2026",
-    badge: "8.19.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-php" },
+    "name": "PHP API",
+    "subtext": "auth0-PHP",
+    "logo": "php.svg",
+    "date": "Apr 1, 2026",
+    "badge": "8.19.0",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-php-api-samples/tree/main/app",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/auth0-php"
       },
-      { label: "Quickstart", url: "/docs/quickstart/backend/php/interactive" },
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-php-api-samples/tree/main/app"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/backend/php/interactive"
+      }
     ]
   },
   "Ruby On Rails API": {
-    name: "Ruby On Rails API",
-    subtext: "omniauth-auth0",
-    logo: "rails.svg",
-    date: "May 28, 2026",
-    badge: "v3.2.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/omniauth-auth0" },
+    "name": "Ruby On Rails API",
+    "subtext": "omniauth-auth0",
+    "logo": "rails.svg",
+    "date": "May 28, 2026",
+    "badge": "v3.2.0",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-rubyonrails-api-samples/tree/master/01-Authentication-RS256",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/omniauth-auth0"
       },
-      { label: "Quickstart", url: "/docs/quickstart/backend/rails/interactive" },
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-rubyonrails-api-samples/tree/master/01-Authentication-RS256"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/backend/rails/interactive"
+      }
     ]
   },
-    "React Native": {
-    name: "React Native",
-    subtext: "react-native-auth0",
-    logo: "react.svg",
-    date: "Jun 1, 2026",
-    badge: "v5.7.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/react-native-auth0" },
+  "React Native": {
+    "name": "React Native",
+    "subtext": "react-native-auth0",
+    "logo": "react.svg",
+    "date": "Jun 1, 2026",
+    "badge": "v5.7.0",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-react-native-sample/tree/master/00-Login-Hooks",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/react-native-auth0"
       },
-      { label: "Quickstart", url: "/docs/quickstart/native/react-native/interactive" },
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-react-native-sample/tree/master/00-Login-Hooks"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/native/react-native/interactive"
+      }
     ]
   },
   "Flutter": {
-    name: "Flutter",
-    subtext: "auth0-flutter",
-    logo: "flutter.svg",
-    date: "May 21, 2026",
-    badge: "af-v2.1.0",
-    links: [
-      { label: "Github", url: "https://www.github.com/auth0/auth0-flutter/" },
+    "name": "Flutter",
+    "subtext": "auth0-flutter",
+    "logo": "flutter.svg",
+    "date": "May 21, 2026",
+    "badge": "af-v2.1.0",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-flutter-samples/tree/main/sample",
+        "label": "GitHub",
+        "url": "https://www.github.com/auth0/auth0-flutter/"
       },
-      { label: "Quickstart", url: "/docs/quickstart/native/flutter/interactive" },
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-flutter-samples/tree/main/sample"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/native/flutter/interactive"
+      }
     ]
   },
   "iOS / macOS": {
-    name: "iOS / macOS",
-    subtext: "Auth0.swift",
-    logo: "apple.svg",
-    date: "May 28, 2026",
-    badge: "2.21.1",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/Auth0.swift" },
+    "name": "iOS / macOS",
+    "subtext": "Auth0.swift",
+    "logo": "apple.svg",
+    "date": "May 28, 2026",
+    "badge": "2.21.1",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-ios-swift-sample/tree/master/Sample-01",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/Auth0.swift"
       },
-      { label: "Quickstart", url: "/docs/quickstart/native/ios-swift/interactive" },
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-ios-swift-sample/tree/master/Sample-01"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/native/ios-swift/interactive"
+      }
     ]
   },
   "Android": {
-    name: "Android",
-    subtext: "Auth0.Android",
-    logo: "android.svg",
-    date: "May 26, 2026",
-    badge: "3.18.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/Auth0.Android" },
+    "name": "Android",
+    "subtext": "Auth0.Android",
+    "logo": "android.svg",
+    "date": "May 26, 2026",
+    "badge": "3.18.0",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-android-sample/tree/master/00-Login-Kt",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/Auth0.Android"
       },
-      { label: "Quickstart", url: "/docs/quickstart/native/android/interactive" },
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-android-sample/tree/master/00-Login-Kt"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/native/android/interactive"
+      }
     ]
   },
   "Expo": {
-    name: "Expo",
-    subtext: "react-native-auth0",
-    logo: "expo.svg",
-    date: "Jun 1, 2026",
-    badge: "v5.7.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/react-native-auth0" },
+    "name": "Expo",
+    "subtext": "react-native-auth0",
+    "logo": "expo.svg",
+    "date": "Jun 1, 2026",
+    "badge": "v5.7.0",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-react-native-sample/tree/master/00-Login-Expo",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/react-native-auth0"
       },
-      { label: "Quickstart", url: "/docs/quickstart/native/react-native-expo/interactive" },
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-react-native-sample/tree/master/00-Login-Expo"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/native/react-native-expo/interactive"
+      }
     ]
   },
   ".NET (OIDC Client)": {
-    name: ".NET (OIDC Client)",
-    subtext: "auth0-oidc-client-net",
-    logo: "dotnet-platform.svg",
-    date: "Jul 22, 2025",
-    badge: "ios-4.4.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-oidc-client-net" },
+    "name": ".NET (OIDC Client)",
+    "subtext": "auth0-oidc-client-net",
+    "logo": "dotnet-platform.svg",
+    "date": "Jul 22, 2025",
+    "badge": "ios-4.4.0",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-xamarin-oidc-samples/tree/master/Quickstart/01-Login",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/auth0-oidc-client-net"
       },
-      { label: "Quickstart", url: "/docs/quickstart/native/net-android-ios/interactive" },
-    ]
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-xamarin-oidc-samples/tree/master/Quickstart/01-Login"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/native/net-android-ios/interactive"
+      }
+    ],
+    "monorepo": {
+      "tagPrefix": "ios-",
+      "stripPrefix": "false"
+    }
   },
   "MAUI": {
-    name: "MAUI",
-    subtext: "auth0-oidc-client-net",
-    logo: "dotnet.svg",
-    date: "Jul 22, 2025",
-    badge: "ios-4.4.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-oidc-client-net" },
+    "name": "MAUI",
+    "subtext": "auth0-oidc-client-net",
+    "logo": "dotnet.svg",
+    "date": "Jul 22, 2025",
+    "badge": "ios-4.4.0",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-maui-samples/tree/master/Sample",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/auth0-oidc-client-net"
       },
-      { label: "Quickstart", url: "/docs/quickstart/native/maui/interactive" },
-    ]
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-maui-samples/tree/master/Sample"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/native/maui/interactive"
+      }
+    ],
+    "monorepo": {
+      "tagPrefix": "ios-",
+      "stripPrefix": "false"
+    }
   },
   "Xamarin": {
-    name: "Xamarin",
-    subtext: "auth0-oidc-client-net",
-    logo: "xamarin.svg",
-    date: "Jul 22, 2025",
-    badge: "ios-4.4.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-oidc-client-net" },
+    "name": "Xamarin",
+    "subtext": "auth0-oidc-client-net",
+    "logo": "xamarin.svg",
+    "date": "Jul 22, 2025",
+    "badge": "ios-4.4.0",
+    "links": [
       {
-        label: "Sample App",
-        url: "https://github.com/auth0-samples/auth0-xamarin-oidc-samples/tree/master/Quickstart/01-Login",
+        "label": "GitHub",
+        "url": "https://github.com/auth0/auth0-oidc-client-net"
       },
-      { label: "Quickstart", url: "/docs/quickstart/native/xamarin/interactive" },
-    ]
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-xamarin-oidc-samples/tree/master/Quickstart/01-Login"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/native/xamarin/interactive"
+      }
+    ],
+    "monorepo": {
+      "tagPrefix": "ios-",
+      "stripPrefix": "false"
+    }
   },
   "JS SDK": {
-    name: "JS SDK",
-    subtext: "universal-login",
-    logo: "auth0.svg",
-    date: "on December 12,2025",
-    badge: "v1.1.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/universal-login/blob/master/packages/auth0-acul-js/README.md" },
-      { label: "Sample App", url: "https://github.com/auth0-samples/auth0-acul-samples" },
-      { label: "Get started", url: "/docs/libraries/acul/js-sdk" }
+    "name": "JS SDK",
+    "subtext": "universal-login",
+    "logo": "auth0.svg",
+    "date": "on December 12,2025",
+    "badge": "v1.1.0",
+    "links": [
+      {
+        "label": "GitHub",
+        "url": "https://github.com/auth0/universal-login/blob/master/packages/auth0-acul-js/README.md"
+      },
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-acul-samples"
+      },
+      {
+        "label": "Get started",
+        "url": "/docs/libraries/acul/js-sdk"
+      }
     ]
   },
   "React SDK": {
-    name: "React SDK",
-    subtext: "universal-login",
-    logo: "auth0.svg",
-    date: "on December 12,2025",
-    badge: "v1.1.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/universal-login/blob/master/packages/auth0-acul-react/README.md" },
-      { label: "Sample App", url: "https://github.com/auth0-samples/auth0-acul-samples" },
-      { label: "Get started", url: "/docs/libraries/acul/react-sdk" }
+    "name": "React SDK",
+    "subtext": "universal-login",
+    "logo": "auth0.svg",
+    "date": "on December 12,2025",
+    "badge": "v1.1.0",
+    "links": [
+      {
+        "label": "GitHub",
+        "url": "https://github.com/auth0/universal-login/blob/master/packages/auth0-acul-react/README.md"
+      },
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0-samples/auth0-acul-samples"
+      },
+      {
+        "label": "Get started",
+        "url": "/docs/libraries/acul/react-sdk"
+      }
     ]
   },
   ".NET": {
-    name: ".NET",
-    subtext: "auth0.net",
-    logo: "dotnet-platform.svg",
-    date: "May 28, 2026",
-    badge: "mgmt-8.4.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0.net" }
-    ]
-  },
-  "Go": {
-    name: "Go",
-    subtext: "go-auth0",
-    logo: "golang.svg",
-    date: "May 28, 2026",
-    badge: "v2.12.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/go-auth0" }
+    "name": ".NET",
+    "subtext": "auth0.net",
+    "logo": "dotnet-platform.svg",
+    "date": "May 28, 2026",
+    "badge": "mgmt-8.4.0",
+    "links": [
+      {
+        "label": "GitHub",
+        "url": "https://github.com/auth0/auth0.net"
+      }
     ]
   },
   "Go JWT Middleware": {
-    name: "Go JWT Middleware",
-    subtext: "go-jwt-middleware",
-    logo: "golang.svg",
-    date: "May 15, 2026",
-    badge: "v3.2.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/go-jwt-middleware" }
+    "name": "Go JWT Middleware",
+    "subtext": "go-jwt-middleware",
+    "logo": "golang.svg",
+    "date": "May 15, 2026",
+    "badge": "v3.2.0",
+    "links": [
+      {
+        "label": "GitHub",
+        "url": "https://github.com/auth0/go-jwt-middleware"
+      }
     ]
   },
   "Java": {
-    name: "Java",
-    subtext: "auth0-java",
-    logo: "java.svg",
-    date: "May 28, 2026",
-    badge: "3.7.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-java" }
+    "name": "Java",
+    "subtext": "auth0-java",
+    "logo": "java.svg",
+    "date": "May 28, 2026",
+    "badge": "3.7.0",
+    "links": [
+      {
+        "label": "GitHub",
+        "url": "https://github.com/auth0/auth0-java"
+      }
     ]
   },
   "Node": {
-    name: "Node",
-    subtext: "node-auth0",
-    logo: "nodejs.svg",
-    date: "May 28, 2026",
-    badge: "v5.11.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/node-auth0" }
+    "name": "Node",
+    "subtext": "node-auth0",
+    "logo": "nodejs.svg",
+    "date": "May 28, 2026",
+    "badge": "v5.11.0",
+    "links": [
+      {
+        "label": "GitHub",
+        "url": "https://github.com/auth0/node-auth0"
+      }
     ]
   },
   "Node JWT Bearer": {
-    name: "Node JWT Bearer",
-    subtext: "node-oauth2-jwt-bearer",
-    logo: "nodejs.svg",
-    date: "May 20, 2026",
-    badge: "v1.9.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/node-oauth2-jwt-bearer" }
-    ]
-  },
-  "PHP": {
-    name: "PHP",
-    subtext: "auth0-php",
-    logo: "php.svg",
-    date: "Apr 1, 2026",
-    badge: "8.19.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-php" }
-    ]
-  },
-  "Python": {
-    name: "Python",
-    subtext: "auth0-python",
-    logo: "python.svg",
-    date: "May 28, 2026",
-    badge: "5.6.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/auth0-python" }
+    "name": "Node JWT Bearer",
+    "subtext": "node-oauth2-jwt-bearer",
+    "logo": "nodejs.svg",
+    "date": "May 20, 2026",
+    "badge": "v1.9.0",
+    "links": [
+      {
+        "label": "GitHub",
+        "url": "https://github.com/auth0/node-oauth2-jwt-bearer"
+      }
     ]
   },
   "Ruby": {
-    name: "Ruby",
-    subtext: "ruby-auth0",
-    logo: "ruby.svg",
-    date: "May 29, 2026",
-    badge: "v5.20.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/ruby-auth0" }
+    "name": "Ruby",
+    "subtext": "ruby-auth0",
+    "logo": "ruby.svg",
+    "date": "May 29, 2026",
+    "badge": "v5.20.0",
+    "links": [
+      {
+        "label": "GitHub",
+        "url": "https://github.com/auth0/ruby-auth0"
+      }
     ]
   },
   "Lock for Android": {
-    name: "Lock for Android",
-    subtext: "Lock.Android",
-    logo: "android.svg",
-    date: "Jan 11, 2023",
-    badge: "3.2.2",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/Lock.Android" },
-      { label: "Get started", url: "/docs/libraries/lock-android" }
+    "name": "Lock for Android",
+    "subtext": "Lock.Android",
+    "logo": "android.svg",
+    "date": "Jan 11, 2023",
+    "badge": "3.2.2",
+    "links": [
+      {
+        "label": "GitHub",
+        "url": "https://github.com/auth0/Lock.Android"
+      },
+      {
+        "label": "Get started",
+        "url": "/docs/libraries/lock-android"
+      }
     ]
   },
   "Lock for iOS": {
-    name: "Lock for iOS",
-    subtext: "Lock.swift",
-    logo: "apple.svg",
-    date: "Nov 30, 2021",
-    badge: "2.24.1",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/Lock.swift" },
-      { label: "Get started", url: "/docs/libraries/lock-ios" }
+    "name": "Lock for iOS",
+    "subtext": "Lock.swift",
+    "logo": "apple.svg",
+    "date": "Nov 30, 2021",
+    "badge": "2.24.1",
+    "links": [
+      {
+        "label": "GitHub",
+        "url": "https://github.com/auth0/Lock.swift"
+      },
+      {
+        "label": "Get started",
+        "url": "/docs/libraries/lock-ios"
+      }
     ]
   },
   "Lock for Web": {
-    name: "Lock for Web",
-    subtext: "lock",
-    logo: "auth0.svg",
-    date: "Apr 6, 2026",
-    badge: "v14.3.0",
-    links: [
-      { label: "Github", url: "https://github.com/auth0/lock" },
-      { label: "Get started", url: "/docs/libraries/lock" }
+    "name": "Lock for Web",
+    "subtext": "lock",
+    "logo": "auth0.svg",
+    "date": "Apr 6, 2026",
+    "badge": "v14.3.0",
+    "links": [
+      {
+        "label": "GitHub",
+        "url": "https://github.com/auth0/lock"
+      },
+      {
+        "label": "Get started",
+        "url": "/docs/libraries/lock"
+      }
     ]
   }
-};
+}
+;

--- a/main/snippets/sdks/versions.mdx
+++ b/main/snippets/sdks/versions.mdx
@@ -809,7 +809,7 @@ export const sdkCardInfo =
     "name": "JS SDK",
     "subtext": "universal-login",
     "logo": "auth0.svg",
-    "date": "on December 12,2025",
+    "date": "December 12,2025",
     "badge": "v1.1.0",
     "links": [
       {
@@ -824,13 +824,17 @@ export const sdkCardInfo =
         "label": "Get started",
         "url": "/docs/libraries/acul/js-sdk"
       }
-    ]
+    ],
+    "monorepo": {
+      "tagPrefix": "auth0-acul-js-v",
+      "stripPrefix": "true"
+    }
   },
   "React SDK": {
     "name": "React SDK",
     "subtext": "universal-login",
     "logo": "auth0.svg",
-    "date": "on December 12,2025",
+    "date": "December 12,2025",
     "badge": "v1.1.0",
     "links": [
       {
@@ -845,7 +849,11 @@ export const sdkCardInfo =
         "label": "Get started",
         "url": "/docs/libraries/acul/react-sdk"
       }
-    ]
+    ],
+    "monorepo": {
+      "tagPrefix": "auth0-acul-react-v",
+      "stripPrefix": "true"
+    }
   },
   ".NET": {
     "name": ".NET",

--- a/main/snippets/sdks/versions.mdx
+++ b/main/snippets/sdks/versions.mdx
@@ -1,0 +1,704 @@
+export const sdkCardInfo = {
+  "React": {
+    name: "React",
+    subtext: "auth0-react",
+    logo: "react.svg",
+    date: "May 22, 2026",
+    badge: "v2.17.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/auth0-react" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-react-samples/tree/master/Sample-01",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/spa/react/interactive" },
+    ]
+  },
+  "Vue": {
+    name: "Vue",
+    subtext: "auth0-vue",
+    logo: "vuejs.svg",
+    date: "May 8, 2026",
+    badge: "v2.7.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/auth0-vue" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-vue-samples/tree/master/01-Login",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/spa/vuejs/interactive" },
+    ]
+  },
+  "Angular": {
+    name: "Angular",
+    subtext: "auth0-angular",
+    logo: "angular.svg",
+    date: "Apr 28, 2026",
+    badge: "v2.9.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/auth0-angular" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-angular-samples/tree/main/Standalone",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/spa/angular/interactive" },
+    ]
+  },
+  "JavaScript": {
+    name: "JavaScript",
+    subtext: "auth0-spa-js",
+    logo: "javascript.svg",
+    date: "Jun 1, 2026",
+    badge: "v2.21.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/auth0-spa-js" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-javascript-samples/tree/master/01-Login",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/spa/vanillajs/interactive" },
+    ]
+  },
+  "Flutter (Web)": {
+    name: "Flutter (Web)",
+    subtext: "auth0-flutter",
+    logo: "flutter.svg",
+    date: "May 21, 2026",
+    badge: "af-v2.1.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/auth0-flutter" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-flutter-samples/tree/main/sample",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/spa/flutter/interactive" },
+    ]
+  },
+  "Next.js": {
+    name: "Next.js",
+    subtext: "nextjs-auth0",
+    logo: "nextjs.svg",
+    date: "Jun 1, 2026",
+    badge: "v4.22.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/nextjs-auth0/" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-nextjs-samples/tree/main/Sample-01",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/webapp/nextjs/interactive" },
+    ]
+  },
+  "Express": {
+    name: "Express",
+    subtext: "express-openid-connect",
+    logo: "nodejs.svg",
+    date: "May 15, 2026",
+    badge: "v3.0.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/express-openid-connect" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-express-webapp-sample/tree/master/01-Login",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/webapp/express/interactive" },
+    ]
+  },
+  "Fastify": {
+    name: "Fastify",
+    subtext: "auth0-fastify",
+    logo: "nodejs.svg",
+    date: "Apr 9, 2026",
+    badge: "1.3.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/auth0-fastify" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0/auth0-fastify/tree/main/examples",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/webapp/fastify" },
+    ]
+  },
+  "Nuxt": {
+    name: "Nuxt",
+    subtext: "auth0-nuxt",
+    logo: "nuxt.svg",
+    date: "Apr 13, 2026",
+    badge: "1.1.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/auth0-nuxt" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-nuxt-samples",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/webapp/nuxt" },
+    ]
+  },
+  "ASP.NET Core MVC": {
+    name: "ASP.NET Core MVC",
+    subtext: "auth0-aspnetcore-authentication",
+    logo: "dotnet-platform.svg",
+    date: "Apr 9, 2026",
+    badge: "1.7.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/auth0-aspnetcore-authentication" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-aspnetcore-mvc-samples/tree/master/Quickstart/Sample",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/webapp/aspnet-core/interactive" },
+    ]
+  },
+  "ASP.NET Core Blazor": {
+    name: "ASP.NET Core Blazor",
+    subtext: "auth0-aspnetcore-authentication",
+    logo: "dotnet.svg",
+    date: "Apr 9, 2026",
+    badge: "1.7.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/auth0-aspnetcore-authentication" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-aspnetcore-blazor-server-samples/tree/main/Quickstart/Sample",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/webapp/aspnet-core-blazor-server/interactive" },
+    ]
+  },
+  "Laravel": {
+    name: "Laravel",
+    subtext: "laravel-auth0",
+    logo: "laravel.svg",
+    date: "Apr 8, 2026",
+    badge: "7.22.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/laravel-auth0" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/laravel/tree/7.x/sample",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/webapp/laravel/interactive" },
+    ]
+  },
+  "Java Spring Boot": {
+    name: "Java Spring Boot",
+    subtext: "okta-spring-boot",
+    logo: "spring.svg",
+    date: "Apr 9, 2026",
+    badge: "1.0.0-beta.1",
+    links: [
+      { label: "Github", url: "https://github.com/okta/okta-spring-boot/" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-spring-boot-login-samples/tree/master/mvc-login",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/webapp/java-spring-boot/interactive" },
+    ]
+  },
+  "Python": {
+    name: "Python",
+    subtext: "auth0-python",
+    logo: "python.svg",
+    date: "May 28, 2026",
+    badge: "5.6.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/auth0-python" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-python-web-app/tree/master/01-Login",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/webapp/python/interactive" },
+    ]
+  },
+  "Go": {
+    name: "Go",
+    subtext: "go-auth0",
+    logo: "golang.svg",
+    date: "May 28, 2026",
+    badge: "v2.12.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/go-auth0" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-golang-web-app/tree/master/01-Login-Quickstart",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/webapp/golang" },
+    ]
+  },
+  "PHP": {
+    name: "PHP",
+    subtext: "auth0-php",
+    logo: "php.svg",
+    date: "Apr 1, 2026",
+    badge: "8.19.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/auth0-php" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-php-web-app/tree/main/app",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/webapp/php/interactive" },
+    ]
+  },
+  "Ruby on Rails": {
+    name: "Ruby on Rails",
+    subtext: "omniauth-auth0",
+    logo: "rails.svg",
+    date: "May 28, 2026",
+    badge: "v3.2.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/omniauth-auth0" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-rubyonrails-sample/tree/master/sample",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/webapp/rails/interactive" },
+    ]
+  },
+  "Java": {
+    name: "Java",
+    subtext: "auth0-java-mvc-common",
+    logo: "java.svg",
+    date: "Apr 9, 2026",
+    badge: "1.12.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/auth0-java-mvc-common" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-servlet-sample/tree/master/01-Login",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/webapp/java/interactive" },
+    ]
+  },
+  "Java EE": {
+    name: "Java EE",
+    subtext: "auth0-java-mvc-common",
+    logo: "java.svg",
+    date: "Apr 9, 2026",
+    badge: "1.12.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/auth0-java-mvc-common" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-java-ee-sample/tree/master/01-Login",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/webapp/java-ee/interactive" },
+    ]
+  },
+  "Hono": {
+    name: "Hono",
+    subtext: "auth0-hono",
+    logo: "hono.svg",
+    date: "Dec 4, 2025",
+    badge: "v1.2.6",
+    links: [
+      { label: "Github", url: "https://github.com/auth0-lab/auth0-hono" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-hono-sample/tree/master/01-Login",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/webapp/hono" },
+    ]
+  },
+  "Node (Express) API": {
+    name: "Node (Express) API",
+    subtext: "node-oauth2-jwt-bearer",
+    logo: "nodejs.svg",
+    date: "May 20, 2026",
+    badge: "v1.9.0",
+    links: [
+      {
+        label: "Github",
+        url: "https://github.com/auth0/node-oauth2-jwt-bearer/tree/main/packages/express-oauth2-jwt-bearer",
+      },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-express-api-samples/tree/master/01-Authorization-RS256",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/backend/nodejs/interactive" },
+    ]
+  },
+  "Fastify API": {
+    name: "Fastify API",
+    subtext: "auth0-fastify-api",
+    logo: "nodejs.svg",
+    date: "May 18, 2026",
+    badge: "1.3.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/auth0-fastify" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0/auth0-fastify/tree/main/examples/example-fastify-api",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/backend/fastify" },
+    ]
+  },
+  "Spring Boot API": {
+    name: "Spring Boot API",
+    subtext: "auth0-springboot-api",
+    logo: "spring.svg",
+    date: "May 12, 2026",
+    badge: "1.0.0-beta.1",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/auth0-auth-java" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-spring-security5-api-sample/tree/master/01-Authorization-MVC",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/backend/java-spring-security5/interactive" },
+    ]
+  },
+  "Go API": {
+    name: "Go API",
+    subtext: "go-jwt-middleware",
+    logo: "golang.svg",
+    date: "May 15, 2026",
+    badge: "v3.2.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/go-jwt-middleware" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-golang-api-samples/tree/master/01-Quickstart-Go-API",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/backend/golang" },
+    ]
+  },
+  "ASP.NET Core Web API": {
+    name: "ASP.NET Core Web API",
+    subtext: "aspnetcore-api",
+    logo: "dotnet-platform.svg",
+    date: "Dec 18, 2025",
+    badge: "v1.0.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/aspnetcore-api" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-aspnetcore-webapi-samples/tree/master",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/backend/aspnet-core-webapi" },
+    ]
+  },
+  "Laravel API": {
+    name: "Laravel API",
+    subtext: "laravel-auth0",
+    logo: "laravel.svg",
+    date: "Apr 8, 2026",
+    badge: "7.22.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/laravel-auth0" },
+      { label: "Sample App", url: "https://github.com/auth0-samples/laravel/tree/7.x/sample" },
+      { label: "Quickstart", url: "/docs/quickstart/backend/laravel/interactive" },
+    ]
+  },
+  "Python API": {
+    name: "Python API",
+    subtext: "auth0-python",
+    logo: "python.svg",
+    date: "May 28, 2026",
+    badge: "5.6.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/auth0-python" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-python-api-samples/tree/master/00-Starter-Seed",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/backend/python/interactive" },
+    ]
+  },
+  "PHP API": {
+    name: "PHP API",
+    subtext: "auth0-PHP",
+    logo: "php.svg",
+    date: "Apr 1, 2026",
+    badge: "8.19.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/auth0-php" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-php-api-samples/tree/main/app",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/backend/php/interactive" },
+    ]
+  },
+  "Ruby On Rails API": {
+    name: "Ruby On Rails API",
+    subtext: "omniauth-auth0",
+    logo: "rails.svg",
+    date: "May 28, 2026",
+    badge: "v3.2.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/omniauth-auth0" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-rubyonrails-api-samples/tree/master/01-Authentication-RS256",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/backend/rails/interactive" },
+    ]
+  },
+    "React Native": {
+    name: "React Native",
+    subtext: "react-native-auth0",
+    logo: "react.svg",
+    date: "Jun 1, 2026",
+    badge: "v5.7.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/react-native-auth0" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-react-native-sample/tree/master/00-Login-Hooks",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/native/react-native/interactive" },
+    ]
+  },
+  "Flutter": {
+    name: "Flutter",
+    subtext: "auth0-flutter",
+    logo: "flutter.svg",
+    date: "May 21, 2026",
+    badge: "af-v2.1.0",
+    links: [
+      { label: "Github", url: "https://www.github.com/auth0/auth0-flutter/" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-flutter-samples/tree/main/sample",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/native/flutter/interactive" },
+    ]
+  },
+  "iOS / macOS": {
+    name: "iOS / macOS",
+    subtext: "Auth0.swift",
+    logo: "apple.svg",
+    date: "May 28, 2026",
+    badge: "2.21.1",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/Auth0.swift" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-ios-swift-sample/tree/master/Sample-01",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/native/ios-swift/interactive" },
+    ]
+  },
+  "Android": {
+    name: "Android",
+    subtext: "Auth0.Android",
+    logo: "android.svg",
+    date: "May 26, 2026",
+    badge: "3.18.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/Auth0.Android" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-android-sample/tree/master/00-Login-Kt",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/native/android/interactive" },
+    ]
+  },
+  "Expo": {
+    name: "Expo",
+    subtext: "react-native-auth0",
+    logo: "expo.svg",
+    date: "Jun 1, 2026",
+    badge: "v5.7.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/react-native-auth0" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-react-native-sample/tree/master/00-Login-Expo",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/native/react-native-expo/interactive" },
+    ]
+  },
+  ".NET (OIDC Client)": {
+    name: ".NET (OIDC Client)",
+    subtext: "auth0-oidc-client-net",
+    logo: "dotnet-platform.svg",
+    date: "Jul 22, 2025",
+    badge: "ios-4.4.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/auth0-oidc-client-net" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-xamarin-oidc-samples/tree/master/Quickstart/01-Login",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/native/net-android-ios/interactive" },
+    ]
+  },
+  "MAUI": {
+    name: "MAUI",
+    subtext: "auth0-oidc-client-net",
+    logo: "dotnet.svg",
+    date: "Jul 22, 2025",
+    badge: "ios-4.4.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/auth0-oidc-client-net" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-maui-samples/tree/master/Sample",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/native/maui/interactive" },
+    ]
+  },
+  "Xamarin": {
+    name: "Xamarin",
+    subtext: "auth0-oidc-client-net",
+    logo: "xamarin.svg",
+    date: "Jul 22, 2025",
+    badge: "ios-4.4.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/auth0-oidc-client-net" },
+      {
+        label: "Sample App",
+        url: "https://github.com/auth0-samples/auth0-xamarin-oidc-samples/tree/master/Quickstart/01-Login",
+      },
+      { label: "Quickstart", url: "/docs/quickstart/native/xamarin/interactive" },
+    ]
+  },
+  "JS SDK": {
+    name: "JS SDK",
+    subtext: "universal-login",
+    logo: "auth0.svg",
+    date: "on December 12,2025",
+    badge: "v1.1.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/universal-login/blob/master/packages/auth0-acul-js/README.md" },
+      { label: "Sample App", url: "https://github.com/auth0-samples/auth0-acul-samples" },
+      { label: "Get started", url: "/docs/libraries/acul/js-sdk" }
+    ]
+  },
+  "React SDK": {
+    name: "React SDK",
+    subtext: "universal-login",
+    logo: "auth0.svg",
+    date: "on December 12,2025",
+    badge: "v1.1.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/universal-login/blob/master/packages/auth0-acul-react/README.md" },
+      { label: "Sample App", url: "https://github.com/auth0-samples/auth0-acul-samples" },
+      { label: "Get started", url: "/docs/libraries/acul/react-sdk" }
+    ]
+  },
+  ".NET": {
+    name: ".NET",
+    subtext: "auth0.net",
+    logo: "dotnet-platform.svg",
+    date: "May 28, 2026",
+    badge: "mgmt-8.4.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/auth0.net" }
+    ]
+  },
+  "Go": {
+    name: "Go",
+    subtext: "go-auth0",
+    logo: "golang.svg",
+    date: "May 28, 2026",
+    badge: "v2.12.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/go-auth0" }
+    ]
+  },
+  "Go JWT Middleware": {
+    name: "Go JWT Middleware",
+    subtext: "go-jwt-middleware",
+    logo: "golang.svg",
+    date: "May 15, 2026",
+    badge: "v3.2.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/go-jwt-middleware" }
+    ]
+  },
+  "Java": {
+    name: "Java",
+    subtext: "auth0-java",
+    logo: "java.svg",
+    date: "May 28, 2026",
+    badge: "3.7.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/auth0-java" }
+    ]
+  },
+  "Node": {
+    name: "Node",
+    subtext: "node-auth0",
+    logo: "nodejs.svg",
+    date: "May 28, 2026",
+    badge: "v5.11.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/node-auth0" }
+    ]
+  },
+  "Node JWT Bearer": {
+    name: "Node JWT Bearer",
+    subtext: "node-oauth2-jwt-bearer",
+    logo: "nodejs.svg",
+    date: "May 20, 2026",
+    badge: "v1.9.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/node-oauth2-jwt-bearer" }
+    ]
+  },
+  "PHP": {
+    name: "PHP",
+    subtext: "auth0-php",
+    logo: "php.svg",
+    date: "Apr 1, 2026",
+    badge: "8.19.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/auth0-php" }
+    ]
+  },
+  "Python": {
+    name: "Python",
+    subtext: "auth0-python",
+    logo: "python.svg",
+    date: "May 28, 2026",
+    badge: "5.6.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/auth0-python" }
+    ]
+  },
+  "Ruby": {
+    name: "Ruby",
+    subtext: "ruby-auth0",
+    logo: "ruby.svg",
+    date: "May 29, 2026",
+    badge: "v5.20.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/ruby-auth0" }
+    ]
+  },
+  "Lock for Android": {
+    name: "Lock for Android",
+    subtext: "Lock.Android",
+    logo: "android.svg",
+    date: "Jan 11, 2023",
+    badge: "3.2.2",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/Lock.Android" },
+      { label: "Get started", url: "/docs/libraries/lock-android" }
+    ]
+  },
+  "Lock for iOS": {
+    name: "Lock for iOS",
+    subtext: "Lock.swift",
+    logo: "apple.svg",
+    date: "Nov 30, 2021",
+    badge: "2.24.1",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/Lock.swift" },
+      { label: "Get started", url: "/docs/libraries/lock-ios" }
+    ]
+  },
+  "Lock for Web": {
+    name: "Lock for Web",
+    subtext: "lock",
+    logo: "auth0.svg",
+    date: "Apr 6, 2026",
+    badge: "v14.3.0",
+    links: [
+      { label: "Github", url: "https://github.com/auth0/lock" },
+      { label: "Get started", url: "/docs/libraries/lock" }
+    ]
+  }
+};

--- a/scripts/fetch-sdk-versions.py
+++ b/scripts/fetch-sdk-versions.py
@@ -1,0 +1,46 @@
+import sys, subprocess, json, datetime
+import datetime as dt
+from urllib.parse import urlsplit
+
+sdks = json.load(sys.stdin)
+
+for sdk in sdks.values():
+    repo_url = next(link['url'] for link in sdk['links'] if link['label'] == 'GitHub')
+    path = urlsplit(repo_url).path.strip('/')
+    # Strip to owner/repo (in case of deeper GitHub link for monorepos)
+    repo = '/'.join(path.split('/')[:2])
+
+    flags = [
+        '--exclude-drafts',
+        '--exclude-pre-releases',
+        '--json tagName,publishedAt'
+    ]
+
+    monorepo = 'monorepo' in sdk
+    if monorepo:
+        prefix = sdk['monorepo']['tagPrefix']
+        strip = (sdk['monorepo']['stripPrefix'] == "true")
+        jq = f'first(.[] | select(.tagName | startswith("{prefix}")))'
+    else:
+        flags.append('-L 1')
+        jq = f'.[]' # Return the object instead of a list with the object
+    flags.append(f'--jq \'{jq}\'')
+
+    flags = ' '.join(flags)
+    cmd = f'gh release list -R {repo} {flags}'
+    releases_process = subprocess.run(cmd, shell=True, capture_output=True)
+
+    if not releases_process.stdout:
+        continue
+
+    release_info = json.loads(releases_process.stdout)
+
+    tag = release_info['tagName']
+    sdk['badge'] = tag.replace(prefix, 'v') if (monorepo and strip) else tag
+
+    # datetime doesn't support military time zones
+    publishedAt = release_info['publishedAt'].strip('Z')
+    date = dt.datetime.fromisoformat(publishedAt)
+    sdk['date'] = f'{date.strftime("%b")} {date.day}, {date.year}'
+
+print(json.dumps(sdks, indent=2))


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## tl;dr

moves the SDK card data into a variable in a snippets file and strengthens the version update github action.

## Description

the original github action for SDK version updates used brittle string parsing to pull the subsections out of a full content file containing YAML, markdown, HTML, JS, and JSON.

this version uses actual JSON parsing to parse a file that only contains that JSON.

the github action also now no longer depends on a hard-coded path to where the data is used in content. the original version would have broken if we ever changed the URL of the page or otherwise reorganized the content.

moving the data to its own file also has the consequence of making the sdk cards in content go from this:

```
<SectionCard item={{
    name: "React",
    subtext: "auth0-react",
    logo: "react.svg",
    date: "May 22, 2026",
    badge: "v2.17.0",
    links: [
      { label: "Github", url: "https://github.com/auth0/auth0-react" },
      {
        label: "Sample App",
        url: "https://github.com/auth0-samples/auth0-react-samples/tree/master/Sample-01",
      },
      { label: "Quickstart", url: "/docs/quickstart/spa/react/interactive" },
    ],
}}/>
```

to this:

```
<SectionCard item={sdkCardInfo["React"]} />
```

which i daresay is a bit nicer.

### Testing

to test the action, i ran it manually based on this branch. you can see the [successful action run](https://github.com/auth0/docs-v2/actions/runs/27042142481) and the [resulting PR](https://github.com/auth0/docs-v2/pull/1352).

to test the cards / moving the data to its own snippet file, you can view them [on the SDK page in the deploy preview](https://docs-staging-chore-sdk-versioning.auth0-mintlify.app/docs/libraries).

if the above is insufficient, you can also test the python script by running the same commands from the github action locally (you'll need `gh` installed, but it's available by default on github action runners) and then check out this branch and run `mint dev` locally.

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
