### PR TITLE
feat: Add guidance on JWKS caching

### DIFF
--- a/main/docs/secure/tokens/json-web-tokens/json-web-key-sets.mdx
+++ b/main/docs/secure/tokens/json-web-tokens/json-web-key-sets.mdx
@@ -21,6 +21,26 @@ Currently, Auth0 signs with only one JWK at a time; however, it is important to 
 
 </Warning>
 
+## Cache the JSON Web Key Set
+
+We recommend that you cache the JWKS your application retrieves from the JWKS endpoint, as this will:
+
+* Improve performance by avoiding a network request to the JWKS endpoint on every token validation.
+* Avoid consuming your tenant's [rate limits](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy) with repeated requests.
+* Improve resiliency, so your application can continue validating tokens if the JWKS endpoint is briefly unavailable.
+
+### Pick up rotated keys
+
+Cache the JWKS for at least 5-10 minutes to avoid fetching it on every request. Longer intervals further reduce requests and latency.
+
+When you [rotate signing keys](/docs/get-started/tenant-settings/signing-keys/rotate-signing-keys), Auth0 signs new tokens with the new key. If you validate a token whose key ID (`kid`) is not in your cached JWKS, invalidate your cache and fetch the JWKS again to retrieve the new key. This refetch on an unknown `kid` - not the cache lifetime - is what lets your application pick up rotated keys promptly, so a longer cache interval does not delay rotation.
+
+Limit how often you refetch on a cache miss - for example, retry only once - so that a batch of tokens signed with unknown keys cannot trigger a flood of requests to the JWKS endpoint and consume your rate limits. Set your cache interval based on how quickly you need to stop accepting tokens signed with a manually [revoked key](/docs/get-started/tenant-settings/signing-keys/revoke-signing-keys).
+
+### Use a library
+
+Rather than implement caching yourself, use a JWKS library or your framework's middleware that caches keys, refetches on an unknown `kid`, and rate-limits those refetches. Our [Quickstarts](/docs/quickstarts) use libraries that handle this for you.
+
 ## Learn more
 
 * [Signing Keys](/docs/get-started/tenant-settings/signing-keys)

--- a/main/docs/secure/tokens/json-web-tokens/json-web-key-sets.mdx
+++ b/main/docs/secure/tokens/json-web-tokens/json-web-key-sets.mdx
@@ -23,23 +23,22 @@ Currently, Auth0 signs with only one JWK at a time; however, it is important to 
 
 ## Cache the JSON Web Key Set
 
-We recommend that you cache the JWKS your application retrieves from the JWKS endpoint, as this will:
+You should ensure that you cache the JWKS your application retrieves from the JWKS endpoint, as this will:
 
-* Improve performance by avoiding a network request to the JWKS endpoint on every token validation.
 * Avoid consuming your tenant's [rate limits](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy) with repeated requests.
+* Improve performance by avoiding a network request to the JWKS endpoint on every token validation.
 * Improve resiliency, so your application can continue validating tokens if the JWKS endpoint is briefly unavailable.
 
-### Pick up rotated keys
+Rather than implement caching yourself, we recommend you use a JWKS library or your framework's middleware that caches keys, refetches on an unknown `kid`, and rate-limits those refetches. Our [Quickstarts](/docs/quickstarts) use libraries that handle this for you. If you instead implement this yourself, follow the guidance below.
+
+### Implementation guidance
 
 Cache the JWKS for at least 5-10 minutes to avoid fetching it on every request. Longer intervals further reduce requests and latency.
 
-When you [rotate signing keys](/docs/get-started/tenant-settings/signing-keys/rotate-signing-keys), Auth0 signs new tokens with the new key. If you validate a token whose key ID (`kid`) is not in your cached JWKS, invalidate your cache and fetch the JWKS again to retrieve the new key. This refetch on an unknown `kid` - not the cache lifetime - is what lets your application pick up rotated keys promptly, so a longer cache interval does not delay rotation.
+When you [rotate signing keys](/docs/get-started/tenant-settings/signing-keys/rotate-signing-keys), Auth0 signs new tokens with the new key. If you receive a token whose key ID (`kid`) is not in your cached JWKS, invalidate your cache and fetch the JWKS again to retrieve the new key. This refetch on an unknown `kid` - not the cache lifetime - is what lets your application pick up rotated keys promptly, so a longer cache interval does not delay rotation.
 
 Limit how often you refetch on a cache miss - for example, retry only once - so that a batch of tokens signed with unknown keys cannot trigger a flood of requests to the JWKS endpoint and consume your rate limits. Set your cache interval based on how quickly you need to stop accepting tokens signed with a manually [revoked key](/docs/get-started/tenant-settings/signing-keys/revoke-signing-keys).
 
