### PR TITLE
Add subject_type_authorization and API access policy for anonymous sessions

### DIFF
--- a/main/docs/manage-users/sessions/anonymous-sessions/configure-anonymous-sessions.mdx
+++ b/main/docs/manage-users/sessions/anonymous-sessions/configure-anonymous-sessions.mdx
@@ -58,8 +58,26 @@ To enable anonymous sessions in your API, make a `PATCH` request to the [`/api/v
 
 ```json
 {
-"allow_anonymous_access": true,
-"token_lifetime_for_anonymous_access_tokens": 7200
+  "allow_anonymous_access": true,
+  "token_lifetime_for_anonymous_access_tokens": 86400,
+  "subject_type_authorization": {
+    "user":           { "policy": "allow_all" },
+    "client":         { "policy": "deny_all" },
+    "anonymous_user": { "policy": "require_client_grant" }
+  }
+}
+```
+
+### Create an API Access policy for anonymous users
+
+Once anonymous sessions are enabled in your API, make a `POST` request to the [`/api/v2/client-grants`](/docs/api/management/v2/client-grants/post-client-grants) endpoint:
+
+```json
+{
+  "audience": "{{anon_sessions_audience_identifier}}",
+  "client_id": "{{anon_sessions_clientid}}",
+  "scope": [ "read", "write", "delete" ],
+  "subject_type": "anonymous_user"
 }
 ```
 


### PR DESCRIPTION
## Summary

- Expands the `PATCH /api/v2/apis/{id}` example to include `subject_type_authorization` configuration with per-subject-type policies
- Updates `token_lifetime_for_anonymous_access_tokens` to `86400` in the example
- Adds a new section explaining how to create an API access policy for anonymous users via `POST /api/v2/client-grants` with `subject_type: "anonymous_user"`

## Test plan

- [ ] Verify MDX renders correctly with `mint dev` in `main/`
- [ ] Confirm code blocks display properly
- [ ] Check links to Management API endpoints resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)