### PR TITLE
DOCS-5530 update events-best-practices doc

### DIFF
--- a/main/docs/customize/events/events-best-practices.mdx
+++ b/main/docs/customize/events/events-best-practices.mdx
@@ -24,7 +24,7 @@ Auth0 does not guarantee that events are delivered in the same sequence that the
 * `user.deleted (for User 2)`
 * `user.updated (for User 2)`
 
-To ensure you do not overwrite your data with stale information, check the timestamp of the incoming webhook data against the timestamp of the data in your system. Each `data.object` in the payload includes a `created_at` field and an `updated_at` field.
+To ensure you do not overwrite your data with stale information, check the timestamp of the incoming webhook data against the timestamp of the data in your system. Each `data.object` in the payload includes a `time` field of when the event occurred.
 
 ### Listen for specific event types
 


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

Added `time` field to the Handle out-of-sequence events section


### References

DOCS-5530

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
