### PR TITLE
docs: document redirect to custom domain requirement

### DIFF
--- a/main/docs/customize/email/email-templates/customize-email-templates.mdx
+++ b/main/docs/customize/email/email-templates/customize-email-templates.mdx
@@ -54,6 +54,20 @@ Email templates that include a link (**Verification Email (Link)**, **Change Pas
 * The **Redirect To** field sets a URL where a user is redirected after completing the action at an included link.
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+
+Tenants created on or after **May 5, 2026** cannot customize the **Redirect To** field (`resultUrl` in the Management API) unless the tenant has a [verified custom domain](/docs/customize/custom-domains). This requirement was added to mitigate an open-redirect abuse vector.
+
+Attempting to set `resultUrl` via the Management API on an affected tenant returns:
+
+```text
+403 — Customizations for resultUrl are not allowed for non-enterprise tenants
+```
+
+Despite the wording, this is not a subscription-tier restriction. The gate is a verified custom domain, regardless of plan. To enable customization of the **Redirect To** field, [configure a custom domain](/docs/customize/custom-domains) and complete domain verification, then retry the request.
+
+</Callout>
+
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 Universal Login currently ignores the value of the **Redirect To** field in the **Password Reset** template and instead redirects to the [default login route](/docs/authenticate/login/auth0-universal-login/configure-default-login-routes) or an [error page](/docs/authenticate/login/auth0-universal-login/error-pages).
 
 To customize the password reset **Redirect To** URL when using Universal Login, use [`api.transaction.setResultURL()` from the `post-challenge` Actions trigger](/docs/customize/actions/explore-triggers/password-reset-triggers/post-challenge-trigger/post-challenge-api-object#api-transaction-setresulturl-url,-options)

--- a/main/docs/customize/email/email-templates/customize-email-templates.mdx
+++ b/main/docs/customize/email/email-templates/customize-email-templates.mdx
@@ -55,15 +55,15 @@ Email templates that include a link (**Verification Email (Link)**, **Change Pas
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 
-Tenants created on or after **May 5, 2026** cannot customize the **Redirect To** field (`resultUrl` in the Management API) unless the tenant has a [verified custom domain](/docs/customize/custom-domains). This requirement was added to mitigate an open-redirect abuse vector.
+Tenants created on or after **May 5, 2026** with a non-enterprise subscription cannot customize the **Redirect To** field (`resultUrl` in the Management API). Tenants created before this date are exempt regardless of subscription type. This restriction was added to mitigate an open-redirect abuse vector.
 
-Attempting to set `resultUrl` via the Management API on an affected tenant returns:
+Attempting to set `resultUrl` on an affected tenant returns:
 
 ```text
 403 — Customizations for resultUrl are not allowed for non-enterprise tenants
 ```
 
-Despite the wording, this is not a subscription-tier restriction. The gate is a verified custom domain, regardless of plan. To enable customization of the **Redirect To** field, [configure a custom domain](/docs/customize/custom-domains) and complete domain verification, then retry the request.
+To customize the **Redirect To** field on a non-enterprise tenant created on or after May 5, 2026, contact your Auth0 account team about upgrading your subscription.
 
 </Callout>
 

--- a/main/docs/customize/email/email-templates/supported-liquid-syntax.mdx
+++ b/main/docs/customize/email/email-templates/supported-liquid-syntax.mdx
@@ -135,7 +135,7 @@ In email templates with a **Redirect To** URL field, only the following three va
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 
-Custom **Redirect To** values may not be available on tenants created on or after May 5, 2026 without a verified custom domain. See [URL Lifetime and Redirect to](/docs/customize/email/email-templates/customize-email-templates#url-lifetime-and-redirect-to).
+Custom **Redirect To** values are not available on non-enterprise tenants created on or after May 5, 2026. See [URL Lifetime and Redirect to](/docs/customize/email/email-templates/customize-email-templates#url-lifetime-and-redirect-to).
 
 </Callout>
 

--- a/main/docs/customize/email/email-templates/supported-liquid-syntax.mdx
+++ b/main/docs/customize/email/email-templates/supported-liquid-syntax.mdx
@@ -133,6 +133,12 @@ To use custom domains in emails, ensure you have:
 
 In email templates with a **Redirect To** URL field, only the following three variables are supported:
 
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+
+Custom **Redirect To** values may not be available on tenants created on or after May 5, 2026 without a verified custom domain. See [URL Lifetime and Redirect to](/docs/customize/email/email-templates/customize-email-templates#url-lifetime-and-redirect-to).
+
+</Callout>
+
 * `application.name` (or its synonym `client.name`)
 * `application.clientID`
 * `application.callback_domain` (or its synonym `client.callback_domain`), which contains the origin of the first URL listed in the application's **Allowed Callback URL** list. This is an origin and therefore includes the protocol (like `https://`) in addition to the domain.


### PR DESCRIPTION
## Description

Documents the restriction on the email template **Redirect To** field (`resultUrl`) for tenants created on or after May 5, 2026 without a verified custom domain.


### References

https://auth0team.atlassian.net/browse/DOCS-5447

### Testing


## Checklist

- [ x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ x] I've tested the site build for this change locally.
- [ x] I've made appropriate docs updates for any code or config changes.
- [ x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
