### PR TITLE
fix(docs): remove unsupported scope param and align resource param do…

### DIFF
--- a/main/docs/ai-agents-mcp/cross-app-access/end-to-end-testing.mdx
+++ b/main/docs/ai-agents-mcp/cross-app-access/end-to-end-testing.mdx
@@ -234,8 +234,8 @@ grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer
 |---------------|-----------------|
 | `grant_type` | The grant type. It tells the Authorization Server to expect a JSON Web Token (JWT) as the primary credential in the request. | 
 | `client_id` | The client ID of the Requesting App within the Resource App Authorization Server making the API call. |
-| `resource` | The resource identifier of the resource server (API) in your Auth0 tenant. |
 | `assertion` | The ID-JAG or JSON Web Token (JWT) that acts as the bearer of the identity assertion. | 
+| `resource` | (Optional) The resource identifier of the resource server (API) in your Auth0 tenant. If the ID-JAG assertion includes a `resource` claim, that value takes precedence over this parameter. If no resource is specified in the ID-JAG or in the request body, your tenant's [default audience](https://auth0.com/docs/get-started/tenant-settings#api-authorization-settings) is used. |
 | `client_secret` | (Optional) The client secret of the Requesting App within the Resource App Authorization Server making the API call. |
 | `client_assertion` | (Optional) The client assertion, optionally used to authenticate the Requesting App via Private Key JWT. |
 | `client_assertion_type` | (Optional) The type of the client assertion. For Private Key JWT, set to `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`. |

--- a/main/docs/api/authentication/cross-app-access/get-token.mdx
+++ b/main/docs/api/authentication/cross-app-access/get-token.mdx
@@ -35,10 +35,6 @@ Cross App Access (XAA) for Resource App is in **Early Access**. Enterprise, B2B 
   The Client Secret of the Requesting App registered in the Resource App's Auth0 tenant. As for other grant types, you can also pass the Client Secret in the Authorization header using HTTP Basic Auth.
 </ParamField>
 
-<ParamField body="scope" type="string">
-  (Optional) A space-delimited list of permissions requested for the access token. Subject to RBAC and other authorization policies configured on the target API.
-</ParamField>
-
 <ParamField body="resource" type="string">
   (Optional) The resource identifier of the resource server (API) in your Auth0 tenant. If the ID-JAG assertion includes a `resource` claim, that value takes precedence over this parameter. If no resource is specified in the ID-JAG or in the request body, your tenant's [default audience](https://auth0.com/docs/get-started/tenant-settings#api-authorization-settings) is used.
 </ParamField>


### PR DESCRIPTION
- Drop the scope parameter from the Cross App Access Get Token API spec's Request Body (it's only taken from the id-jag).
- Update end-to-end-testing.mdx's resource param description to match the API spec exactly, and reorder it as the first optional parameter after the mandatory ones.