### PR TITLE
docs: update QS SDK with newer auth0 qs setup command usage

### DIFF
--- a/main/docs/quickstart/native/ionic-angular.mdx
+++ b/main/docs/quickstart/native/ionic-angular.mdx
@@ -101,15 +101,31 @@ export const localEnvSnippet = `export const environment = {
       <Tab title="CLI">
         Run the following command in your project's root directory to create a Native Auth0 app and generate an environment file. Update `PACKAGE_ID` if your `capacitor.config.ts` uses a different `appId`:
 
-        <AuthCodeGroup>
+        <CodeGroup>
           ```shellscript Mac
-          AUTH0_APP_NAME="My Ionic Angular App" && PACKAGE_ID="io.ionic.starter" && brew tap auth0/auth0-cli && brew install auth0 && auth0 login --no-input && DOMAIN=$(auth0 tenants list --json | jq -r '.[] | select(.active == true) | .name') && CALLBACK_URL="${PACKAGE_ID}://${DOMAIN}/capacitor/${PACKAGE_ID}/callback" && auth0 apps create -n "${AUTH0_APP_NAME}" -t native -c "${CALLBACK_URL}" -l "${CALLBACK_URL}" -o "capacitor://localhost,http://localhost" --json --metadata created_by="quickstart-docs-cli" > auth0-app-details.json && CLIENT_ID=$(jq -r '.client_id' auth0-app-details.json) && mkdir -p src/environments && echo "export const environment = { production: false, auth0: { domain: '${DOMAIN}', clientId: '${CLIENT_ID}' } };" > src/environments/environment.ts && rm auth0-app-details.json && echo "Environment file created at src/environments/environment.ts with your Auth0 details:" && cat src/environments/environment.ts
+          # Install Auth0 CLI (if not already installed)
+          brew tap auth0/auth0-cli && brew install auth0
+
+          # Set up Auth0 app and generate environment file
+          auth0 qs setup --app --type native --framework ionic-angular --name "My Ionic Angular App"
           ```
 
-          ```shellscript Windows
-          $AppName = "My Ionic Angular App"; $PackageId = "io.ionic.starter"; winget install Auth0.CLI; auth0 login --no-input; $Domain = (auth0 tenants list --json | ConvertFrom-Json | Where-Object { $_.active -eq $true }).name; $CallbackUrl = "${PackageId}://${Domain}/capacitor/${PackageId}/callback"; auth0 apps create -n "$AppName" -t native -c "$CallbackUrl" -l "$CallbackUrl" -o "capacitor://localhost,http://localhost" --json --metadata created_by="quickstart-docs-cli" | Set-Content -Path auth0-app-details.json; $ClientId = (Get-Content -Raw auth0-app-details.json | ConvertFrom-Json).client_id; New-Item -ItemType Directory -Force -Path "src\environments"; Set-Content -Path "src\environments\environment.ts" -Value "export const environment = { production: false, auth0: { domain: '$Domain', clientId: '$ClientId' } };"; Remove-Item auth0-app-details.json; Write-Output "Environment file created at src\environments\environment.ts with your Auth0 details:"; Get-Content "src\environments\environment.ts"
+          ```powershell Windows
+          # Install Auth0 CLI (if not already installed)
+          scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git
+          scoop install auth0
+
+          # Set up Auth0 app and generate environment file
+          auth0 qs setup --app --type native --framework ionic-angular --name "My Ionic Angular App"
           ```
-        </AuthCodeGroup>
+        </CodeGroup>
+
+        <Note>
+          This command will:
+          1. Check if you're authenticated (and prompt for login if needed)
+          2. Create an Auth0 Native application
+          3. Generate `src/environments/environment.ts` with your Auth0 domain and client ID
+        </Note>
       </Tab>
 
       <Tab title="Dashboard">

--- a/main/docs/quickstart/native/ionic-react.mdx
+++ b/main/docs/quickstart/native/ionic-react.mdx
@@ -116,13 +116,8 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
           # Install Auth0 CLI (if not already installed)
           brew tap auth0/auth0-cli && brew install auth0
 
-          # Create an Auth0 Native application
-          auth0 apps create \
-            --name "Ionic React App" \
-            --type native \
-            --callbacks "YOUR_PACKAGE_ID://YOUR_AUTH0_DOMAIN/capacitor/YOUR_PACKAGE_ID/callback" \
-            --logout-urls "YOUR_PACKAGE_ID://YOUR_AUTH0_DOMAIN/capacitor/YOUR_PACKAGE_ID/callback" \
-            --origins "capacitor://localhost,http://localhost"
+          # Set up Auth0 app and generate .env file
+          auth0 qs setup --app --type native --framework ionic-react --build-tool vite --name "My Ionic React App"
           ```
 
           ```powershell Windows
@@ -130,13 +125,8 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
           scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git
           scoop install auth0
 
-          # Create an Auth0 Native application
-          auth0 apps create `
-            --name "Ionic React App" `
-            --type native `
-            --callbacks "YOUR_PACKAGE_ID://YOUR_AUTH0_DOMAIN/capacitor/YOUR_PACKAGE_ID/callback" `
-            --logout-urls "YOUR_PACKAGE_ID://YOUR_AUTH0_DOMAIN/capacitor/YOUR_PACKAGE_ID/callback" `
-            --origins "capacitor://localhost,http://localhost"
+          # Set up Auth0 app and generate .env file
+          auth0 qs setup --app --type native --framework ionic-react --build-tool vite --name "My Ionic React App"
           ```
         </CodeGroup>
 
@@ -144,7 +134,7 @@ VITE_AUTH0_CLIENT_ID={yourClientId}`;
           This command will:
           1. Check if you're authenticated (and prompt for login if needed)
           2. Create an Auth0 Native application
-          3. Display the **Domain** and **Client ID** — copy these into a `.env` file in your project root
+          3. Generate a `.env` file with `VITE_AUTH0_DOMAIN` and `VITE_AUTH0_CLIENT_ID`
         </Note>
 
         Create a `.env` file with the values from the CLI output:

--- a/main/docs/quickstart/native/ionic-vue.mdx
+++ b/main/docs/quickstart/native/ionic-vue.mdx
@@ -87,12 +87,8 @@ This quickstart demonstrates how to add Auth0 authentication to an Ionic Vue app
           # Install Auth0 CLI (if not already installed)
           brew tap auth0/auth0-cli && brew install auth0
 
-          # Log in and create a Native application
-          auth0 login && auth0 apps create \
-            -n "My Ionic Vue App" \
-            -t native \
-            -o "capacitor://localhost,http://localhost" \
-            --no-input
+          # Set up Auth0 app and generate .env file
+          auth0 qs setup --app --type native --framework ionic-vue --build-tool vite --name "My Ionic Vue App"
           ```
 
           ```powershell Windows
@@ -100,22 +96,16 @@ This quickstart demonstrates how to add Auth0 authentication to an Ionic Vue app
           scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git
           scoop install auth0
 
-          # Log in and create a Native application
-          auth0 login; auth0 apps create `
-            -n "My Ionic Vue App" `
-            -t native `
-            -o "capacitor://localhost,http://localhost" `
-            --no-input
+          # Set up Auth0 app and generate .env file
+          auth0 qs setup --app --type native --framework ionic-vue --build-tool vite --name "My Ionic Vue App"
           ```
         </CodeGroup>
 
         <Note>
           This command will:
-          1. Authenticate you with Auth0 (and prompt for login if needed)
-          2. Create a **Native** application with allowed origins set
-          3. Output the **Domain** and **Client ID** to use in your project
-
-          You'll still need to configure callback and logout URLs in the Dashboard. See below.
+          1. Check if you're authenticated (and prompt for login if needed)
+          2. Create an Auth0 Native application
+          3. Generate a `.env` file with your Auth0 domain and client ID
         </Note>
       </Tab>
 

