### PR TITLE
fix: clarify cf-connecting-ip cannot be used for custom_client_ip_header

### DIFF
--- a/main/docs/customize/custom-domains/self-managed-certificates/configure-cloudflare-for-use-as-reverse-proxy.mdx
+++ b/main/docs/customize/custom-domains/self-managed-certificates/configure-cloudflare-for-use-as-reverse-proxy.mdx
@@ -148,6 +148,14 @@ Call the Auth0 <Tooltip tip="Management API: A product to allow customers to per
 }
 ```
 
+This will configure Auth0 to take the end user's IP address from HTTP header `true-client-ip`.
+
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+
+Always aim to use `true-client-ip`. Using HTTP header `cf-connecting-ip` for this purpose is unsupported by Cloudflare.
+
+</Callout>
+
 ## Learn more
 
 * [Configure Features to Use Custom Domains](/docs/customize/custom-domains/configure-features-to-use-custom-domains)


### PR DESCRIPTION

## Description

Add clarification that `cf-connecting-ip` cannot be used to relay an end user's ip address. (that header is used internally by Cloudflare)

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
