### PR TITLE
fix: nest rate-limit-configurations as nav group

### DIFF
--- a/main/config/navigation/platform.json
+++ b/main/config/navigation/platform.json
@@ -39,17 +39,22 @@
           "pages": [
             "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-use-cases",
             "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies",
-            "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations",
-            "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/free-public",
-            "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/essentials-professional-b2b",
-            "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/enterprise-public",
-            "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/tier-20-development-private-cloud",
-            "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/tier-100-rps-private-cloud",
-            "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/tier-500-rps-private-cloud",
-            "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/tier-1500-rps-private-cloud",
-            "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/tier-3000-rps-private-cloud",
-            "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/tier-6000-rps-private-cloud",
-            "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/tier-10000-rps-private-cloud"
+            {
+              "group": "Rate Limit Configurations",
+              "root": "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations",
+              "pages": [
+                "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/free-public",
+                "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/essentials-professional-b2b",
+                "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/enterprise-public",
+                "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/tier-20-development-private-cloud",
+                "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/tier-100-rps-private-cloud",
+                "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/tier-500-rps-private-cloud",
+                "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/tier-1500-rps-private-cloud",
+                "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/tier-3000-rps-private-cloud",
+                "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/tier-6000-rps-private-cloud",
+                "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/tier-10000-rps-private-cloud"
+              ]
+            }
           ]
         },
         "docs/troubleshoot/customer-support/operational-policies/entity-limit-policy",


### PR DESCRIPTION
## Description

Fixes a Mintlify deployment failure (500 on prod) introduced by #1252.

The `rate-limit-configurations` sub-pages were listed flat in the `platform.json` pages array alongside their parent index page. Mintlify requires sub-pages to be nested inside a group object. This wraps them into a proper nested group:

```json
{
  "group": "Rate Limit Configurations",
  "root": "docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations",
  "pages": [ ... ]
}
```

## References

Fixes regression from #1252

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've made appropriate docs updates for any code or config changes.