--- a/main/docs/quickstart/spa/angular.mdx
+++ b/main/docs/quickstart/spa/angular.mdx
@@ -88,15 +88,31 @@ export const localEnvSnippet = `export const environment = {
       <Tab title="CLI">
         Run the following shell command on your project's root directory to create an Auth0 app and generate an environment file:
 
-        <AuthCodeGroup>
+        <CodeGroup>
           ```shellscript Mac
-          AUTH0_APP_NAME="My Angular App" && brew tap auth0/auth0-cli && brew install auth0 && auth0 login --no-input && auth0 apps create -n "${AUTH0_APP_NAME}" -t spa -c http://localhost:4200 -l http://localhost:4200 -o http://localhost:4200 --json --metadata created_by="quickstart-docs-cli" > auth0-app-details.json && CLIENT_ID=$(jq -r '.client_id' auth0-app-details.json) && DOMAIN=$(auth0 tenants list --json | jq -r '.[] | select(.active == true) | .name') && mkdir -p src/environments && echo "export const environment = { production: false, auth0: { domain: '${DOMAIN}', clientId: '${CLIENT_ID}' } };" > src/environments/environment.ts && rm auth0-app-details.json && echo "Environment file created at src/environments/environment.ts with your Auth0 details:" && cat src/environments/environment.ts
+          # Install Auth0 CLI (if not already installed)
+          brew tap auth0/auth0-cli && brew install auth0
+
+          # Set up Auth0 app and generate environment file
+          auth0 qs setup --app --type spa --framework angular --name "My Angular App" --port 4200
           ```
 
-          ```shellscript Windows
-          $AppName = "My Angular App"; winget install Auth0.CLI; auth0 login --no-input; auth0 apps create -n "$AppName" -t spa -c http://localhost:4200 -l http://localhost:4200 -o http://localhost:4200 --json --metadata created_by="quickstart-docs-cli" | Set-Content -Path auth0-app-details.json; $ClientId = (Get-Content -Raw auth0-app-details.json | ConvertFrom-Json).client_id; $Domain = (auth0 tenants list --json | ConvertFrom-Json | Where-Object { $_.active -eq $true }).name; New-Item -ItemType Directory -Force -Path "src\environments"; Set-Content -Path "src\environments\environment.ts" -Value "export const environment = { production: false, auth0: { domain: '$Domain', clientId: '$ClientId' } };"; Remove-Item auth0-app-details.json; Write-Output "Environment file created at src\environments\environment.ts with your Auth0 details:"; Get-Content "src\environments\environment.ts"
+          ```powershell Windows
+          # Install Auth0 CLI (if not already installed)
+          scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git
+          scoop install auth0
+
+          # Set up Auth0 app and generate environment file
+          auth0 qs setup --app --type spa --framework angular --name "My Angular App" --port 4200
           ```
-        </AuthCodeGroup>
+        </CodeGroup>
+
+        <Note>
+          This command will:
+          1. Check if you're authenticated (and prompt for login if needed)
+          2. Create an Auth0 Single Page Application configured for `http://localhost:4200`
+          3. Generate `src/environments/environment.ts` with your Auth0 domain and client ID
+        </Note>
       </Tab>
 
       <Tab title="Dashboard">

--- a/main/docs/quickstart/spa/flutter.mdx
+++ b/main/docs/quickstart/spa/flutter.mdx
@@ -92,42 +92,36 @@ This quickstart demonstrates how to add Auth0 authentication to a Flutter Web ap
   <Step title="Setup your Auth0 App" stepNumber={3}>
     Next, you need to create a new application on your Auth0 tenant.
 
-    You can choose to do this automatically by running a CLI command or manually via the Dashboard:
+    You can choose to set up your Auth0 app automatically by running a CLI command, or do it manually via the Dashboard:
 
     <Tabs>
       <Tab title="CLI">
-        Run the following shell command in your project's root directory to create an Auth0 application:
+        Run the following command in your project's root directory to create an Auth0 application:
 
-        **macOS / Linux:**
+        <CodeGroup>
+          ```shellscript Mac
+          # Install Auth0 CLI (if not already installed)
+          brew tap auth0/auth0-cli && brew install auth0
 
-        ```bash
-        AUTH0_APP_NAME="My Flutter Web App" && \
-        auth0 apps create -n "${AUTH0_APP_NAME}" -t spa \
-          --callbacks http://localhost:3000 \
-          --logout-urls http://localhost:3000 \
-          --origins http://localhost:3000 \
-          --json
-        ```
+          # Set up Auth0 app and generate lib/auth_config.dart
+          auth0 qs setup --app --type spa --framework flutter-web --port 3000 --name "My Flutter Web App"
+          ```
 
-        **Windows (PowerShell):**
+          ```powershell Windows
+          # Install Auth0 CLI (if not already installed)
+          scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git
+          scoop install auth0
 
-        ```powershell
-        $appName = "My Flutter Web App"
-        auth0 apps create -n $appName -t spa `
-          --callbacks http://localhost:3000 `
-          --logout-urls http://localhost:3000 `
-          --origins http://localhost:3000 `
-          --json
-        ```
-
-        Copy the **domain** and **client_id** values from the output. You'll use these in the next step.
+          # Set up Auth0 app and generate lib/auth_config.dart
+          auth0 qs setup --app --type spa --framework flutter-web --port 3000 --name "My Flutter Web App"
+          ```
+        </CodeGroup>
 
         <Note>
-          If you haven't installed the Auth0 CLI yet, run:
-          ```bash
-          brew tap auth0/auth0-cli && brew install auth0
-          ```
-          Then authenticate with `auth0 login`.
+          This command will:
+          1. Check if you're authenticated (and prompt for login if needed)
+          2. Create an Auth0 Single Page Application configured for `http://localhost:3000`
+          3. Generate `lib/auth_config.dart` with your Auth0 domain and client ID as Dart constants
         </Note>
       </Tab>
 

--- a/main/docs/quickstart/webapp/aspnet-core-blazor-server.mdx
+++ b/main/docs/quickstart/webapp/aspnet-core-blazor-server.mdx
@@ -62,62 +62,37 @@ Auth0 allows you to quickly add authentication and gain access to user profile i
   <Step title="Setup your Auth0 Application" stepNumber={3}>
     Next up, you need to create a new Application on your Auth0 tenant and add the configuration to your project.
 
-    You can choose to do this automatically by running a CLI command or do it manually via the Dashboard:
+    You can choose to set up your Auth0 app automatically by running a CLI command, or do it manually via the Dashboard:
 
     <Tabs>
       <Tab title="CLI">
         Run the following shell command on your project's root directory to create an Auth0 Application and update your `appsettings.json`:
 
