### PR TITLE
chore(docs): content maintenance (2026-07-14)

### DIFF
--- a/main/docs/get-started/applications/rotate-client-secret.mdx
+++ b/main/docs/get-started/applications/rotate-client-secret.mdx
@@ -1,6 +1,7 @@
 ---
 description: Learn how to rotate an application's client secret using the Auth Dashboard or the Management API.
 title: Rotate Client Secrets
+validatedOn: 2026-07-14
 ---
 import {AuthCodeBlock} from "/snippets/AuthCodeBlock.jsx";
 
@@ -16,7 +17,7 @@ Client secrets should not be stored in public client applications. To learn more
 
 <Warning>
 
-New secrets may be delayed up to thirty seconds while rotating. To minimize downtime, we suggest you store the new client secret in your application's code/system configuration as a fallback to the previous secret. This way, if the client application request doesn't work with the old secret, your app will use the new secret.
+New secrets may be delayed up to thirty seconds while rotating. During this propagation window, either the old or the new secret may be accepted, so your application should be configured to try both. To avoid downtime, deploy the new secret to your application *before* it becomes active. The recommended approach is to set a custom client secret in advance (see [Set a custom client secret](#set-a-custom-client-secret)): store the future secret in your application's code/system configuration as a fallback so it's already deployed when the rotation takes effect. Your app can then use whichever secret succeeds—if a request fails with the old secret, it falls back to the new one.
 
 Secrets can be stored in a list (or similar structure) until they're no longer needed. Once you're sure that an old secret is obsolete, you can remove its value from your app's code.
 
@@ -36,17 +37,17 @@ Secrets can be stored in a list (or similar structure) until they're no longer n
 
 ## Use the Management API
 
-1. Call the Management API [Rotate a client secret](https://auth0.com/docs/api/management/v2#!/Clients/post_rotate_secret) endpoint. Replace the `{yourClientId}` and `MGMT_API_ACCESS_TOKEN` placeholder values with your client ID and Management API access token, respectively.
+1. Call the Management API [Rotate a client secret](https://auth0.com/docs/api/management/v2#!/Clients/post_rotate_secret) endpoint. Replace the `{yourClientId}` and `{yourMgmtApiAccessToken}` placeholder values with your client ID and Management API access token, respectively.
 
 <AuthCodeGroup>
 ```bash cURL
    curl --request POST \
---url 'https://{yourDomain}/api/v2/clients/%7ByourClientId%7D/rotate-secret' \
+--url 'https://{yourDomain}/api/v2/clients/{yourClientId}/rotate-secret' \
 --header 'authorization: Bearer {yourMgmtApiAccessToken}'
 
 ```
 ```csharp C#
-   var client = new RestClient("https://{yourDomain}/api/v2/clients/%7ByourClientId%7D/rotate-secret");
+   var client = new RestClient("https://{yourDomain}/api/v2/clients/{yourClientId}/rotate-secret");
 var request = new RestRequest(Method.POST);
 request.AddHeader("authorization", "Bearer {yourMgmtApiAccessToken}");
 IRestResponse response = client.Execute(request);
@@ -63,7 +64,7 @@ import (
 
 func main() {
 
-url := "https://{yourDomain}/api/v2/clients/%7ByourClientId%7D/rotate-secret"
+url := "https://{yourDomain}/api/v2/clients/{yourClientId}/rotate-secret"
 
 req, _ := http.NewRequest("POST", url, nil)
 
@@ -81,7 +82,7 @@ fmt.Println(string(body))
 
 ```
 ```java Java
-   HttpResponse response = Unirest.post("https://{yourDomain}/api/v2/clients/%7ByourClientId%7D/rotate-secret")
+   HttpResponse response = Unirest.post("https://{yourDomain}/api/v2/clients/{yourClientId}/rotate-secret")
   .header("authorization", "Bearer {yourMgmtApiAccessToken}")
   .asString();
 
@@ -91,7 +92,7 @@ fmt.Println(string(body))
 
 var options = {
   method: 'POST',
-  url: 'https://{yourDomain}/api/v2/clients/%7ByourClientId%7D/rotate-secret',
+  url: 'https://{yourDomain}/api/v2/clients/{yourClientId}/rotate-secret',
   headers: {authorization: 'Bearer {yourMgmtApiAccessToken}'}
 };
 
@@ -130,7 +131,7 @@ NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
    $curl = curl_init();
 
 curl_setopt_array($curl, [
-  CURLOPT_URL => "https://{yourDomain}/api/v2/clients/%7ByourClientId%7D/rotate-secret",
+  CURLOPT_URL => "https://{yourDomain}/api/v2/clients/{yourClientId}/rotate-secret",
   CURLOPT_RETURNTRANSFER => true,
   CURLOPT_ENCODING => "",
   CURLOPT_MAXREDIRS => 10,


### PR DESCRIPTION
Addresses reader feedback on `/docs/get-started/applications/rotate-client-secret`.

**Context:** (contextual) [] How does this prevent downtime if auth0 rotates the secret before the new value has been deployed ?

(code_snippet) `%7ByourClientId%7D` should be `{yourClientId}` -- it's a placeholder like "yourDomain", not part of the URL.  Also the description refers to `MGMT_API_ACCESS_TOKEN` when the actual placeholder in the code is `{yourMgmtApiAccessToken}`.
Themes: placeholder

**Proposed edits (8):**
- Fix URL-encoded placeholder in cURL snippet
- Fix URL-encoded placeholder in C# snippet
- Fix URL-encoded placeholder in Go snippet
- Fix URL-encoded placeholder in Java snippet
- Fix URL-encoded placeholder in Node.JS snippet
- Fix URL-encoded placeholder in PHP snippet
- Fix placeholder names in Management API description and table
- Clarify how the fallback prevents downtime during rotation