### PR TITLE
Remove Rate Limit EA notice

### DIFF
--- a/main/docs/api/myaccount.mdx
+++ b/main/docs/api/myaccount.mdx
@@ -114,10 +114,6 @@ curl --request POST \
   --data '{  "grant_type": "urn:okta:params:oauth:grant-type:webauthn",  "client_id": "{yourClientId}",  "scope": "create:me:authentication_methods offline_access",  "audience": "https://{yourDomain}/me/"  "auth_session": "{sessionIdFromTheFirstRequest}",  "authn_response": "{authenticatorResponse}"}'
 ```
 
-## Rate limits
-
-During Early Access, the My Account API is limited at a tenant level to 25 requests per second.
-
 ### Authentication
 
 <Tabs class="width-1/2" borderBottom>

--- a/main/docs/manage-users/my-account-api.mdx
+++ b/main/docs/manage-users/my-account-api.mdx
@@ -836,10 +836,6 @@ Remove an enrolled authentication method. Replace `{id}` with the method's `id` 
   </Tab>
 </Tabs>
 
-## Rate limits
-
-During Early Access, the My Account API is limited at a tenant level to 25 requests per second.
-
 ## Cross-Origin Requests
 
 If you intend to call the My Account API directly from a browser-based application (like a Single Page Application) running on a different domain than your Auth0 tenant, you may encounter browser security policies known as [Cross-Origin Resource Sharing (CORS)](/docs/authenticate/passwordless/implement-login/embedded-login/spa#configure-cross-origin-resource-sharing-cors). By default, browsers block these cross-origin requests.


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

My Account API is now GA. The change to remove the EA Rate Limit notice needs to be removed. Authentication Assurance is still in EA.

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
