### PR TITLE
feat: add redirect `/docs/search` -> `/docs`

### DIFF
--- a/main/config/redirects.json
+++ b/main/config/redirects.json
@@ -22762,5 +22762,9 @@
   {
     "source": "/docs/ja-jp/api/myorganization/org-member-management/unassign-organization-member-roles",
     "destination": "/docs/ja-jp/api/myorganization/org-member-management/unassign-organization-member-roles-legacy"
+  },
+  {
+    "source": "/docs/search",
+    "destination": "/docs"
   }
 ]


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

- Add redirect `/docs/search` -> `/docs`

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

```sh
$ curl -I http://localhost:3001/docs/search\?q\=foo
HTTP/1.1 307 Temporary Redirect
X-Powered-By: Express
Vary: rsc, next-router-state-tree, next-router-prefetch, next-router-segment-prefetch, Accept-Encoding
link: </_next/static/media/bb3ef058b751a6ad-s.p.woff2>; rel=preload; as="font"; crossorigin=""; type="font/woff2", </_next/static/media/c4b700dcb2187787-s.p.woff2>; rel=preload; as="font"; crossorigin=""; type="font/woff2", </_next/static/media/e4af272ccee01ff0-s.p.woff2>; rel=preload; as="font"; crossorigin=""; type="font/woff2", </_next/static/css/460b5fb341962453.css>; rel=preload; as="style", </_next/static/css/5d67779c001f4e97.css>; rel=preload; as="style", </_next/static/css/05d6d8fcb903870d.css>; rel=preload; as="style"
location: /docs
Cache-Control: private, no-cache, no-store, max-age=0, must-revalidate
Content-Type: text/html; charset=utf-8
Date: Tue, 07 Jul 2026 15:07:47 GMT
Connection: keep-alive
Keep-Alive: timeout=5
```

_Note: Locally, with `mint dev` this results in a temporary redirect (`307`). In production, this will be a permanent redirect (`308`)_

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
