### PR TITLE
feat: add beta Express and Express API quickstarts

### DIFF
--- a/main/config/navigation/quickstarts.json
+++ b/main/config/navigation/quickstarts.json
@@ -20,6 +20,7 @@
         "docs/quickstart/webapp/nextjs",
         "docs/quickstart/webapp/nuxt",
         "docs/quickstart/webapp/express",
+        "docs/quickstart/webapp/express-beta",
         "docs/quickstart/webapp/fastify",
         "docs/quickstart/webapp/python",
         "docs/quickstart/webapp/django/interactive",
@@ -64,6 +65,7 @@
       "group": "Backend/API",
       "pages": [
         "docs/quickstart/backend/nodejs",
+        "docs/quickstart/backend/express-api-beta",
         "docs/quickstart/backend/fastify/index",
         "docs/quickstart/backend/django/interactive",
         "docs/quickstart/backend/python/index",

--- a/main/docs/quickstart/backend/express-api-beta.mdx
+++ b/main/docs/quickstart/backend/express-api-beta.mdx
@@ -223,11 +223,11 @@ Test the protected endpoint without a token (should fail):
 curl -i http://localhost:3001/api/private
 ```
 
-The request is rejected with `400 Bad Request` and a `WWW-Authenticate` header. The response body is:
+The request is rejected with `401 Unauthorized` and a `WWW-Authenticate` header. The response body is:
 
 ```json
 {
-  "error": "invalid_request",
+  "error": "invalid_token",
   "error_description": "No Authorization provided"
 }
 ```
@@ -259,7 +259,7 @@ Expected response:
 
   You should now have a protected API. Your API:
   1. Accepts requests to public endpoints without a token
-  2. Rejects requests with no `Authorization` header (returns `400`) and requests with an invalid or expired JWT (returns `401`)
+  2. Rejects requests with no `Authorization` header, or with an invalid or expired JWT (returns `401`)
   3. Validates JWTs against your Auth0 domain and audience
   4. Exposes decoded token claims via `req.auth0.user`
 </Check>
@@ -389,9 +389,9 @@ Your client application must then request these scopes when obtaining an access 
 
 <AccordionGroup>
 
-<Accordion title="'No Authorization provided' (400)">
+<Accordion title="'No Authorization provided' (401)">
 
-**Cause:** The `Authorization` header is missing or malformed, so no bearer token could be extracted. The SDK returns `400 invalid_request` in this case (a token that is present but invalid or expired returns `401 invalid_token`).
+**Cause:** The `Authorization` header is missing or malformed, so no bearer token could be extracted. The SDK returns `401 invalid_token` in this case — the same status it returns for a token that is present but invalid or expired.
 
 **Fix:**
 1. Ensure the header is present: `Authorization: Bearer YOUR_TOKEN`

--- a/main/docs/quickstart/backend/express-api-beta.mdx
+++ b/main/docs/quickstart/backend/express-api-beta.mdx
@@ -237,23 +237,10 @@ app.get('/api/editor', requiresAuth(), claimIncludes('roles', ['admin', 'editor'
 
 // Protected with claimCheck — custom logic
 app.get('/api/premium', requiresAuth(), claimCheck(
-  (token) => token.tier === 'premium' || token.roles?.includes('admin'),
+  (req, token) => token.tier === 'premium' || token.roles?.includes('admin'),
   { errorMessage: 'Premium tier or admin role required' }
 ), (req, res) => {
   res.json({ message: 'Premium content access granted.' });
-});
-
-// Error handling middleware — must be last
-app.use((err, req, res, next) => {
-  const status = err.status || 500;
-  res.status(status).json({
-    error: err.code || 'server_error',
-    message: status === 401
-      ? 'Authentication required'
-      : status === 403
-      ? err.message || 'Insufficient permissions'
-      : 'Internal server error',
-  });
 });
 
 app.listen(port, () => {
@@ -290,15 +277,15 @@ Expected response:
 Test the protected endpoint without a token (should fail):
 
 ```shell
-curl http://localhost:3001/api/private
+curl -i http://localhost:3001/api/private
 ```
 
-Expected response:
+The request is rejected with `400 Bad Request` and a `WWW-Authenticate` header. The response body is:
 
 ```json
 {
-  "error": "unauthorized",
-  "message": "Authentication required"
+  "error": "invalid_request",
+  "error_description": "No Authorization provided"
 }
 ```
 
@@ -328,7 +315,7 @@ Expected response:
 
   You should now have a protected API. Your API:
   1. Accepts requests to public endpoints without a token
-  2. Rejects requests to protected endpoints without a valid JWT (returns `401`)
+  2. Rejects requests with no `Authorization` header (returns `400`) and requests with an invalid or expired JWT (returns `401`)
   3. Validates JWTs against your Auth0 domain and audience
   4. Exposes decoded token claims via `req.auth0.user`
 </Check>

--- a/main/docs/quickstart/backend/express-api-beta.mdx
+++ b/main/docs/quickstart/backend/express-api-beta.mdx
@@ -223,13 +223,11 @@ Test the protected endpoint without a token (should fail):
 curl -i http://localhost:3001/api/private
 ```
 
-The request is rejected with `401 Unauthorized` and a `WWW-Authenticate` header. The response body is:
+The request is rejected with `401 Unauthorized` and a bare `WWW-Authenticate: Bearer` header. Per [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750#section-3), when a request carries no authentication information the API returns no error code and an empty body:
 
-```json
-{
-  "error": "invalid_token",
-  "error_description": "No Authorization provided"
-}
+```http
+HTTP/1.1 401 Unauthorized
+WWW-Authenticate: Bearer
 ```
 
 To test with a valid token:
@@ -259,9 +257,10 @@ Expected response:
 
   You should now have a protected API. Your API:
   1. Accepts requests to public endpoints without a token
-  2. Rejects requests with no `Authorization` header, or with an invalid or expired JWT (returns `401`)
-  3. Validates JWTs against your Auth0 domain and audience
-  4. Exposes decoded token claims via `req.auth0.user`
+  2. Rejects requests with no `Authorization` header (returns `401` with a bare `WWW-Authenticate: Bearer` header and no body)
+  3. Rejects requests with an invalid or expired JWT (returns `401` with an `invalid_token` error)
+  4. Validates JWTs against your Auth0 domain and audience
+  5. Exposes decoded token claims via `req.auth0.user`
 </Check>
 
 </Steps>
@@ -389,14 +388,13 @@ Your client application must then request these scopes when obtaining an access 
 
 <AccordionGroup>
 
-<Accordion title="'No Authorization provided' (401)">
+<Accordion title="401 with an empty body and a bare 'WWW-Authenticate: Bearer' header">
 
-**Cause:** The `Authorization` header is missing or malformed, so no bearer token could be extracted. The SDK returns `401 invalid_token` in this case — the same status it returns for a token that is present but invalid or expired.
+**Cause:** The `Authorization` header is missing or malformed, so no bearer token could be extracted. Per [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750#section-3), the SDK returns `401` with a bare `WWW-Authenticate: Bearer` header and no error body in this case. This is distinct from a token that is *present but invalid or expired*, which returns `401` with an `invalid_token` error and a JSON body (see below).
 
 **Fix:**
 1. Ensure the header is present: `Authorization: Bearer YOUR_TOKEN`
 2. Verify "Bearer" (with a capital B and a space) precedes the token
-3. Confirm the token is not expired — decode at [jwt.io](https://jwt.io) and check the `exp` claim
 
 </Accordion>
 

--- a/main/docs/quickstart/backend/express-api-beta.mdx
+++ b/main/docs/quickstart/backend/express-api-beta.mdx
@@ -469,7 +469,6 @@ Or rename your server file to `server.mjs`.
 
 ## Resources
 
-- **[@auth0/auth0-express-api GitHub](https://github.com/auth0/auth0-express/tree/main/packages/auth0-express-api)** — Source code and examples
+- **[auth0/auth0-express-api GitHub](https://github.com/auth0/auth0-express/tree/main/packages/auth0-express-api)** — Source code and examples
 - **[Auth0 Community](https://community.auth0.com/)** — Get help from the community
 - **[JWT.io](https://jwt.io/)** — Debug and decode JWTs
-- **[Stable Express API Quickstart](/docs/quickstart/backend/nodejs)** — Using `express-oauth2-jwt-bearer`

--- a/main/docs/quickstart/backend/express-api-beta.mdx
+++ b/main/docs/quickstart/backend/express-api-beta.mdx
@@ -126,9 +126,9 @@ Create your `.env` file:
 
 <AuthCodeBlock children={envSnippetDashboard} language="shellscript" filename=".env" />
 
-<Warning>
+<Callout>
 Replace `YOUR_AUTH0_DOMAIN` with your Auth0 tenant domain (e.g., `dev-abc123.us.auth0.com`) and `YOUR_API_IDENTIFIER` with the API identifier you set above.
-</Warning>
+</Callout>
 
 </Tab>
 </Tabs>
@@ -397,9 +397,9 @@ Your client application must then request these scopes when obtaining an access 
 
 <AccordionGroup>
 
-<Accordion title="'No authorization token was found' (401)">
+<Accordion title="'No Authorization provided' (400)">
 
-**Cause:** The `Authorization` header is missing or malformed.
+**Cause:** The `Authorization` header is missing or malformed, so no bearer token could be extracted. The SDK returns `400 invalid_request` in this case (a token that is present but invalid or expired returns `401 invalid_token`).
 
 **Fix:**
 1. Ensure the header is present: `Authorization: Bearer YOUR_TOKEN`

--- a/main/docs/quickstart/backend/express-api-beta.mdx
+++ b/main/docs/quickstart/backend/express-api-beta.mdx
@@ -160,7 +160,7 @@ app.get('/api/public', (req, res) => {
 app.get('/api/private', requiresAuth(), (req, res) => {
   res.json({
     message: 'Hello from a protected endpoint! You are authenticated.',
-    sub: req.auth0.user.sub,
+    sub: req.auth0.user?.sub,
     timestamp: new Date().toISOString(),
   });
 });
@@ -175,78 +175,20 @@ app.listen(port, () => {
 - `requiresAuth()` validates the `Authorization: Bearer <token>` header on each request
 - `req.auth0.user` contains the decoded JWT claims for authenticated requests — `sub` is the user's unique identifier
 
-## Add scope and claim-based authorization
+## Protect a route with a required scope
 
-Protect routes with fine-grained access control using scopes and claims.
+Beyond requiring a valid token, you can require a specific scope. Pass a `scopes` option to `requiresAuth()` — the SDK returns `403 insufficient_scope` if the token is missing the scope.
 
-```javascript server.js expandable
-import 'dotenv/config';
-import express from 'express';
-import {
-  createAuth0Api,
-  requiresAuth,
-  scopesInclude,
-  claimEquals,
-  claimIncludes,
-  claimCheck,
-} from '@auth0/auth0-express-api';
-
-const app = express();
-const port = process.env.PORT || 3001;
-
-app.use(express.json());
-app.use(createAuth0Api());
-
-// Public route
-app.get('/api/public', (req, res) => {
-  res.json({ message: 'Public endpoint — no authentication required.' });
-});
-
-// Protected route — any valid token
-app.get('/api/private', requiresAuth(), (req, res) => {
-  res.json({
-    message: 'Authenticated endpoint.',
-    sub: req.auth0.user.sub,
-  });
-});
-
-// Protected with inline scope check
+```javascript server.js
+// Requires the "read:messages" scope
 app.get('/api/messages', requiresAuth({ scopes: ['read:messages'] }), (req, res) => {
   res.json({ messages: ['Hello!', 'World!'] });
 });
-
-// Protected with scopesInclude — requires ANY of these scopes
-app.get('/api/feed', requiresAuth(), scopesInclude('read:feed read:admin'), (req, res) => {
-  res.json({ feed: [] });
-});
-
-// Protected with scopesInclude — requires ALL scopes
-app.get('/api/admin/edit', requiresAuth(), scopesInclude(['read:admin', 'write:admin'], { match: 'all' }), (req, res) => {
-  res.json({ message: 'Admin editor access granted.' });
-});
-
-// Protected with claimEquals — exact claim value
-app.get('/api/admin', requiresAuth(), claimEquals('isAdmin', true), (req, res) => {
-  res.json({ message: 'Admin access granted.' });
-});
-
-// Protected with claimIncludes — claim array contains all values
-app.get('/api/editor', requiresAuth(), claimIncludes('roles', ['admin', 'editor']), (req, res) => {
-  res.json({ message: 'Editor access granted.' });
-});
-
-// Protected with claimCheck — custom logic
-app.get('/api/premium', requiresAuth(), claimCheck(
-  (req, token) => token.tier === 'premium' || token.roles?.includes('admin'),
-  { errorMessage: 'Premium tier or admin role required' }
-), (req, res) => {
-  res.json({ message: 'Premium content access granted.' });
-});
-
-app.listen(port, () => {
-  console.log(`API server running at http://localhost:${port}`);
-});
 ```
+
+<Note>
+Define the scope in your API's **Permissions** tab (see [Advanced Usage](#advanced-usage)) and request it when obtaining the access token. For matching multiple scopes or authorizing on custom claims, the SDK also provides `scopesInclude`, `claimEquals`, `claimIncludes`, and `claimCheck` — covered in [Advanced Usage](#advanced-usage).
+</Note>
 
 ## Run your API
 
@@ -270,7 +212,8 @@ Expected response:
 
 ```json
 {
-  "message": "Public endpoint — no authentication required."
+  "message": "Hello from a public endpoint! No authentication required.",
+  "timestamp": "2026-06-22T12:00:00.000Z"
 }
 ```
 
@@ -305,8 +248,9 @@ Expected response:
 
 ```json
 {
-  "message": "Authenticated endpoint.",
-  "sub": "auth0|abc123..."
+  "message": "Hello from a protected endpoint! You are authenticated.",
+  "sub": "auth0|abc123...",
+  "timestamp": "2026-06-22T12:00:00.000Z"
 }
 ```
 
@@ -327,6 +271,54 @@ Expected response:
 ## Advanced Usage
 
 <AccordionGroup>
+
+<Accordion title="Matching multiple scopes with scopesInclude">
+
+Use `scopesInclude` when a route should accept any one of several scopes, or require several at once. By default it matches **any** of the listed scopes; pass `{ match: 'all' }` to require all of them.
+
+```javascript server.js
+import { scopesInclude } from '@auth0/auth0-express-api';
+
+// Requires ANY of these scopes
+app.get('/api/feed', requiresAuth(), scopesInclude('read:feed read:admin'), (req, res) => {
+  res.json({ feed: [] });
+});
+
+// Requires ALL of these scopes
+app.get('/api/admin/edit', requiresAuth(), scopesInclude(['read:admin', 'write:admin'], { match: 'all' }), (req, res) => {
+  res.json({ message: 'Admin editor access granted.' });
+});
+```
+
+</Accordion>
+
+<Accordion title="Authorizing on custom claims">
+
+When authorization depends on claims other than `scope`, use `claimEquals`, `claimIncludes`, or `claimCheck`. Each runs after `requiresAuth()` and returns `401 invalid_token` if the claim requirement isn't met.
+
+```javascript server.js
+import { claimEquals, claimIncludes, claimCheck } from '@auth0/auth0-express-api';
+
+// claimEquals — claim must equal an exact value
+app.get('/api/admin', requiresAuth(), claimEquals('isAdmin', true), (req, res) => {
+  res.json({ message: 'Admin access granted.' });
+});
+
+// claimIncludes — array claim must contain all listed values
+app.get('/api/editor', requiresAuth(), claimIncludes('roles', ['admin', 'editor']), (req, res) => {
+  res.json({ message: 'Editor access granted.' });
+});
+
+// claimCheck — custom logic over the decoded token
+app.get('/api/premium', requiresAuth(), claimCheck(
+  (req, token) => token.tier === 'premium' || token.roles?.includes('admin'),
+  { errorMessage: 'Premium tier or admin role required' }
+), (req, res) => {
+  res.json({ message: 'Premium content access granted.' });
+});
+```
+
+</Accordion>
 
 <Accordion title="Defining custom token claims with TypeScript">
 

--- a/main/docs/quickstart/backend/express-api-beta.mdx
+++ b/main/docs/quickstart/backend/express-api-beta.mdx
@@ -1,0 +1,499 @@
+---
+mode: wide
+title: Protect Your Express.js API
+sidebarTitle: Express API (Beta)
+description: This guide demonstrates how to protect Express.js API endpoints using JWT access tokens with the @auth0/auth0-express-api SDK (Beta).
+---
+
+import {HowToSchema} from "/snippets/HowToSchema.jsx";
+import {QuickstartButtons} from "/snippets/QuickstartButtons.jsx";
+import {AuthCodeBlock} from "/snippets/AuthCodeBlock.jsx";
+import {AuthCodeGroup} from "/snippets/AuthCodeGroup.jsx";
+
+<HowToSchema />
+<Callout icon="pencil" color="#FFC107" iconType="solid">
+  This Quickstart is currently in **Beta**. We'd love to hear your feedback!
+</Callout>
+
+<QuickstartButtons githubLink="https://github.com/auth0-samples/auth0-express-api-samples/tree/beta" />
+
+export const envSnippet = `AUTH0_DOMAIN={yourDomain}
+AUTH0_AUDIENCE=YOUR_API_IDENTIFIER`;
+
+export const envSnippetDashboard = `AUTH0_DOMAIN=YOUR_AUTH0_DOMAIN
+AUTH0_AUDIENCE=YOUR_API_IDENTIFIER`;
+
+<Note>
+  **Prerequisites:** Before you begin, ensure you have the following installed:
+  - [Node.js](https://nodejs.org/) 22 LTS or newer
+  - [npm](https://www.npmjs.com/) 10+ or [yarn](https://yarnpkg.com/) 1.22+
+</Note>
+
+## Get Started
+
+This quickstart demonstrates how to protect Express.js API endpoints using JWT access tokens. You'll build a secure API that validates Auth0 access tokens, protects routes, and implements scope- and claim-based authorization.
+
+<Steps>
+
+## Create a new project
+
+Create a new directory for your Express API and initialize a Node.js project.
+
+<AuthCodeGroup>
+```shellscript Mac
+mkdir auth0-express-api && cd auth0-express-api
+npm init -y
+touch server.js .env
+```
+```shellscript Windows
+mkdir auth0-express-api; cd auth0-express-api
+npm init -y
+New-Item server.js, .env
+```
+</AuthCodeGroup>
+
+Update your `package.json` to use ES modules and add start scripts:
+
+```json package.json
+{
+  "name": "auth0-express-api",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "node --watch server.js"
+  }
+}
+```
+
+## Install the SDK
+
+Install `@auth0/auth0-express-api` along with Express and dotenv:
+
+```shell
+npm install @auth0/auth0-express-api@beta express dotenv
+```
+
+## Setup your Auth0 API
+
+You need to create a new API on your Auth0 tenant and configure your environment variables.
+
+<Tabs>
+<Tab title="CLI">
+
+Run the following command in your project root to create an Auth0 API:
+
+<AuthCodeGroup>
+```shellscript Mac
+# Install Auth0 CLI (if not already installed)
+brew tap auth0/auth0-cli && brew install auth0
+
+# Create Auth0 API
+auth0 apis create \
+  --name "My Express API" \
+  --identifier https://my-express-api.example.com
+```
+```powershell Windows
+# Install Auth0 CLI (if not already installed)
+scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git
+scoop install auth0
+
+# Create Auth0 API
+auth0 apis create `
+  --name "My Express API" `
+  --identifier https://my-express-api.example.com
+```
+</AuthCodeGroup>
+
+After creation, copy the **Identifier** and your **Domain** values, then create your `.env` file:
+
+<AuthCodeBlock children={envSnippet} language="shellscript" filename=".env" />
+
+Replace `YOUR_API_IDENTIFIER` with the identifier you used above (e.g., `https://my-express-api.example.com`).
+
+</Tab>
+<Tab title="Dashboard">
+
+1. Go to [Auth0 Dashboard](https://manage.auth0.com/) → **Applications > APIs** → **Create API**
+2. Enter a name (e.g., "My Express API")
+3. Set the **Identifier** — this is your API audience (e.g., `https://my-express-api.example.com`). It doesn't need to be a real URL.
+4. Keep **Signing Algorithm** as **RS256**
+5. Click **Create**
+6. Copy the **Domain** from your tenant and the **Identifier** from **API Settings**
+
+Create your `.env` file:
+
+<AuthCodeBlock children={envSnippetDashboard} language="shellscript" filename=".env" />
+
+<Warning>
+Replace `YOUR_AUTH0_DOMAIN` with your Auth0 tenant domain (e.g., `dev-abc123.us.auth0.com`) and `YOUR_API_IDENTIFIER` with the API identifier you set above.
+</Warning>
+
+</Tab>
+</Tabs>
+
+## Configure the JWT middleware
+
+Register `createAuth0Api()` on your Express application to configure JWT validation. Then add public and protected routes.
+
+```javascript server.js
+import 'dotenv/config';
+import express from 'express';
+import { createAuth0Api, requiresAuth } from '@auth0/auth0-express-api';
+
+const app = express();
+const port = process.env.PORT || 3001;
+
+app.use(express.json());
+app.use(createAuth0Api());
+
+// Public route — no token required
+app.get('/api/public', (req, res) => {
+  res.json({
+    message: 'Hello from a public endpoint! No authentication required.',
+    timestamp: new Date().toISOString(),
+  });
+});
+
+// Protected route — requires a valid access token
+app.get('/api/private', requiresAuth(), (req, res) => {
+  res.json({
+    message: 'Hello from a protected endpoint! You are authenticated.',
+    sub: req.auth0.user.sub,
+    timestamp: new Date().toISOString(),
+  });
+});
+
+app.listen(port, () => {
+  console.log(`API server running at http://localhost:${port}`);
+});
+```
+
+**What this does:**
+- `createAuth0Api()` reads `AUTH0_DOMAIN` and `AUTH0_AUDIENCE` from environment variables automatically
+- `requiresAuth()` validates the `Authorization: Bearer <token>` header on each request
+- `req.auth0.user` contains the decoded JWT claims for authenticated requests — `sub` is the user's unique identifier
+
+## Add scope and claim-based authorization
+
+Protect routes with fine-grained access control using scopes and claims.
+
+```javascript server.js expandable
+import 'dotenv/config';
+import express from 'express';
+import {
+  createAuth0Api,
+  requiresAuth,
+  scopesInclude,
+  claimEquals,
+  claimIncludes,
+  claimCheck,
+} from '@auth0/auth0-express-api';
+
+const app = express();
+const port = process.env.PORT || 3001;
+
+app.use(express.json());
+app.use(createAuth0Api());
+
+// Public route
+app.get('/api/public', (req, res) => {
+  res.json({ message: 'Public endpoint — no authentication required.' });
+});
+
+// Protected route — any valid token
+app.get('/api/private', requiresAuth(), (req, res) => {
+  res.json({
+    message: 'Authenticated endpoint.',
+    sub: req.auth0.user.sub,
+  });
+});
+
+// Protected with inline scope check
+app.get('/api/messages', requiresAuth({ scopes: ['read:messages'] }), (req, res) => {
+  res.json({ messages: ['Hello!', 'World!'] });
+});
+
+// Protected with scopesInclude — requires ANY of these scopes
+app.get('/api/feed', requiresAuth(), scopesInclude('read:feed read:admin'), (req, res) => {
+  res.json({ feed: [] });
+});
+
+// Protected with scopesInclude — requires ALL scopes
+app.get('/api/admin/edit', requiresAuth(), scopesInclude(['read:admin', 'write:admin'], { match: 'all' }), (req, res) => {
+  res.json({ message: 'Admin editor access granted.' });
+});
+
+// Protected with claimEquals — exact claim value
+app.get('/api/admin', requiresAuth(), claimEquals('isAdmin', true), (req, res) => {
+  res.json({ message: 'Admin access granted.' });
+});
+
+// Protected with claimIncludes — claim array contains all values
+app.get('/api/editor', requiresAuth(), claimIncludes('roles', ['admin', 'editor']), (req, res) => {
+  res.json({ message: 'Editor access granted.' });
+});
+
+// Protected with claimCheck — custom logic
+app.get('/api/premium', requiresAuth(), claimCheck(
+  (token) => token.tier === 'premium' || token.roles?.includes('admin'),
+  { errorMessage: 'Premium tier or admin role required' }
+), (req, res) => {
+  res.json({ message: 'Premium content access granted.' });
+});
+
+// Error handling middleware — must be last
+app.use((err, req, res, next) => {
+  const status = err.status || 500;
+  res.status(status).json({
+    error: err.code || 'server_error',
+    message: status === 401
+      ? 'Authentication required'
+      : status === 403
+      ? err.message || 'Insufficient permissions'
+      : 'Internal server error',
+  });
+});
+
+app.listen(port, () => {
+  console.log(`API server running at http://localhost:${port}`);
+});
+```
+
+## Run your API
+
+Start the development server:
+
+```shell
+npm run dev
+```
+
+Your API is now running at [http://localhost:3001](http://localhost:3001).
+
+## Test your API
+
+Test the public endpoint (no token required):
+
+```shell
+curl http://localhost:3001/api/public
+```
+
+Expected response:
+
+```json
+{
+  "message": "Public endpoint — no authentication required."
+}
+```
+
+Test the protected endpoint without a token (should fail):
+
+```shell
+curl http://localhost:3001/api/private
+```
+
+Expected response:
+
+```json
+{
+  "error": "unauthorized",
+  "message": "Authentication required"
+}
+```
+
+To test with a valid token:
+1. Go to [Auth0 Dashboard](https://manage.auth0.com/) → **Applications > APIs**
+2. Select your API → **Test** tab
+3. Copy the generated access token
+
+Test the protected endpoint:
+
+```shell
+curl http://localhost:3001/api/private \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
+Expected response:
+
+```json
+{
+  "message": "Authenticated endpoint.",
+  "sub": "auth0|abc123..."
+}
+```
+
+<Check>
+  **Checkpoint**
+
+  You should now have a protected API. Your API:
+  1. Accepts requests to public endpoints without a token
+  2. Rejects requests to protected endpoints without a valid JWT (returns `401`)
+  3. Validates JWTs against your Auth0 domain and audience
+  4. Exposes decoded token claims via `req.auth0.user`
+</Check>
+
+</Steps>
+
+---
+
+## Advanced Usage
+
+<AccordionGroup>
+
+<Accordion title="Defining custom token claims with TypeScript">
+
+If you're using TypeScript, augment the `Token` interface to get type-safe access to custom claims:
+
+```typescript server.ts
+import '@auth0/auth0-express-api';
+
+declare module '@auth0/auth0-express-api' {
+  interface Token {
+    tier: 'free' | 'premium';
+    roles: string[];
+    'https://myapp.com/org_id': string;
+  }
+}
+```
+
+Install type support:
+
+```shell
+npm install -D typescript @types/express @types/node
+```
+
+</Accordion>
+
+<Accordion title="CORS configuration for web clients">
+
+Enable CORS to allow your web application to call the API:
+
+```shell
+npm install cors
+```
+
+```javascript server.js
+import cors from 'cors';
+
+app.use(cors({
+  origin: ['http://localhost:3000', 'http://localhost:5173'],
+  allowedHeaders: ['Authorization', 'Content-Type'],
+  exposedHeaders: ['WWW-Authenticate'],
+}));
+
+app.use(createAuth0Api());
+```
+
+For production, specify exact allowed origins instead of wildcards.
+
+</Accordion>
+
+<Accordion title="Configuring scopes in the Auth0 Dashboard">
+
+To use scope-based authorization, first define the permissions on your API:
+
+1. Go to [Auth0 Dashboard](https://manage.auth0.com/) → **Applications > APIs** → your API
+2. Navigate to the **Permissions** tab
+3. Add permissions like `read:messages`, `write:messages`, `read:admin`
+4. Click **Save**
+
+Your client application must then request these scopes when obtaining an access token. If a token lacks the required scope, the API returns `403 Forbidden`.
+
+</Accordion>
+
+</AccordionGroup>
+
+---
+
+## Troubleshooting
+
+<AccordionGroup>
+
+<Accordion title="'No authorization token was found' (401)">
+
+**Cause:** The `Authorization` header is missing or malformed.
+
+**Fix:**
+1. Ensure the header is present: `Authorization: Bearer YOUR_TOKEN`
+2. Verify "Bearer" (with a capital B and a space) precedes the token
+3. Confirm the token is not expired — decode at [jwt.io](https://jwt.io) and check the `exp` claim
+
+</Accordion>
+
+<Accordion title="'Invalid token' or audience/issuer mismatch (401)">
+
+**Cause:** The token was not issued for this API, or the domain/audience values don't match.
+
+**Fix:**
+1. Decode your token at [jwt.io](https://jwt.io)
+2. Check `iss` matches `https://{yourDomain}/` (note the trailing slash)
+3. Check `aud` matches your `AUTH0_AUDIENCE` exactly
+4. Make sure you're using an **access token**, not an ID token — access tokens are obtained with the `audience` parameter
+
+</Accordion>
+
+<Accordion title="'Insufficient scope' (403)">
+
+**Cause:** The token does not include the required scope.
+
+**Fix:**
+1. Verify the scope is defined in your API's Permissions tab in the Auth0 Dashboard
+2. Ensure the client is requesting the scope when obtaining the access token
+3. Decode the token at [jwt.io](https://jwt.io) and check the `scope` claim
+
+</Accordion>
+
+<Accordion title="Environment variables not loaded">
+
+**Cause:** `dotenv` is not configured, or variable names are wrong.
+
+**Fix:**
+1. Ensure `import 'dotenv/config'` is the first import in your entry file
+2. Verify `.env` contains `AUTH0_DOMAIN` and `AUTH0_AUDIENCE`
+3. Debug:
+
+```javascript
+console.log({
+  domain: !!process.env.AUTH0_DOMAIN,
+  audience: !!process.env.AUTH0_AUDIENCE,
+});
+```
+
+</Accordion>
+
+<Accordion title="ESM import errors ('Cannot use import statement')">
+
+**Cause:** The `@auth0/auth0-express-api` SDK uses ES modules.
+
+**Fix:** Add `"type": "module"` to your `package.json`:
+
+```json package.json
+{
+  "type": "module"
+}
+```
+
+Or rename your server file to `server.mjs`.
+
+</Accordion>
+
+</AccordionGroup>
+
+---
+
+## Next Steps
+
+- **[Add Login to an Express Web App](/docs/quickstart/webapp/express-beta)** — Use `@auth0/auth0-express` for session-based auth in web apps
+- **[Role-Based Access Control](https://auth0.com/docs/manage-users/access-control/rbac)** — Implement fine-grained permissions
+- **[Access Token Best Practices](https://auth0.com/docs/secure/tokens/access-tokens)** — Learn about access token handling
+- **[Monitor Your API](https://auth0.com/docs/deploy-monitor/logs)** — Set up logging and monitoring
+
+---
+
+## Resources
+
+- **[@auth0/auth0-express-api GitHub](https://github.com/auth0/auth0-express/tree/main/packages/auth0-express-api)** — Source code and examples
+- **[Auth0 Community](https://community.auth0.com/)** — Get help from the community
+- **[JWT.io](https://jwt.io/)** — Debug and decode JWTs
+- **[Stable Express API Quickstart](/docs/quickstart/backend/nodejs)** — Using `express-oauth2-jwt-bearer`

--- a/main/docs/quickstart/backend/express-api-beta.mdx
+++ b/main/docs/quickstart/backend/express-api-beta.mdx
@@ -32,7 +32,7 @@ This quickstart demonstrates how to protect Express.js API endpoints using JWT a
 
 <Steps>
 
-## Create a new project
+<Step title="Create a new project" stepNumber={1}>
 
 Create a new directory for your Express API and initialize a Node.js project.
 
@@ -51,7 +51,7 @@ New-Item server.js, .env
 
 Update your `package.json` to use ES modules and add start scripts:
 
-```json package.json
+```json
 {
   "name": "auth0-express-api",
   "version": "1.0.0",
@@ -64,15 +64,19 @@ Update your `package.json` to use ES modules and add start scripts:
 }
 ```
 
-## Install the SDK
+</Step>
 
-Install `@auth0/auth0-express-api` along with Express and dotenv:
+<Step title="Install the SDK" stepNumber={2}>
+
+Install `@auth0/auth0-express-api` along with `express` and `dotenv`:
 
 ```shell
 npm install @auth0/auth0-express-api@beta express dotenv
 ```
 
-## Setup your Auth0 API
+</Step>
+
+<Step title="Setup your Auth0 API" stepNumber={3}>
 
 You need to create a new API on your Auth0 tenant and configure your environment variables.
 
@@ -130,7 +134,9 @@ Replace `YOUR_AUTH0_DOMAIN` with your Auth0 tenant domain (e.g., `dev-abc123.us.
 </Tab>
 </Tabs>
 
-## Configure the JWT middleware
+</Step>
+
+<Step title="Configure the JWT middleware" stepNumber={4}>
 
 Register `createAuth0Api()` on your Express application to configure JWT validation. Then add public and protected routes.
 
@@ -172,7 +178,9 @@ app.listen(port, () => {
 - `requiresAuth()` validates the `Authorization: Bearer <token>` header on each request
 - `req.auth0.user` contains the decoded JWT claims for authenticated requests — `sub` is the user's unique identifier
 
-## Protect a route with a required scope
+</Step>
+
+<Step title="Protect a route with a required scope" stepNumber={5}>
 
 Beyond requiring a valid token, you can require a specific scope. Pass a `scopes` option to `requiresAuth()` — the SDK returns `403 insufficient_scope` if the token is missing the scope.
 
@@ -187,7 +195,9 @@ app.get('/api/messages', requiresAuth({ scopes: ['read:messages'] }), (req, res)
 Define the scope in your API's **Permissions** tab (see [Advanced Usage](#advanced-usage)) and request it when obtaining the access token. For matching multiple scopes or authorizing on custom claims, the SDK also provides `scopesInclude`, `claimEquals`, `claimIncludes`, and `claimCheck` — covered in [Advanced Usage](#advanced-usage).
 </Note>
 
-## Run your API
+</Step>
+
+<Step title="Run your API" stepNumber={6}>
 
 Start the development server:
 
@@ -197,7 +207,9 @@ npm run dev
 
 Your API is now running at [http://localhost:3001](http://localhost:3001).
 
-## Test your API
+</Step>
+
+<Step title="Test your API" stepNumber={7}>
 
 Test the public endpoint (no token required):
 
@@ -214,20 +226,7 @@ Expected response:
 }
 ```
 
-Test the protected endpoint without a token (should fail):
-
-```shell
-curl -i http://localhost:3001/api/private
-```
-
-The request is rejected with `401 Unauthorized` and a bare `WWW-Authenticate: Bearer` header. Per [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750#section-3), when a request carries no authentication information the API returns no error code and an empty body:
-
-```http
-HTTP/1.1 401 Unauthorized
-WWW-Authenticate: Bearer
-```
-
-To test with a valid token:
+To call the protected endpoint, you need an access token:
 1. Go to [Auth0 Dashboard](https://manage.auth0.com/) → **Applications > APIs**
 2. Select your API → **Test** tab
 3. Copy the generated access token
@@ -254,11 +253,12 @@ Expected response:
 
   You should now have a protected API. Your API:
   1. Accepts requests to public endpoints without a token
-  2. Rejects requests with no `Authorization` header (returns `401` with a bare `WWW-Authenticate: Bearer` header and no body)
-  3. Rejects requests with an invalid or expired JWT (returns `401` with an `invalid_token` error)
-  4. Validates JWTs against your Auth0 domain and audience
-  5. Exposes decoded token claims via `req.auth0.user`
+  2. Returns the protected response when a valid access token is provided
+  3. Validates JWTs against your Auth0 domain and audience
+  4. Exposes decoded token claims via `req.auth0.user`
 </Check>
+
+</Step>
 
 </Steps>
 
@@ -442,7 +442,9 @@ console.log({
 
 **Fix:** Add `"type": "module"` to your `package.json`:
 
-```json package.json
+📁 **package.json**
+
+```json
 {
   "type": "module"
 }

--- a/main/docs/quickstart/backend/express-api-beta.mdx
+++ b/main/docs/quickstart/backend/express-api-beta.mdx
@@ -270,13 +270,13 @@ Expected response:
 
 <Accordion title="Matching multiple scopes with scopesInclude">
 
-Use `scopesInclude` when a route should accept any one of several scopes, or require several at once. By default it matches **any** of the listed scopes; pass `{ match: 'all' }` to require all of them.
+Use `scopesInclude` when a route should accept any one of several scopes, or require several at once. By default it matches **any** of the listed scopes; pass `{ match: 'all' }` to require all of them. Scopes can be passed as an array or a space-separated string — these examples use arrays.
 
 ```javascript server.js
 import { scopesInclude } from '@auth0/auth0-express-api';
 
 // Requires ANY of these scopes
-app.get('/api/feed', requiresAuth(), scopesInclude('read:feed read:admin'), (req, res) => {
+app.get('/api/feed', requiresAuth(), scopesInclude(['read:feed', 'read:admin']), (req, res) => {
   res.json({ feed: [] });
 });
 

--- a/main/docs/quickstart/backend/express-api-beta.mdx
+++ b/main/docs/quickstart/backend/express-api-beta.mdx
@@ -6,7 +6,6 @@ description: This guide demonstrates how to protect Express.js API endpoints usi
 ---
 
 import {HowToSchema} from "/snippets/HowToSchema.jsx";
-import {QuickstartButtons} from "/snippets/QuickstartButtons.jsx";
 import {AuthCodeBlock} from "/snippets/AuthCodeBlock.jsx";
 import {AuthCodeGroup} from "/snippets/AuthCodeGroup.jsx";
 
@@ -14,8 +13,6 @@ import {AuthCodeGroup} from "/snippets/AuthCodeGroup.jsx";
 <Callout icon="pencil" color="#FFC107" iconType="solid">
   This Quickstart is currently in **Beta**. We'd love to hear your feedback!
 </Callout>
-
-<QuickstartButtons githubLink="https://github.com/auth0-samples/auth0-express-api-samples/tree/beta" />
 
 export const envSnippet = `AUTH0_DOMAIN={yourDomain}
 AUTH0_AUDIENCE=YOUR_API_IDENTIFIER`;

--- a/main/docs/quickstart/backend/nodejs.mdx
+++ b/main/docs/quickstart/backend/nodejs.mdx
@@ -8,6 +8,9 @@ mode: wide
 import {HowToSchema} from "/snippets/HowToSchema.jsx";
 
 <HowToSchema />
+<Callout icon="pencil" color="#FFC107" iconType="solid">
+  A new **Beta** version of this quickstart is available using the `@auth0/auth0-express-api` SDK, which will soon replace this guide. [Try the Beta quickstart →](/docs/quickstart/backend/express-api-beta)
+</Callout>
 
 <Accordion title="Use AI to integrate Auth0" icon="microchip-ai" iconType="solid" defaultOpen>
 If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, you can add Auth0 API authentication automatically in minutes using [agent skills](https://agentskills.io/home).

--- a/main/docs/quickstart/webapp/express-beta.mdx
+++ b/main/docs/quickstart/webapp/express-beta.mdx
@@ -397,6 +397,8 @@ app.get('/admin', requireAdmin, (req, res) => {
 });
 ```
 
+The `https://myapp.com/roles` claim is not present by default — add it to the ID token with an [Action](https://auth0.com/docs/customize/actions) and use a namespaced claim name.
+
 </Accordion>
 
 </AccordionGroup>

--- a/main/docs/quickstart/webapp/express-beta.mdx
+++ b/main/docs/quickstart/webapp/express-beta.mdx
@@ -164,9 +164,9 @@ Create your `.env` file:
 
 <AuthCodeBlock children={envSnippetDashboard} language="shellscript" filename=".env" />
 
-<Warning>
+<Callout>
 Replace `YOUR_AUTH0_DOMAIN`, `YOUR_AUTH0_CLIENT_ID`, and `YOUR_AUTH0_CLIENT_SECRET` with the values from your Auth0 Application Settings.
-</Warning>
+</Callout>
 
 Generate a secure session secret and replace the placeholder value:
 
@@ -356,37 +356,6 @@ app.get('/dashboard', async (req, res) => {
     return res.redirect('/auth/login?returnTo=/dashboard');
   }
   res.send('Welcome to your dashboard!');
-});
-```
-
-</Accordion>
-
-<Accordion title="Disabling automatic route mounting">
-
-If you need to implement custom auth routes, disable the automatic mounts:
-
-```javascript server.js
-app.use(createAuth0({ mountRoutes: false }));
-
-// Implement custom login route — startInteractiveLogin returns a URL
-app.get('/login', async (req, res) => {
-  const url = await req.auth0.client.startInteractiveLogin({
-    appState: { returnTo: '/' },
-  });
-  res.redirect(url.href);
-});
-
-// Implement custom callback route — completeInteractiveLogin expects a URL object
-app.get('/callback', async (req, res) => {
-  const callbackUrl = new URL(req.url, process.env.APP_BASE_URL);
-  await req.auth0.client.completeInteractiveLogin(callbackUrl);
-  res.redirect('/');
-});
-
-// Implement custom logout route — logout returns a URL
-app.get('/logout', async (req, res) => {
-  const url = await req.auth0.client.logout({ returnTo: process.env.APP_BASE_URL });
-  res.redirect(url.href);
 });
 ```
 

--- a/main/docs/quickstart/webapp/express-beta.mdx
+++ b/main/docs/quickstart/webapp/express-beta.mdx
@@ -108,6 +108,10 @@ node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 
 Copy the output and use it as the `AUTH0_SESSION_SECRET` value.
 
+<Note>
+On macOS or Linux you can also run `openssl rand -hex 32`. The Node command works on every platform, since Node is already a prerequisite.
+</Note>
+
 </Tab>
 <Tab title="CLI">
 
@@ -173,6 +177,10 @@ Generate a secure session secret and replace the placeholder value:
 ```shell
 node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 ```
+
+<Note>
+On macOS or Linux you can also run `openssl rand -hex 32`. The Node command works on every platform, since Node is already a prerequisite.
+</Note>
 
 </Tab>
 </Tabs>

--- a/main/docs/quickstart/webapp/express-beta.mdx
+++ b/main/docs/quickstart/webapp/express-beta.mdx
@@ -487,7 +487,5 @@ console.log({
 
 ## Resources
 
-- **[@auth0/auth0-express GitHub](https://github.com/auth0/auth0-express/tree/main/packages/auth0-express)** — Source code and examples
-- **[Auth0 Express Sample App](https://github.com/auth0-samples/auth0-express-webapp-sample/tree/beta)** — Full sample application (beta branch)
+- **[auth0/auth0-express GitHub](https://github.com/auth0/auth0-express/tree/main/packages/auth0-express)** — Source code and examples
 - **[Auth0 Community](https://community.auth0.com/)** — Get help from the community
-- **[Stable Express Quickstart](/docs/quickstart/webapp/express)** — Using `express-openid-connect`

--- a/main/docs/quickstart/webapp/express-beta.mdx
+++ b/main/docs/quickstart/webapp/express-beta.mdx
@@ -39,7 +39,7 @@ This guide demonstrates how to integrate Auth0, add authentication, and display 
 
 <Steps>
 
-## Create a new project
+<Step title="Create a new project" stepNumber={1}>
 
 Create a new directory for your Express application and initialize a Node.js project.
 
@@ -58,7 +58,7 @@ New-Item server.js, .env
 
 Update your `package.json` to use ES modules and add start scripts:
 
-```json package.json
+```json
 {
   "name": "auth0-express-app",
   "version": "1.0.0",
@@ -71,15 +71,19 @@ Update your `package.json` to use ES modules and add start scripts:
 }
 ```
 
-## Install the SDK
+</Step>
 
-Install `@auth0/auth0-express` along with Express and dotenv:
+<Step title="Install the SDK" stepNumber={2}>
+
+Install `@auth0/auth0-express` along with `express` and `dotenv`:
 
 ```shell
 npm install @auth0/auth0-express@beta express dotenv
 ```
 
-## Configure Auth0
+</Step>
+
+<Step title="Configure Auth0" stepNumber={3}>
 
 You need to create a new application on your Auth0 tenant and configure your environment variables.
 
@@ -182,9 +186,11 @@ On macOS or Linux you can also run `openssl rand -hex 32`. The Node command work
 </Tab>
 </Tabs>
 
-## Configure the middleware
+</Step>
 
-Add the `@auth0/auth0-express` middleware to your Express application. The SDK automatically mounts `/auth/login`, `/auth/logout`, `/auth/callback`, and `/auth/backchannel-logout` routes.
+<Step title="Configure the middleware" stepNumber={4}>
+
+Add the `createAuth0()` middleware to your Express application. The SDK automatically mounts `/auth/login`, `/auth/logout`, `/auth/callback`, and `/auth/backchannel-logout` routes.
 
 ```javascript server.js
 import 'dotenv/config';
@@ -211,11 +217,13 @@ app.listen(port, () => {
 - Mounts four auth routes under `/auth/`
 - Attaches `req.auth0.client` to every request for session and token access
 
-## Add login, logout, and a protected profile route
+</Step>
+
+<Step title="Add login, logout, and a protected profile route" stepNumber={5}>
 
 Protect routes using the `requiresAuth` middleware from the SDK, and display user profile data via `getUser()`.
 
-```javascript server.js expandable
+```javascript server.js
 import 'dotenv/config';
 import express from 'express';
 import { createAuth0, requiresAuth } from '@auth0/auth0-express';
@@ -294,7 +302,9 @@ app.listen(port, () => {
 - `req.auth0.client.getUser()` returns the authenticated user's profile
 - Login link points to `/auth/login`, logout to `/auth/logout` — both are automatically mounted
 
-## Run your application
+</Step>
+
+<Step title="Run your application" stepNumber={6}>
 
 Start the development server:
 
@@ -313,6 +323,8 @@ Open your browser to [http://localhost:3000](http://localhost:3000).
   3. Visit `/profile` — you see your user information
   4. Click **Logout** — your session is cleared and you're logged out of Auth0
 </Check>
+
+</Step>
 
 </Steps>
 
@@ -456,22 +468,6 @@ console.log({
 1. Ensure `APP_BASE_URL` matches the URL you access in your browser (e.g., `http://localhost:3000`)
 2. Clear your browser cookies and try again
 3. In production, ensure you are using HTTPS
-
-</Accordion>
-
-<Accordion title="ESM import errors ('Cannot use import statement')">
-
-**Cause:** The `@auth0/auth0-express` SDK uses ES modules. If your project uses CommonJS, you'll see this error.
-
-**Fix:** Add `"type": "module"` to your `package.json`, or use dynamic imports:
-
-```json package.json
-{
-  "type": "module"
-}
-```
-
-Alternatively, use `.mjs` extension for your server file.
 
 </Accordion>
 

--- a/main/docs/quickstart/webapp/express-beta.mdx
+++ b/main/docs/quickstart/webapp/express-beta.mdx
@@ -6,7 +6,6 @@ description: This guide demonstrates how to integrate Auth0, add authentication,
 ---
 
 import {HowToSchema} from "/snippets/HowToSchema.jsx";
-import {QuickstartButtons} from "/snippets/QuickstartButtons.jsx";
 import {AuthCodeBlock} from "/snippets/AuthCodeBlock.jsx";
 import {AuthCodeGroup} from "/snippets/AuthCodeGroup.jsx";
 import {CreateInteractiveApp} from "/snippets/recipe.jsx";
@@ -15,8 +14,6 @@ import {CreateInteractiveApp} from "/snippets/recipe.jsx";
 <Callout icon="pencil" color="#FFC107" iconType="solid">
   This Quickstart is currently in **Beta**. We'd love to hear your feedback!
 </Callout>
-
-<QuickstartButtons githubLink="https://github.com/auth0-samples/auth0-express-webapp-sample/tree/beta" />
 
 export const envSnippet = `AUTH0_DOMAIN={yourDomain}
 AUTH0_CLIENT_ID={yourClientId}

--- a/main/docs/quickstart/webapp/express-beta.mdx
+++ b/main/docs/quickstart/webapp/express-beta.mdx
@@ -371,22 +371,25 @@ If you need to implement custom auth routes, disable the automatic mounts:
 ```javascript server.js
 app.use(createAuth0({ mountRoutes: false }));
 
-// Implement custom login route
+// Implement custom login route — startInteractiveLogin returns a URL
 app.get('/login', async (req, res) => {
-  const { url } = await req.auth0.client.startInteractiveLogin({ returnTo: '/' });
-  res.redirect(url);
+  const url = await req.auth0.client.startInteractiveLogin({
+    appState: { returnTo: '/' },
+  });
+  res.redirect(url.href);
 });
 
-// Implement custom callback route
+// Implement custom callback route — completeInteractiveLogin expects a URL object
 app.get('/callback', async (req, res) => {
-  await req.auth0.client.completeInteractiveLogin(req.url);
+  const callbackUrl = new URL(req.url, process.env.APP_BASE_URL);
+  await req.auth0.client.completeInteractiveLogin(callbackUrl);
   res.redirect('/');
 });
 
-// Implement custom logout route
+// Implement custom logout route — logout returns a URL
 app.get('/logout', async (req, res) => {
-  const { url } = await req.auth0.client.logout({ returnTo: '/' });
-  res.redirect(url);
+  const url = await req.auth0.client.logout({ returnTo: process.env.APP_BASE_URL });
+  res.redirect(url.href);
 });
 ```
 

--- a/main/docs/quickstart/webapp/express-beta.mdx
+++ b/main/docs/quickstart/webapp/express-beta.mdx
@@ -1,0 +1,523 @@
+---
+mode: wide
+title: Add Login to Your Express Application
+sidebarTitle: Express (Beta)
+description: This guide demonstrates how to integrate Auth0, add authentication, and display user profile information in an Express.js web application using the @auth0/auth0-express SDK (Beta).
+---
+
+import {HowToSchema} from "/snippets/HowToSchema.jsx";
+import {QuickstartButtons} from "/snippets/QuickstartButtons.jsx";
+import {AuthCodeBlock} from "/snippets/AuthCodeBlock.jsx";
+import {AuthCodeGroup} from "/snippets/AuthCodeGroup.jsx";
+import {CreateInteractiveApp} from "/snippets/recipe.jsx";
+
+<HowToSchema />
+<Callout icon="pencil" color="#FFC107" iconType="solid">
+  This Quickstart is currently in **Beta**. We'd love to hear your feedback!
+</Callout>
+
+<QuickstartButtons githubLink="https://github.com/auth0-samples/auth0-express-webapp-sample/tree/beta" />
+
+export const envSnippet = `AUTH0_DOMAIN={yourDomain}
+AUTH0_CLIENT_ID={yourClientId}
+AUTH0_CLIENT_SECRET={yourClientSecret}
+APP_BASE_URL=http://localhost:3000
+AUTH0_SESSION_SECRET=use-a-long-random-string-at-least-32-characters`;
+
+export const envSnippetDashboard = `AUTH0_DOMAIN=YOUR_AUTH0_DOMAIN
+AUTH0_CLIENT_ID=YOUR_AUTH0_CLIENT_ID
+AUTH0_CLIENT_SECRET=YOUR_AUTH0_CLIENT_SECRET
+APP_BASE_URL=http://localhost:3000
+AUTH0_SESSION_SECRET=use-a-long-random-string-at-least-32-characters`;
+
+<Note>
+  **Prerequisites:** Before you begin, ensure you have the following installed:
+  - [Node.js](https://nodejs.org/) 22 LTS or newer
+  - [npm](https://www.npmjs.com/) 10+ or [yarn](https://yarnpkg.com/) 1.22+
+</Note>
+
+## Get Started
+
+This guide demonstrates how to integrate Auth0, add authentication, and display user profile information in an Express.js web application using the `@auth0/auth0-express` SDK.
+
+<Steps>
+
+## Create a new project
+
+Create a new directory for your Express application and initialize a Node.js project.
+
+<AuthCodeGroup>
+```shellscript Mac
+mkdir auth0-express-app && cd auth0-express-app
+npm init -y
+touch server.js .env
+```
+```shellscript Windows
+mkdir auth0-express-app; cd auth0-express-app
+npm init -y
+New-Item server.js, .env
+```
+</AuthCodeGroup>
+
+Update your `package.json` to use ES modules and add start scripts:
+
+```json package.json
+{
+  "name": "auth0-express-app",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "node --watch server.js"
+  }
+}
+```
+
+## Install the SDK
+
+Install `@auth0/auth0-express` along with Express and dotenv:
+
+```shell
+npm install @auth0/auth0-express@beta express dotenv
+```
+
+## Configure Auth0
+
+You need to create a new application on your Auth0 tenant and configure your environment variables.
+
+<Tabs>
+<Tab title="Quick Setup">
+
+<CreateInteractiveApp
+  name="My Express App"
+  appType="regular_web"
+  callbackUrl="http://localhost:3000/auth/callback"
+  logoutUrl="http://localhost:3000"
+/>
+
+Once your app is created, add these values to your `.env` file:
+
+<AuthCodeBlock children={envSnippet} language="shellscript" filename=".env" />
+
+Generate a secure session secret:
+
+```shell
+node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+```
+
+Copy the output and use it as the `AUTH0_SESSION_SECRET` value.
+
+</Tab>
+<Tab title="CLI">
+
+Run the following command in your project root to create an Auth0 application:
+
+<AuthCodeGroup>
+```shellscript Mac
+AUTH0_APP_NAME="My Express App" && \
+auth0 apps create \
+  -n "${AUTH0_APP_NAME}" \
+  -t regular \
+  --callbacks http://localhost:3000/auth/callback \
+  --logout-urls http://localhost:3000 \
+  --json | jq -r '"AUTH0_DOMAIN=\(.domain)\nAUTH0_CLIENT_ID=\(.client_id)\nAUTH0_CLIENT_SECRET=\(.client_secret)\nAPP_BASE_URL=http://localhost:3000\nAUTH0_SESSION_SECRET='$(node -e "console.log(require('crypto').randomBytes(32).toString('hex'))")'"' > .env
+```
+```powershell Windows
+$appName = "My Express App"
+$secret = [System.Convert]::ToBase64String([System.Security.Cryptography.RandomNumberGenerator]::GetBytes(32))
+auth0 apps create -n $appName -t regular `
+  --callbacks http://localhost:3000/auth/callback `
+  --logout-urls http://localhost:3000 `
+  --json | ConvertFrom-Json | ForEach-Object {
+    "AUTH0_DOMAIN=$($_.domain)`nAUTH0_CLIENT_ID=$($_.client_id)`nAUTH0_CLIENT_SECRET=$($_.client_secret)`nAPP_BASE_URL=http://localhost:3000`nAUTH0_SESSION_SECRET=$secret"
+  } | Out-File .env -Encoding utf8
+```
+</AuthCodeGroup>
+
+<Note>
+If you haven't installed the Auth0 CLI yet, run:
+```shell
+brew tap auth0/auth0-cli && brew install auth0
+```
+Then authenticate with `auth0 login`.
+</Note>
+
+</Tab>
+<Tab title="Dashboard">
+
+1. Go to [Auth0 Dashboard](https://manage.auth0.com/) → **Applications > Applications**
+2. Select **Create Application**
+3. Enter a name (e.g., "My Express App") and select **Regular Web Applications**
+4. Click **Create**
+5. In the **Application Settings** tab, configure:
+
+| Field | Value |
+|-------|-------|
+| Allowed Callback URLs | `http://localhost:3000/auth/callback` |
+| Allowed Logout URLs | `http://localhost:3000` |
+
+6. Click **Save Changes**
+7. Copy your **Domain**, **Client ID**, and **Client Secret** from **Basic Information**
+
+Create your `.env` file:
+
+<AuthCodeBlock children={envSnippetDashboard} language="shellscript" filename=".env" />
+
+<Warning>
+Replace `YOUR_AUTH0_DOMAIN`, `YOUR_AUTH0_CLIENT_ID`, and `YOUR_AUTH0_CLIENT_SECRET` with the values from your Auth0 Application Settings.
+</Warning>
+
+Generate a secure session secret and replace the placeholder value:
+
+```shell
+node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+```
+
+</Tab>
+</Tabs>
+
+## Configure the middleware
+
+Add the `@auth0/auth0-express` middleware to your Express application. The SDK automatically mounts `/auth/login`, `/auth/logout`, `/auth/callback`, and `/auth/backchannel-logout` routes.
+
+```javascript server.js
+import 'dotenv/config';
+import express from 'express';
+import { createAuth0 } from '@auth0/auth0-express';
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(createAuth0());
+
+app.get('/', async (req, res) => {
+  const session = await req.auth0.client.getSession();
+  res.send(session ? 'Logged in' : 'Logged out');
+});
+
+app.listen(port, () => {
+  console.log(`Server running at http://localhost:${port}`);
+});
+```
+
+**What this does:**
+- `createAuth0()` reads credentials from environment variables (`AUTH0_DOMAIN`, `AUTH0_CLIENT_ID`, etc.) automatically
+- Mounts four auth routes under `/auth/`
+- Attaches `req.auth0.client` to every request for session and token access
+
+## Add login, logout, and a protected profile route
+
+Protect routes using the `requiresAuth` middleware from the SDK, and display user profile data via `getUser()`.
+
+```javascript server.js expandable
+import 'dotenv/config';
+import express from 'express';
+import { createAuth0, requiresAuth } from '@auth0/auth0-express';
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(createAuth0());
+
+// Public home route
+app.get('/', async (req, res) => {
+  const session = await req.auth0.client.getSession();
+  const isAuthenticated = !!session;
+
+  res.send(`
+    <html>
+      <head>
+        <title>Auth0 Express (Beta) Quickstart</title>
+        <style>
+          body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; padding: 2rem; max-width: 600px; margin: 0 auto; }
+          a { color: #0066cc; text-decoration: none; margin-right: 1rem; }
+          .status { padding: 1rem; border-radius: 4px; margin: 1rem 0; }
+          .logged-in { background: #d4edda; color: #155724; }
+          .logged-out { background: #f8d7da; color: #721c24; }
+        </style>
+      </head>
+      <body>
+        <h1>Auth0 Express (Beta) Quickstart</h1>
+        <div class="status ${isAuthenticated ? 'logged-in' : 'logged-out'}">
+          ${isAuthenticated ? '✓ You are logged in' : '✗ You are logged out'}
+        </div>
+        <nav>
+          ${isAuthenticated
+            ? '<a href="/profile">Profile</a> | <a href="/auth/logout">Logout</a>'
+            : '<a href="/auth/login">Login</a>'}
+        </nav>
+      </body>
+    </html>
+  `);
+});
+
+// Protected profile route — requiresAuth redirects unauthenticated users to /auth/login
+app.get('/profile', requiresAuth(), async (req, res) => {
+  const user = await req.auth0.client.getUser();
+
+  res.send(`
+    <html>
+      <head>
+        <title>Profile</title>
+        <style>
+          body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; padding: 2rem; max-width: 600px; margin: 0 auto; }
+          pre { background: #f4f4f4; padding: 1rem; border-radius: 4px; overflow-x: auto; }
+          img { border-radius: 50%; }
+        </style>
+      </head>
+      <body>
+        <h1>User Profile</h1>
+        ${user.picture ? `<img src="${user.picture}" alt="Profile" width="80" />` : ''}
+        <h2>${user.name || user.nickname || 'User'}</h2>
+        <p><strong>Email:</strong> ${user.email || 'N/A'}</p>
+        <h3>Full Profile</h3>
+        <pre>${JSON.stringify(user, null, 2)}</pre>
+        <a href="/">← Back</a> | <a href="/auth/logout">Logout</a>
+      </body>
+    </html>
+  `);
+});
+
+app.listen(port, () => {
+  console.log(`Server running at http://localhost:${port}`);
+});
+```
+
+**Key points:**
+- `requiresAuth()` from `@auth0/auth0-express` protects routes — unauthenticated users are redirected to `/auth/login`
+- `req.auth0.client.getUser()` returns the authenticated user's profile
+- Login link points to `/auth/login`, logout to `/auth/logout` — both are automatically mounted
+
+## Run your application
+
+Start the development server:
+
+```shell
+npm run dev
+```
+
+Open your browser to [http://localhost:3000](http://localhost:3000).
+
+<Check>
+  **Checkpoint**
+
+  You should now have a fully functional Auth0 login flow. When you:
+  1. Click **Login** — you're redirected to Auth0's Universal Login page
+  2. Complete authentication — you're redirected back to your app at `/auth/callback`
+  3. Visit `/profile` — you see your user information
+  4. Click **Logout** — your session is cleared and you're logged out of Auth0
+</Check>
+
+</Steps>
+
+---
+
+## Advanced Usage
+
+<AccordionGroup>
+
+<Accordion title="Calling a protected API with an access token">
+
+Configure the SDK with an `audience` to request an access token for your API, then retrieve it with `getAccessToken()`.
+
+Add your API audience to `.env`:
+
+```shell .env
+AUTH0_AUDIENCE=https://your-api.example.com
+```
+
+Retrieve the token in a protected route:
+
+```javascript server.js
+app.get('/api-data', requiresAuth(), async (req, res) => {
+  const { accessToken } = await req.auth0.client.getAccessToken({
+    request: req,
+    response: res,
+  });
+
+  const response = await fetch('https://your-api.example.com/data', {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  res.json(await response.json());
+});
+```
+
+The SDK handles token refresh automatically when the access token expires.
+
+</Accordion>
+
+<Accordion title="Using custom login with returnTo">
+
+Redirect users back to a specific page after login using the `returnTo` parameter:
+
+```javascript server.js
+app.get('/dashboard', async (req, res) => {
+  const session = await req.auth0.client.getSession();
+  if (!session) {
+    return res.redirect('/auth/login?returnTo=/dashboard');
+  }
+  res.send('Welcome to your dashboard!');
+});
+```
+
+</Accordion>
+
+<Accordion title="Disabling automatic route mounting">
+
+If you need to implement custom auth routes, disable the automatic mounts:
+
+```javascript server.js
+app.use(createAuth0({ mountRoutes: false }));
+
+// Implement custom login route
+app.get('/login', async (req, res) => {
+  const { url } = await req.auth0.client.startInteractiveLogin({ returnTo: '/' });
+  res.redirect(url);
+});
+
+// Implement custom callback route
+app.get('/callback', async (req, res) => {
+  await req.auth0.client.completeInteractiveLogin(req.url);
+  res.redirect('/');
+});
+
+// Implement custom logout route
+app.get('/logout', async (req, res) => {
+  const { url } = await req.auth0.client.logout({ returnTo: '/' });
+  res.redirect(url);
+});
+```
+
+</Accordion>
+
+<Accordion title="Custom authorization middleware">
+
+Build your own authorization logic on top of the session:
+
+```javascript server.js
+async function requireAdmin(req, res, next) {
+  const user = await req.auth0.client.getUser();
+  if (!user) return res.redirect('/auth/login');
+  if (!user['https://myapp.com/roles']?.includes('admin')) {
+    return res.status(403).send('Forbidden');
+  }
+  next();
+}
+
+app.get('/admin', requireAdmin, (req, res) => {
+  res.send('Admin panel');
+});
+```
+
+</Accordion>
+
+</AccordionGroup>
+
+---
+
+## Troubleshooting
+
+<AccordionGroup>
+
+<Accordion title="'req.auth0 is undefined'">
+
+**Cause:** `createAuth0()` middleware was not registered before your route handler.
+
+**Fix:** Ensure `app.use(createAuth0())` appears before any route that accesses `req.auth0`:
+
+```javascript
+// ✅ Correct
+app.use(createAuth0());
+app.get('/profile', requiresAuth(), handler);
+
+// ❌ Wrong
+app.get('/profile', requiresAuth(), handler);
+app.use(createAuth0());
+```
+
+</Accordion>
+
+<Accordion title="Callback URL mismatch error">
+
+**Cause:** The callback URL in your Auth0 Application Settings does not match `http://localhost:3000/auth/callback`.
+
+**Fix:**
+1. Go to [Auth0 Dashboard](https://manage.auth0.com/) → **Applications > Applications** → your app → **Application Settings**
+2. Add `http://localhost:3000/auth/callback` to **Allowed Callback URLs**
+3. Add `http://localhost:3000` to **Allowed Logout URLs**
+4. Click **Save Changes**
+
+Note: the `@auth0/auth0-express` SDK uses `/auth/callback` (not `/callback` as in `express-openid-connect`).
+
+</Accordion>
+
+<Accordion title="Environment variables not loaded">
+
+**Cause:** `dotenv/config` is not imported, or the `.env` file is missing required values.
+
+**Fix:**
+1. Ensure `import 'dotenv/config'` (or `require('dotenv').config()`) is at the top of your entry file
+2. Verify your `.env` contains all five required variables: `AUTH0_DOMAIN`, `AUTH0_CLIENT_ID`, `AUTH0_CLIENT_SECRET`, `APP_BASE_URL`, `AUTH0_SESSION_SECRET`
+3. Debug missing values:
+
+```javascript
+console.log({
+  domain: !!process.env.AUTH0_DOMAIN,
+  clientId: !!process.env.AUTH0_CLIENT_ID,
+  clientSecret: !!process.env.AUTH0_CLIENT_SECRET,
+  appBaseUrl: !!process.env.APP_BASE_URL,
+  sessionSecret: !!process.env.AUTH0_SESSION_SECRET,
+});
+```
+
+</Accordion>
+
+<Accordion title="'Invalid state' error after login">
+
+**Cause:** Session cookie is not being set correctly, or the callback URL is accessed directly.
+
+**Fix:**
+1. Ensure `APP_BASE_URL` matches the URL you access in your browser (e.g., `http://localhost:3000`)
+2. Clear your browser cookies and try again
+3. In production, ensure you are using HTTPS
+
+</Accordion>
+
+<Accordion title="ESM import errors ('Cannot use import statement')">
+
+**Cause:** The `@auth0/auth0-express` SDK uses ES modules. If your project uses CommonJS, you'll see this error.
+
+**Fix:** Add `"type": "module"` to your `package.json`, or use dynamic imports:
+
+```json package.json
+{
+  "type": "module"
+}
+```
+
+Alternatively, use `.mjs` extension for your server file.
+
+</Accordion>
+
+</AccordionGroup>
+
+---
+
+## Next Steps
+
+- **[Protect an Express API](/docs/quickstart/backend/express-api-beta)** — Use `@auth0/auth0-express-api` to validate access tokens in your API
+- **[Add Authorization](https://auth0.com/docs/manage-users/access-control/rbac)** — Implement role-based access control
+- **[Customize Universal Login](https://auth0.com/docs/customize/universal-login-pages)** — Brand your login experience
+- **[Add Social Connections](https://auth0.com/docs/connections/social)** — Enable Google, GitHub, and other social logins
+- **[Implement MFA](https://auth0.com/docs/secure/multi-factor-authentication)** — Add multi-factor authentication
+
+---
+
+## Resources
+
+- **[@auth0/auth0-express GitHub](https://github.com/auth0/auth0-express/tree/main/packages/auth0-express)** — Source code and examples
+- **[Auth0 Express Sample App](https://github.com/auth0-samples/auth0-express-webapp-sample/tree/beta)** — Full sample application (beta branch)
+- **[Auth0 Community](https://community.auth0.com/)** — Get help from the community
+- **[Stable Express Quickstart](/docs/quickstart/webapp/express)** — Using `express-openid-connect`

--- a/main/docs/quickstart/webapp/express-beta.mdx
+++ b/main/docs/quickstart/webapp/express-beta.mdx
@@ -331,10 +331,7 @@ Retrieve the token in a protected route:
 
 ```javascript server.js
 app.get('/api-data', requiresAuth(), async (req, res) => {
-  const { accessToken } = await req.auth0.client.getAccessToken({
-    request: req,
-    response: res,
-  });
+  const { accessToken } = await req.auth0.client.getAccessToken();
 
   const response = await fetch('https://your-api.example.com/data', {
     headers: { Authorization: `Bearer ${accessToken}` },

--- a/main/docs/quickstart/webapp/express.mdx
+++ b/main/docs/quickstart/webapp/express.mdx
@@ -10,6 +10,10 @@ import {CreateInteractiveApp} from "/snippets/recipe.jsx";
 import {HowToSchema} from "/snippets/HowToSchema.jsx";
 
 <HowToSchema />
+<Callout icon="pencil" color="#FFC107" iconType="solid">
+  A new **Beta** version of this quickstart is available using the `@auth0/auth0-express` SDK, which will soon replace this guide. [Try the Beta quickstart →](/docs/quickstart/webapp/express-beta)
+</Callout>
+
 <Accordion title="Use AI to integrate Auth0" icon="microchip-ai" iconType="solid" defaultOpen>
 
 If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, you can add Auth0 authentication automatically in minutes using [agent skills](https://agentskills.io/home).

--- a/main/docs/quickstarts.mdx
+++ b/main/docs/quickstarts.mdx
@@ -191,6 +191,17 @@ Traditional web app that runs on the server
 
 <SectionCard
   item={{
+    name: "Express (Beta)",
+    subtext: "",
+    logo: "express.svg",
+    date: "",
+    badge: "",
+    links: [{ label: "Quickstart", url: "/docs/quickstart/webapp/express-beta" }],
+  }}
+/>
+
+<SectionCard
+  item={{
     name: "Fastify",
     subtext: "",
     logo: "fastify.svg",
@@ -663,6 +674,17 @@ An API or service protected by Auth0
     badge: "",
     links: [
       { label: "Quickstart", url: "/docs/quickstart/backend/nodejs/interactive" },
+    ],
+  }}/>
+
+  <SectionCard item={{
+    name: "Express API (Beta)",
+    subtext: "",
+    logo: "express.svg",
+    date: "",
+    badge: "",
+    links: [
+      { label: "Quickstart", url: "/docs/quickstart/backend/express-api-beta" },
     ],
   }}/>
 


### PR DESCRIPTION
## Description

Adds new **beta** quickstarts for the `@auth0/auth0-express` (web app) and `@auth0/auth0-express-api` (backend API) SDKs.

- New pages: `docs/quickstart/webapp/express-beta` and `docs/quickstart/backend/express-api-beta`
- Both are wired into the sidebar navigation (`config/navigation/quickstarts.json`) and the quickstarts landing page (`docs/quickstarts.mdx`) next to their stable counterparts, labeled "(Beta)"
- The existing stable Express and Express API quickstarts now show a beta-notice callout linking to the new beta versions

### References

- SDK source: [auth0/auth0-express](https://github.com/auth0/auth0-express)

### Testing

Tested locally with `mint dev`:
- `/docs/quickstart/webapp/express-beta` and `/docs/quickstart/backend/express-api-beta` render with the beta callout and OS-tabbed commands
- Stable `/docs/quickstart/webapp/express` and `/docs/quickstart/backend/nodejs` show the beta notice
- Both beta entries appear in the sidebar and on the quickstarts landing page

Additionally scaffolded both quickstarts end-to-end against the published `@auth0/auth0-express@beta` and `@auth0/auth0-express-api@beta` (1.0.0-beta.1):
- Web app: server boots, home route renders, `/profile` redirects unauthenticated browsers to `/auth/login` (and returns 401 for JSON clients), `/auth/login` redirects to Auth0 with PKCE
- API: public route returns 200, valid/invalid tokens and scope checks behave as documented

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.