### PR TITLE
Primary color update as per new Auth0 branding

### DIFF
--- a/main/docs.json
+++ b/main/docs.json
@@ -13,8 +13,8 @@
     }
   },
   "colors": {
-    "primary": "#7549F2",
-    "light": "#B3A7FF",
+    "primary": "#9921FE",
+    "light": "#BC6DFF",
     "dark": "#343434"
   },
   "contextual": {

--- a/main/ui/css/styles.css
+++ b/main/ui/css/styles.css
@@ -178,12 +178,122 @@ img.icon.inline {
   }
 }
 
-/* Accent tabs on hover */
+/* Accent tabs on hover. Dark mode uses --primary-light (a lighter tint),
+   since --primary itself doesn't change between light/dark and doesn't
+   have enough contrast against the dark background on its own. */
 .nav-tabs-item:hover {
   color: rgb(var(--primary));
   background-color: rgb(var(--primary) / .1);
   transition: all 0.15s ease-out;
   border-radius: 0.75rem;
+}
+
+.dark .nav-tabs-item:hover {
+  color: rgb(var(--primary-light));
+  background-color: rgb(var(--primary-light) / .1);
+}
+
+/* Dev Tools is a dropdown <button>, not a link, so its label sits in an
+   inner div with its own gray text classes that block inheriting the
+   hover color above. Force it to follow the parent on hover. */
+.nav-tabs-item:hover > div {
+  color: rgb(var(--primary));
+}
+
+.dark .nav-tabs-item:hover > div {
+  color: rgb(var(--primary-light));
+}
+
+/* Dev Tools' dropdown chevron has its own group-hover:text-gray-* class
+   (higher specificity than a plain descendant selector), so it needs
+   !important to follow the purple hover color like everything else. */
+.nav-tabs-item:hover svg {
+  color: rgb(var(--primary)) !important;
+}
+
+.dark .nav-tabs-item:hover svg {
+  color: rgb(var(--primary-light)) !important;
+}
+
+/* Locale switcher (the language dropdown in the navbar): same purple hover
+   accent as the top nav tabs. Its own classes use Tailwind's !important
+   modifier on the hover background and a group-hover chevron color, so
+   ours needs !important too to win. */
+#localization-select-trigger:hover {
+  color: rgb(var(--primary)) !important;
+  background-color: rgb(var(--primary) / .1) !important;
+}
+
+.dark #localization-select-trigger:hover {
+  color: rgb(var(--primary-light)) !important;
+  background-color: rgb(var(--primary-light) / .1) !important;
+}
+
+#localization-select-trigger:hover svg {
+  color: rgb(var(--primary)) !important;
+}
+
+.dark #localization-select-trigger:hover svg {
+  color: rgb(var(--primary-light)) !important;
+}
+
+/* Tab icons that are custom SVG files render as <img>, whose fill is baked
+   into the file, so text-color hover rules above can't reach them. Repaint
+   them with a masked pseudo-element that follows currentColor instead.
+   Matched by icon src (not href) since one tab, Dev Tools, is a dropdown
+   <button> with the <img> nested inside a wrapper div, not a direct child. */
+.nav-tabs-item img[src^="/icons/"] {
+  display: none;
+}
+
+.nav-tabs-item::before {
+  content: "";
+  display: none;
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
+  background-color: currentColor;
+}
+
+.nav-tabs-item:has(img[src="/icons/authenticate.svg"])::before,
+.nav-tabs-item:has(img[src="/icons/manage-users.svg"])::before,
+.nav-tabs-item:has(img[src="/icons/customize.svg"])::before,
+.nav-tabs-item:has(img[src="/icons/auth0-ai.svg"])::before,
+.nav-tabs-item:has(img[src="/icons/platform.svg"])::before,
+.nav-tabs-item:has(img[src="/icons/dev-tools.svg"])::before {
+  display: block;
+  -webkit-mask: no-repeat center / contain;
+  mask: no-repeat center / contain;
+}
+
+.nav-tabs-item:has(img[src="/icons/authenticate.svg"])::before {
+  -webkit-mask-image: url(/icons/authenticate.svg);
+  mask-image: url(/icons/authenticate.svg);
+}
+
+.nav-tabs-item:has(img[src="/icons/manage-users.svg"])::before {
+  -webkit-mask-image: url(/icons/manage-users.svg);
+  mask-image: url(/icons/manage-users.svg);
+}
+
+.nav-tabs-item:has(img[src="/icons/customize.svg"])::before {
+  -webkit-mask-image: url(/icons/customize.svg);
+  mask-image: url(/icons/customize.svg);
+}
+
+.nav-tabs-item:has(img[src="/icons/auth0-ai.svg"])::before {
+  -webkit-mask-image: url(/icons/auth0-ai.svg);
+  mask-image: url(/icons/auth0-ai.svg);
+}
+
+.nav-tabs-item:has(img[src="/icons/platform.svg"])::before {
+  -webkit-mask-image: url(/icons/platform.svg);
+  mask-image: url(/icons/platform.svg);
+}
+
+.nav-tabs-item:has(img[src="/icons/dev-tools.svg"])::before {
+  -webkit-mask-image: url(/icons/dev-tools.svg);
+  mask-image: url(/icons/dev-tools.svg);
 }
 
 /* Left nav: remove right border */


### PR DESCRIPTION

Auth0's brand color is updating to new purple theme. This updates the primary accent color used across docs tabs and links) from the previous blue/violet (`#7549F2`) to the new brand purple (`#9921FE` in light mode, `#BC6DFF` in dark mode).

## Accessibility
Verified WCAG contrast for the new purple against both themes:
- Light mode (#9921FE on white): 5.24:1 - passes AA (4.5:1 required).
- Dark mode (#BC6DFF for dark mode): 6.37:1 - passes AA comfortably.
