### PR TITLE
docs: add Free Tenant Inactivity Policy page

### DIFF
--- a/main/config/navigation/platform.json
+++ b/main/config/navigation/platform.json
@@ -57,6 +57,7 @@
           ]
         },
         "docs/troubleshoot/customer-support/operational-policies/entity-limit-policy",
+        "docs/troubleshoot/customer-support/operational-policies/free-tenant-inactivity-policy",
         "docs/troubleshoot/customer-support/versioning-strategy"
       ]
     },

--- a/main/docs/troubleshoot/customer-support/operational-policies/free-tenant-inactivity-policy.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/free-tenant-inactivity-policy.mdx
@@ -5,15 +5,17 @@ title: Free Tenant Inactivity Policy
 
 **Effective Date:** June 30, 2026
 
-This policy applies to **free Auth0 tenants only**. Auth0 periodically removes free tenants that have had no activity for an extended period in order to maintain platform health and meet data privacy obligations. If your tenant is on a paid plan, this policy does not apply to you.
+<Callout icon="triangle-exclamation" color="#F97316" iconType="regular">
+  This policy applies to **free Auth0 tenants only**. Auth0 periodically removes free tenants that have had no activity for an extended period in order to maintain platform health and meet data privacy obligations. If your tenant is on a paid plan, this policy does not apply to you.
+</Callout>
 
-## How It Works
+## How it works
 
 If your free tenant shows no activity for **90 consecutive days**, it is marked as inactive and the deletion process begins. Auth0 will attempt to send up to three email notifications to the admin email added to your tenant before your tenant is permanently deleted.
 
-1. **First notice** — sent after 90 days of inactivity
-2. **Second notice** — sent after 120 days of inactivity
-3. **Final notice** — sent after 150 days of inactivity
+1. **First notice**: sent after 90 days of inactivity
+2. **Second notice**: sent after 120 days of inactivity
+3. **Final notice**: sent after 150 days of inactivity
 
 If no activity is detected by the final notice, your tenant is queued for permanent deletion.
 
@@ -21,7 +23,7 @@ If no activity is detected by the final notice, your tenant is queued for perman
   Keep your administrator email address current in the Auth0 Dashboard. Notifications sent to outdated or invalid addresses do not pause the deletion timeline.
 </Callout>
 
-## Prevent Deletion
+## Prevent deletion
 
 The best way to keep your free tenant is to maintain regular activity. Auth0 counts any of the following as qualifying activity:
 
@@ -35,7 +37,7 @@ Any one of these actions resets the inactivity clock. Auth0 checks for activity 
   If you need to keep a tenant but do not expect regular usage, consider upgrading to a paid plan. Paid tenants are not subject to inactivity deletion.
 </Callout>
 
-## What Happens to Your Data
+## What happens to your data
 
 Once a tenant is queued for deletion, all associated data is **permanently and irreversibly deleted**. Auth0 cannot recover data after deletion is complete.
 

--- a/main/docs/troubleshoot/customer-support/operational-policies/free-tenant-inactivity-policy.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/free-tenant-inactivity-policy.mdx
@@ -1,0 +1,47 @@
+---
+description: Describes Auth0's inactivity policy for free tenants.
+title: Free Tenant Inactivity Policy
+---
+
+**Effective Date:** June 30, 2026
+
+This policy applies to **free Auth0 tenants only**. Auth0 periodically removes free tenants that have had no activity for an extended period in order to maintain platform health and meet data privacy obligations. If your tenant is on a paid plan, this policy does not apply to you.
+
+## How It Works
+
+If your free tenant shows no activity for **90 consecutive days**, it is marked as inactive and the deletion process begins. Auth0 will attempt to send up to three email notifications to the admin email added to your tenant before your tenant is permanently deleted.
+
+1. **First notice** — sent after 90 days of inactivity
+2. **Second notice** — sent after 120 days of inactivity
+3. **Final notice** — sent after 150 days of inactivity
+
+If no activity is detected by the final notice, your tenant is queued for permanent deletion.
+
+<Callout icon="triangle-exclamation" color="#F97316" iconType="regular">
+  Keep your administrator email address current in the Auth0 Dashboard. Notifications sent to outdated or invalid addresses do not pause the deletion timeline.
+</Callout>
+
+## Prevent Deletion
+
+The best way to keep your free tenant is to maintain regular activity. Auth0 counts any of the following as qualifying activity:
+
+- A user login through any application on the tenant
+- An Auth0 Dashboard login by an administrator
+- A Machine-to-Machine (M2M) token request from any application
+
+Any one of these actions resets the inactivity clock. Auth0 checks for activity on a regular basis, so keeping a scheduled login or token request is sufficient to prevent deletion.
+
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+  If you need to keep a tenant but do not expect regular usage, consider upgrading to a paid plan. Paid tenants are not subject to inactivity deletion.
+</Callout>
+
+## What Happens to Your Data
+
+Once a tenant is queued for deletion, all associated data is **permanently and irreversibly deleted**. Auth0 cannot recover data after deletion is complete.
+
+This process is carried out in compliance with applicable data privacy regulations, including those governing personal data.
+
+## Learn more
+
+- [Auth0 Community](https://community.auth0.com)
+- [Auth0 Operational Policies](/docs/troubleshoot/customer-support/operational-policies)


### PR DESCRIPTION
## Description

Adds a new operational policy page documenting Auth0's inactivity policy for free tenants. The page covers how the policy works (90/120/150 day notice schedule), what counts as qualifying activity to prevent deletion, and what happens to tenant data once deletion is queued.

Also adds the page to the English navigation under **Troubleshoot → Customer Support → Operational Policies**, after the Entity Limit Policy entry.

### Testing

- Verified the page renders and appears in the sidebar locally with `mint dev`.
- Ran `mint broken-links` to confirm no broken links.

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