-        <Tabs>
-          <Tab title="Mac/Linux">
-            ```shellscript
-            AUTH0_APP_NAME="My Blazor App" && brew tap auth0/auth0-cli && brew install auth0 && auth0 login --no-input && auth0 apps create -n "${AUTH0_APP_NAME}" -t regular -c http://localhost:5000/callback -l http://localhost:5000 -o http://localhost:5000 --reveal-secrets --json --metadata created_by="quickstart-docs-cli" > auth0-app-details.json && CLIENT_ID=$(jq -r '.client_id' auth0-app-details.json) && CLIENT_SECRET=$(jq -r '.client_secret' auth0-app-details.json) && DOMAIN=$(auth0 tenants list --json | jq -r '.[] | select(.active == true) | .name') && rm auth0-app-details.json && cat > appsettings.json << EOF
-            {
-              "Logging": {
-                "LogLevel": {
-                  "Default": "Information",
-                  "Microsoft.AspNetCore": "Warning"
-                }
-              },
-              "AllowedHosts": "*",
-              "Auth0": {
-                "Domain": "${DOMAIN}",
-                "ClientId": "${CLIENT_ID}",
-                "ClientSecret": "${CLIENT_SECRET}"
-              }
-            }
-            EOF
-            echo "appsettings.json created with your Auth0 details:" && cat appsettings.json
-            ```
-          </Tab>
+        <CodeGroup>
+          ```shellscript Mac
+          # Install Auth0 CLI (if not already installed)
+          brew tap auth0/auth0-cli && brew install auth0
 
-          <Tab title="Windows (PowerShell)">
-            ```powershell
-            $AUTH0_APP_NAME = "My Blazor App"
-            $latestRelease = Invoke-RestMethod -Uri "https://api.github.com/repos/auth0/auth0-cli/releases/latest"
-            $latestVersion = $latestRelease.tag_name
-            $version = $latestVersion -replace "^v"
-            Invoke-WebRequest -Uri "https://github.com/auth0/auth0-cli/releases/download/${latestVersion}/auth0-cli_${version}_Windows_x86_64.zip" -OutFile ".\auth0.zip"
-            Expand-Archive ".\auth0.zip" .\
-            [System.Environment]::SetEnvironmentVariable('PATH', $Env:PATH + ";${pwd}")
-            auth0 login --no-input
-            auth0 apps create -n "${AUTH0_APP_NAME}" -t regular -c http://localhost:5000/callback -l http://localhost:5000 -o http://localhost:5000 --reveal-secrets --json --metadata created_by="quickstart-docs-cli" | Set-Content -Path auth0-app-details.json
-            $AppDetails = Get-Content -Raw auth0-app-details.json | ConvertFrom-Json
-            $ClientId = $AppDetails.client_id
-            $ClientSecret = $AppDetails.client_secret
-            $Domain = (auth0 tenants list --json | ConvertFrom-Json | Where-Object { $_.active -eq $true }).name
-            $Config = Get-Content -Raw appsettings.json | ConvertFrom-Json
-            if (-not $Config.Auth0) { $Config | Add-Member -MemberType NoteProperty -Name Auth0 -Value @{} }
-            $Config.Auth0.Domain = $Domain
-            $Config.Auth0.ClientId = $ClientId
-            $Config.Auth0.ClientSecret = $ClientSecret
-            $Config | ConvertTo-Json -Depth 10 | Set-Content appsettings.json
-            Remove-Item auth0-app-details.json
-            Write-Output "✅ appsettings.json updated with your Auth0 details:"
-            Get-Content appsettings.json
-            ```
-          </Tab>
-        </Tabs>
+          # Set up Auth0 app and generate appsettings.json
+          auth0 qs setup --app --type regular --framework aspnet-blazor --port 5000 --name "My Blazor Server App"
+          ```
+
+          ```powershell Windows
+          # Install Auth0 CLI (if not already installed)
+          scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git
+          scoop install auth0
+
+          # Set up Auth0 app and generate appsettings.json
+          auth0 qs setup --app --type regular --framework aspnet-blazor --port 5000 --name "My Blazor Server App"
+          ```
+        </CodeGroup>
+
+        <Note>
+          This command will:
+          1. Check if you're authenticated (and prompt for login if needed)
+          2. Create an Auth0 Regular Web Application configured for `http://localhost:5000`
+          3. Update `appsettings.json` with `Auth0:Domain`, `Auth0:ClientId`, and `Auth0:ClientSecret`
+        </Note>
       </Tab>
 
       <Tab title="Dashboard">

--- a/main/docs/quickstart/webapp/aspnet-core.mdx
+++ b/main/docs/quickstart/webapp/aspnet-core.mdx
@@ -61,62 +61,37 @@ Auth0 allows you to quickly add authentication and gain access to user profile i
   <Step title="Setup your Auth0 Application" stepNumber={3}>
     Next up, you need to create a new Application on your Auth0 tenant and add the configuration to your project.
 
-    You can choose to do this automatically by running a CLI command or do it manually via the Dashboard:
+    You can choose to set up your Auth0 app automatically by running a CLI command, or do it manually via the Dashboard:
 
     <Tabs>
       <Tab title="CLI">
         Run the following shell command on your project's root directory to create an Auth0 Application and update your `appsettings.json`:
 
-        <Tabs>
-          <Tab title="Mac/Linux">
-            ```shellscript
-            AUTH0_APP_NAME="My App" && brew tap auth0/auth0-cli && brew install auth0 && auth0 login --no-input && auth0 apps create -n "${AUTH0_APP_NAME}" -t regular -c http://localhost:5000/callback -l http://localhost:5000 -o http://localhost:5000 --reveal-secrets --json --metadata created_by="quickstart-docs-cli" > auth0-app-details.json && CLIENT_ID=$(jq -r '.client_id' auth0-app-details.json) && CLIENT_SECRET=$(jq -r '.client_secret' auth0-app-details.json) && DOMAIN=$(auth0 tenants list --json | jq -r '.[] | select(.active == true) | .name') && rm auth0-app-details.json && cat > appsettings.json << EOF
-            {
-              "Logging": {
-                "LogLevel": {
-                  "Default": "Information",
-                  "Microsoft.AspNetCore": "Warning"
-                }
-              },
-              "AllowedHosts": "*",
-              "Auth0": {
-                "Domain": "${DOMAIN}",
-                "ClientId": "${CLIENT_ID}",
-                "ClientSecret": "${CLIENT_SECRET}"
-              }
-            }
-            EOF
-            echo "appsettings.json created with your Auth0 details:" && cat appsettings.json
-            ```
-          </Tab>
+        <CodeGroup>
+          ```shellscript Mac
+          # Install Auth0 CLI (if not already installed)
+          brew tap auth0/auth0-cli && brew install auth0
 
-          <Tab title="Windows (PowerShell)">
-            ```powershell
-            $AUTH0_APP_NAME = "My MVC App"
-            $latestRelease = Invoke-RestMethod -Uri "https://api.github.com/repos/auth0/auth0-cli/releases/latest"
-            $latestVersion = $latestRelease.tag_name
-            $version = $latestVersion -replace "^v"
-            Invoke-WebRequest -Uri "https://github.com/auth0/auth0-cli/releases/download/${latestVersion}/auth0-cli_${version}_Windows_x86_64.zip" -OutFile ".\auth0.zip"
-            Expand-Archive ".\auth0.zip" .\
-            [System.Environment]::SetEnvironmentVariable('PATH', $Env:PATH + ";${pwd}")
-            auth0 login --no-input
-            auth0 apps create -n "${AUTH0_APP_NAME}" -t regular -c http://localhost:5000/callback -l http://localhost:5000 -o http://localhost:5000 --reveal-secrets --json --metadata created_by="quickstart-docs-cli" | Set-Content -Path auth0-app-details.json
-            $AppDetails = Get-Content -Raw auth0-app-details.json | ConvertFrom-Json
-            $ClientId = $AppDetails.client_id
-            $ClientSecret = $AppDetails.client_secret
-            $Domain = (auth0 tenants list --json | ConvertFrom-Json | Where-Object { $_.active -eq $true }).name
-            $Config = Get-Content -Raw appsettings.json | ConvertFrom-Json
-            if (-not $Config.Auth0) { $Config | Add-Member -MemberType NoteProperty -Name Auth0 -Value @{} }
-            $Config.Auth0.Domain = $Domain
-            $Config.Auth0.ClientId = $ClientId
-            $Config.Auth0.ClientSecret = $ClientSecret
-            $Config | ConvertTo-Json -Depth 10 | Set-Content appsettings.json
-            Remove-Item auth0-api-details.json
-            Write-Output "✅ appsettings.json updated with your Auth0 API details:"
-            Get-Content appsettings.json
-            ```
-          </Tab>
-        </Tabs>
+          # Set up Auth0 app and generate appsettings.json
+          auth0 qs setup --app --type regular --framework aspnet-mvc --port 5000 --name "My ASP.NET MVC App"
+          ```
+
+          ```powershell Windows
+          # Install Auth0 CLI (if not already installed)
+          scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git
+          scoop install auth0
+
+          # Set up Auth0 app and generate appsettings.json
+          auth0 qs setup --app --type regular --framework aspnet-mvc --port 5000 --name "My ASP.NET MVC App"
+          ```
+        </CodeGroup>
+
+        <Note>
+          This command will:
+          1. Check if you're authenticated (and prompt for login if needed)
+          2. Create an Auth0 Regular Web Application configured for `http://localhost:5000`
+          3. Update `appsettings.json` with `Auth0:Domain`, `Auth0:ClientId`, and `Auth0:ClientSecret`
+        </Note>
       </Tab>
 
       <Tab title="Dashboard">

