### PR TITLE
fix: correct Authentication API explorer links in passkey-apis page

### DIFF
--- a/main/docs/authenticate/database-connections/passkeys/passkey-apis.mdx
+++ b/main/docs/authenticate/database-connections/passkeys/passkey-apis.mdx
@@ -217,7 +217,7 @@ Content-Type: application/json
   "expires_in": 86400
 }
 ```
-To learn more about about calls and parameters for the signup flow, review the [Authentication API explorer](/api/authentication).
+To learn more about about calls and parameters for the signup flow, review the [Authentication API explorer](/docs/api/authentication).
 
 
 ### Login flow
@@ -309,7 +309,7 @@ Content-Type: application/json
 }
 ```
 
-To learn more about about calls and parameters for the login flow, review the [Authentication API explorer](/api/authentication).
+To learn more about about calls and parameters for the login flow, review the [Authentication API explorer](/docs/api/authentication).
 
 ### Enrollment flow
 


### PR DESCRIPTION
## Description

  Fix two broken "Authentication API explorer" links on the [Passkey APIs for
  Embedded Applications](https://auth0.com/docs/authenticate/database-connection
  s/passkeys/passkey-apis) page.

  The links were using the relative path `/api/authentication`, which resolves
  to `https://auth0.com/api/authentication` (a broken URL). They should point to
  `/docs/api/authentication`, which resolves to
  `https://auth0.com/docs/api/authentication` (the correct Authentication API
  reference).

  Affected links:
  - "Authentication API explorer" in the signup flow section
  - "Authentication API explorer" in the login flow section

  ## Checklist

  - [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs
  -v2/blob/main/CONTRIBUTING.md).
  - [ ] I've tested the site build for this change locally.
  - [x] I've made appropriate docs updates for any code or config changes.
  - [x] I've coordinated with the Product Docs and/or Docs Management team about
  non-trivial changes.
