### PR TITLE
Add Passkeys to Authentication API

### DIFF
--- a/main/config/navigation/api.authentication.en.json
+++ b/main/config/navigation/api.authentication.en.json
@@ -28,6 +28,13 @@
       ]
     },
     {
+      "group": "Passkeys",
+      "pages": [
+        "docs/api/authentication/passkey/challenge",
+        "docs/api/authentication/passkey/register"
+      ]
+    },
+    {
       "group": "Signup",
       "pages": ["docs/api/authentication/signup/create-a-new-user"]
     },

--- a/main/docs/api/authentication/passkey/challenge.mdx
+++ b/main/docs/api/authentication/passkey/challenge.mdx
@@ -57,7 +57,7 @@ A successful response contains the WebAuthn parameters your application passes t
     </ResponseField>
 
     <ResponseField name="rpId" type="string">
-      [Relying party identifier(RP ID)](/docs/authenticate/database-connections/passkeys#relying-party-id-for-passkeys). Defaults to the tenant custom domain. When the tenant has a custom relying party identifier configured, Auth0 returns the `rp.id` value instead.
+      [Relying party identifier (RP ID)](/docs/authenticate/database-connections/passkeys#relying-party-id-for-passkeys). Defaults to the tenant custom domain. When the tenant has a custom relying party identifier configured, Auth0 returns the `rp.id` value instead.
     </ResponseField>
 
     <ResponseField name="userVerification" type="string">


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

This PR add /challenge.mdx and /register.mdx to Authentication API.

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
