### PR TITLE
feat: add OpenTofu provider docs, infrastructure section in support matrix, and missing SDKs

### DIFF
--- a/main/docs/deploy-monitor/auth0-terraform-provider.mdx
+++ b/main/docs/deploy-monitor/auth0-terraform-provider.mdx
@@ -4,15 +4,17 @@ title: Auth0 Terraform Provider
 ---
 The Deploy CLI is not the only tool available for managing your Auth0 tenant configuration, there is also an [officially supported Terraform Provider](https://github.com/auth0/terraform-provider-auth0). [Terraform](https://terraform.io/) is a third-party tool for representing your cloud resources’ configurations as code. It has an established plug-in framework that supports a wide array of cloud providers, including Auth0.
 
+The Auth0 Terraform Provider is also available for [OpenTofu](https://opentofu.org/), the open-source Terraform-compatible tool. You can find the Auth0 provider in the [OpenTofu Registry](https://search.opentofu.org/provider/auth0/auth0/latest).
+
 Both the Deploy CLI and Terraform Provider exist to help you manage your Auth0 tenant configurations, but each has their own set of pros and cons.
 
 You may want to consider the Auth0 Terraform Provider if:
 
-* Your development workflows already leverages Terraform
+* Your development workflows already leverages Terraform or OpenTofu
 * Your tenant management needs are granular or only pertain to a few specific resources
 
 You may not want to consider the Auth0 Terraform Provider if:
 
-* Your development workflow does not use Terraform, requiring extra setup upfront
+* Your development workflow does not use Terraform or OpenTofu, requiring extra setup upfront
 * Your development workflows are primarily concerned with managing your tenants in bulk
-* Your tenant has lots of existing resources, may require significant effort to “import"
+* Your tenant has lots of existing resources, may require significant effort to “import”

--- a/main/docs/troubleshoot/customer-support/product-support-matrix.mdx
+++ b/main/docs/troubleshoot/customer-support/product-support-matrix.mdx
@@ -119,6 +119,8 @@ All listed operating systems are the latest versions unless otherwise indicated.
 | [Auth0 API JS](https://github.com/auth0/auth0-auth-js/tree/main/packages/auth0-api-js) | Supported |
 | [Express OpenID Connect](https://github.com/auth0/express-openid-connect) | Supported |
 | [Express OAuth2 JWT Bearer](https://github.com/auth0/node-oauth2-jwt-bearer/tree/main/packages/express-oauth2-jwt-bearer) | Supported |
+| [Auth0 Fastify](https://github.com/auth0/auth0-fastify/tree/main/packages/auth0-fastify) | Supported |
+| [Auth0 Fastify API](https://github.com/auth0/auth0-fastify/tree/main/packages/auth0-fastify-api) | Supported |
 | [Auth0 Python](https://github.com/auth0/auth0-python/tree/master) | Supported |
 | [Auth0 Server Python](https://github.com/auth0/auth0-server-python) | Supported |
 | [Auth0 API Python](https://github.com/auth0/auth0-api-python) | Supported |
@@ -138,6 +140,13 @@ All listed operating systems are the latest versions unless otherwise indicated.
 | [JWT Auth Bundle](https://github.com/auth0/jwt-auth-bundle/tree/master) | Supported |
 | [Auth0 ACUL JS](https://github.com/auth0/universal-login/blob/master/packages/auth0-acul-js/README.md) | Supported |
 | [Auth0 ACUL React](https://github.com/auth0/universal-login/blob/master/packages/auth0-acul-react/README.md) | Supported |
+
+### Infrastructure as code
+
+| Tool | Support Level |
+| --- | --- |
+| [Auth0 Terraform Provider](https://github.com/auth0/terraform-provider-auth0) | Supported |
+| [Auth0 OpenTofu Provider](https://search.opentofu.org/provider/auth0/auth0/latest) | Supported |
 
 ### Content Management Systems Plugins
 

--- a/main/docs/troubleshoot/customer-support/product-support-matrix.mdx
+++ b/main/docs/troubleshoot/customer-support/product-support-matrix.mdx
@@ -121,6 +121,7 @@ All listed operating systems are the latest versions unless otherwise indicated.
 | [Express OAuth2 JWT Bearer](https://github.com/auth0/node-oauth2-jwt-bearer/tree/main/packages/express-oauth2-jwt-bearer) | Supported |
 | [Auth0 Fastify](https://github.com/auth0/auth0-fastify/tree/main/packages/auth0-fastify) | Supported |
 | [Auth0 Fastify API](https://github.com/auth0/auth0-fastify/tree/main/packages/auth0-fastify-api) | Supported |
+| [Auth0 Hono](https://github.com/auth0/auth0-hono) | Supported |
 | [Auth0 Python](https://github.com/auth0/auth0-python/tree/master) | Supported |
 | [Auth0 Server Python](https://github.com/auth0/auth0-server-python) | Supported |
 | [Auth0 API Python](https://github.com/auth0/auth0-api-python) | Supported |
@@ -130,6 +131,7 @@ All listed operating systems are the latest versions unless otherwise indicated.
 | [Auth0 ASP.NET Core API](https://github.com/auth0/aspnetcore-api) | Supported |
 | [Auth0 Java](https://github.com/auth0/Auth0-java/tree/master) | Supported |
 | [Auth0 Java MVC Common](https://github.com/auth0/auth0-java-mvc-common/tree/master) | Supported |
+| [Auth0 Spring Boot API](https://github.com/auth0/auth0-auth-java) | Supported |
 | [Auth0 PHP](https://github.com/auth0/auth0-php/tree/master) | Supported |
 | [Laravel Auth0](https://github.com/auth0/laravel-auth0) | Supported |
 | [Go Auth0](https://github.com/auth0/go-auth0) | Supported |


### PR DESCRIPTION
## Summary

- **OpenTofu support**: Added a paragraph on the [Auth0 Terraform Provider page](https://auth0.com/docs/deploy-monitor/auth0-terraform-provider) noting that the provider is also available for [OpenTofu](https://search.opentofu.org/provider/auth0/auth0/latest), with a link to the OpenTofu Registry. Updated the pros/cons bullets to reference "Terraform or OpenTofu."
- **Support matrix — infrastructure tools**: Added a new "Infrastructure as code" section to the Product Support Matrix with rows for the Auth0 Terraform Provider and OpenTofu Provider (both Supported).
- **Support matrix — missing SDKs**: Added Auth0 Fastify and Auth0 Fastify API, which were absent from the Auth0 SDKs table.

## Test plan

- [ ] Verify the OpenTofu Registry link resolves: https://search.opentofu.org/provider/auth0/auth0/latest
- [ ] Verify Fastify SDK links resolve: https://github.com/auth0/auth0-fastify/tree/main/packages/auth0-fastify and https://github.com/auth0/auth0-fastify/tree/main/packages/auth0-fastify-api
- [ ] Check the Terraform Provider page renders the new paragraph correctly
- [ ] Check the support matrix renders the new section and rows correctly