### PR TITLE
fix(auth-api): mark client_id as optional in signup and change_password

### DIFF
--- a/main/docs/api/authentication/change-password/change-password.mdx
+++ b/main/docs/api/authentication/change-password/change-password.mdx
@@ -30,8 +30,8 @@ Optionally, you may provide an Organization ID to support Organization-specific 
 - [Auth0 API Rate Limit Policy](https://auth0.com/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations)
 
 ## Body Parameters
-<ParamField body="client_id" type="string" required>
-  The `client_id` of your client.
+<ParamField body="client_id" type="string">
+  The `client_id` of your client. Required only when the [password-reset-post-challenge Actions trigger](/docs/customize/actions/explore-triggers/password-reset-triggers/post-challenge-trigger) is bound to your tenant; otherwise optional.
 </ParamField>
 
 <ParamField body="email" type="string" required>

--- a/main/docs/api/authentication/signup/create-a-new-user.mdx
+++ b/main/docs/api/authentication/signup/create-a-new-user.mdx
@@ -24,8 +24,8 @@ This endpoint only works for database connections.
 - [Metadata Overview](https://auth0.com/docs/manage-users/user-accounts/metadata)
 
 ## Body Parameters
-<ParamField body="client_id" type="string" required>
-  The `client_id` of your client.
+<ParamField body="client_id" type="string">
+  The `client_id` of your client. If omitted, the request falls back to the tenant's global client ID.
 </ParamField>
 
 <ParamField body="email" type="string">


### PR DESCRIPTION
## Description

fix(auth-api): mark client_id as optional in signup and change_password

### References

https://auth0team.atlassian.net/browse/DR-2799

### Testing

## Checklist

- [x ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ x] I've tested the site build for this change locally.
- [ x] I've made appropriate docs updates for any code or config changes.
- [ x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
