### PR TITLE
feat: add request body disclaimer to oauth token endpoints

### DIFF
--- a/main/docs/api/authentication/authorization-code-flow-with-enhanced-privacy-protection/exchange-authorization-code-for-token.mdx
+++ b/main/docs/api/authentication/authorization-code-flow-with-enhanced-privacy-protection/exchange-authorization-code-for-token.mdx
@@ -25,6 +25,9 @@ To make a call to the `/oauth/token` endpoint, you must:
 </ParamField>
 
 ## Body Parameters
+<div className="prose-sm prose-gray dark:prose-invert">
+  <span data-as="p">The request body is in `application/x-www-form-urlencoded` format.</span>
+</div>
 <ParamField body="grant_type" type="string" required>
   Denotes the flow; use `authorization_code` with a valid authorization code.
 </ParamField>

--- a/main/docs/api/authentication/authorization-code-flow-with-pkce/get-token-pkce.mdx
+++ b/main/docs/api/authentication/authorization-code-flow-with-pkce/get-token-pkce.mdx
@@ -29,6 +29,9 @@ This is the flow that mobile apps use to access an API. Use this endpoint to exc
 </ParamField>
 
 ## Body Parameters
+<div className="prose-sm prose-gray dark:prose-invert">
+  <span data-as="p">The request body is in `application/x-www-form-urlencoded` format.</span>
+</div>
 <ParamField body="grant_type" type="string" required>
   Denotes the flow you are using. For Authorization Code (PKCE) use `authorization_code`.
 

--- a/main/docs/api/authentication/authorization-code-flow/get-token.mdx
+++ b/main/docs/api/authentication/authorization-code-flow/get-token.mdx
@@ -27,6 +27,9 @@ This is the flow that regular web apps use to access an API. Use this endpoint t
 </ParamField>
 
 ## Body Parameters
+<div className="prose-sm prose-gray dark:prose-invert">
+  <span data-as="p">The request body is in `application/x-www-form-urlencoded` format.</span>
+</div>
 <ParamField body="grant_type" type="string" required>
   Denotes the flow you are using. For Authorization Code, use `authorization_code`.
 </ParamField>

--- a/main/docs/api/authentication/client-credential-flow/get-token.mdx
+++ b/main/docs/api/authentication/client-credential-flow/get-token.mdx
@@ -38,6 +38,9 @@ A successful response will return an access token.
 </ParamField>
 
 ## Body Parameters
+<div className="prose-sm prose-gray dark:prose-invert">
+  <span data-as="p">The request body is in `application/x-www-form-urlencoded` format.</span>
+</div>
 <ParamField body="grant_type" type="string" required>
   Denotes the flow you are using. For Client Credentials use `client_credentials`.
 

--- a/main/docs/api/authentication/custom-token-exchange/get-token.mdx
+++ b/main/docs/api/authentication/custom-token-exchange/get-token.mdx
@@ -43,6 +43,9 @@ Custom Token Exchange is currently available in Early Access. By using this feat
 </ParamField>
 
 ## Body Parameters
+<div className="prose-sm prose-gray dark:prose-invert">
+  <span data-as="p">The request body is in `application/x-www-form-urlencoded` format.</span>
+</div>
 <ParamField body="grant_type" type="string" required>
   Denotes the flow you are using. For Custom Token Exchange, use `urn:ietf:params:oauth:grant-type:token-exchange`.
 

--- a/main/docs/api/authentication/login/check-back-channel-login-status.mdx
+++ b/main/docs/api/authentication/login/check-back-channel-login-status.mdx
@@ -66,6 +66,9 @@ Include an optional parameter for application authentication in the request:
 - mTLS, where the `client_id` parameter is required and the `client-certificate` and `client-certificate-ca-verified` headers are required.
 
 ## Body Parameters
+<div className="prose-sm prose-gray dark:prose-invert">
+  <span data-as="p">The request body is in `application/x-www-form-urlencoded` format.</span>
+</div>
 <ParamField body="client_id" type="string" required>
   The `client_id` of your application.
 </ParamField>

--- a/main/docs/api/authentication/multi-factor-authentication/verify-mfa-with-otp.mdx
+++ b/main/docs/api/authentication/multi-factor-authentication/verify-mfa-with-otp.mdx
@@ -22,6 +22,9 @@ Verifies multi-factor authentication (MFA) using a one-time password (OTP). To v
 </ParamField>
 
 ## Body Parameters
+<div className="prose-sm prose-gray dark:prose-invert">
+  <span data-as="p">The request body is in `application/x-www-form-urlencoded` format.</span>
+</div>
 <ParamField body="grant_type" type="string" required>
   Denotes the flow you are using. For OTP MFA use `http://auth0.com/oauth/grant-type/mfa-otp`.
 </ParamField>