--- a/main/docs/quickstart/webapp/aspnet-owin.mdx
+++ b/main/docs/quickstart/webapp/aspnet-owin.mdx
@@ -36,69 +36,37 @@ Before you begin:
 
 Every application that uses Auth0 needs to be registered in the Auth0 Dashboard. Auth0 issues a **Client ID** and **Domain** that your app uses to communicate with Auth0.
 
-You can create and configure the Auth0 application automatically using the Auth0 CLI, or manually via the Dashboard:
+You can choose to set up your Auth0 app automatically by running a CLI command, or do it manually via the Dashboard:
 
 <Tabs>
   <Tab title="CLI">
-    Run the following command from your project's root directory. It creates an Auth0 application and outputs a ready-to-paste `Web.config` snippet with your credentials filled in:
+    Run the following command from your project's root directory to create an Auth0 application and generate your `Web.config` values:
 
-    <Tabs>
-      <Tab title="Mac/Linux">
-        ```bash
-        brew tap auth0/auth0-cli && brew install auth0 && auth0 login --no-input && \
-        AUTH0_RESULT=$(auth0 apps create \
-          --name "My OWIN App" \
-          --type regular \
-          --auth-method post \
-          --callbacks http://localhost:3000/callback \
-          --logout-urls http://localhost:3000/ \
-          --web-origins http://localhost:3000 \
-          --reveal-secrets \
-          --json \
-          --metadata created_by="quickstart-docs-cli") && \
-        CLIENT_ID=$(echo $AUTH0_RESULT | jq -r '.client_id') && \
-        DOMAIN=$(echo $AUTH0_RESULT | jq -r '.domain') && \
-        echo "Add the following to your Web.config <appSettings> section:" && \
-        echo "<add key=\"auth0:Domain\" value=\"$DOMAIN\" />" && \
-        echo "<add key=\"auth0:ClientId\" value=\"$CLIENT_ID\" />"
-        ```
-      </Tab>
-      <Tab title="Windows (PowerShell)">
-        ```powershell
-        $latestRelease = Invoke-RestMethod -Uri "https://api.github.com/repos/auth0/auth0-cli/releases/latest"
-        $latestVersion = $latestRelease.tag_name
-        $version = $latestVersion -replace "^v"
-        Invoke-WebRequest -Uri "https://github.com/auth0/auth0-cli/releases/download/${latestVersion}/auth0-cli_${version}_Windows_x86_64.zip" -OutFile ".\auth0.zip"
-        Expand-Archive ".\auth0.zip" .\
-        [System.Environment]::SetEnvironmentVariable('PATH', $Env:PATH + ";${pwd}")
-        auth0 login --no-input
-        $AppDetails = auth0 apps create `
-          --name "My OWIN App" `
-          --type regular `
-          --auth-method post `
-          --callbacks http://localhost:3000/callback `
-          --logout-urls http://localhost:3000/ `
-          --web-origins http://localhost:3000 `
-          --reveal-secrets `
-          --json `
-          --metadata created_by="quickstart-docs-cli" | ConvertFrom-Json
-        Write-Output "Add the following to your Web.config <appSettings> section:"
-        Write-Output "<add key=`"auth0:Domain`" value=`"$($AppDetails.domain)`" />"
-        Write-Output "<add key=`"auth0:ClientId`" value=`"$($AppDetails.client_id)`" />"
-        ```
-      </Tab>
-    </Tabs>
+    <CodeGroup>
+      ```shellscript Mac
+      # Install Auth0 CLI (if not already installed)
+      brew tap auth0/auth0-cli && brew install auth0
 
-    Copy the two `<add>` lines from the output into your `Web.config` `<appSettings>` section:
+      # Set up Auth0 app and generate Web.config values
+      auth0 qs setup --app --type regular --framework aspnet-owin --port 5000 --name "My OWIN App"
+      ```
 
-    ```xml Web.config
-    <?xml version="1.0" encoding="utf-8"?>
-    <configuration>
-      <appSettings>
-        <!-- paste your output here -->
-      </appSettings>
-    </configuration>
-    ```
+      ```powershell Windows
+      # Install Auth0 CLI (if not already installed)
+      scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git
+      scoop install auth0
+
+      # Set up Auth0 app and generate Web.config values
+      auth0 qs setup --app --type regular --framework aspnet-owin --port 5000 --name "My OWIN App"
+      ```
+    </CodeGroup>
+
+    <Note>
+      This command will:
+      1. Check if you're authenticated (and prompt for login if needed)
+      2. Create an Auth0 Regular Web Application configured for `http://localhost:5000`
+      3. Generate `Web.config` values with `auth0:Domain`, `auth0:ClientId`, and `auth0:ClientSecret`
+    </Note>
   </Tab>
 
   <Tab title="Dashboard">

--- a/main/docs/quickstart/webapp/express.mdx
+++ b/main/docs/quickstart/webapp/express.mdx
@@ -109,41 +109,37 @@ Update your `package.json` to add start scripts:
 
 Next, you need to create a new application on your Auth0 tenant and add the environment variables to your project.
 
-You can choose to do this automatically by running a CLI command or manually via the Dashboard:
+You can choose to set up your Auth0 app automatically by running a CLI command, or do it manually via the Dashboard:
 
 <Tabs>
   <Tab title="CLI">
 
 Run the following shell command in your project's root directory to create an Auth0 application and generate your `.env` file:
 
-**macOS / Linux:**
+<CodeGroup>
+  ```shellscript Mac
+  # Install Auth0 CLI (if not already installed)
+  brew tap auth0/auth0-cli && brew install auth0
 
-```bash
-AUTH0_APP_NAME="My Express App" && \
-auth0 apps create -n "${AUTH0_APP_NAME}" -t regular \
-  --callbacks http://localhost:3000 \
-  --logout-urls http://localhost:3000 \
-  --json | jq -r '"ISSUER_BASE_URL=https://\(.domain)\nCLIENT_ID=\(.client_id)\nSECRET='$(openssl rand -hex 32)'\nBASE_URL=http://localhost:3000"' > .env
-```
+  # Set up Auth0 app and generate .env file
+  auth0 qs setup --app --type regular --framework express --port 3000 --name "My Express App"
+  ```
 
-**Windows (PowerShell):**
+  ```powershell Windows
+  # Install Auth0 CLI (if not already installed)
+  scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git
+  scoop install auth0
 
-```powershell
-$appName = "My Express App"
-auth0 apps create -n $appName -t regular `
-  --callbacks http://localhost:3000 `
-  --logout-urls http://localhost:3000 `
-  --json | ConvertFrom-Json | ForEach-Object {
-    "ISSUER_BASE_URL=https://$($_.domain)`nCLIENT_ID=$($_.client_id)`nSECRET=$([guid]::NewGuid().ToString())`nBASE_URL=http://localhost:3000"
-  } | Out-File .env -Encoding utf8
-```
+  # Set up Auth0 app and generate .env file
+  auth0 qs setup --app --type regular --framework express --port 3000 --name "My Express App"
+  ```
+</CodeGroup>
 
 <Note>
-If you haven't installed the Auth0 CLI yet, run:
-```bash
-brew tap auth0/auth0-cli && brew install auth0
-```
-Then authenticate with `auth0 login`.
+  This command will:
+  1. Check if you're authenticated (and prompt for login if needed)
+  2. Create an Auth0 Regular Web Application configured for `http://localhost:3000`
+  3. Generate a `.env` file with `ISSUER_BASE_URL`, `CLIENT_ID`, `SECRET`, and `BASE_URL`
 </Note>
 
   </Tab>

--- a/main/docs/quickstart/webapp/fastapi.mdx
+++ b/main/docs/quickstart/webapp/fastapi.mdx
@@ -67,11 +67,14 @@ import {HowToSchema} from "/snippets/HowToSchema.jsx";
 
   If MacOS, execute the following command:
 
