### PR TITLE
update: docs maint for new logs catalog

### DIFF
--- a/main/config/redirects.json
+++ b/main/config/redirects.json
@@ -368,6 +368,10 @@
     "destination": "/docs/customize/log-streams"
   },
   {
+    "source": "/docs/deploy-monitor/logs/log-event-type-codes",
+    "destination": "/docs/tenant-logs"
+  },
+  {
     "source": "/docs/customize/login-pages/advanced-customizations/screens/passkey-enrollment-local",
     "destination": "/docs/customize/login-pages/advanced-customizations"
   },

--- a/main/docs/deploy-monitor/logs.mdx
+++ b/main/docs/deploy-monitor/logs.mdx
@@ -35,3 +35,7 @@ Auth0 provides a wide variety of log types and well as filtering to allow you to
 ## Log streaming and exporting
 
 Use log streaming to export logs to your preferred processing and analysis tools. We provide integrations with several analysis services as well as a way to create a custom log stream using webhooks. To learn more, read [Log Streaming](/docs/customize/log-streams).
+
+## Log type codes
+
+Details for each log type code can be found in the [Tenant Log Catalog](/docs/tenant-logs). You can also reference our [Log Schemas for Auth0](https://github.com/auth0/auth0-log-schemas) GitHub repository for more information.


### PR DESCRIPTION
## Description

Adds a section to Logs overview page pointing to the new log catalog. Also removes the existing manual log type code page, and redirects to explorer.


## Checklist

- [ x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ x] I've tested the site build for this change locally.
- [ x] I've made appropriate docs updates for any code or config changes.
- [ x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