-### Use a library
-
-Rather than implement caching yourself, use a JWKS library or your framework's middleware that caches keys, refetches on an unknown `kid`, and rate-limits those refetches. Our [Quickstarts](/docs/quickstarts) use libraries that handle this for you.
 
 ## Learn more
 

--- a/main/docs/secure/tokens/json-web-tokens/json-web-key-sets.mdx
+++ b/main/docs/secure/tokens/json-web-tokens/json-web-key-sets.mdx
@@ -29,15 +29,13 @@ We recommend that you cache the JWKS your application retrieves from the JWKS en
 * Improve performance by avoiding a network request to the JWKS endpoint on every token validation.
 * Improve resiliency, so your application can continue validating tokens if the JWKS endpoint is briefly unavailable.
 
-Rather than implement caching yourself, we recommend you use a JWKS library or your framework's middleware, which handle caching, refetching on an unknown `kid`, and rate-limiting those refetches correctly, so you don't have to build and maintain this logic yourself. Our [Quickstarts](/docs/quickstarts) use libraries that handle this for you. If you instead implement this yourself, follow the guidance below.
+You can use a JWKS library or your framework's middleware to handle caching, including refetching on an unknown `kid` and rate limiting refetches. For example, our [Quickstarts](/docs/quickstarts) use libraries that handle this for you.
 
-### Implementation guidance
+To avoid the development and maintenance burden, we recommend against implementing caching yourself. However, if your use case requires it, you can follow this guidance:
 
-Cache the JWKS for at least 5-10 minutes to avoid fetching it on every request. Longer intervals further reduce requests and latency.
-
-When you [rotate signing keys](/docs/get-started/tenant-settings/signing-keys/rotate-signing-keys), Auth0 signs new tokens with the new key. If you receive a token whose key ID (`kid`) is not in your cached JWKS, invalidate your cache and fetch the JWKS again to retrieve the new key. Refreshing on an unknown `kid` rather than the cache lifetime lets your application pick up rotated keys promptly. This way, a longer cache interval does not delay rotation.
-
-Limit how often you refetch on a cache miss (for example, retry only once) so that a batch of tokens signed with unknown keys cannot trigger a flood of requests to the JWKS endpoint and consume your rate limits. Set your cache interval based on how quickly you need to stop accepting tokens signed with a manually [revoked key](/docs/get-started/tenant-settings/signing-keys/revoke-signing-keys).
+* Cache the JWKS for 5-10 minutes to avoid fetching it on every request. Longer intervals further reduce requests and latency.
+* When you [rotate signing keys](/docs/get-started/tenant-settings/signing-keys/rotate-signing-keys), Auth0 signs new tokens with the new key. If you receive a token whose key ID (`kid`) is not in your cached JWKS, invalidate your cache and fetch the JWKS again to retrieve the new key. Refreshing on an unknown `kid` rather than the cache lifetime lets your application pick up rotated keys promptly. This way, a longer cache interval does not delay rotation.
+* Limit how often you refetch on a cache miss (for example, retry only once) so that a batch of tokens signed with unknown keys cannot trigger a flood of requests to the JWKS endpoint and consume your rate limits. Set your cache interval based on how quickly you need to stop accepting tokens signed with a manually [revoked key](/docs/get-started/tenant-settings/signing-keys/revoke-signing-keys).
 
 
 ## Learn more

--- a/main/docs/secure/tokens/json-web-tokens/json-web-key-sets.mdx
+++ b/main/docs/secure/tokens/json-web-tokens/json-web-key-sets.mdx
@@ -23,21 +23,21 @@ Currently, Auth0 signs with only one JWK at a time; however, it is important to 
 
 ## Cache the JSON Web Key Set
 
-You should ensure that you cache the JWKS your application retrieves from the JWKS endpoint, as this will:
+We recommend that you cache the JWKS your application retrieves from the JWKS endpoint, as this will:
 
 * Avoid consuming your tenant's [rate limits](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy) with repeated requests.
 * Improve performance by avoiding a network request to the JWKS endpoint on every token validation.
 * Improve resiliency, so your application can continue validating tokens if the JWKS endpoint is briefly unavailable.
 
