### PR TITLE
fix: add openapi redirect

### DIFF
--- a/main/config/redirects.json
+++ b/main/config/redirects.json
@@ -22746,5 +22746,9 @@
   {
     "source": "/docs/get-started/universal-components/my-account/factors/passkeys",
     "destination": "/docs/get-started/universal-components/ios/components/factors/passkeys"
+  },
+  {
+    "source": "/docs/api/management/openapi.json",
+    "destination": "/docs/oas/management/v2/management-api-oas.json"
   }
 ]


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

This PR ensures the old URL for the management API spec is still functional. 

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