-    AUTH0_APP_NAME="My FastAPI App" && brew tap auth0/auth0-cli && brew install auth0 && auth0 login --no-input && auth0 apps create -n "${AUTH0_APP_NAME}" -t regular -c http://localhost:3000/auth/callback -l http://localhost:3000 -o http://localhost:3000 --reveal-secrets --json > auth0-app-details.json && CLIENT_ID=$(jq -r '.client_id' auth0-app-details.json) && CLIENT_SECRET=$(jq -r '.client_secret' auth0-app-details.json) && DOMAIN=$(auth0 tenants list --json | jq -r '.[] | select(.active == true) | .name') && SESSION_SECRET=$(openssl rand -hex 64) && echo "AUTH0_DOMAIN=${DOMAIN}" > .env && echo "AUTH0_CLIENT_ID=${CLIENT_ID}" >> .env && echo "AUTH0_CLIENT_SECRET=${CLIENT_SECRET}" >> .env && echo "SESSION_SECRET=${SESSION_SECRET}" >> .env && echo "APP_BASE_URL=http://localhost:3000" >> .env && rm auth0-app-details.json && echo ".env file created with your Auth0 details:" && cat .env
+    brew tap auth0/auth0-cli && brew install auth0
+    auth0 qs setup --app --type regular --framework vanilla-python --port 3000 --name "My FastAPI App"
 
   If Windows, execute the following command:
 
-    $AppName = "My FastAPI App"; winget install Auth0.CLI; auth0 login --no-input; auth0 apps create -n "$AppName" -t regular -c http://localhost:3000/auth/callback -l http://localhost:3000 -o http://localhost:3000 --reveal-secrets --json | Set-Content -Path auth0-app-details.json; $ClientId = (Get-Content -Raw auth0-app-details.json | ConvertFrom-Json).client_id; $ClientSecret = (Get-Content -Raw auth0-app-details.json | ConvertFrom-Json).client_secret; $Domain = (auth0 tenants list --json | ConvertFrom-Json | Where-Object { $_.active -eq $true }).name; $SessionSecret = -join ((1..128) | ForEach {'{0:X}' -f (Get-Random -Max 16)}); Set-Content -Path .env -Value "AUTH0_DOMAIN=$Domain"; Add-Content -Path .env -Value "AUTH0_CLIENT_ID=$ClientId"; Add-Content -Path .env -Value "AUTH0_CLIENT_SECRET=$ClientSecret"; Add-Content -Path .env -Value "SESSION_SECRET=$SessionSecret"; Add-Content -Path .env -Value "APP_BASE_URL=http://localhost:3000"; Remove-Item auth0-app-details.json; Write-Output ".env file created with your Auth0 details:"; Get-Content .env
+    scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git
+    scoop install auth0
+    auth0 qs setup --app --type regular --framework vanilla-python --port 3000 --name "My FastAPI App"
 
   Step 2.1b: Create manual .env template (if automatic setup fails)
 
@@ -442,7 +445,7 @@ This quickstart demonstrates how to add Auth0 authentication to a Python FastAPI
   <Step title="Setup your Auth0 App" stepNumber={3}>
     Next up, you need to create a new app on your Auth0 tenant and add the environment variables to your project.
 
-    You can choose to do this automatically by running a CLI command or do it manually via the Dashboard:
+    You can choose to set up your Auth0 app automatically by running a CLI command, or do it manually via the Dashboard:
 
     <Tabs>
       <Tab title="CLI">
@@ -450,13 +453,29 @@ This quickstart demonstrates how to add Auth0 authentication to a Python FastAPI
 
         <CodeGroup>
           ```shellscript Mac
-          AUTH0_APP_NAME="My FastAPI App" && brew tap auth0/auth0-cli && brew install auth0 && auth0 login --no-input && auth0 apps create -n "${AUTH0_APP_NAME}" -t regular -c http://localhost:3000/auth/callback -l http://localhost:3000 -o http://localhost:3000 --reveal-secrets --json > auth0-app-details.json && CLIENT_ID=$(jq -r '.client_id' auth0-app-details.json) && CLIENT_SECRET=$(jq -r '.client_secret' auth0-app-details.json) && DOMAIN=$(auth0 tenants list --json | jq -r '.[] | select(.active == true) | .name') && SESSION_SECRET=$(openssl rand -hex 64) && echo "AUTH0_DOMAIN=${DOMAIN}" > .env && echo "AUTH0_CLIENT_ID=${CLIENT_ID}" >> .env && echo "AUTH0_CLIENT_SECRET=${CLIENT_SECRET}" >> .env && echo "SESSION_SECRET=${SESSION_SECRET}" >> .env && echo "APP_BASE_URL=http://localhost:3000" >> .env && rm auth0-app-details.json && echo ".env file created with your Auth0 details:" && cat .env
+          # Install Auth0 CLI (if not already installed)
+          brew tap auth0/auth0-cli && brew install auth0
+
+          # Set up Auth0 app and generate .env file
+          auth0 qs setup --app --type regular --framework vanilla-python --port 3000 --name "My FastAPI App"
           ```
 
-          ```shellscript Windows
-          $AppName = "My FastAPI App"; winget install Auth0.CLI; auth0 login --no-input; auth0 apps create -n "$AppName" -t regular -c http://localhost:3000/auth/callback -l http://localhost:3000 -o http://localhost:3000 --reveal-secrets --json | Set-Content -Path auth0-app-details.json; $ClientId = (Get-Content -Raw auth0-app-details.json | ConvertFrom-Json).client_id; $ClientSecret = (Get-Content -Raw auth0-app-details.json | ConvertFrom-Json).client_secret; $Domain = (auth0 tenants list --json | ConvertFrom-Json | Where-Object { $_.active -eq $true }).name; $SessionSecret = -join ((1..128) | ForEach {'{0:X}' -f (Get-Random -Max 16)}); Set-Content -Path .env -Value "AUTH0_DOMAIN=$Domain"; Add-Content -Path .env -Value "AUTH0_CLIENT_ID=$ClientId"; Add-Content -Path .env -Value "AUTH0_CLIENT_SECRET=$ClientSecret"; Add-Content -Path .env -Value "SESSION_SECRET=$SessionSecret"; Add-Content -Path .env -Value "APP_BASE_URL=http://localhost:3000"; Remove-Item auth0-app-details.json; Write-Output ".env file created with your Auth0 details:"; Get-Content .env
+          ```powershell Windows
+          # Install Auth0 CLI (if not already installed)
+          scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git
+          scoop install auth0
+
+          # Set up Auth0 app and generate .env file
+          auth0 qs setup --app --type regular --framework vanilla-python --port 3000 --name "My FastAPI App"
           ```
         </CodeGroup>
+
+        <Note>
+          This command will:
+          1. Check if you're authenticated (and prompt for login if needed)
+          2. Create an Auth0 Regular Web Application configured for `http://localhost:3000`
+          3. Generate a `.env` file with `AUTH0_DOMAIN`, `AUTH0_CLIENT_ID`, `AUTH0_CLIENT_SECRET`, `SESSION_SECRET`, and `APP_BASE_URL`
+        </Note>
       </Tab>
 
       <Tab title="Dashboard">

--- a/main/docs/quickstart/webapp/golang.mdx
+++ b/main/docs/quickstart/webapp/golang.mdx
@@ -107,12 +107,8 @@ SESSION_SECRET=a-long-random-secret-key-for-cookie-encryption`;
           # Install Auth0 CLI (if not already installed)
           brew tap auth0/auth0-cli && brew install auth0
 
-          # Create Auth0 application
-          auth0 apps create \
-            --name "My Go App" \
-            --type regular \
-            --callbacks http://localhost:3000/callback \
-            --logout-urls http://localhost:3000
+          # Set up Auth0 app and generate .env file
+          auth0 qs setup --app --type regular --framework vanilla-go --port 3000 --name "My Go App"
           ```
 
           ```powershell Windows
@@ -120,12 +116,8 @@ SESSION_SECRET=a-long-random-secret-key-for-cookie-encryption`;
           scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git
           scoop install auth0
 
