### PR TITLE
chore: rewrite Agent Skills page for the single auth0 skill

### DIFF
--- a/main/docs/quickstart/agent-skills.mdx
+++ b/main/docs/quickstart/agent-skills.mdx
@@ -119,7 +119,7 @@ The skill guides your assistant through the full implementation — installing t
 There's a single `auth0` skill — you don't need to pick anything manually. It detects your framework automatically and handles features like MFA or migration when you describe what you need. If your assistant doesn't pick it up automatically, invoke it explicitly with `/auth0`.
 </Info>
 
-## What it covers
+## Skill capabilities
 
 The `auth0` skill handles authentication setup, API protection, migration, CLI tooling, and advanced features across the frameworks below. Each example prompt can be pasted directly into your AI coding assistant.
 

--- a/main/docs/quickstart/agent-skills.mdx
+++ b/main/docs/quickstart/agent-skills.mdx
@@ -106,8 +106,8 @@ Provide context when prompting — mention your framework, router type, and whet
 Tell your assistant what you want — add login to your React app, secure a Spring Boot API, migrate from Cognito, add MFA, or customize your login page. You don't need to know which skill or SDK to use.
 </Step>
 
-<Step title="The right skill activates">
-The assistant reads your project files (`package.json`, `requirements.txt`, `build.gradle`, etc.), identifies your framework, and activates the matching skill from 25 available.
+<Step title="The right guidance loads">
+The `auth0` skill's router reads your project files (`package.json`, `requirements.txt`, `build.gradle`, etc.), identifies your framework, and loads the matching reference files for your stack.
 </Step>
 
 <Step title="You get working code">
@@ -116,24 +116,24 @@ The skill guides your assistant through the full implementation — installing t
 </Steps>
 
 <Info>
-You don't need to pick skills manually. Framework detection handles SDK skills automatically, and you can invoke feature skills like MFA or Migration directly by describing what you need.
+There's a single `auth0` skill — you don't need to pick anything manually. It detects your framework automatically and handles features like MFA or migration when you describe what you need. If your assistant doesn't pick it up automatically, invoke it explicitly with `/auth0`.
 </Info>
 
-## Available skills
+## What it covers
 
-25 skills covering authentication setup, API protection, migration, CLI tooling, and advanced features. Each example prompt below can be pasted directly into your AI coding assistant.
+The `auth0` skill handles authentication setup, API protection, migration, CLI tooling, and advanced features across the frameworks below. Each example prompt can be pasted directly into your AI coding assistant.
 
 ### Get started
 
-| Skill | What it does | Try it |
+| Capability | What it does | Try it |
 |-------|-------------|--------|
-| **Quickstart Router** | Detects your framework and sets up Auth0 with the right SDK | `Add Auth0 authentication to my app` |
+| **Framework detection** | Detects your framework and sets up Auth0 with the right SDK | `Add Auth0 authentication to my app` |
 | **Migration** | Migrate users and code from Firebase, Cognito, Supabase, Clerk, or custom auth | `Help me migrate from Firebase Auth to Auth0` |
 | **CLI** | Auth0 CLI command reference — manage apps, APIs, users, roles, orgs, actions, logs, custom domains, and Universal Login | `Create an Auth0 application using the CLI` |
 
 ### Frontend
 
-| Skill | What it does | Try it |
+| Capability | What it does | Try it |
 |-------|-------------|--------|
 | **React** | Login, logout, user sessions, and protected routes for React SPAs | `Add Auth0 login to my React app` |
 | **Vue** | Authentication for Vue 3 applications with composables and route guards | `Set up Auth0 in my Vue 3 app` |
@@ -142,7 +142,7 @@ You don't need to pick skills manually. Framework detection handles SDK skills a
 
 ### Backend & Fullstack
 
-| Skill | What it does | Try it |
+| Capability | What it does | Try it |
 |-------|-------------|--------|
 | **Next.js** | Auth for Next.js 13+ with App Router, Pages Router, middleware, and server components | `Set up Auth0 in my Next.js app with protected routes` |
 | **Nuxt** | Server-side sessions and route protection for Nuxt 3/4 | `Add Auth0 authentication to my Nuxt app` |
@@ -153,7 +153,7 @@ You don't need to pick skills manually. Framework detection handles SDK skills a
 
 ### API
 
