### PR TITLE
docs: warn against storing sensitive data in refresh token metadata

### DIFF
--- a/main/docs/secure/tokens/refresh-tokens/refresh-token-metadata.mdx
+++ b/main/docs/secure/tokens/refresh-tokens/refresh-token-metadata.mdx
@@ -19,6 +19,12 @@ You can access and modify refresh token metadata during a refresh token's lifecy
 
 To learn more, read [how to Configure Refresh Token Metadata](/docs/secure/tokens/refresh-tokens/refresh-token-metadata/configure-refresh-token-metadata). 
 
+<Warning>
+
+Auth0 refresh token Metadata is not a secure data store and should not be used to store sensitive information. This includes secrets and high-risk PII like social security numbers or credit card numbers, etc. Auth0 customers are strongly encouraged to evaluate the data stored in metadata and only store that which is necessary for identity and access management purposes. To learn more, read [Auth0 General Data Protection Regulation Compliance](/docs/secure/data-privacy-and-compliance/gdpr).
+
+</Warning>
+
 ## Supported flows
 
 You can set refresh token metadata using Post-Login Actions with the following OAuth 2.0 flows:

--- a/main/docs/secure/tokens/refresh-tokens/refresh-token-metadata.mdx
+++ b/main/docs/secure/tokens/refresh-tokens/refresh-token-metadata.mdx
@@ -20,9 +20,9 @@ You can access and modify refresh token metadata during a refresh token's lifecy
 To learn more, read [how to Configure Refresh Token Metadata](/docs/secure/tokens/refresh-tokens/refresh-token-metadata/configure-refresh-token-metadata). 
 
 <Warning>
+Refresh token metadata is not a secure data store. Do not use it to store sensitive information, like secrets, credit card numbers, social security numbers, or other high-risk PII.
 
-Auth0 refresh token Metadata is not a secure data store and should not be used to store sensitive information. This includes secrets and high-risk PII like social security numbers or credit card numbers, etc. Auth0 customers are strongly encouraged to evaluate the data stored in metadata and only store that which is necessary for identity and access management purposes. To learn more, read [Auth0 General Data Protection Regulation Compliance](/docs/secure/data-privacy-and-compliance/gdpr).
-
+To learn more, read [Auth0 General Data Protection Regulation Compliance](/docs/secure/data-privacy-and-compliance/gdpr).
 </Warning>
 
 ## Supported flows


### PR DESCRIPTION
## Summary
- Adds a warning to the refresh token metadata doc clarifying it is not a secure data store and should not be used for secrets or high-risk PII (e.g. SSNs, credit card numbers).
- Links to the GDPR compliance doc for further guidance.

## Test plan
- [ ] Preview the page to confirm the `<Warning>` block renders correctly