### PR TITLE
docs: swift quickstart improvements as guided by evals flywheel to improve Agentic experience

### DIFF
--- a/main/docs/quickstart/native/ios-swift.mdx
+++ b/main/docs/quickstart/native/ios-swift.mdx
@@ -374,6 +374,10 @@ This is **required** for certain features to work properly:
 <Accordion title="Advanced Integration">
 ### Programmatic Configuration
 
+<Warning>
+Never hardcode `clientId` or `domain` values directly in Swift source files — they will be committed to version control. Read them from environment variables or a build-time configuration file at runtime. For most apps, prefer `Auth0.plist` (the default approach in this quickstart).
+</Warning>
+
 Instead of using `Auth0.plist`, you can pass credentials directly in your code. This is useful when credentials need to be dynamic or environment-specific (e.g., different Auth0 tenants for dev/staging/production).
 
 **Replace `Auth0.webAuth()` calls with `Auth0.webAuth(clientId:domain:)`:**

--- a/main/docs/quickstart/native/ios-swift.mdx
+++ b/main/docs/quickstart/native/ios-swift.mdx
@@ -163,7 +163,11 @@ Your AI assistant will automatically create your Auth0 application, fetch creden
   </Step>
   
   <Step title="Create the Authentication Service" stepNumber={5}>
-    Create `AuthenticationService.swift`:
+    Create `AuthenticationService.swift` to handle login, logout, and token storage.
+
+    <Info>
+      **Use `CredentialsManager` for token storage.** The `CredentialsManager` class securely stores credentials in the Keychain and automatically refreshes expired access tokens. Always use it — do not store tokens in memory, `UserDefaults`, or `localStorage`.
+    </Info>
 
     1. Right-click your project → **New File...** → **Swift File**
     2. Name it `AuthenticationService`


### PR DESCRIPTION
  ## Description

  Improves the iOS/Swift quickstart based on eval-flywheel findings. When an LLM
  agent follows the current quickstart, it tends to hardcode `clientId`/`domain`
  directly in Swift source (following the "Advanced Integration / Programmatic
  Configuration" section) instead of using `Auth0.plist`, and is not explicitly
  steered toward `CredentialsManager` for token storage.

  This PR adds two guidance callouts to nudge both human and AI readers toward the
  secure, idiomatic defaults — without removing the programmatic-configuration
  escape hatch:

  - **`<Info>` (Step 5 – Authentication Service):** use `CredentialsManager` for
    token storage; do not store tokens in memory, `UserDefaults`, or `localStorage`.
  - **`<Warning>` (Advanced Integration):** never hardcode `clientId`/`domain` in
    Swift source; prefer `Auth0.plist` (the quickstart default).

  ### References

  - Eval framework: `auth0-evals` `swift_quickstart` eval
  - Related: staging preview for eval testing
    (`docs-staging-eval-flywheel-swift-quickstart-v2.auth0-mintlify.app`)

  ### Testing

  Measured with the `swift_quickstart` eval (agent + MCP, `claude-opus-4-8`):

  - **Current production docs:** Grade B (~57% graders). Agent hardcoded
    credentials in source → Security dimension 0/F, plus L1 `webAuth()` and L5
    `Auth0.plist` graders failing.
  - **With these docs (via staging content):** Grade A (~86% graders). Agent used
    `Auth0.plist` and stopped hardcoding → security + plist graders pass.

  Single-run signal, not a statistical average — directional evidence that the
  guidance changes agent behavior in the intended direction.

  ## Checklist

  - [x] I've read and followed `CONTRIBUTING.md`.
  - [x] I've tested the site build for this change locally.
  - [x] I've made appropriate docs updates for any code or config changes.
  - [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.