### PR TITLE
FGI-2209 docs(obo): document token binding behavior for OBO token exchange

### DIFF
--- a/main/docs/secure/call-apis-on-users-behalf/on-behalf-of-token-exchange.mdx
+++ b/main/docs/secure/call-apis-on-users-behalf/on-behalf-of-token-exchange.mdx
@@ -380,36 +380,6 @@ curl --location --request PATCH 'https://{yourDomain}/api/v2/clients/{clientId}'
 </Tab>
 </Tabs>
 
-## Token binding
-
-<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-When tokens are sender-constrained using [DPoP](/docs/secure/sender-constraining/demonstrating-proof-of-possession-dpop) or [mTLS](/docs/secure/sender-constraining/mtls-sender-constraining), only the specific holder of the key or certificate can prove possession and use the token. During an OBO exchange, the intermediate service (not the end user) holds the token. Auth0 cannot cryptographically verify that the intermediate service has the original holder's key or certificate, so Auth0 does not re-verify the original token's binding as part of the exchange.
-</Callout>
-
-**Verifying token binding is the responsibility of the intermediate service.** Binding is a cryptographic proof that the token holder possesses the original holder's key or certificate. Before exchanging a bound token, validate that the original token's binding is verified:
-
-* **DPoP**: Compute the JWK SHA-256 thumbprint of the `jwk` in the incoming DPoP proof (per [RFC 7638](https://www.rfc-editor.org/rfc/rfc7638)) and verify it matches the `cnf.jkt` claim in the subject token. Auth0 does not perform this check during token exchange.
-* **mTLS**: Compute the base64url-encoded SHA-256 thumbprint of the client certificate's DER encoding and verify it matches the `cnf.x5t#S256` claim in the subject token.
-
-If validation fails, reject the request without attempting the exchange.
-
-**Binding the new token**: Auth0 will sender-constrain the newly issued access token when the [downstream resource server has sender-constraining enabled or required](/docs/secure/sender-constraining), and the intermediate service presents a valid DPoP proof or mTLS certificate to the `/oauth/token` endpoint.
-
-| Mechanism | How to bind the new token |
-|-----------|--------------------------|
-| DPoP | Include a freshly generated `DPoP` proof header in the `/oauth/token` request. The proof must be scoped to this request: set `htm` to `POST` and `htu` to your Auth0 tenant's `/oauth/token` endpoint URI. The issued token will be DPoP-bound and `token_type` in the response will be `DPoP`. |
-| mTLS | For mTLS binding, OBO token exchange requires mutual TLS — the intermediate service must authenticate with a client certificate, not just rely on server-side TLS. The certificate must be [provisioned to the intermediate client in Auth0](/docs/get-started/applications/configure-mtls). Auth0 will issue a token containing a `cnf.x5t#S256` confirmation claim. |
-
-If neither a DPoP proof nor an mTLS certificate is presented, Auth0 issues an unbound bearer token regardless of the original subject token's binding status.
-
-**Binding mechanism transitions and mismatched capabilities**: The intermediate service can switch binding mechanisms during an OBO exchange (for example, from DPoP to mTLS), provided it possesses the necessary credentials for the new mechanism (for example, a provisioned mTLS certificate). The newly issued token reflects the new binding type. **Before exchanging, verify that the downstream API supports the binding mechanism you are presenting.** Auth0 does not validate mechanism compatibility — it will issue the token regardless. If the downstream API does not support the presented mechanism, it will reject the token at runtime. If mechanisms cannot be reconciled, do not attempt the exchange — return an error to the caller instead.
-
-**DPoP nonces**: If the original subject token was issued to a public client (such as a SPA or mobile app) using DPoP with a server-issued nonce, the intermediate service may not have a valid nonce for re-binding at the `/oauth/token` endpoint. In this case, Auth0 will return a `use_dpop_nonce` error with a fresh nonce in the `DPoP-Nonce` response header. Retry the request using that nonce in the new DPoP proof.
-
-<Callout icon="triangle-exclamation" color="#F59E0B" iconType="regular">
-If the original subject token was sender-constrained but the intermediate service does not present binding credentials (DPoP proof or mTLS certificate) to the `/oauth/token` endpoint, Auth0 does not reject the request — it issues an unbound bearer token without an error signal. The downstream API will accept it without proof of possession, making it replayable if intercepted. If the downstream resource server requires sender-constrained tokens, do not forward the unbound token — reject it and return an error to the caller.
-</Callout>
-
 ## Perform OBO token exchange
 
 To perform the OBO token exchange, you can use [`auth0-api-js`](https://github.com/auth0/auth0-auth-js), [`auth0_api_python`](https://github.com/auth0/auth0-api-python), or the [Authentication API](https://auth0.com/docs/api/authentication).
@@ -538,6 +508,38 @@ If successful, you should receive a response like the following:
 
 </Tab>
 </Tabs>
+
+## Token binding
+
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+When tokens are sender-constrained using [DPoP](/docs/secure/sender-constraining/demonstrating-proof-of-possession-dpop) or [mTLS](/docs/secure/sender-constraining/mtls-sender-constraining), only the specific holder of the key or certificate can prove possession and use the token. During an OBO exchange, the middle-tier service (not the end user) holds the token. Auth0 cannot cryptographically verify that the middle-tier service has the original holder's key or certificate, so Auth0 does not re-verify the original token's binding during the exchange.
+</Callout>
+
+Verifying token binding is the responsibility of the middle-tier service. Binding is a cryptographic proof that the token holder possesses the original holder's key or certificate. Before exchanging a bound token, validate that the original token's binding is verified:
+
+* DPoP: Compute the JWK SHA-256 thumbprint of the `jwk` in the incoming DPoP proof (per [RFC 7638](https://www.rfc-editor.org/rfc/rfc7638)) and verify it matches the `cnf.jkt` claim in the subject token. Auth0 does not perform this check during token exchange.
+* mTLS: Compute the base64url-encoded SHA-256 thumbprint of the client certificate's DER encoding and verify it matches the `cnf.x5t#S256` claim in the subject token.
+
+If validation fails, reject the request without attempting the exchange.
+
+**Binding the new token**: Auth0 will sender-constrain the newly issued access token when the [downstream resource server has sender-constraining enabled or required](/docs/secure/sender-constraining), and the middle-tier service presents a valid DPoP proof or mTLS certificate to the `/oauth/token` endpoint.
+
+| **Mechanism** | **How to bind the new token** |
+|-----------|--------------------------|
+| DPoP | Include a freshly generated `DPoP` proof header in the `/oauth/token` request. The proof must be scoped to this request: set `htm` to `POST` and `htu` to your Auth0 tenant's `/oauth/token` endpoint URI. The issued token will be DPoP-bound and `token_type` in the response will be `DPoP`. |
+| mTLS | For mTLS binding, OBO token exchange requires mutual TLS, where the intermediate service must authenticate with a client certificate, not just rely on server-side TLS. The certificate must be [provisioned to the middle-tier client in Auth0](/docs/get-started/applications/configure-mtls). Auth0 will issue a token containing a `cnf.x5t#S256` confirmation claim. |
+
+If neither a DPoP proof nor an mTLS certificate is presented, Auth0 issues an unbound bearer token regardless of the original subject token's binding status.
+
+**Binding mechanism transitions and mismatched capabilities**: The middle-tier service can switch binding mechanisms during an OBO exchange (for example, from DPoP to mTLS), provided it possesses the necessary credentials for the new mechanism (for example, a provisioned mTLS certificate). The newly issued token reflects the new binding type.
+
+Before exchanging, verify that the downstream API supports the binding mechanism you are presenting. Auth0 does not validate mechanism compatibility; it will issue the token regardless. If the downstream API does not support the presented mechanism, it will reject the token at runtime. If mechanisms cannot be reconciled, do not attempt the exchange; return an error to the caller instead.
+
+**DPoP nonces**: If the original subject token was issued to a public client (such as a SPA or mobile app) using DPoP with a server-issued nonce, the middle-tier service may not have a valid nonce for re-binding at the `/oauth/token` endpoint. In this case, Auth0 returns a `use_dpop_nonce` error with a fresh nonce in the `DPoP-Nonce` response header. Retry the request using that nonce in the new DPoP proof.
+
+<Callout icon="triangle-exclamation" color="#F59E0B" iconType="regular">
+If the original subject token was sender-constrained but the middle-tier service does not present binding credentials (DPoP proof or mTLS certificate) to the `/oauth/token` endpoint, Auth0 does not reject the request; instead, it issues an unbound bearer token without an error signal. The downstream API will accept it without proof of possession, making it replayable if intercepted. If the downstream resource server requires sender-constrained tokens, do not forward the unbound token. Reject it and return an error to the caller.
+</Callout>
 
 ## Organizations support
 

--- a/main/docs/secure/call-apis-on-users-behalf/on-behalf-of-token-exchange.mdx
+++ b/main/docs/secure/call-apis-on-users-behalf/on-behalf-of-token-exchange.mdx
@@ -380,6 +380,36 @@ curl --location --request PATCH 'https://{yourDomain}/api/v2/clients/{clientId}'
 </Tab>
 </Tabs>
 
+## Token binding
+
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+When tokens are sender-constrained using [DPoP](/docs/secure/sender-constraining/demonstrating-proof-of-possession-dpop) or [mTLS](/docs/secure/sender-constraining/mtls-sender-constraining), only the specific holder of the key or certificate can prove possession and use the token. During an OBO exchange, the intermediate service (not the end user) holds the token. Auth0 cannot cryptographically verify that the intermediate service has the original holder's key or certificate, so Auth0 does not re-verify the original token's binding as part of the exchange.
+</Callout>
+
+**Verifying token binding is the responsibility of the intermediate service.** Binding is a cryptographic proof that the token holder possesses the original holder's key or certificate. Before exchanging a bound token, validate that the original token's binding is verified:
+
+* **DPoP**: Compute the JWK SHA-256 thumbprint of the `jwk` in the incoming DPoP proof (per [RFC 7638](https://www.rfc-editor.org/rfc/rfc7638)) and verify it matches the `cnf.jkt` claim in the subject token. Auth0 does not perform this check during token exchange.
+* **mTLS**: Compute the base64url-encoded SHA-256 thumbprint of the client certificate's DER encoding and verify it matches the `cnf.x5t#S256` claim in the subject token.
+
+If validation fails, reject the request without attempting the exchange.
+
+**Binding the new token**: Auth0 will sender-constrain the newly issued access token when the [downstream resource server has sender-constraining enabled or required](/docs/secure/sender-constraining), and the intermediate service presents a valid DPoP proof or mTLS certificate to the `/oauth/token` endpoint.
+
+| Mechanism | How to bind the new token |
+|-----------|--------------------------|
+| DPoP | Include a freshly generated `DPoP` proof header in the `/oauth/token` request. The proof must be scoped to this request: set `htm` to `POST` and `htu` to your Auth0 tenant's `/oauth/token` endpoint URI. The issued token will be DPoP-bound and `token_type` in the response will be `DPoP`. |
+| mTLS | For mTLS binding, OBO token exchange requires mutual TLS — the intermediate service must authenticate with a client certificate, not just rely on server-side TLS. The certificate must be [provisioned to the intermediate client in Auth0](/docs/get-started/applications/configure-mtls). Auth0 will issue a token containing a `cnf.x5t#S256` confirmation claim. |
+
+If neither a DPoP proof nor an mTLS certificate is presented, Auth0 issues an unbound bearer token regardless of the original subject token's binding status.
+
+**Binding mechanism transitions and mismatched capabilities**: The intermediate service can switch binding mechanisms during an OBO exchange (for example, from DPoP to mTLS), provided it possesses the necessary credentials for the new mechanism (for example, a provisioned mTLS certificate). The newly issued token reflects the new binding type. **Before exchanging, verify that the downstream API supports the binding mechanism you are presenting.** Auth0 does not validate mechanism compatibility — it will issue the token regardless. If the downstream API does not support the presented mechanism, it will reject the token at runtime. If mechanisms cannot be reconciled, do not attempt the exchange — return an error to the caller instead.
+
+**DPoP nonces**: If the original subject token was issued to a public client (such as a SPA or mobile app) using DPoP with a server-issued nonce, the intermediate service may not have a valid nonce for re-binding at the `/oauth/token` endpoint. In this case, Auth0 will return a `use_dpop_nonce` error with a fresh nonce in the `DPoP-Nonce` response header. Retry the request using that nonce in the new DPoP proof.
+
+<Callout icon="triangle-exclamation" color="#F59E0B" iconType="regular">
+If the original subject token was sender-constrained but the intermediate service does not present binding credentials (DPoP proof or mTLS certificate) to the `/oauth/token` endpoint, Auth0 does not reject the request — it issues an unbound bearer token without an error signal. The downstream API will accept it without proof of possession, making it replayable if intercepted. If the downstream resource server requires sender-constrained tokens, do not forward the unbound token — reject it and return an error to the caller.
+</Callout>
+
 ## Perform OBO token exchange
 
 To perform the OBO token exchange, you can use [`auth0-api-js`](https://github.com/auth0/auth0-auth-js), [`auth0_api_python`](https://github.com/auth0/auth0-api-python), or the [Authentication API](https://auth0.com/docs/api/authentication).

--- a/main/docs/secure/call-apis-on-users-behalf/on-behalf-of-token-exchange.mdx
+++ b/main/docs/secure/call-apis-on-users-behalf/on-behalf-of-token-exchange.mdx
@@ -511,9 +511,19 @@ If successful, you should receive a response like the following:
 
 ## Token binding
 
-<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-When tokens are sender-constrained using [DPoP](/docs/secure/sender-constraining/demonstrating-proof-of-possession-dpop) or [mTLS](/docs/secure/sender-constraining/mtls-sender-constraining), only the specific holder of the key or certificate can prove possession and use the token. During an OBO exchange, the middle-tier service (not the end user) holds the token. Auth0 cannot cryptographically verify that the middle-tier service has the original holder's key or certificate, so Auth0 does not re-verify the original token's binding during the exchange.
-</Callout>
+<Warning>
+When tokens are sender-constrained using [DPoP](/docs/secure/sender-constraining/demonstrating-proof-of-possession-dpop) or [mTLS](/docs/secure/sender-constraining/mtls-sender-constraining), only the specific holder of the key or certificate can prove possession and use the token.
+
+During an OBO exchange, the [middle-tier service](/docs/secure/call-apis-on-users-behalf/on-behalf-of-token-exchange) holds the token.
+
+Auth0 cannot cryptographically verify that the middle-tier service holds the original holder's key or certificate, so it does not re-verify the original token's binding during the exchange.
+
+The middle-tier service is responsible for:
+
+* Verifying token binding
+* Binding new tokens
+* Managing binding switch mechanism between DPoP and mTLS
+</Warning>
 
 Verifying token binding is the responsibility of the middle-tier service. Binding is a cryptographic proof that the token holder possesses the original holder's key or certificate. Before exchanging a bound token, validate that the original token's binding is verified:
 


### PR DESCRIPTION
docs(obo): document token binding behavior for OBO token exchange

  ## Description

  Adds a "Token binding" section to the On-Behalf-Of token exchange documentation. Covers:

  - **Verification responsibility**: The intermediate service must verify sender-constrained tokens (DPoP/mTLS) before calling the OBO endpoint. Auth0 does not re-verify the original token's binding during exchange.
  - **Binding the new token**: How to present a DPoP proof or mTLS certificate to `/oauth/token` so the newly issued access token is sender-constrained.
  - **Mechanism transitions**: The intermediate service can switch binding mechanisms (e.g. DPoP → mTLS) during exchange, provided it holds the necessary credentials.
  - **DPoP nonces**: Handling the `use_dpop_nonce` error when the original token was issued to a public client.
  - **Silent downgrade risk**: Auth0 issues an unbound bearer token when no binding credentials are presented, without an error signal — callers must guard against this explicitly.

  ### References

  - [FGI-2209](https://auth0team.atlassian.net/browse/FGI-2209)
  - [Threat Model PSREV-2473 — OBO Token Exchange](https://oktainc.atlassian.net/wiki/spaces/REX/pages/836632654/Threat+Model+PSREV-2473+On-Behalf-Of+Token+Exchange)

  ## Checklist

  - [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
  - [x] I've tested the site build for this change locally.
  - [x] I've made appropriate docs updates for any code or config changes.
  - [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.