### PR TITLE
Docs fix: /docs/customize/login-pages/universal-login/customize-signup-and-login-prompts/language-selection

### DIFF
--- a/main/docs/customize/login-pages/universal-login/customize-signup-and-login-prompts/language-selection.mdx
+++ b/main/docs/customize/login-pages/universal-login/customize-signup-and-login-prompts/language-selection.mdx
@@ -1,6 +1,7 @@
 ---
 description: Learn how you can add a preferred language menu to Universal Login prompts.
 title: Configure Flexible Language Selection
+validatedOn: 2026-07-14
 ---
 import {AuthCodeBlock} from "/snippets/AuthCodeBlock.jsx";
 
@@ -117,7 +118,7 @@ func main() {
 
 	url := "https://{yourDomain}/api/v2/branding/templates/universal-login"
 
-	payload := strings.NewReader("<!DOCTYPE html>
+	payload := strings.NewReader(`<!DOCTYPE html>
 <html>
 <head>{%- auth0:head -%}</head>
 <body class='_widget-auto-layout'>{%- auth0:widget -%}</body>
@@ -135,7 +136,7 @@ func main() {
     }
     document.getElementById('changeLanguage').click();
   }
-</script>")
+</script>`)
 
 	req, _ := http.NewRequest("PUT", url, payload)
 
@@ -156,7 +157,8 @@ func main() {
 HttpResponse<String> response = Unirest.put("https://{yourDomain}/api/v2/branding/templates/universal-login")
   .header("content-type", "text/html")
   .header("authorization", "Bearer MANAGEMENT_API_TOKEN")
-  .body("<!DOCTYPE html>
+  .body("""
+<!DOCTYPE html>
 <html>
 <head>{%- auth0:head -%}</head>
 <body class='_widget-auto-layout'>{%- auth0:widget -%}</body>
@@ -174,7 +176,7 @@ HttpResponse<String> response = Unirest.put("https://{yourDomain}/api/v2/brandin
     }
     document.getElementById('changeLanguage').click();
   }
-</script>")
+</script>""")
   .asString();
 ```
 ```javascript Node.JS
@@ -184,7 +186,7 @@ var options = {
   method: 'PUT',
   url: 'https://{yourDomain}/api/v2/branding/templates/universal-login',
   headers: {'content-type': 'text/html', authorization: 'Bearer MANAGEMENT_API_TOKEN'},
-  data: '<!DOCTYPE html>
+  data: `<!DOCTYPE html>
 <html>
 <head>{%- auth0:head -%}</head>
 <body class='_widget-auto-layout'>{%- auth0:widget -%}</body>
@@ -202,7 +204,7 @@ var options = {
     }
     document.getElementById('changeLanguage').click();
   }
-</script>'
+</script>`
 };
 
 axios.request(options).then(function (response) {
@@ -308,7 +310,7 @@ import http.client
 
 conn = http.client.HTTPSConnection("")
 
-payload = "<!DOCTYPE html>
+payload = """<!DOCTYPE html>
 <html>
 <head>{%- auth0:head -%}</head>
 <body class='_widget-auto-layout'>{%- auth0:widget -%}</body>
@@ -326,7 +328,7 @@ payload = "<!DOCTYPE html>
     }
     document.getElementById('changeLanguage').click();
   }
-</script>"
+</script>"""
 
 headers = {
     'content-type': "text/html",


### PR DESCRIPTION
Addresses reader feedback on `/docs/customize/login-pages/universal-login/customize-signup-and-login-prompts/language-selection`.

**Context:** (code_snippet) The Node.JS code (at least that one, I didn't review the others) has unbalanced quotes in the strings causing syntax errors. Also newlines are not allowed in JS with single quotes.

**Proposed edits (8):**
- Fix Node.js multiline string syntax error
- Fix unbalanced quotes in Node.js data string — body class attribute
- Fix Go multiline string literal syntax error
- Fix Go multiline string literal closing delimiter
- Fix Java multiline string literal syntax error
- Fix Java multiline string literal closing delimiter
- Fix Python multiline string syntax error
- Fix Python multiline string closing delimiter