### PR TITLE
chore: reference unified auth0 skill in quickstarts

### DIFF
--- a/main/docs/quickstart/backend/aspnet-core-webapi.mdx
+++ b/main/docs/quickstart/backend/aspnet-core-webapi.mdx
@@ -17,7 +17,7 @@ If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, y
 **Install:**
 
 ```bash
-npx skills add auth0/agent-skills --skill auth0-quickstart --skill auth0-aspnetcore-api
+npx skills add auth0/agent-skills --skill auth0
 ```
 
 **Then ask your AI assistant:**

--- a/main/docs/quickstart/backend/fastify/index.mdx
+++ b/main/docs/quickstart/backend/fastify/index.mdx
@@ -15,7 +15,7 @@ If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, y
 **Install:**
 
 ```bash
-npx skills add auth0/agent-skills --skill auth0-quickstart --skill auth0-fastify-api
+npx skills add auth0/agent-skills --skill auth0
 ```
 
 **Then ask your AI assistant:**

--- a/main/docs/quickstart/backend/golang.mdx
+++ b/main/docs/quickstart/backend/golang.mdx
@@ -23,7 +23,7 @@ If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, y
 **Install:**
 
 ```bash
-npx skills add auth0/agent-skills --skill auth0-quickstart --skill go-jwt-middleware
+npx skills add auth0/agent-skills --skill auth0
 ```
 
 **Then ask your AI assistant:**

--- a/main/docs/quickstart/backend/java-spring-security5/index.mdx
+++ b/main/docs/quickstart/backend/java-spring-security5/index.mdx
@@ -17,7 +17,7 @@ If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, y
 **Install:**
 
 ```bash
-npx skills add auth0/agent-skills --skill auth0-quickstart --skill auth0-springboot-api
+npx skills add auth0/agent-skills --skill auth0
 ```
 
 **Then ask your AI assistant:**

--- a/main/docs/quickstart/backend/nodejs.mdx
+++ b/main/docs/quickstart/backend/nodejs.mdx
@@ -18,7 +18,7 @@ If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, y
 **Install:**
 
 ```bash
-npx skills add auth0/agent-skills --skill auth0-quickstart --skill auth0-express-api
+npx skills add auth0/agent-skills --skill auth0
 ```
 
 **Then ask your AI assistant:**

--- a/main/docs/quickstart/native/android.mdx
+++ b/main/docs/quickstart/native/android.mdx
@@ -14,7 +14,7 @@ If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, y
 **Install:**
 
 ```bash
-npx skills add auth0/agent-skills --skill auth0-quickstart --skill auth0-android
+npx skills add auth0/agent-skills --skill auth0
 ```
 
 **Then ask your AI assistant:**

--- a/main/docs/quickstart/native/flutter.mdx
+++ b/main/docs/quickstart/native/flutter.mdx
@@ -18,7 +18,7 @@ If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, y
 **Install:**
 
 ```bash
-npx skills add auth0/agent-skills --skill auth0-quickstart --skill auth0-flutter-native
+npx skills add auth0/agent-skills --skill auth0
 ```
 
 **Then ask your AI assistant:**

--- a/main/docs/quickstart/native/ionic-angular.mdx
+++ b/main/docs/quickstart/native/ionic-angular.mdx
@@ -18,7 +18,7 @@ If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, y
 First, install the Auth0 agent skills:
 
 ```bash
-npx skills add auth0/agent-skills --skill auth0-quickstart --skill auth0-ionic-angular
+npx skills add auth0/agent-skills --skill auth0
 ```
 
 Then, ask your AI assistant:

--- a/main/docs/quickstart/native/ionic-react.mdx
+++ b/main/docs/quickstart/native/ionic-react.mdx
@@ -18,7 +18,7 @@ If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, y
 First, install the Auth0 agent skills:
 
 ```bash
-npx skills add auth0/agent-skills --skill auth0-quickstart --skill auth0-ionic-react
+npx skills add auth0/agent-skills --skill auth0
 ```
 
 Then, ask your AI assistant:

