### PR TITLE
chore(security): uses pinned versions of actions

### DIFF
--- a/.github/workflows/sync-agent-skills.yml
+++ b/.github/workflows/sync-agent-skills.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout docs-v2
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Fetch latest skills from agent-skills
         run: |

--- a/.github/workflows/update-sdk-versions.yml
+++ b/.github/workflows/update-sdk-versions.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Fetch latest SDK releases and update libraries.mdx
         env:

--- a/.github/workflows/vale-check.yml
+++ b/.github/workflows/vale-check.yml
@@ -16,8 +16,8 @@ jobs:
       - name: Install mdx2vast
         run: npm install -g mdx2vast
 
-      - uses: actions/checkout@v4
-      - uses: errata-ai/vale-action@v2.1.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: errata-ai/vale-action@d89dee975228ae261d22c15adcd03578634d429c # v2.1.1
         with:
           files: '["auth4genai/"]'
           fail_on_error: true


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow files to use pinned commit SHAs for all third-party actions, improving security and reproducibility.
<!-- PR created with github.com/jcchavezs/pin-gha -->