-          # Create Auth0 application
-          auth0 apps create `
-            --name "My Go App" `
-            --type regular `
-            --callbacks http://localhost:3000/callback `
-            --logout-urls http://localhost:3000
+          # Set up Auth0 app and generate .env file
+          auth0 qs setup --app --type regular --framework vanilla-go --port 3000 --name "My Go App"
           ```
         </CodeGroup>
 
@@ -137,7 +129,7 @@ SESSION_SECRET=a-long-random-secret-key-for-cookie-encryption`;
           This command will:
           1. Check if you're authenticated (and prompt for login if needed)
           2. Create an Auth0 Regular Web Application configured for `http://localhost:3000`
-          3. Display the application details including the domain, client ID, and client secret
+          3. Generate a `.env` file with your Auth0 domain, client ID, and client secret
         </Note>
       </Tab>
 

--- a/main/docs/quickstart/webapp/hono.mdx
+++ b/main/docs/quickstart/webapp/hono.mdx
@@ -65,23 +65,37 @@ This quickstart shows the minimal, recommended way to secure a Hono application 
 
   <Step title="Create an Auth0 application" stepNumber={3}>
     Create an Auth0 Application in your Auth0 tenant (Regular Web Application) and record the **Domain**, **Client ID**, and **Client Secret** in environment variables to your project.
-    You can choose to do this automatically by running a CLI command or do it manually via the Dashboard:
+    You can choose to set up your Auth0 app automatically by running a CLI command, or do it manually via the Dashboard:
 
     <Tabs>
       <Tab title="CLI">
         Run the following shell command on your project’s root directory to create an Auth0 app and generate a `.env` file:
 
-        <AuthCodeGroup>
+        <CodeGroup>
           ```shellscript Mac
-          AUTH0_APP_NAME="Hono Quickstart" && brew tap auth0/auth0-cli && brew install auth0 && auth0 login --no-input && auth0 apps create -n "${AUTH0_APP_NAME}" -t regular -c http://localhost:3000/auth/callback -l http://localhost:3000 -o http://localhost:3000 --reveal-secrets --json --metadata created_by="quickstart-docs-cli" > auth0-app-details.json && CLIENT_ID=$(jq -r '.client_id' auth0-app-details.json) && CLIENT_SECRET=$(jq -r '.client_secret' auth0-app-details.json) && DOMAIN=$(auth0 tenants list --json | jq -r '.[] | select(.active == true) | .name') && SECRET=$(openssl rand -hex 32) && echo "AUTH0_DOMAIN=${DOMAIN}" > .env && echo "AUTH0_CLIENT_ID=${CLIENT_ID}" >> .env && echo "AUTH0_CLIENT_SECRET=${CLIENT_SECRET}" >> .env && echo "APP_BASE_URL=http://localhost:3000" >> .env && echo "AUTH0_SESSION_ENCRYPTION_KEY=$(openssl rand -hex 32)" >> .env && rm auth0-app-details.json && cat .env
+          # Install Auth0 CLI (if not already installed)
+          brew tap auth0/auth0-cli && brew install auth0
+
+          # Set up Auth0 app and generate .env file
+          auth0 qs setup --app --type regular --framework hono --port 3000 --name "My Hono App"
           ```
 
-          ```shellscript Windows
-          $AppName = "Hono Quickstart"; winget install Auth0.CLI; auth0 login --no-input; auth0 apps create -n "$AppName" -t regular -c http://localhost:3000/auth/callback -l http://localhost:3000 -o http://localhost:3000 --reveal-secrets --json --metadata created_by="quickstart-docs-cli" | Set-Content -Path auth0-app-details.json; $ClientId = (Get-Content -Raw auth0-app-details.json | ConvertFrom-Json).client_id; $ClientSecret = (Get-Content -Raw auth0-app-details.json | ConvertFrom-Json).client_secret; $Domain = (auth0 tenants list --json | ConvertFrom-Json | Where-Object { $_.active -eq $true }).name; $Secret = [System.Convert]::ToHexString([System.Security.Cryptography.RandomNumberGenerator]::GetBytes(32)).ToLower(); Set-Content -Path .env -Value "AUTH0_DOMAIN=$Domain"; Add-Content -Path .env -Value "AUTH0_CLIENT_ID=$ClientId"; Add-Content -Path .env -Value "AUTH0_CLIENT_SECRET=$ClientSecret"; Add-Content -Path .env -Value "AUTH0_SESSION_ENCRYPTION_KEY=$Secret"; Add-Content -Path .env -Value "APP_BASE_URL=http://localhost:3000"; Remove-Item auth0-app-details.json; Write-Output ".env file created with your Auth0 details:"; Get-Content .env
-          ```
-        </AuthCodeGroup>
+          ```powershell Windows
+          # Install Auth0 CLI (if not already installed)
+          scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git
+          scoop install auth0
 
-        Use the generated `.env` or update values manually as needed.
+          # Set up Auth0 app and generate .env file
+          auth0 qs setup --app --type regular --framework hono --port 3000 --name "My Hono App"
+          ```
+        </CodeGroup>
+
+        <Note>
+          This command will:
+          1. Check if you’re authenticated (and prompt for login if needed)
+          2. Create an Auth0 Regular Web Application configured for `http://localhost:3000`
+          3. Generate a `.env` file with `AUTH0_DOMAIN`, `AUTH0_CLIENT_ID`, `AUTH0_CLIENT_SECRET`, `AUTH0_SESSION_ENCRYPTION_KEY`, and `BASE_URL`
+        </Note>
       </Tab>
 
       <Tab title="Dashboard">

--- a/main/docs/quickstart/webapp/java-spring-boot.mdx
+++ b/main/docs/quickstart/webapp/java-spring-boot.mdx
@@ -111,72 +111,39 @@ This quickstart demonstrates how to add Auth0 login to a Spring Boot web applica
   <Step title="Configure Auth0" stepNumber={3}>
     Create a Regular Web Application in your Auth0 tenant and add the configuration to your project.
 
-    You can choose to do this automatically by running a CLI command or do it manually via the Dashboard:
+    You can choose to set up your Auth0 app automatically by running a CLI command, or do it manually via the Dashboard:
 
     <Tabs>
       <Tab title="CLI">
-        Run the following shell command on your project's root directory to create an Auth0 application and update your `application.yml` file:
+        Run the following shell command on your project's root directory to create an Auth0 application and update your `src/main/resources/application.yml`:
 
-        <Tabs>
-          <Tab title="Mac/Linux">
+        <CodeGroup>
+          ```shellscript Mac
+          # Install Auth0 CLI (if not already installed)
+          brew tap auth0/auth0-cli && brew install auth0
 
-            ```bash expandable
-            AUTH0_APP_NAME="My Spring Boot Webapp" && \
-            brew tap auth0/auth0-cli && \
-            brew install auth0 && \
-            auth0 login --no-input && \
-            auth0 apps create -n "${AUTH0_APP_NAME}" -t regular \
-                --callbacks "http://localhost:3000/login/oauth2/code/okta" \
-                --logout-urls "http://localhost:3000/" \
-                --json > auth0-app-details.json && \
-            DOMAIN=$(auth0 tenants list --json | jq -r '.[] | select(.active == true) | .name') && \
-            CLIENT_ID=$(jq -r '.client_id' auth0-app-details.json) && \
-            CLIENT_SECRET=$(jq -r '.client_secret' auth0-app-details.json) && \
-            mkdir -p src/main/resources && \
-            printf 'server:\n  port: 3000\n\nokta:\n  oauth2:\n    issuer: https://%s/\n    client-id: %s\n    client-secret: %s\n' "$DOMAIN" "$CLIENT_ID" "$CLIENT_SECRET" > src/main/resources/application.yml && \
-            rm auth0-app-details.json && \
-            echo "✅ application.yml created with your Auth0 app details:" && \
-            cat src/main/resources/application.yml
-            ```
+          # Set up Auth0 app and generate application.yml
+          auth0 qs setup --app --type regular --framework spring-boot --build-tool maven --port 3000 --name "My Spring Boot App"
+          ```
 