--- a/main/docs/quickstart/native/ionic-vue.mdx
+++ b/main/docs/quickstart/native/ionic-vue.mdx
@@ -16,7 +16,7 @@ import {HowToSchema} from "/snippets/HowToSchema.jsx";
 If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, you can add Auth0 authentication automatically in minutes using [agent skills](https://agentskills.io/home).
 First, install the Auth0 agent skills:
 ```bash
-npx skills add auth0/agent-skills --skill auth0-quickstart --skill auth0-ionic-vue
+npx skills add auth0/agent-skills --skill auth0
 ```
 Then, ask your AI assistant:
 ```text

--- a/main/docs/quickstart/native/ios-swift.mdx
+++ b/main/docs/quickstart/native/ios-swift.mdx
@@ -14,7 +14,7 @@ If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, y
 **Install:**
 
 ```bash
-npx skills add auth0/agent-skills --skill auth0-quickstart --skill auth0-swift
+npx skills add auth0/agent-skills --skill auth0
 ```
 
 **Then ask your AI assistant:**

--- a/main/docs/quickstart/native/maui.mdx
+++ b/main/docs/quickstart/native/maui.mdx
@@ -17,7 +17,7 @@ If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, y
 **Install:**
 
 ```bash
-npx skills add auth0/agent-skills --skill auth0-quickstart --skill auth0-maui
+npx skills add auth0/agent-skills --skill auth0
 ```
 
 **Then ask your AI assistant:**

--- a/main/docs/quickstart/native/net-android-ios/index.mdx
+++ b/main/docs/quickstart/native/net-android-ios/index.mdx
@@ -14,7 +14,7 @@ If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, y
 **Install:**
 
 ```bash
-npx skills add auth0/agent-skills --skill auth0-quickstart --skill auth0-net-android --skill auth0-net-ios
+npx skills add auth0/agent-skills --skill auth0
 ```
 
 **Then ask your AI assistant:**

--- a/main/docs/quickstart/native/react-native-expo.mdx
+++ b/main/docs/quickstart/native/react-native-expo.mdx
@@ -19,7 +19,7 @@ If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, y
 **Install:**
 
 ```bash
-npx skills add auth0/agent-skills --skill auth0-quickstart --skill auth0-expo
+npx skills add auth0/agent-skills --skill auth0
 ```
 
 **Then ask your AI assistant:**

--- a/main/docs/quickstart/native/react-native.mdx
+++ b/main/docs/quickstart/native/react-native.mdx
@@ -19,7 +19,7 @@ If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, y
 **Install:**
 
 ```bash
-npx skills add https://github.com/auth0/agent-skills --skill auth0-react-native
+npx skills add auth0/agent-skills --skill auth0
 ```
 
 **Then ask your AI assistant:**

--- a/main/docs/quickstart/native/wpf-winforms.mdx
+++ b/main/docs/quickstart/native/wpf-winforms.mdx
@@ -15,7 +15,7 @@ If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, y
 **Install:**
 
 ```bash
-npx skills add auth0/agent-skills --skill auth0-quickstart --skill auth0-wpf --skill auth0-winforms
+npx skills add auth0/agent-skills --skill auth0
 ```
 
 **Then ask your AI assistant:**

--- a/main/docs/quickstart/spa/angular.mdx
+++ b/main/docs/quickstart/spa/angular.mdx
@@ -17,7 +17,7 @@ If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, y
 **Install:**
 
 ```bash
-npx skills add auth0/agent-skills --skill auth0-quickstart --skill auth0-angular
+npx skills add auth0/agent-skills --skill auth0
 ```
 
 **Then ask your AI assistant:**

--- a/main/docs/quickstart/spa/flutter.mdx
+++ b/main/docs/quickstart/spa/flutter.mdx
@@ -16,7 +16,7 @@ If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, y
 **Install:**
 
 ```bash
-npx skills add auth0/agent-skills --skill auth0-quickstart --skill auth0-flutter-web
+npx skills add auth0/agent-skills --skill auth0
 ```
 
 **Then ask your AI assistant:**

--- a/main/docs/quickstart/spa/react.mdx
+++ b/main/docs/quickstart/spa/react.mdx
@@ -17,7 +17,7 @@ If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, y
 **Install:**
 
 ```bash
-npx skills add auth0/agent-skills --skill auth0-quickstart --skill auth0-react
+npx skills add auth0/agent-skills --skill auth0
 ```
 
 **Then ask your AI assistant:**

--- a/main/docs/quickstart/spa/vuejs.mdx
+++ b/main/docs/quickstart/spa/vuejs.mdx
@@ -17,7 +17,7 @@ If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, y
 **Install:**
 
 ```bash
-npx skills add auth0/agent-skills --skill auth0-quickstart --skill auth0-vue
+npx skills add auth0/agent-skills --skill auth0
 ```
 
 **Then ask your AI assistant:**

--- a/main/docs/quickstart/webapp/apache/index.mdx
+++ b/main/docs/quickstart/webapp/apache/index.mdx
@@ -34,7 +34,7 @@ If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, y
 **Install:**
 
 ```bash
-npx skills add auth0/agent-skills --skill auth0-quickstart --skill auth0-apache
+npx skills add auth0/agent-skills --skill auth0
 ```
 
 **Then ask your AI assistant:**

--- a/main/docs/quickstart/webapp/aspnet-core-blazor-server.mdx
+++ b/main/docs/quickstart/webapp/aspnet-core-blazor-server.mdx
@@ -16,7 +16,7 @@ If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, y
 **Install:**
 
 ```bash
-npx skills add auth0/agent-skills --skill auth0-quickstart --skill auth0-aspnetcore-authentication
+npx skills add auth0/agent-skills --skill auth0
 ```
 
 **Then ask your AI assistant:**

--- a/main/docs/quickstart/webapp/aspnet-core.mdx
+++ b/main/docs/quickstart/webapp/aspnet-core.mdx
@@ -15,7 +15,7 @@ If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, y
 **Install:**
 
 ```bash
-npx skills add auth0/agent-skills --skill auth0-quickstart --skill auth0-aspnetcore-authentication
+npx skills add auth0/agent-skills --skill auth0
 ```
 
 **Then ask your AI assistant:**

--- a/main/docs/quickstart/webapp/express.mdx
+++ b/main/docs/quickstart/webapp/express.mdx
@@ -21,7 +21,7 @@ If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, y
 **Install:**
 
 ```bash
-npx skills add https://github.com/auth0/agent-skills --skill auth0-express
+npx skills add auth0/agent-skills --skill auth0
 ```
 
 **Then ask your AI assistant:**

--- a/main/docs/quickstart/webapp/fastify.mdx
+++ b/main/docs/quickstart/webapp/fastify.mdx
@@ -29,7 +29,7 @@ If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, y
 **Install:**
 
 ```bash
-npx skills add auth0/agent-skills --skill auth0-quickstart --skill auth0-fastify
+npx skills add auth0/agent-skills --skill auth0
 ```
 
 **Then ask your AI assistant:**

--- a/main/docs/quickstart/webapp/java-ee.mdx
+++ b/main/docs/quickstart/webapp/java-ee.mdx
@@ -17,7 +17,7 @@ If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, y
 **Install:**
 
 ```bash
-npx skills add auth0/agent-skills --skill auth0-quickstart --skill auth0-java-mvc-common
+npx skills add auth0/agent-skills --skill auth0
 ```
 
 **Then ask your AI assistant:**

--- a/main/docs/quickstart/webapp/java.mdx
+++ b/main/docs/quickstart/webapp/java.mdx
@@ -26,7 +26,7 @@ If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, y
 **Install:**
 
 ```bash
-npx skills add auth0/agent-skills --skill auth0-quickstart --skill auth0-java-mvc-common
+npx skills add auth0/agent-skills --skill auth0
 ```
 
 **Then ask your AI assistant:**

--- a/main/docs/quickstart/webapp/laravel/interactive.mdx
+++ b/main/docs/quickstart/webapp/laravel/interactive.mdx
@@ -20,7 +20,7 @@ AUTH0_CLIENT_SECRET={yourClientSecret}`;
   **Install:**
 
   ```bash
-  npx skills add auth0/agent-skills --skill auth0-quickstart --skill auth0-laravel
+  npx skills add auth0/agent-skills --skill auth0
   ```
 
   **Then ask your AI assistant:**

--- a/main/docs/quickstart/webapp/nextjs.mdx
+++ b/main/docs/quickstart/webapp/nextjs.mdx
@@ -19,7 +19,7 @@ import {HowToSchema} from "/snippets/HowToSchema.jsx";
   **Install:**
 
   ```bash
-  npx skills add auth0/agent-skills --skill auth0-quickstart --skill auth0-nextjs
+  npx skills add auth0/agent-skills --skill auth0
   ```
 
   **Then ask your AI assistant:**

--- a/main/docs/quickstart/webapp/nuxt.mdx
+++ b/main/docs/quickstart/webapp/nuxt.mdx
@@ -19,7 +19,7 @@ If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, y
 **Install:**
 
 ```bash
-npx skills add https://github.com/auth0/agent-skills --skill auth0-nuxt
+npx skills add auth0/agent-skills --skill auth0
 ```
 
 **Then ask your AI assistant:**


### PR DESCRIPTION
## What

The agent-skills re-architecture ([auth0/agent-skills#137](https://github.com/auth0/agent-skills/pull/137)) consolidates all per-SDK skills into a single `auth0` skill (plugin bumped to v2.0.0). Old per-SDK skill names (`auth0-react`, `auth0-angular`, `auth0-mfa`, etc.) no longer resolve.

This updates all quickstarts so they never reference individual skill names. Every `npx skills add ... --skill <name>` install command becomes:

```
npx skills add auth0/agent-skills --skill auth0
```

## Why `--skill auth0` (and not a bare `npx skills add auth0/agent-skills`)

Per the [skills CLI docs](https://github.com/vercel-labs/skills), omitting `--skill` triggers an **interactive selection prompt**, which breaks the copy-paste / agent-run flow in a quickstart. `--skill auth0` installs **non-interactively** and resolves cleanly to the single skill named [`auth0`](https://github.com/auth0/agent-skills/tree/worktree-single-skill/plugins/auth0/skills/auth0).

## Changes

- **30 quickstart files** updated (one install command each) across `spa/`, `webapp/`, `backend/`, and `native/`.
- Removed all individual `--skill` references (`auth0-quickstart`, `auth0-react`, `go-jwt-middleware`, `auth0-net-android`/`auth0-net-ios`, `auth0-wpf`/`auth0-winforms`, etc.).
- Normalized the 3 files that used the full `https://github.com/auth0/agent-skills` source (`nuxt`, `express`, `react-native`) to the short `auth0/agent-skills` form, so all 30 are consistent.
- Preserved indentation on the two indented cases (`webapp/nextjs.mdx`, `webapp/laravel/interactive.mdx`).

## Not touched

- `agent-skills.mdx` hub page — only references the `auth0` plugin and whole-repo installs, no individual skills.
- Surrounding prose and npm package identifiers (e.g. `@auth0/auth0-react`), which are SDK packages, not skills.