### PR TITLE
chore: add tenant-logs to docs-management CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,6 +18,9 @@ main/docs/oas           @auth0/project-docs-management-codeowner
 main/docs/events        @auth0/project-docs-management-codeowner
 main/docs/fr-ca/events  @auth0/project-docs-management-codeowner
 main/docs/ja-jp/events  @auth0/project-docs-management-codeowner
+main/docs/tenant-logs        @auth0/project-docs-management-codeowner
+main/docs/fr-ca/tenant-logs  @auth0/project-docs-management-codeowner
+main/docs/ja-jp/tenant-logs  @auth0/project-docs-management-codeowner
 main/config/navigation/generated @auth0/project-docs-management-codeowner
 
 # Shared ownership for shared config files


### PR DESCRIPTION
Tenant Logs docs are generated artifacts from docs-content-pipeline, like api and events. Without an explicit rule they fell through to the default docs-writers rule, requiring writer review on automated PRs.

<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
