### PR TITLE
fix: make property lifecycle badge blue

### DIFF
--- a/main/ui/css/styles.css
+++ b/main/ui/css/styles.css
@@ -255,3 +255,13 @@ img.icon.inline {
     right: 0;
   }
 }
+
+[data-component-part="field-meta-post"] {
+  background-color: lab(91.896% .077188 -6.94053);
+  color: lab(36.091% 25.9241 -68.0384);
+}
+
+.dark [data-component-part="field-meta-post"] {
+  background-color: lab(16.0426% 6.71726 -27.2409);
+  color: lab(72.6029% 4.08953 -41.9669);
+}


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

Makes property-level lifecycle badges blue (similar to top/endpoint level lifecycle badges)

### Testing

#### Before:

Light:
<img width="987" height="253" alt="Screenshot 2026-06-16 at 1 04 46 PM" src="https://github.com/user-attachments/assets/7009b48f-c3c4-4611-84d3-9e9118ddb2b8" />

Dark:
<img width="971" height="256" alt="Screenshot 2026-06-16 at 1 04 40 PM" src="https://github.com/user-attachments/assets/6ca36e2f-5d0a-4635-8972-f3313fdbb39d" />

#### After

Light:
<img width="856" height="250" alt="Screenshot 2026-06-16 at 1 03 49 PM" src="https://github.com/user-attachments/assets/0f5f6cbf-6f1f-48e6-a585-f079b7934aba" />

Dark:
<img width="840" height="322" alt="Screenshot 2026-06-16 at 1 03 43 PM" src="https://github.com/user-attachments/assets/cee65f2a-690f-4e78-b179-0e30572d84a9" />

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