-Rather than implement caching yourself, we recommend you use a JWKS library or your framework's middleware that caches keys, refetches on an unknown `kid`, and rate-limits those refetches. Our [Quickstarts](/docs/quickstarts) use libraries that handle this for you. If you instead implement this yourself, follow the guidance below.
+Rather than implement caching yourself, we recommend you use a JWKS library or your framework's middleware, which handle caching, refetching on an unknown `kid`, and rate-limiting those refetches correctly, so you don't have to build and maintain this logic yourself. Our [Quickstarts](/docs/quickstarts) use libraries that handle this for you. If you instead implement this yourself, follow the guidance below.
 
 ### Implementation guidance
 
 Cache the JWKS for at least 5-10 minutes to avoid fetching it on every request. Longer intervals further reduce requests and latency.
 
-When you [rotate signing keys](/docs/get-started/tenant-settings/signing-keys/rotate-signing-keys), Auth0 signs new tokens with the new key. If you receive a token whose key ID (`kid`) is not in your cached JWKS, invalidate your cache and fetch the JWKS again to retrieve the new key. This refetch on an unknown `kid` - not the cache lifetime - is what lets your application pick up rotated keys promptly, so a longer cache interval does not delay rotation.
+When you [rotate signing keys](/docs/get-started/tenant-settings/signing-keys/rotate-signing-keys), Auth0 signs new tokens with the new key. If you receive a token whose key ID (`kid`) is not in your cached JWKS, invalidate your cache and fetch the JWKS again to retrieve the new key. Refreshing on an unknown `kid` rather than the cache lifetime lets your application pick up rotated keys promptly. This way, a longer cache interval does not delay rotation.
 
-Limit how often you refetch on a cache miss - for example, retry only once - so that a batch of tokens signed with unknown keys cannot trigger a flood of requests to the JWKS endpoint and consume your rate limits. Set your cache interval based on how quickly you need to stop accepting tokens signed with a manually [revoked key](/docs/get-started/tenant-settings/signing-keys/revoke-signing-keys).
+Limit how often you refetch on a cache miss (for example, retry only once) so that a batch of tokens signed with unknown keys cannot trigger a flood of requests to the JWKS endpoint and consume your rate limits. Set your cache interval based on how quickly you need to stop accepting tokens signed with a manually [revoked key](/docs/get-started/tenant-settings/signing-keys/revoke-signing-keys).
 
 
 ## Learn more