--- a/main/docs/api/authentication/multi-factor-authentication/verify-with-out-of-band.mdx
+++ b/main/docs/api/authentication/multi-factor-authentication/verify-with-out-of-band.mdx
@@ -29,6 +29,9 @@ When the challenge response includes a `binding_method: prompt`, your app needs 
 </ParamField>
 
 ## Body Parameters
+<div className="prose-sm prose-gray dark:prose-invert">
+  <span data-as="p">The request body is in `application/x-www-form-urlencoded` format.</span>
+</div>
 <ParamField body="grant_type" type="string" required>
   Denotes the flow you are using. For OTP MFA, use `http://auth0.com/oauth/grant-type/mfa-oob`.
 

--- a/main/docs/api/authentication/multi-factor-authentication/verify-with-recovery-code.mdx
+++ b/main/docs/api/authentication/multi-factor-authentication/verify-with-recovery-code.mdx
@@ -19,7 +19,10 @@ To verify MFA using a recovery code your app must prompt the user for the recove
   A DPoP proof for the request. This is optional and only required if your application uses Demonstrating Proof-of-Possession.
 </ParamField>
 
-## Body Parameters
+## Body Parameters 
+<div className="prose-sm prose-gray dark:prose-invert">
+  <span data-as="p">The request body is in `application/x-www-form-urlencoded` format.</span>
+</div>
 <ParamField body="grant_type" type="string" required>
   Denotes the flow you are using. For recovery code use `http://auth0.com/oauth/grant-type/mfa-recovery-code`.
 

--- a/main/docs/api/authentication/passwordless/authenticate-user.mdx
+++ b/main/docs/api/authentication/passwordless/authenticate-user.mdx
@@ -28,6 +28,9 @@ Once you have a verification code, use this endpoint to login the user with thei
 </ParamField>
 
 ## Body Parameters
+<div className="prose-sm prose-gray dark:prose-invert">
+  <span data-as="p">The request body is in `application/x-www-form-urlencoded` format.</span>
+</div>
 <ParamField body="grant_type" type="string" required>
   Should be http://auth0.com/oauth/grant-type/passwordless/otp.
 </ParamField>

--- a/main/docs/api/authentication/refresh-token/refresh-token.mdx
+++ b/main/docs/api/authentication/refresh-token/refresh-token.mdx
@@ -22,6 +22,9 @@ Use this endpoint to refresh an Access Token using the Refresh Token you got dur
 </ParamField>
 
 ## Body Parameters
+<div className="prose-sm prose-gray dark:prose-invert">
+  <span data-as="p">The request body is in `application/x-www-form-urlencoded` format.</span>
+</div>
 <ParamField body="grant_type" type="string" required>
   Specifies the flow being used. For refreshing an access token, this must be set to `refresh_token`.
 

--- a/main/docs/api/authentication/resource-owner-password-flow/get-token.mdx
+++ b/main/docs/api/authentication/resource-owner-password-flow/get-token.mdx
@@ -56,6 +56,9 @@ Content-Type: application/json
 </ParamField>
 
 ## Body Parameters
+<div className="prose-sm prose-gray dark:prose-invert">
+  <span data-as="p">The request body is in `application/x-www-form-urlencoded` format.</span>
+</div>
 <ParamField body="grant_type" type="string" required>
   Denotes the flow you are using. For Resource Owner Password use `password`.
 </ParamField>

--- a/main/docs/api/authentication/token-exchange-for-native-social/token-exchange-native-social.mdx
+++ b/main/docs/api/authentication/token-exchange-for-native-social/token-exchange-native-social.mdx
@@ -33,6 +33,9 @@ Artifacts returned by this flow (and the contents thereof) will be determined by
 </ParamField>
 
 ## Body Parameters
+<div className="prose-sm prose-gray dark:prose-invert">
+  <span data-as="p">The request body is in `application/x-www-form-urlencoded` format.</span>
+</div>
 <ParamField body="auth0-forwarded-for" type="string">
   End user IP as a string value. Set this if you want brute-force protection to work in server-side scenarios. To learn more about how and when to use this header, read [Using resource owner password from server-side](/api-auth/tutorials/using-resource-owner-password-from-server-side).
 </ParamField>


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

Adds a statement under the "Body Parameters" section of each `POST /oauth/token` endpoint doc in Authentication API that specifies the request body type as `application/x-www-form-urlencoded`.

Wrote original `div` element and used Claude to copy said element under each `POST /oauth/token` endpoint doc's `Body Parameters` header 

### Testing

Light Mode/Dark Mode scrreenshots of new div element

<img width="1259" height="816" alt="Screenshot 2026-07-13 at 1 19 27 PM" src="https://github.com/user-attachments/assets/18b356a5-feb1-4dba-987b-4f39349825bf" />

<img width="1256" height="894" alt="Screenshot 2026-07-13 at 1 09 53 PM" src="https://github.com/user-attachments/assets/8a5fe755-46c7-499c-842f-031cebe6b30f" />

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
