### PR TITLE
docs(agent-experience): update scoring methodology for agentic experience leaderboard

### DIFF
--- a/main/docs/get-started/auth0-agent-experience.mdx
+++ b/main/docs/get-started/auth0-agent-experience.mdx
@@ -15,28 +15,29 @@ Each model is tested with and without Auth0 tools ([MCP Server](/docs/get-starte
 
 ## Score dimensions
 
-Every run is scored across 7 dimensions split into two categories. Four dimensions address the agent process from end-to-end with Auth0 tools. Three dimensions score the final output. Each dimension is scored 0–100 individually, then weighted and combined into the overall score.
+Every run is scored across 8 dimensions split into two categories — 50% process, 50% output. Five dimensions address the agent process from end-to-end with Auth0 tools. Three dimensions score the final output. Each dimension is scored 0–100 individually, then weighted and combined into the overall score.
 
-| Dimension | Category | Description |
-|-----------|----------|-------------|
-| **Setup Friction** | Process | Score determined by the agent's ability to complete the task autonomously. If the agent paused to ask questions or encountered errors, the score decreased. |
-| **Setup Speed** | Process | Score determined by the agent's active execution time. Results are comparable across environments. |
-| **Efficiency** | Process | Score determined by the number of tool calls required to complete the task. Fewer tool calls means less cost and less complexity. |
-| **Error Recovery** | Process | Score determined by infrastructure errors (rate limits, timeouts) that disrupted the execution. |
-| **Correctness** | Output | Score determined by whether the generated code imports real packages, calls real methods, and wires components correctly. |
-| **Hallucination** | Output | Score determined by whether the agent invented packages that don't exist or used incorrect SDK variants. |
-| **Security** | Output | Score determined by whether the agent hardcoded secrets, stored tokens insecurely, or committed credentials to source code. |
+| Dimension | Category | Weight | Description |
+|-----------|----------|--------|-------------|
+| **Setup Friction** | Process | 12% | Score determined by the agent's ability to complete the task autonomously. If the agent paused to ask questions or encountered errors, the score decreased. |
+| **Setup Speed** | Process | 12% | Score determined by the agent's active execution time. Results are comparable across environments. |
+| **Efficiency** | Process | 12% | Score determined by the proportion of wasteful tool calls — duplicate reads, errored calls, retries, and overwritten writes. Fewer wasted calls means less cost and less complexity. |
+| **Error Recovery** | Process | 7% | Score determined by infrastructure errors (rate limits, timeouts) that disrupted the execution. |
+| **Docs Quality** | Process | 7% | Score determined by whether the agent correctly referenced Auth0 documentation — valid URLs, successful fetches, used the documentation output, and achieved structural correctness. |
+| **Correctness** | Output | 25% | Score determined by whether the generated code imports real packages, calls real methods, and wires components correctly. |
+| **Hallucination** | Output | 15% | Score determined by whether the agent invented packages that don't exist or used incorrect SDK variants. |
+| **Security** | Output | 10% | Score determined by whether the agent hardcoded secrets, stored tokens insecurely, or committed credentials to source code. |
 
 ## Grades
 
 Overall scores map to letter grades:
 
-| Grade | Min score | Description |
-|-------|-----------|-------------|
-| A | 90 | Production-ready. Minimal issues. |
-| B | 75 | Solid, but with a few gaps to fix. |
-| C | 60 | Usable, but needs cleanup. |
-| D | 40 | Significant problems. |
+| Grade | Score range | Description |
+|-------|-------------|-------------|
+| A | 90+ | Production-ready with 1–2 minor issues. |
+| B | 75–89 | Sound fundamentals with notable gaps. |
+| C | 60–74 | Usable but needs significant cleanup. |
+| D | 40–59 | Major failures or severe process problems. |
 | F | < 40 | Not useful — faster to start from scratch. |
 
 Grades are calibrated to match developer intuition. A score of 91 should feel like code you'd accept with minimal review. A score of 55 should feel like something that needs real work to fix.

--- a/main/docs/get-started/auth0-agent-experience.mdx
+++ b/main/docs/get-started/auth0-agent-experience.mdx
@@ -23,7 +23,7 @@ Every run is scored across 8 dimensions split into two categories — 50% proces
 | **Setup Speed** | Process | 12% | Score determined by the agent's active execution time. Results are comparable across environments. |
 | **Efficiency** | Process | 12% | Score determined by the proportion of wasteful tool calls — duplicate reads, errored calls, retries, and overwritten writes. Fewer wasted calls means less cost and less complexity. |
 | **Error Recovery** | Process | 7% | Score determined by infrastructure errors (rate limits, timeouts) that disrupted the execution. |
-| **Docs Quality** | Process | 7% | Score determined by whether the agent correctly referenced Auth0 documentation — valid URLs, successful fetches, used the documentation output, and achieved structural correctness. |
+| **Docs Quality** | Process | 7% | Score determined by how well the agent used external documentation during the task — whether it looked up valid, relevant sources, successfully retrieved content, and incorporated that information into the implementation rather than discarding it. |
 | **Correctness** | Output | 25% | Score determined by whether the generated code imports real packages, calls real methods, and wires components correctly. |
 | **Hallucination** | Output | 15% | Score determined by whether the agent invented packages that don't exist or used incorrect SDK variants. |
 | **Security** | Output | 10% | Score determined by whether the agent hardcoded secrets, stored tokens insecurely, or committed credentials to source code. |


### PR DESCRIPTION
## Summary

- Adds missing 8th dimension (**Docs Quality**, 7%) to the score dimensions table, sourced from `auth0-evals/docs/SCORING_METHODOLOGY.md`
- Adds **Weight** column with exact percentages (12/12/12/7/7% process, 25/15/10% output) reflecting the 50/50 process/output split
- Corrects intro text: 7→8 dimensions, 4→5 process dims, calls out the 50% / 50% category split
- Updates **Efficiency** description to reflect the waste-ratio formula (duplicate reads, errored calls, retries, overwrites) rather than total call count
- Updates grade table: adds score ranges (e.g. 75–89 instead of just 75) and aligns descriptions to the repo copy
- Broadens **Docs Quality** description so it's accessible to readers unfamiliar with the internal grader terminology

## Test plan

- [ ] Verify page renders correctly at `localhost:3000/docs/get-started/auth0-agent-experience` with `mint dev`
- [ ] Check that all 8 dimension rows display in the table with correct weights
- [ ] Confirm grade ranges are correct and no row is missing
