### PR TITLE
docs: migrate Rules to Actions in authenticate/login/auth0-universal-login/passwordless-login/webauthn-device-biometrics.mdx

### DIFF
--- a/main/docs/authenticate/login/auth0-universal-login/passwordless-login/webauthn-device-biometrics.mdx
+++ b/main/docs/authenticate/login/auth0-universal-login/passwordless-login/webauthn-device-biometrics.mdx
@@ -1,6 +1,7 @@
 ---
 description: Learn how to configure WebAuthn with device biometrics for passwordless authentication.
 title: Configure WebAuthn with Device Biometrics for Passwordless Authentication
+validatedOn: 2026-07-14
 ---
 You can configure <Tooltip tip="Universal Login: Your application redirects to Universal Login, hosted on Auth0's Authorization Server, to verify a user's identity." cta="View Glossary" href="/docs/glossary?term=Universal+Login">Universal Login</Tooltip> to let users authenticate using [WebAuthn](/docs/secure/multi-factor-authentication/fido-authentication-with-webauthn) with Device Biometrics instead of a password.
 
@@ -76,21 +77,7 @@ The next time they log in, they can log in with password + another authenticatio
 * When users authenticate using WebAuthn Biometrics as their only authentication method, the `amr` value in the <Tooltip tip="ID Token: Credential meant for the client itself, rather than for accessing a resource." cta="View Glossary" href="/docs/glossary?term=ID+Token">ID Token</Tooltip> will be set to `mfa`.
 * If you want to enable MFA from our extensibility platform, you’ll be able to consider how users authenticated to decide if they should be prompted for MFA or not. The rule below will only perform MFA if the user did not authenticate with the `webauthn-platform` authentication method:
 
-```javascript javascript lines
-function (user, context, callback) {
-  let authMethods = context.authentication.methods;
 
-  const amr = authMethods.find((method) => method.name === 'webauthn-platform');
-
-  if (!amr) {
-    context.multifactor = {
-      provider: 'any',
-      allowRememberBrowser: false
-    };
-  }
-  return callback(null, user, context);
-}
-```
 
 
 This post-login action will have the same effect:
@@ -109,7 +96,7 @@ exports.onExecutePostLogin = async (event, api) => {
 
 ## Device Recognition
 
-Auth0 will use the rules to determine if the device is already enrolled or not, and prompt the user for enrollment. To learn more, read [Device recognition](/docs/secure/multi-factor-authentication/fido-authentication-with-webauthn/configure-webauthn-device-biometrics-for-mfa#device-recognition) in the article [Configure WebAuthn with Device Biometrics for MFA](/docs/secure/multi-factor-authentication/fido-authentication-with-webauthn/configure-webauthn-device-biometrics-for-mfa).
+Auth0 will use actions to determine if the device is already enrolled or not, and prompt the user for enrollment. To learn more, read [Device recognition](/docs/secure/multi-factor-authentication/fido-authentication-with-webauthn/configure-webauthn-device-biometrics-for-mfa#device-recognition) in the article [Configure WebAuthn with Device Biometrics for MFA](/docs/secure/multi-factor-authentication/fido-authentication-with-webauthn/configure-webauthn-device-biometrics-for-mfa).
 
 To avoid user enumeration attacks, Auth0 will only prompt users for biometrics as the first factor if users are logging in from a known device. If not, they'll need to login with the password.
 


### PR DESCRIPTION
## Summary

Migrates Auth0 Rules references to Auth0 Actions in `authenticate/login/auth0-universal-login/passwordless-login/webauthn-device-biometrics.mdx`.

---

Generated by auth0-ia Rules Deprecation Tracker