### PR TITLE
update: add callout for register-applications-with-cimd

### DIFF
--- a/main/docs/get-started/auth0-overview/create-applications/register-applications-with-cimd.mdx
+++ b/main/docs/get-started/auth0-overview/create-applications/register-applications-with-cimd.mdx
@@ -11,7 +11,7 @@ When you import an application from its CIMD URL, Auth0 fetches, validates, and 
 You can only register [third-party applications](/docs/get-started/applications/third-party-applications) using manual CIMD, which are subject to [enhanced security controls](/docs/get-started/applications/third-party-applications/security-controls). Once registered, [set up your CIMD client](#set-up-cimd-client) as a third-party application in Auth0.
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-CIMD clients always register with `third_party_security_mode: "strict"`,regardless of your tenant's **Create Permissive Third-Party Clients by Default** setting. Permissive mode is not available for CIMD clients. Strict third-party applications [do not support Rules](/docs/get-started/applications/third-party-applications/security-controls#features-not-supported), and login flows for CIMD clients fail if your tenant has active Rules. If you use Rules, [migrate to Actions](/docs/customize/actions/migrate/migrate-from-rules-to-actions) before registering CIMD clients.
+CIMD clients always register with `third_party_security_mode: "strict"`, regardless of your tenant's **Create Permissive Third-Party Clients by Default** setting. Permissive mode is not available for CIMD clients. Strict third-party applications [do not support Rules](/docs/get-started/applications/third-party-applications/security-controls#features-not-supported), and login flows for CIMD clients fail if your tenant has active Rules. If you use Rules, [migrate to Actions](/docs/customize/actions/migrate/migrate-from-rules-to-actions) before registering CIMD clients.
 </Callout>
 
 ## Key benefits

--- a/main/docs/get-started/auth0-overview/create-applications/register-applications-with-cimd.mdx
+++ b/main/docs/get-started/auth0-overview/create-applications/register-applications-with-cimd.mdx
@@ -10,6 +10,10 @@ When you import an application from its CIMD URL, Auth0 fetches, validates, and 
 
 You can only register [third-party applications](/docs/get-started/applications/third-party-applications) using manual CIMD, which are subject to [enhanced security controls](/docs/get-started/applications/third-party-applications/security-controls). Once registered, [set up your CIMD client](#set-up-cimd-client) as a third-party application in Auth0.
 
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+CIMD clients always register with `third_party_security_mode: "strict"`,regardless of your tenant's **Create Permissive Third-Party Clients by Default** setting. Permissive mode is not available for CIMD clients. Strict third-party applications [do not support Rules](/docs/get-started/applications/third-party-applications/security-controls#features-not-supported), and login flows for CIMD clients fail if your tenant has active Rules. If you use Rules, [migrate to Actions](/docs/customize/actions/migrate/migrate-from-rules-to-actions) before registering CIMD clients.
+</Callout>
+
 ## Key benefits
 
 Manual CIMD registration has the following benefits:


### PR DESCRIPTION
## Description

The documentation for registering applications with CIMD does not explicitly state that CIMD clients are always created in strict mode, regardless of the tenant's "Create Permissive Third-Party Clients by Default" toggle, which makes them incompatible with legacy Rules.

### References

(https://auth0team.atlassian.net/browse/DR-2812)

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [ x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ x] I've tested the site build for this change locally.
- [ x] I've made appropriate docs updates for any code or config changes.
- [ x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
