### PR TITLE
Removed callout for inaccurate statement

### DIFF
--- a/main/docs/secure/multi-factor-authentication/adaptive-mfa/customize-adaptive-mfa.mdx
+++ b/main/docs/secure/multi-factor-authentication/adaptive-mfa/customize-adaptive-mfa.mdx
@@ -86,13 +86,10 @@ This template provides an example and starting point for how to build a custom b
 * The [`api.multifactor.enable`](/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-api-object#api-multifactor) Action trigger to handle both enrollment and issue configured MFA challenges at the end of the login flow.
 * The [`event.user.multifactor`](/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-event-object) Actions trigger with the user's enrolled factors.
 
-<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-Since `email` notifications are not an independent factor, the condition `event.user.multifactor && event.user.multifactor.length > 0` will return `false` if the user only has `email` as a factor. To learn more, read [Configure Email Notifications for MFA](/docs/secure/multi-factor-authentication/multi-factor-authentication-factors/configure-email-notifications-for-mfa).
-</Callout>
 
 ```javascript lines expandable
 /**
-* Handler that will be called during the execution of a PostLogin flow.
+* Handler that will be called during the execution of a Post-Login flow.
 *
 * @param {Event} event - Details about the user and the context in which they are logging in.
 * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

### References

Support advised this statement is misleading. The statement is only true until email MFA has been used once and then is populated with `guardian`.  Removing the callout.

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
