### PR TITLE
fix: resolve 500 errors on Express beta quickstart pages

### DIFF
--- a/main/docs/quickstart/backend/express-api-beta.mdx
+++ b/main/docs/quickstart/backend/express-api-beta.mdx
@@ -9,16 +9,16 @@ import {HowToSchema} from "/snippets/HowToSchema.jsx";
 import {AuthCodeBlock} from "/snippets/AuthCodeBlock.jsx";
 import {AuthCodeGroup} from "/snippets/AuthCodeGroup.jsx";
 
-<HowToSchema />
-<Callout icon="pencil" color="#FFC107" iconType="solid">
-  This Quickstart is currently in **Beta**. We'd love to hear your feedback!
-</Callout>
-
 export const envSnippet = `AUTH0_DOMAIN={yourDomain}
 AUTH0_AUDIENCE=YOUR_API_IDENTIFIER`;
 
 export const envSnippetDashboard = `AUTH0_DOMAIN=YOUR_AUTH0_DOMAIN
 AUTH0_AUDIENCE=YOUR_API_IDENTIFIER`;
+
+<HowToSchema />
+<Callout icon="pencil" color="#FFC107" iconType="solid">
+  This Quickstart is currently in **Beta**. We'd love to hear your feedback!
+</Callout>
 
 <Note>
   **Prerequisites:** Before you begin, ensure you have the following installed:

--- a/main/docs/quickstart/webapp/express-beta.mdx
+++ b/main/docs/quickstart/webapp/express-beta.mdx
@@ -10,11 +10,6 @@ import {AuthCodeBlock} from "/snippets/AuthCodeBlock.jsx";
 import {AuthCodeGroup} from "/snippets/AuthCodeGroup.jsx";
 import {CreateInteractiveApp} from "/snippets/recipe.jsx";
 
-<HowToSchema />
-<Callout icon="pencil" color="#FFC107" iconType="solid">
-  This Quickstart is currently in **Beta**. We'd love to hear your feedback!
-</Callout>
-
 export const envSnippet = `AUTH0_DOMAIN={yourDomain}
 AUTH0_CLIENT_ID={yourClientId}
 AUTH0_CLIENT_SECRET={yourClientSecret}
@@ -26,6 +21,11 @@ AUTH0_CLIENT_ID=YOUR_AUTH0_CLIENT_ID
 AUTH0_CLIENT_SECRET=YOUR_AUTH0_CLIENT_SECRET
 APP_BASE_URL=http://localhost:3000
 AUTH0_SESSION_SECRET=use-a-long-random-string-at-least-32-characters`;
+
+<HowToSchema />
+<Callout icon="pencil" color="#FFC107" iconType="solid">
+  This Quickstart is currently in **Beta**. We'd love to hear your feedback!
+</Callout>
 
 <Note>
   **Prerequisites:** Before you begin, ensure you have the following installed:
@@ -91,10 +91,10 @@ You need to create a new application on your Auth0 tenant and configure your env
 <Tab title="Quick Setup">
 
 <CreateInteractiveApp
-  name="My Express App"
+  placeholderText="Express"
   appType="regular_web"
-  callbackUrl="http://localhost:3000/auth/callback"
-  logoutUrl="http://localhost:3000"
+  allowedCallbackUrls={["http://localhost:3000/auth/callback"]}
+  allowedLogoutUrls={["http://localhost:3000"]}
 />
 
 Once your app is created, add these values to your `.env` file:


### PR DESCRIPTION
## Summary

- Both Express beta quickstart pages (`/docs/quickstart/webapp/express-beta` and `/docs/quickstart/backend/express-api-beta`) were returning 500 errors due to `export const` declarations appearing after JSX component usage. MDX requires exports to be hoisted before any JSX content — moved both `export const` blocks to immediately follow the `import` statements.
- Fixed incorrect `CreateInteractiveApp` prop names in `express-beta.mdx`: `name` → `placeholderText`, `callbackUrl` (string) → `allowedCallbackUrls` (array), `logoutUrl` (string) → `allowedLogoutUrls` (array), matching the component signature in `snippets/recipe.jsx`.

## Test plan

- [x] `/docs/quickstart/webapp/express-beta` renders without a 500 error
- [x] `/docs/quickstart/backend/express-api-beta` renders without a 500 error
- [x] The Quick Setup tab in `express-beta` shows the correct callback and logout URLs (`http://localhost:3000/auth/callback` and `http://localhost:3000`)
- [x] `envSnippet` and `envSnippetDashboard` code blocks render correctly in both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)