### PR TITLE
docs: add PROFILE_SIZE_EXCEEDED to bulk user import error codes

### DIFF
--- a/main/docs/manage-users/user-migration/bulk-user-imports.mdx
+++ b/main/docs/manage-users/user-migration/bulk-user-imports.mdx
@@ -709,6 +709,7 @@ Each error object will include an error code and a message explaining the error 
 * NOT_PASSED
 * OBJECT_REQUIRED
 * PATTERN
+* PROFILE_SIZE_EXCEEDED
 
 ## Best practices for large-scale migrations
 


### PR DESCRIPTION
## Description

The bulk user import worker now emits a `PROFILE_SIZE_EXCEEDED` error code when a user's profile exceeds the maximum allowed size. This adds it to the list of possible error codes documented on the Bulk User Imports page so customers can interpret the error when retrieving failed entries.

The new entry is inserted alphabetically in `main/docs/manage-users/user-migration/bulk-user-imports.mdx`, after `PATTERN`.

### References

- [IUM-4541](https://auth0team.atlassian.net/browse/IUM-4541) — Update import user worker public docs with new error code

### Testing

- Single-line addition to an existing bulleted list; no build-affecting changes.

## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.

> Note: The translated copies (`docs/fr-ca/...` and `docs/ja-jp/...` of this page) also list these error codes and will need the same addition — flagging for the Docs team to queue translation.