### PR TITLE
docs(ios-swift): remove programmatic configuration section

### DIFF
--- a/main/docs/quickstart/native/ios-swift.mdx
+++ b/main/docs/quickstart/native/ios-swift.mdx
@@ -325,7 +325,6 @@ Your AI assistant will automatically create your Auth0 application, fetch creden
 1. Verify `Auth0.plist` is in your Xcode project navigator
 2. Select the file → Inspector → Ensure your app target is checked
 3. Confirm it has `ClientId` and `Domain` keys with your values
-4. **Alternative**: Use programmatic configuration (see Advanced Integration section below)
 
 ### Browser opens but never returns to app
 **Fix**: 
@@ -372,53 +371,6 @@ This is **required** for certain features to work properly:
 </Accordion>
 
 <Accordion title="Advanced Integration">
-### Programmatic Configuration
-
-<Warning>
-Never hardcode `clientId` or `domain` values directly in Swift source files — they will be committed to version control. Read them from environment variables or a build-time configuration file at runtime. For most apps, prefer `Auth0.plist` (the default approach in this quickstart).
-</Warning>
-
-Instead of using `Auth0.plist`, you can pass credentials directly in your code. This is useful when credentials need to be dynamic or environment-specific (e.g., different Auth0 tenants for dev/staging/production).
-
-**Replace `Auth0.webAuth()` calls with `Auth0.webAuth(clientId:domain:)`:**
-
-```swift
-// In AuthenticationService.swift - login function
-func login() async {
-    isLoading = true
-    errorMessage = nil
-    defer { isLoading = false }
-    
-    do {
-        let credentials = try await Auth0
-            .webAuth(clientId: "{yourClientId}", domain: "{yourDomain}")
-            .scope("openid profile email offline_access")
-            .start()
-        
-        _ = credentialsManager.store(credentials: credentials)
-        isAuthenticated = true
-        user = credentials.user
-    } catch {
-        errorMessage = "Login failed: \(error.localizedDescription)"
-    }
-}
-
-// In AuthenticationService.swift - logout function
-func logout() async {
-    isLoading = true
-    defer { isLoading = false }
-    
-    do {
-        try await Auth0.webAuth(clientId: "{yourClientId}", domain: "{yourDomain}").clearSession()
-        _ = credentialsManager.clear()
-        isAuthenticated = false
-        user = nil
-    } catch {
-        errorMessage = "Logout failed: \(error.localizedDescription)"
-    }
-}
-```
-
 ### Enhanced Keychain Security with Biometrics
 Require Face ID or Touch ID to access stored credentials:
 


### PR DESCRIPTION
## Description

Removes the "Programmatic Configuration" subsection that taught passing credentials inline via Auth0.webAuth(clientId:domain:). Eval-flywheel runs showed agents adopting this as the primary pattern — hardcoding clientId/ domain into Swift source (a security finding) instead of using Auth0.plist, and varying the webAuth() call form run-to-run.

Auth0.plist is the recommended default for the quickstart; the remaining Advanced Integration topics (biometrics, token refresh, app extensions, flow comparison) are kept.

This was the behavior observed with claude-opus-4-6,  claude-opus-4-8, GPT-5.4  locally. security graders were consistently failing

for example

##### Measured with the swift_quickstart eval (agent + MCP, claude-opus-4-8):

Current production docs: Grade B (~57% graders). Agent hardcoded
credentials in source → Security dimension 0/F, plus L1 webAuth() and L5
Auth0.plist graders failing.

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->



## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
