### PR TITLE
feat: Update tenant log catalog icon 

### DIFF
--- a/main/config/nav.en.json
+++ b/main/config/nav.en.json
@@ -67,6 +67,11 @@
           "$ref": "./navigation/generated/events-catalog.en.json"
         },
         {
+          "item": "Tenant Log Catalog",
+          "icon": "/icons/tenant-logs.svg",
+          "$ref": "./navigation/generated/tenant-logs.en.json"
+        },
+        {
           "item": "Universal Components",
           "icon": "/icons/universal-components.svg",
           "$ref": "./navigation/universal-components.json"

--- a/main/icons/tenant-logs.svg
+++ b/main/icons/tenant-logs.svg
@@ -1,4 +1,8 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<style>path{fill:#191919}@media(prefers-color-scheme:dark){path{fill:#fff}}</style>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M3 3H21V21H3V3ZM5 5V19H19V5H5ZM7.5 7.5H10.5V10.5H7.5V7.5ZM13.5 7.5H16.5V10.5H13.5V7.5ZM7.5 13.5H10.5V16.5H7.5V13.5ZM13.5 13.5H16.5V16.5H13.5V13.5Z"/>
+<style>path,rect{fill:#191919}@media(prefers-color-scheme:dark){path,rect{fill:#fff}}</style>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M5 3C3.89543 3 3 3.89543 3 5V19C3 20.1046 3.89543 21 5 21H19C20.1046 21 21 20.1046 21 19V5C21 3.89543 20.1046 3 19 3H5ZM5 5H19V19H5V5Z"/>
+<rect x="8" y="8" width="3" height="3" rx="0.5"/>
+<rect x="13" y="8" width="3" height="3" rx="0.5"/>
+<rect x="8" y="13" width="3" height="3" rx="0.5"/>
+<rect x="13" y="13" width="3" height="3" rx="0.5"/>
 </svg>

--- a/main/icons/tenant-logs.svg
+++ b/main/icons/tenant-logs.svg
@@ -1,0 +1,8 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<style>path,rect{fill:#191919}@media(prefers-color-scheme:dark){path,rect{fill:#fff}}</style>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M4 3C2.89543 3 2 3.89543 2 5V19C2 20.1046 2.89543 21 4 21H16C17.1046 21 18 20.1046 18 19V8.41421L12.5858 3H4ZM4 5H11V9H16V19H4V5ZM13 5.41421L15.5858 8H13V5.41421Z"/>
+<rect x="6" y="12" width="8" height="1.5" rx="0.75"/>
+<rect x="6" y="15" width="6" height="1.5" rx="0.75"/>
+<path d="M20 6V17H22V6H20Z"/>
+<path d="M20 19V21H22V19H20Z"/>
+</svg>

--- a/main/icons/tenant-logs.svg
+++ b/main/icons/tenant-logs.svg
@@ -1,8 +1,8 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<style>path,rect{fill:#191919}@media(prefers-color-scheme:dark){path,rect{fill:#fff}}</style>
+<style>path,circle{fill:#191919}@media(prefers-color-scheme:dark){path,circle{fill:#fff}}</style>
 <path fill-rule="evenodd" clip-rule="evenodd" d="M5 3C3.89543 3 3 3.89543 3 5V19C3 20.1046 3.89543 21 5 21H19C20.1046 21 21 20.1046 21 19V5C21 3.89543 20.1046 3 19 3H5ZM5 5H19V19H5V5Z"/>
-<rect x="8" y="8" width="3" height="3" rx="0.5"/>
-<rect x="13" y="8" width="3" height="3" rx="0.5"/>
-<rect x="8" y="13" width="3" height="3" rx="0.5"/>
-<rect x="13" y="13" width="3" height="3" rx="0.5"/>
+<circle cx="9.5" cy="9.5" r="1.5"/>
+<circle cx="14.5" cy="9.5" r="1.5"/>
+<circle cx="9.5" cy="14.5" r="1.5"/>
+<circle cx="14.5" cy="14.5" r="1.5"/>
 </svg>

--- a/main/icons/tenant-logs.svg
+++ b/main/icons/tenant-logs.svg
@@ -1,8 +1,4 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<style>path,rect{fill:#191919}@media(prefers-color-scheme:dark){path,rect{fill:#fff}}</style>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M4 3C2.89543 3 2 3.89543 2 5V19C2 20.1046 2.89543 21 4 21H16C17.1046 21 18 20.1046 18 19V8.41421L12.5858 3H4ZM4 5H11V9H16V19H4V5ZM13 5.41421L15.5858 8H13V5.41421Z"/>
-<rect x="6" y="12" width="8" height="1.5" rx="0.75"/>
-<rect x="6" y="15" width="6" height="1.5" rx="0.75"/>
-<path d="M20 6V17H22V6H20Z"/>
-<path d="M20 19V21H22V19H20Z"/>
+<style>path{fill:#191919}@media(prefers-color-scheme:dark){path{fill:#fff}}</style>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M3 3H21V21H3V3ZM5 5V19H19V5H5ZM7.5 7.5H10.5V10.5H7.5V7.5ZM13.5 7.5H16.5V10.5H13.5V7.5ZM7.5 13.5H10.5V16.5H7.5V13.5ZM13.5 13.5H16.5V16.5H13.5V13.5Z"/>
 </svg>


### PR DESCRIPTION
## Summary

- Adds a new **Tenant Log Catalog** entry to the Dev Tools navigation menu
- Introduces a custom SVG icon (`/icons/tenant-logs.svg`) — a minimal building outline with 4 circular dots

## Icon theme support

The icon uses a CSS media query inside the SVG to adapt automatically:
- **Light mode** — renders in `#191919` (dark)
- **Dark mode** — renders in `#fff` (white)