### PR TITLE
update: descriptions for events/hooks/rules (flagging for deprecation)

### DIFF
--- a/main/docs/customize/events.mdx
+++ b/main/docs/customize/events.mdx
@@ -1,6 +1,6 @@
 ---
 title: Events
-description: Use real-time notifications of events on your Auth0 tenant to orchestrate changes to external apps or third-party services.
+description: Understand Auth0 Events, an API-based mechanism for streaming real-time notifications of tenant changes like user creation to external systems, identity correlation, and workflow orchestration.
 ---
 
 Events are real-time notifications about specific actions that have occurred within your Auth0 tenant. You can use events in two ways:

--- a/main/docs/customize/events/event-testing-observability-and-failure-recovery.mdx
+++ b/main/docs/customize/events/event-testing-observability-and-failure-recovery.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn more about testing and managing your events and event streams.
+description: Test an Auth0 event stream, monitor delivery failutes by polling the Deliveries endpoint, and recover missed events with the single and batch Redelivery APIs to keep your event stream reliable.
 title: Event Testing, Observability, and Failure Recovery
 ---
 

--- a/main/docs/customize/events/event-testing-observability-and-failure-recovery.mdx
+++ b/main/docs/customize/events/event-testing-observability-and-failure-recovery.mdx
@@ -1,5 +1,5 @@
 ---
-description: Test an Auth0 event stream, monitor delivery failutes by polling the Deliveries endpoint, and recover missed events with the single and batch Redelivery APIs to keep your event stream reliable.
+description: Test an Auth0 event stream, monitor delivery failutes by polling the Deliveries endpoint, and recover missed events with a single call and batch Redelivery APIs to keep your event stream reliable.
 title: Event Testing, Observability, and Failure Recovery
 ---
 

--- a/main/docs/customize/events/event-types.mdx
+++ b/main/docs/customize/events/event-types.mdx
@@ -1,6 +1,6 @@
 ---
 title: Event Types
-description: View the Event object schema for supported event types.
+description: Understand the the cloud events schema Auth0 uses to publish event objects, including required fields and the user event data payload, so you can build event streams that listen for supported event types.
 ---
 
 You can create event streams that listen for different types of events, such as the creation of a new user profile. The sections below outline specific details for currently supported event types.

--- a/main/docs/customize/events/events-best-practices.mdx
+++ b/main/docs/customize/events/events-best-practices.mdx
@@ -1,5 +1,5 @@
 ---
-description: Review best practices for using Events in Auth0
+description: Review Auth0 Events best practices for reliably handling event streams, including acknowledging deliveries, using asynchronous queues, deduplicating and ordering events, and understanding retry and auto-disable behavior.
 title: Events Best Practices
 ---
 

--- a/main/docs/customize/hooks/delete-hooks.mdx
+++ b/main/docs/customize/hooks/delete-hooks.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn how to delete Hooks using the Dashboard and Management API.
+description: Delete an Auth0 Hook you no longer need using the Dashboard or a `DELETE` call to the Management API Hooks endpoint with the `update:hooks` scope.
 title: Delete Hooks
 ---
 import {AuthCodeBlock} from "/snippets/AuthCodeBlock.jsx";

--- a/main/docs/customize/hooks/hook-secrets.mdx
+++ b/main/docs/customize/hooks/hook-secrets.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn about integrated secret management used with Auth0 Hooks.
+description: Understand integrated secret management for Auth0 Hooks, which securely stores secrets accessed via `context.webtask.secrets` and managed through the Dashboard, Management API, or Deploy CLI.
 sidebarTitle: Overview
 title: Hook Secrets
 ---

--- a/main/docs/customize/hooks/view-logs-for-hooks.mdx
+++ b/main/docs/customize/hooks/view-logs-for-hooks.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn how to view logs for hooks using the Auth0 Dashboard.
+description: View real-time logging output for an Auth0 Hook from the Dashboard Hooks Editor to inspect execution and troubleshoot behavior.
 title: View Logs for Hooks
 ---
 <Warning>

