### PR TITLE
docs(DOCS-5590): document client_secret for PKCE token exchange

### DIFF
--- a/main/docs/api/authentication/authorization-code-flow-with-pkce/get-token-pkce.mdx
+++ b/main/docs/api/authentication/authorization-code-flow-with-pkce/get-token-pkce.mdx
@@ -42,6 +42,10 @@ This is the flow that mobile apps use to access an API. Use this endpoint to exc
   Your application's Client ID.
 </ParamField>
 
+<ParamField body="client_secret" type="string">
+  The `client_secret` of your application. Required for confidential applications using the `client_secret_post` token endpoint authentication method.
+</ParamField>
+
 <ParamField body="code" type="string" required>
   The Authorization Code received from the initial `/authorize` call.
 </ParamField>

--- a/main/docs/oas/authentication/authentication-api-oas.json
+++ b/main/docs/oas/authentication/authentication-api-oas.json
@@ -3600,6 +3600,10 @@
             "type": "string",
             "description": "Your application's Client ID"
           },
+          "client_secret": {
+            "type": "string",
+            "description": "Your application's Client Secret. Required for confidential clients."
+          },
           "code_verifier": {
             "type": "string",
             "description": "The original code verifier for the PKCE request. The authorization server will hash this and compare it to the code_challenge from the authorization request.",


### PR DESCRIPTION
## Summary
- Add the `client_secret` body parameter to the Authorization Code Flow with PKCE `get-token-pkce.mdx` page, for confidential clients using `client_secret_post` auth
- Add the matching `client_secret` property to the `AuthorizationCodePKCEGrant` schema in `authentication-api-oas.json`, aligning it with the sibling `AuthorizationCodeGrant` schema

## Test plan
- [ ] Verify page renders correctly with `mint dev`
- [ ] Validate OAS JSON parses and matches Mintlify OAS schema expectations