### PR TITLE
fix: only run UI CI when UI build artifacts are changed

### DIFF
--- a/.github/workflows/ui-build-check.yml
+++ b/.github/workflows/ui-build-check.yml
@@ -3,6 +3,11 @@ name: UI Build Artifacts Check
 on:
   pull_request:
     branches: [main]
+    paths: 
+      - 'ui/src/**'
+      - 'ui/package.json'
+      - 'universal-components/src/**'
+      - 'universal-components/package.json'
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

☝️

### Testing

see that paths match with the changed files in the script. also, see that it doesn't run on this PR, which doesn't change any UI src.

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