--- a/main/docs/customize/rules/cache-resources.mdx
+++ b/main/docs/customize/rules/cache-resources.mdx
@@ -1,5 +1,5 @@
 ---
-description: How to cache expensive resources in your Rules code.
+description: Cache expensive resources across Auth0 Rule executions using a persistent global object to avoid recreating them each run.
 title: Cache Expensive Resources in Rules
 ---
 <Warning>

--- a/main/docs/customize/rules/debug-rules.mdx
+++ b/main/docs/customize/rules/debug-rules.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn how to debug your Auth0 rules.
+description: Debug an Auth0 Rule using `console.log` output surfaced through the Rules Editor Save and Try feature, Actions Real-time Logs, or the legacy Debug Rule CLI.
 title: Debug Rules
 ---
 <Warning>

--- a/main/docs/customize/rules/use-management-api.mdx
+++ b/main/docs/customize/rules/use-management-api.mdx
@@ -1,5 +1,5 @@
 ---
-description: Call the Auth0 Management API from within a RUle using the restricted `auth0 ManagementClient` object, or require a newer `node-auth0` version for additional endpoints and scopes.
+description: Call the Auth0 Management API from within a Rule using the restricted `auth0 ManagementClient` object, or require a newer `node-auth0` version for additional endpoints and scopes.
 title: Use the Management API from within Rules
 ---
 <Warning>

--- a/main/docs/customize/rules/use-management-api.mdx
+++ b/main/docs/customize/rules/use-management-api.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn how to use the Management API from within rules.
+description: Call the Auth0 Management API from within a RUle using the restricted `auth0 ManagementClient` object, or require a newer `node-auth0` version for additional endpoints and scopes.
 title: Use the Management API from within Rules
 ---
 <Warning>

--- a/main/docs/deploy-monitor/deploy-private-cloud.mdx
+++ b/main/docs/deploy-monitor/deploy-private-cloud.mdx
@@ -1,5 +1,5 @@
 ---
-description: Compare Auth0 Private Cloud managed-service deployment options on AWS and Azure to choose a dedicated, isolated environment that meets your data-residency, performance, and guaranteed-RPS requirements beyond the multi-tenant Public Cloud.
+description: Compare Auth0 Private Cloud-managed service deployment options on AWS and Azure to choose a dedicated, isolated environment that meets your data-residency, performance, and guaranteed RPS requirements beyond the multi-tenant Public Cloud.
 sidebarTitle: Overview
 title: Private Cloud Deployments
 ---

--- a/main/docs/deploy-monitor/deploy-private-cloud.mdx
+++ b/main/docs/deploy-monitor/deploy-private-cloud.mdx
@@ -1,5 +1,5 @@
 ---
-description: Describes Auth0 private cloud deployment options.
+description: Compare Auth0 Private Cloud managed-service deployment options on AWS and Azure to choose a dedicated, isolated environment that meets your data-residency, performance, and guaranteed-RPS requirements beyond the multi-tenant Public Cloud.
 sidebarTitle: Overview
 title: Private Cloud Deployments
 ---


### PR DESCRIPTION

## Description
Updating descriptions for:

main/docs/customize/events/event-testing-observability-and-failure-recovery.mdx
main/docs/customize/events/event-types.mdx
main/docs/customize/events/events-best-practices.mdx
main/docs/customize/hooks/delete-hooks.mdx
main/docs/customize/hooks/hook-secrets.mdx
main/docs/customize/hooks/view-logs-for-hooks.mdx
main/docs/customize/rules/cache-resources.mdx
main/docs/customize/rules/debug-rules.mdx
main/docs/customize/rules/use-management-api.mdx
main/docs/customize/events.mdx
main/docs/deploy-monitor/deploy-private-cloud.mdx

### References

https://docs.google.com/spreadsheets/d/1U7Qk1keP5JxDDphs-4mEUbUtdWEDPZb8PBFWF2zgdWw/edit?gid=0#gid=0



## Checklist

- [ x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ x] I've tested the site build for this change locally.
- [ x] I've made appropriate docs updates for any code or config changes.
- [ x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