-          </Tab>
-          <Tab title="Windows (PowerShell)">
+          ```powershell Windows
+          # Install Auth0 CLI (if not already installed)
+          scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git
+          scoop install auth0
 
-            ```powershell expandable
-            $AppName = "My Spring Boot Webapp"
-            $latestRelease = Invoke-RestMethod -Uri "https://api.github.com/repos/auth0/auth0-cli/releases/latest"
-            $latestVersion = $latestRelease.tag_name
-            $version = $latestVersion -replace "^v"
-            Invoke-WebRequest -Uri "https://github.com/auth0/auth0-cli/releases/download/${latestVersion}/auth0-cli_${version}_Windows_x86_64.zip" -OutFile ".\auth0.zip"
-            Expand-Archive ".\auth0.zip" .\
-            [System.Environment]::SetEnvironmentVariable('PATH', $Env:PATH + ";${pwd}")
-            auth0 login --no-input
-            auth0 apps create -n "$AppName" -t regular `
-                --callbacks "http://localhost:3000/login/oauth2/code/okta" `
-                --logout-urls "http://localhost:3000/" `
-                --json | Set-Content -Path auth0-app-details.json
-            $AppDetails = Get-Content -Raw auth0-app-details.json | ConvertFrom-Json
-            $Domain = (auth0 tenants list --json | ConvertFrom-Json | Where-Object { $_.active -eq $true }).name
-            $ClientId = $AppDetails.client_id
-            $ClientSecret = $AppDetails.client_secret
-            New-Item -ItemType Directory -Force -Path "src\main\resources"
-            @"
-            server:
-              port: 3000
+          # Set up Auth0 app and generate application.yml
+          auth0 qs setup --app --type regular --framework spring-boot --build-tool maven --port 3000 --name "My Spring Boot App"
+          ```
+        </CodeGroup>
 
-            okta:
-              oauth2:
-                issuer: "https://$Domain/"
-                client-id: "$ClientId"
-                client-secret: "$ClientSecret"
-            "@ | Set-Content "src\main\resources\application.yml"
-            Remove-Item auth0-app-details.json
-            Write-Output "✅ application.yml created with your Auth0 app details:"
-            Get-Content "src\main\resources\application.yml"
-            ```
+        <Note>
+          This command will:
+          1. Check if you're authenticated (and prompt for login if needed)
+          2. Create an Auth0 Regular Web Application configured for `http://localhost:3000`
+          3. Generate `src/main/resources/application.yml` with `okta.oauth2.issuer`, `okta.oauth2.client-id`, and `okta.oauth2.client-secret`
 
-          </Tab>
-        </Tabs>
+          Gradle users should substitute `--build-tool gradle` for `--build-tool maven`.
+        </Note>
       </Tab>
 
       <Tab title="Dashboard">

--- a/main/docs/quickstart/webapp/laravel/interactive.mdx
+++ b/main/docs/quickstart/webapp/laravel/interactive.mdx
@@ -92,48 +92,32 @@ This quickstart demonstrates how to add Auth0 authentication to a Laravel applic
       </Tab>
 
       <Tab title="CLI">
