### PR TITLE
fix/rate-limit-clarifications

### DIFF
--- a/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/tier-100-rps-private-cloud.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/tier-100-rps-private-cloud.mdx
@@ -4,7 +4,7 @@ title: Private Cloud Basic 100 RPS (1x)
 ---
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-Total sustained throughput to both the Authentication API and MyAccount API in an environment is generally supported up to 500 RPS; however, certain unique workloads, heavy combined usage of Authentication and Management APIs, or certain Auth Flows like ROPG to the Authentication API, may cause degraded performance at lower RPS.
+In scenarios with heavy combined load across Authentication and Management APIs, per-API throughput may be lower than advertised maximums.
 </Callout>
 
 See below for the rate limits in the Private Cloud Basic 100 RPS (1x) subscription type. These limits apply to each tenant you create in the private cloud environment.

--- a/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/tier-10000-rps-private-cloud.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/tier-10000-rps-private-cloud.mdx
@@ -3,10 +3,6 @@ description: Tier 10000 RPS Private Cloud rate limits
 title: Private Cloud Performance 10,000 RPS (100x)
 ---
 
-<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-Total sustained throughput to both the Authentication API and MyAccount API in an environment is generally supported up to 500 RPS; however, certain unique workloads, heavy combined usage of Authentication and Management APIs, or certain Auth Flows like ROPG to the Authentication API, may cause degraded performance at lower RPS.
-</Callout>
-
 See below for the rate limits in the Private Cloud Performance 10,000 RPS (100x) subscription type.
 
 Therefore, we recommend deploying one tenant per private cloud environment for risk mitigation.

--- a/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/tier-1500-rps-private-cloud.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/tier-1500-rps-private-cloud.mdx
@@ -3,10 +3,6 @@ description: Tier 1500 RPS Private Cloud rate limits
 title: Private Cloud Performance 1500 RPS (15x)
 ---
 
-<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-Total sustained throughput to both the Authentication API and MyAccount API in an environment is generally supported up to 500 RPS; however, certain unique workloads, heavy combined usage of Authentication and Management APIs, or certain Auth Flows like ROPG to the Authentication API, may cause degraded performance at lower RPS.
-</Callout>
-
 See below for the rate limits in the Private Cloud Performance 1500 RPS (15x) subscription type. These limits apply to each tenant you create in the private cloud environment.
 
 Therefore, we recommend deploying one tenant per private cloud environment for risk mitigation.

--- a/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/tier-20-development-private-cloud.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/tier-20-development-private-cloud.mdx
@@ -4,7 +4,7 @@ title: Tier Dev Private Cloud
 ---
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-Total sustained throughput to both the Authentication API and MyAccount API in an environment is generally supported up to 500 RPS; however, certain unique workloads, heavy combined usage of Authentication and Management APIs, or certain Auth Flows like ROPG to the Authentication API, may cause degraded performance at lower RPS.
+In scenarios with heavy combined load across Authentication and Management APIs, per-API throughput may be lower than advertised maximums.
 </Callout>
 
 See below for the rate limit policies for the Tier 20 (Development) Private Cloud subscription type.

--- a/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/tier-3000-rps-private-cloud.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/tier-3000-rps-private-cloud.mdx
@@ -3,10 +3,6 @@ description: Tier 3000 RPS Private Cloud rate limits
 title: Private Cloud Performance 3000 RPS (30x) and 3000 RPS (30x) Burst
 ---
 
-<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-Total sustained throughput to both the Authentication API and MyAccount API in an environment is generally supported up to 500 RPS; however, certain unique workloads, heavy combined usage of Authentication and Management APIs, or certain Auth Flows like ROPG to the Authentication API, may cause degraded performance at lower RPS.
-</Callout>
-
 See below for the rate limits in the Private Cloud Performance 3000 RPS (30x) and 3000 RPS (30x) Burst subscription types. These limits apply to each tenant you create in the private cloud environment.
 
 Therefore, we recommend deploying one tenant per private cloud environment for risk mitigation.

--- a/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/tier-500-rps-private-cloud.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/tier-500-rps-private-cloud.mdx
@@ -3,10 +3,6 @@ description: Tier 500 RPS Private Cloud rate limits
 title: Private Cloud Performance 500 RPS (5x)
 ---
 
-<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-In scenarios with heavy combined load across Authentication and Management APIs, per-API throughput may be lower than advertised maximums.
-</Callout>
-
 See below for the rate limits in the Private Cloud Performance 500 RPS (5x) subscription type.
 
 These limits apply to each tenant you create in the private cloud environment.  Therefore, we recommend deploying one tenant per private cloud environment for risk mitigation.

--- a/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/tier-500-rps-private-cloud.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/tier-500-rps-private-cloud.mdx
@@ -4,7 +4,7 @@ title: Private Cloud Performance 500 RPS (5x)
 ---
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-Total sustained throughput to both the Authentication API and MyAccount API in an environment is generally supported up to 500 RPS; however, certain unique workloads, heavy combined usage of Authentication and Management APIs, or certain Auth Flows like ROPG to the Authentication API, may cause degraded performance at lower RPS.
+In scenarios with heavy combined load across Authentication and Management APIs, per-API throughput may be lower than advertised maximums.
 </Callout>
 
 See below for the rate limits in the Private Cloud Performance 500 RPS (5x) subscription type.

--- a/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/tier-6000-rps-private-cloud.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/tier-6000-rps-private-cloud.mdx
@@ -3,10 +3,6 @@ description: Tier 6000 RPS Private Cloud rate limits
 title: Private Cloud Performance 6000 RPS (60x) and 6000 RPS (60x) Burst
 ---
 
-<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-Total sustained throughput to both the Authentication API and MyAccount API in an environment is generally supported up to 500 RPS; however, certain unique workloads, heavy combined usage of Authentication and Management APIs, or certain Auth Flows like ROPG to the Authentication API, may cause degraded performance at lower RPS.
-</Callout>
-
 See below for the rate limits in the Private Cloud Performance 6000 RPS (60x) and 6000 RPS (60x) Burst subscription types.
 
 Therefore, we recommend deploying one tenant per private cloud environment for risk mitigation.


### PR DESCRIPTION
## Description

Remove the callout from the 15x/30x+ plans as it's causing confusion, rewording language it so it doesn't read as contradicting plan limits.

### References

https://auth0.slack.com/archives/C0BLN244V0D/p1785360940177069

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [ x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x ] I've tested the site build for this change locally.
- [x ] I've made appropriate docs updates for any code or config changes.
- [ x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