-| Skill | What it does | Try it |
+| Capability | What it does | Try it |
 |-------|-------------|--------|
 | **Express API** | JWT Bearer validation, scope-based access control for Node.js/Express APIs | `Secure my Express API with Auth0 JWT validation` |
 | **Fastify API** | JWT Bearer validation and scope checks for Fastify API endpoints | `Add Auth0 JWT validation to my Fastify API` |
@@ -164,7 +164,7 @@ You don't need to pick skills manually. Framework detection handles SDK skills a
 
 ### Mobile
 
-| Skill | What it does | Try it |
+| Capability | What it does | Try it |
 |-------|-------------|--------|
 | **React Native** | Auth with biometric support and deep linking for React Native CLI apps | `Add Auth0 login to my React Native app` |
 | **Expo** | Auth with Expo Config Plugin for managed workflow mobile apps | `Set up Auth0 in my Expo app` |
@@ -173,7 +173,7 @@ You don't need to pick skills manually. Framework detection handles SDK skills a
 
 ### Advanced
 
-| Skill | What it does | Try it |
+| Capability | What it does | Try it |
 |-------|-------------|--------|
 | **MFA** | Multi-factor authentication — TOTP, SMS, email, push, WebAuthn | `Add TOTP-based multi-factor authentication to my app` |
 | **ACUL Screen Generator** | Generate custom-branded Universal Login screens with React or vanilla JS | `Create a branded login screen matching our design system` |
@@ -182,7 +182,7 @@ You don't need to pick skills manually. Framework detection handles SDK skills a
 
 <CardGroup cols={2}>
   <Card title="Auth0 Agent Skills on GitHub" icon="github" href="https://github.com/auth0/agent-skills">
-    Source code, all 25 skill definitions, and issue tracker.
+    Source code, the `auth0` skill definition, and issue tracker.
   </Card>
 
   <Card title="Auth0 Quickstarts" icon="rocket" href="/docs/quickstarts">

--- a/main/docs/quickstart/agent-skills.mdx
+++ b/main/docs/quickstart/agent-skills.mdx
@@ -116,7 +116,7 @@ The skill guides your assistant through the full implementation — installing t
 </Steps>
 
 <Info>
-There's a single `auth0` skill — you don't need to pick anything manually. It detects your framework automatically and handles features like MFA or migration when you describe what you need. If your assistant doesn't pick it up automatically, invoke it explicitly with `/auth0`.
+With a single `auth0` skill, you don't need to pick anything manually. It detects your framework automatically and handles features, like [Multi-factor authentication (MFA)](/docs/secure/multi-factor-authentication), when you describe what you need. If your assistant doesn't pick it up automatically, then invoke it explicitly with `/auth0`.
 </Info>
 
 ## Skill capabilities


### PR DESCRIPTION
## What

Companion to #1498. The agent-skills re-architecture ([auth0/agent-skills#137](https://github.com/auth0/agent-skills/pull/137)) consolidates all per-SDK skills into **one `auth0` skill** whose internal **router** reads your project files, detects the framework, and loads the matching reference files.

The Agent Skills hub page (`main/docs/quickstart/agent-skills.mdx`) was still written for the old multi-skill catalog model. This updates the prose so it describes a single skill.

## Changes

- **"How it works"** — step now describes the `auth0` skill's router loading reference files (was "activates the matching skill from 25 available"). Info callout reframed to "a single `auth0` skill" and adds the `/auth0` explicit-invocation escape hatch for smaller models.
- **"Available skills" → "What it covers"** — dropped the "25 skills" count and the per-skill framing; the section now describes what the one skill covers.
- **Table headers** `Skill` → `Capability` (6 tables); rows now read as coverage areas of the single skill rather than separately installable skills. "Quickstart Router" row renamed to "Framework detection."
- **GitHub card** — "all 25 skill definitions" → "the `auth0` skill definition."

## Not touched

- **Install instructions** (Claude Code plugin, Cursor, Copilot, whole-repo CLI) — already reference the `auth0` plugin / whole `auth0/agent-skills` repo, so they're unaffected by the collapse to one skill.
- Capability tables' framework rows and example prompts — still accurate coverage, kept as-is.

## Grounding

Single-skill architecture and router behavior per the [unified-skill branch README](https://github.com/auth0/agent-skills/tree/worktree-single-skill); skill folder confirmed named [`auth0`](https://github.com/auth0/agent-skills/tree/worktree-single-skill/plugins/auth0/skills/auth0).