### PR TITLE
fix(quickstart): enable TLS verification in Ruby backend quickstart example

### DIFF
--- a/main/docs/quickstart/backend/rails/02-using.mdx
+++ b/main/docs/quickstart/backend/rails/02-using.mdx
@@ -277,7 +277,7 @@ url = URI("https://{yourDomain}/oauth/token")
 
 http = Net::HTTP.new(url.host, url.port)
 http.use_ssl = true
-http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+http.verify_mode = OpenSSL::SSL::VERIFY_PEER
 
 request = Net::HTTP::Post.new(url)
 request["content-type"] = 'application/x-www-form-urlencoded'


### PR DESCRIPTION
## Description

Updates the Ruby code sample in the backend (Rails) quickstart to set `http.verify_mode = OpenSSL::SSL::VERIFY_PEER`. The example previously used `VERIFY_NONE`, which disables TLS certificate verification. `VERIFY_PEER` is the correct, secure default for `net/http`. Docs-only, single-line change to `main/docs/quickstart/backend/rails/02-using.mdx`.

### Testing
Ran `mint dev` in `main/` and confirmed the Ruby tab of the backend quickstart renders correctly with the updated line.

## Checklist
- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.