--- a/main/docs/secure/tokens/json-web-tokens/locate-json-web-key-sets.mdx
+++ b/main/docs/secure/tokens/json-web-tokens/locate-json-web-key-sets.mdx
@@ -20,7 +20,7 @@ For more info about the structure of a JWT, see [JSON Web Token Structure](/docs
 
 It's good practice to assume that multiple signing keys could be present in your JWKS. This may seem unnecessary since the Auth0 JWKS endpoint typically contains a single signing key; however, multiple keys can be found in the JWKS when rotating signing certificates.
 
-We recommend that you cache your signing keys to improve application performance and avoid running into [rate limits](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy), but you will want to make sure that if decoding a token fails, you invalidate the cache and retrieve new signing keys before trying **only one** more time.
+We recommend that you cache your signing keys to improve application performance and avoid running into rate limits. To learn how to cache safely and still pick up rotated keys, read [Cache the JSON Web Key Set](/docs/secure/tokens/json-web-tokens/json-web-key-sets#cache-the-json-web-key-set).
 
 ## Learn more
 

--- a/main/docs/secure/tokens/json-web-tokens/locate-json-web-key-sets.mdx
+++ b/main/docs/secure/tokens/json-web-tokens/locate-json-web-key-sets.mdx
@@ -20,11 +20,7 @@ For more info about the structure of a JWT, see [JSON Web Token Structure](/docs
 
 It's good practice to assume that multiple signing keys could be present in your JWKS. This may seem unnecessary since the Auth0 JWKS endpoint typically contains a single signing key; however, multiple keys can be found in the JWKS when rotating signing certificates.
 
-<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-
-We recommend that you cache your signing keys to improve application performance and avoid running into rate limits. To learn how to cache safely and still pick up rotated keys, read [Cache the JSON Web Key Set](/docs/secure/tokens/json-web-tokens/json-web-key-sets#cache-the-json-web-key-set).
-
-</Callout>
+We recommend that you [cache your signing keys](/docs/secure/tokens/json-web-tokens/json-web-key-sets#cache-the-json-web-key-set) to improve application performance and avoid running into rate limits.
 
 ## Learn more
 

--- a/main/docs/secure/tokens/json-web-tokens/locate-json-web-key-sets.mdx
+++ b/main/docs/secure/tokens/json-web-tokens/locate-json-web-key-sets.mdx
@@ -20,7 +20,11 @@ For more info about the structure of a JWT, see [JSON Web Token Structure](/docs
 
 It's good practice to assume that multiple signing keys could be present in your JWKS. This may seem unnecessary since the Auth0 JWKS endpoint typically contains a single signing key; however, multiple keys can be found in the JWKS when rotating signing certificates.
 
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+
 We recommend that you cache your signing keys to improve application performance and avoid running into rate limits. To learn how to cache safely and still pick up rotated keys, read [Cache the JSON Web Key Set](/docs/secure/tokens/json-web-tokens/json-web-key-sets#cache-the-json-web-key-set).
+
+</Callout>
 
 ## Learn more
 

--- a/main/docs/secure/tokens/token-best-practices.mdx
+++ b/main/docs/secure/tokens/token-best-practices.mdx
@@ -96,11 +96,7 @@ The most secure practice, and our recommendation, is to use **RS256** because:
 
 It's good practice to assume that multiple signing keys could be present in your JWKS. This may seem unnecessary since the Auth0 JWKS endpoint typically contains a single signing key; however, multiple keys can be found in the JWKS when rotating signing certificates.
 
-<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-
 We recommend that you cache your signing keys to improve application performance and avoid running into rate limits. To learn how to cache safely and still pick up rotated keys, read [Cache the JSON Web Key Set](/docs/secure/tokens/json-web-tokens/json-web-key-sets#cache-the-json-web-key-set).
-
-</Callout>
 
 ## Learn more
 

--- a/main/docs/secure/tokens/token-best-practices.mdx
+++ b/main/docs/secure/tokens/token-best-practices.mdx
@@ -96,7 +96,11 @@ The most secure practice, and our recommendation, is to use **RS256** because:
 
 It's good practice to assume that multiple signing keys could be present in your JWKS. This may seem unnecessary since the Auth0 JWKS endpoint typically contains a single signing key; however, multiple keys can be found in the JWKS when rotating signing certificates.
 
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+
 We recommend that you cache your signing keys to improve application performance and avoid running into rate limits. To learn how to cache safely and still pick up rotated keys, read [Cache the JSON Web Key Set](/docs/secure/tokens/json-web-tokens/json-web-key-sets#cache-the-json-web-key-set).
+
+</Callout>
 
 ## Learn more
 

--- a/main/docs/secure/tokens/token-best-practices.mdx
+++ b/main/docs/secure/tokens/token-best-practices.mdx
@@ -96,7 +96,7 @@ The most secure practice, and our recommendation, is to use **RS256** because:
 
 It's good practice to assume that multiple signing keys could be present in your JWKS. This may seem unnecessary since the Auth0 JWKS endpoint typically contains a single signing key; however, multiple keys can be found in the JWKS when rotating signing certificates.
 
-We recommend that you cache your signing keys to improve application performance and avoid running into rate limits, but you will want to make sure that if decoding a token fails, you invalidate the cache and retrieve new signing keys before trying **only one** more time.
+We recommend that you cache your signing keys to improve application performance and avoid running into rate limits. To learn how to cache safely and still pick up rotated keys, read [Cache the JSON Web Key Set](/docs/secure/tokens/json-web-tokens/json-web-key-sets#cache-the-json-web-key-set).
 
 ## Learn more
 


### PR DESCRIPTION
## Description
Small improvement to expand on our guidance for caching the tenant /.well-known/jwks.json endpoint used to validate Auth0-issued JWTs.

- Adds a canonical Cache the JSON Web Key Set section to the JWKS hub page (json-web-key-sets.mdx), covering:
  - More in depth reasoning for why caching should be used
  - More in depth info on when to refetch based off receiving new `kid` whilst avoiding retry storm.
- Replaces the duplicated one-line caching advice in locate-json-web-key-sets.mdx and token-best-practices.mdx with a pointer to the new section, so there is a single source of truth.

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
