### PR TITLE
fix(docs): fix multiline string syntax errors in language-selection code snippets

### DIFF
--- a/main/docs/customize/login-pages/universal-login/customize-signup-and-login-prompts/language-selection.mdx
+++ b/main/docs/customize/login-pages/universal-login/customize-signup-and-login-prompts/language-selection.mdx
@@ -108,9 +108,9 @@ package main
 
 import (
 	"fmt"
-	"strings"
-	"net/http"
 	"io/ioutil"
+	"net/http"
+	"strings"
 )
 
 func main() {
@@ -287,7 +287,7 @@ payload = """<!DOCTYPE html>
 headers = {
     'content-type': "text/html",
     'authorization': "Bearer MANAGEMENT_API_TOKEN"
-    }
+}
 
 conn.request("PUT", "/{yourDomain}/api/v2/branding/templates/universal-login", payload, headers)
 

--- a/main/docs/customize/login-pages/universal-login/customize-signup-and-login-prompts/language-selection.mdx
+++ b/main/docs/customize/login-pages/universal-login/customize-signup-and-login-prompts/language-selection.mdx
@@ -117,7 +117,7 @@ func main() {
 
 	url := "https://{yourDomain}/api/v2/branding/templates/universal-login"
 
-	payload := strings.NewReader("<!DOCTYPE html>
+	payload := strings.NewReader(`<!DOCTYPE html>
 <html>
 <head>{%- auth0:head -%}</head>
 <body class='_widget-auto-layout'>{%- auth0:widget -%}</body>
@@ -135,7 +135,7 @@ func main() {
     }
     document.getElementById('changeLanguage').click();
   }
-</script>")
+</script>`)
 
 	req, _ := http.NewRequest("PUT", url, payload)
 
@@ -156,7 +156,8 @@ func main() {
 HttpResponse<String> response = Unirest.put("https://{yourDomain}/api/v2/branding/templates/universal-login")
   .header("content-type", "text/html")
   .header("authorization", "Bearer MANAGEMENT_API_TOKEN")
-  .body("<!DOCTYPE html>
+  .body("""
+<!DOCTYPE html>
 <html>
 <head>{%- auth0:head -%}</head>
 <body class='_widget-auto-layout'>{%- auth0:widget -%}</body>
@@ -174,7 +175,7 @@ HttpResponse<String> response = Unirest.put("https://{yourDomain}/api/v2/brandin
     }
     document.getElementById('changeLanguage').click();
   }
-</script>")
+</script>""")
   .asString();
 ```
 ```javascript Node.JS
@@ -184,7 +185,7 @@ var options = {
   method: 'PUT',
   url: 'https://{yourDomain}/api/v2/branding/templates/universal-login',
   headers: {'content-type': 'text/html', authorization: 'Bearer MANAGEMENT_API_TOKEN'},
-  data: '<!DOCTYPE html>
+  data: `<!DOCTYPE html>
 <html>
 <head>{%- auth0:head -%}</head>
 <body class='_widget-auto-layout'>{%- auth0:widget -%}</body>
@@ -202,7 +203,7 @@ var options = {
     }
     document.getElementById('changeLanguage').click();
   }
-</script>'
+</script>`
 };
 
 axios.request(options).then(function (response) {
@@ -263,7 +264,7 @@ import http.client
 
 conn = http.client.HTTPSConnection("")
 
-payload = "<!DOCTYPE html>
+payload = """<!DOCTYPE html>
 <html>
 <head>{%- auth0:head -%}</head>
 <body class='_widget-auto-layout'>{%- auth0:widget -%}</body>
@@ -281,7 +282,7 @@ payload = "<!DOCTYPE html>
     }
     document.getElementById('changeLanguage').click();
   }
-</script>"
+</script>"""
 
 headers = {
     'content-type': "text/html",


### PR DESCRIPTION
Fixes syntax errors in the Go, Java, Node.js, and Python code samples on /docs/customize/login-pages/universal-login/customize-signup-and-login-prompts/language-selection.

Each snippet passed a multiline HTML string to an HTTP client using a single- or double-quoted string literal — invalid syntax in all four languages, as these delimiters do not allow literal newlines.

Changes:

Go: switch strings.NewReader("...") to a raw string literal (backticks)
Java: switch .body("...") to a text block ("""...""", Java 15+)
Node.js: switch data: '...' to a template literal (backticks); also fixes a secondary issue where single quotes inside the body class attribute value terminated the outer single-quoted string early
Python: switch payload = "..." to a triple-quoted string ("""...""")


ref: mint dash feedback