### PR TITLE
update: password-hash key limitations

### DIFF
--- a/main/docs/manage-users/user-migration/export-password-hashes-and-mfa-secrets.mdx
+++ b/main/docs/manage-users/user-migration/export-password-hashes-and-mfa-secrets.mdx
@@ -17,6 +17,7 @@ Before you submit a request, generate a PGP key pair that meets the following re
 | **Encryption subkey** | The key must include at least one RSA 4096-bit encryption subkey. Auth0 uses this subkey to encrypt your export. Other subkeys may use different parameters; only one needs to meet this requirement. |
 | **Passphrase** | Strong and unique. A randomly generated passphrase is recommended. |
 | **Expiration** | Set an expiration date at least 7 days after the date of generation. To reuse the same key for repeat export requests, adjust the expiration accordingly. |
+| **Public key size** | 35,000 characters or fewer when exported in ASCII-armored format. Keys with many third-party signatures can exceed this limit. See [Export your public key](#export-your-public-key) for how to strip them. |
 
 ## Generate your PGP key pair
 
@@ -116,9 +117,19 @@ Replace `YOUR_KEY_ID` with the alphanumeric string shown under your `pub` line (
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 
-Do not export or share your private key. Auth0 only needs your public key to encrypt the file.
+**PGP key character limit**: Auth0 accepts a maximum of **35,000 characters** for the PGP public key submitted with your support request. Keys with many third-party signatures can exceed this limit.
+
+To export a minimal key without third-party signatures:
+
+```bash
+gpg --armor --export --export-options export-minimal YOUR_KEY_ID > public_key.asc
+```
+
+This strips third-party certifications while preserving the key material Auth0 needs to encrypt your export.
 
 </Callout>
+
+Do not export or share your private key. Auth0 only needs your public key to encrypt the file.
 
 ## Request process
 


### PR DESCRIPTION
## Description

Adds two pieces of information to the export password hashes and MFA secrets doc around public key size and character limit guidance.

### References



### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