-        Install the [Auth0 CLI](https://github.com/auth0/auth0-cli#installation) and log in to your account:
+        Run the following command in your project's root directory to create an Auth0 app and generate a `.env` file:
 
         <CodeGroup>
           ```bash Mac
+          # Install Auth0 CLI (if not already installed)
           brew tap auth0/auth0-cli && brew install auth0
-          auth0 login
+
+          # Set up Auth0 app and generate .env file
+          auth0 qs setup --app --type regular --framework laravel --build-tool composer --name "My Laravel App" --port 8000
           ```
 
           ```powershell Windows
+          # Install Auth0 CLI (if not already installed)
           scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git
           scoop install auth0
-          auth0 login
+
+          # Set up Auth0 app and generate .env file
+          auth0 qs setup --app --type regular --framework laravel --build-tool composer --name "My Laravel App" --port 8000
           ```
         </CodeGroup>
 
-        Create an Auth0 application and API, saving the credentials to JSON files that the SDK reads automatically:
-
-        ```bash
-        auth0 apps create \
-          --name "My Laravel Application" \
-          --type "regular" \
-          --auth-method "post" \
-          --callbacks "http://localhost:8000/callback" \
-          --logout-urls "http://localhost:8000" \
-          --reveal-secrets \
-          --no-input \
-          --json > .auth0.app.json
-
-        auth0 apis create \
-          --name "My Laravel Application's API" \
-          --identifier "https://github.com/auth0/laravel-auth0" \
-          --offline-access \
-          --no-input \
-          --json > .auth0.api.json
-        ```
-
         <Note>
-          These files contain your credentials. Add them to `.gitignore` to keep them out of version control:
-
-          ```bash
-          echo ".auth0.*.json" >> .gitignore
-          ```
+          This command will:
+          1. Check if you're authenticated (and prompt for login if needed)
+          2. Create an Auth0 Regular Web Application configured for `http://localhost:8000`
+          3. Generate a `.env` file with your Auth0 credentials
         </Note>
       </Tab>
 

--- a/main/docs/quickstart/webapp/nuxt.mdx
+++ b/main/docs/quickstart/webapp/nuxt.mdx
@@ -70,7 +70,7 @@ This quickstart demonstrates how to add Auth0 authentication to a Nuxt.js applic
   <Step title="Setup your Auth0 App" stepNumber={3}>
     Next up, you need to create a new app on your Auth0 tenant and add the environment variables to your project.
 
-    You can choose to do this automatically by running a CLI command or do it manually via the Dashboard:
+    You can choose to set up your Auth0 app automatically by running a CLI command, or do it manually via the Dashboard:
 
     <Tabs>
       <Tab title="CLI">
@@ -78,13 +78,29 @@ This quickstart demonstrates how to add Auth0 authentication to a Nuxt.js applic
 
         <CodeGroup>
           ```shellscript Mac
-          AUTH0_APP_NAME="My Nuxt App" && brew tap auth0/auth0-cli && brew install auth0 && auth0 login --no-input && auth0 apps create -n "${AUTH0_APP_NAME}" -t regular -c http://localhost:3000/auth/callback -l http://localhost:3000 -o http://localhost:3000 --reveal-secrets --json > auth0-app-details.json && CLIENT_ID=$(jq -r '.client_id' auth0-app-details.json) && CLIENT_SECRET=$(jq -r '.client_secret' auth0-app-details.json) && DOMAIN=$(auth0 tenants list --json | jq -r '.[] | select(.active == true) | .name') && echo "NUXT_AUTH0_DOMAIN=${DOMAIN}" > .env && echo "NUXT_AUTH0_CLIENT_ID=${CLIENT_ID}" >> .env && echo "NUXT_AUTH0_CLIENT_SECRET=${CLIENT_SECRET}" >> .env && echo "NUXT_AUTH0_SESSION_SECRET=$(openssl rand -hex 64)" >> .env && echo "NUXT_AUTH0_APP_BASE_URL=http://localhost:3000" >> .env && rm auth0-app-details.json && echo ".env file created with your Auth0 details:" && cat .env
+          # Install Auth0 CLI (if not already installed)
+          brew tap auth0/auth0-cli && brew install auth0
+
+          # Set up Auth0 app and generate .env file
+          auth0 qs setup --app --type regular --framework nuxt --port 3000 --name "My Nuxt App"
           ```
 
-          ```shellscript Windows
-          $AppName = "My Nuxt App"; winget install Auth0.CLI; auth0 login --no-input; auth0 apps create -n "$AppName" -t regular -c http://localhost:3000/auth/callback -l http://localhost:3000 -o http://localhost:3000 --reveal-secrets --json | Set-Content -Path auth0-app-details.json; $ClientId = (Get-Content -Raw auth0-app-details.json | ConvertFrom-Json).client_id; $ClientSecret = (Get-Content -Raw auth0-app-details.json | ConvertFrom-Json).client_secret; $Domain = (auth0 tenants list --json | ConvertFrom-Json | Where-Object { $_.active -eq $true }).name; Set-Content -Path .env -Value "NUXT_AUTH0_DOMAIN=$Domain"; Add-Content -Path .env -Value "NUXT_AUTH0_CLIENT_ID=$ClientId"; Add-Content -Path .env -Value "NUXT_AUTH0_CLIENT_SECRET=$ClientSecret"; $SessionSecret = -join ((1..128) | ForEach {'{0:X}' -f (Get-Random -Max 16)}); Add-Content -Path .env -Value "NUXT_AUTH0_SESSION_SECRET=$SessionSecret"; Add-Content -Path .env -Value "NUXT_AUTH0_APP_BASE_URL=http://localhost:3000"; Remove-Item auth0-app-details.json; Write-Output ".env file created with your Auth0 details:"; Get-Content .env
+          ```powershell Windows
+          # Install Auth0 CLI (if not already installed)
+          scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git
+          scoop install auth0
+
+          # Set up Auth0 app and generate .env file
+          auth0 qs setup --app --type regular --framework nuxt --port 3000 --name "My Nuxt App"
           ```
         </CodeGroup>
+
+        <Note>
+          This command will:
+          1. Check if you're authenticated (and prompt for login if needed)
+          2. Create an Auth0 Regular Web Application configured for `http://localhost:3000`
+          3. Generate a `.env` file with `NUXT_AUTH0_DOMAIN`, `NUXT_AUTH0_CLIENT_ID`, `NUXT_AUTH0_CLIENT_SECRET`, `NUXT_AUTH0_SESSION_SECRET`, and `NUXT_AUTH0_APP_BASE_URL`
+        </Note>
       </Tab>
 
       <Tab title="Dashboard">

--- a/main/docs/quickstart/webapp/python.mdx
+++ b/main/docs/quickstart/webapp/python.mdx
@@ -57,7 +57,7 @@ This quickstart demonstrates how to add Auth0 authentication to a Flask applicat
   <Step title="Setup your Auth0 App" stepNumber={3}>
     Next up, you need to create a new app on your Auth0 tenant and add the environment variables to your project.
 
-    You can choose to do this automatically by running a CLI command or do it manually via the Dashboard:
+    You can choose to set up your Auth0 app automatically by running a CLI command, or do it manually via the Dashboard:
 
     <Tabs>
       <Tab title="CLI">
@@ -65,13 +65,29 @@ This quickstart demonstrates how to add Auth0 authentication to a Flask applicat
 
         <CodeGroup>
           ```shellscript Mac
-          AUTH0_APP_NAME="My Flask App" && brew tap auth0/auth0-cli && brew install auth0 && auth0 login --no-input && auth0 apps create -n "${AUTH0_APP_NAME}" -t regular -c http://localhost:5000/callback -l http://localhost:5000 -o http://localhost:5000 --reveal-secrets --json > app-details.json && CLIENT_ID=$(python3 -c "import json; print(json.load(open('app-details.json'))['client_id'])") && CLIENT_SECRET=$(python3 -c "import json; print(json.load(open('app-details.json'))['client_secret'])") && DOMAIN=$(auth0 tenants list --json | python3 -c "import sys, json; print([t['name'] for t in json.load(sys.stdin) if t.get('active')][0])") && SECRET=$(openssl rand -hex 64) && echo "AUTH0_DOMAIN=${DOMAIN}" > .env && echo "AUTH0_CLIENT_ID=${CLIENT_ID}" >> .env && echo "AUTH0_CLIENT_SECRET=${CLIENT_SECRET}" >> .env && echo "AUTH0_SECRET=${SECRET}" >> .env && echo "AUTH0_REDIRECT_URI=http://localhost:5000/callback" >> .env && rm app-details.json && echo ".env file created with your Auth0 details:" && cat .env
+          # Install Auth0 CLI (if not already installed)
+          brew tap auth0/auth0-cli && brew install auth0
+
+          # Set up Auth0 app and generate .env file
+          auth0 qs setup --app --type regular --framework vanilla-python --port 5000 --name "My Flask App"
           ```
 
-          ```shellscript Windows
-          $AppName = "My Flask App"; winget install Auth0.CLI; auth0 login --no-input; auth0 apps create -n "$AppName" -t regular -c http://localhost:5000/callback -l http://localhost:5000 -o http://localhost:5000 --reveal-secrets --json | Set-Content -Path app-details.json; $ClientId = (Get-Content -Raw app-details.json | ConvertFrom-Json).client_id; $ClientSecret = (Get-Content -Raw app-details.json | ConvertFrom-Json).client_secret; $Domain = (auth0 tenants list --json | ConvertFrom-Json | Where-Object { $_.active -eq $true }).name; $Secret = [System.Convert]::ToHexString([System.Security.Cryptography.RandomNumberGenerator]::GetBytes(64)).ToLower(); Set-Content -Path .env -Value "AUTH0_DOMAIN=$Domain"; Add-Content -Path .env -Value "AUTH0_CLIENT_ID=$ClientId"; Add-Content -Path .env -Value "AUTH0_CLIENT_SECRET=$ClientSecret"; Add-Content -Path .env -Value "AUTH0_SECRET=$Secret"; Add-Content -Path .env -Value "AUTH0_REDIRECT_URI=http://localhost:5000/callback"; Remove-Item app-details.json; Write-Output ".env file created with your Auth0 details:"; Get-Content .env
+          ```powershell Windows
+          # Install Auth0 CLI (if not already installed)
+          scoop bucket add auth0 https://github.com/auth0/scoop-auth0-cli.git
+          scoop install auth0
+
+          # Set up Auth0 app and generate .env file
+          auth0 qs setup --app --type regular --framework vanilla-python --port 5000 --name "My Flask App"
           ```
         </CodeGroup>
+
+        <Note>
+          This command will:
+          1. Check if you're authenticated (and prompt for login if needed)
+          2. Create an Auth0 Regular Web Application configured for `http://localhost:5000`
+          3. Generate a `.env` file with `AUTH0_DOMAIN`, `AUTH0_CLIENT_ID`, `AUTH0_CLIENT_SECRET`, `AUTH0_SECRET`, and `AUTH0_REDIRECT_URI`
+        </Note>
       </Tab>
 
       <Tab title="Dashboard">


### PR DESCRIPTION
 ## Description

  Replaces the long, complex inline shell scripts in the CLI setup tabs of 16 SDK
  quickstarts with the new `auth0 qs setup --app` command. This affects quickstarts across
  native (Ionic Angular, Ionic React, Ionic Vue), SPA (Angular, Flutter), and web app
  (ASP.NET Core, ASP.NET Core Blazor, ASP.NET OWIN, Express, FastAPI, Go, Hono, Java Spring
  Boot, Laravel, Nuxt, Python/Flask) categories.

  Key changes per file:
  - Replaces multi-line `auth0 apps create` (and config file generation) scripts with a
  single `auth0 qs setup --app --type <type> --framework <framework>` invocation
  - Switches Windows installation instructions from `winget` to `scoop` for consistency
  - Replaces `AuthCodeGroup` with `CodeGroup` and nested `<Tabs>` (Mac/Linux vs Windows)
  with `<CodeGroup>` using labeled code blocks
  - Adds a `<Note>` block after each code group explaining what the command does (auth
  check, app creation, config file generation)

  ### Testing

  - [x] Verify `auth0 qs setup` commands render correctly in each quickstart's CLI tab
  - [x] Check that `<CodeGroup>` Mac/Windows tabs display and switch correctly
  - [x] Confirm `<Note>` blocks render properly below each code group

  ## Checklist

  - [x] I've read and followed
  [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
  - [x] I've tested the site build for this change locally.
  - [x] I've made appropriate docs updates for any code or config changes.
  - [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial
  changes.