### PR TITLE
feat: add back-channel auth nav group to auth API

### DIFF
--- a/main/config/navigation/api.authentication.en.json
+++ b/main/config/navigation/api.authentication.en.json
@@ -1,13 +1,6 @@
 {
   "pages": [
     {
-      "group": "Back-Channel Authentication",
-      "pages": [
-        "docs/api/authentication/login/start-back-channel-login",
-        "docs/api/authentication/login/check-back-channel-login-status"
-      ]
-    },
-    {
       "group": "Login",
       "pages": [
         "docs/api/authentication/login/index",
@@ -22,6 +15,13 @@
         "docs/api/authentication/logout/oidc-logout",
         "docs/api/authentication/logout/saml-logout",
         "docs/api/authentication/logout/global-token-revocation"
+      ]
+    },
+    {
+      "group": "Back-Channel Authentication",
+      "pages": [
+        "docs/api/authentication/login/start-back-channel-login",
+        "docs/api/authentication/login/check-back-channel-login-status"
       ]
     },
     {

--- a/main/config/navigation/api.authentication.en.json
+++ b/main/config/navigation/api.authentication.en.json
@@ -1,13 +1,18 @@
 {
   "pages": [
     {
+      "group": "Back-Channel Authentication",
+      "pages": [
+        "docs/api/authentication/login/start-back-channel-login",
+        "docs/api/authentication/login/check-back-channel-login-status"
+      ]
+    },
+    {
       "group": "Login",
       "pages": [
         "docs/api/authentication/login/index",
         "docs/api/authentication/login/authenticate-using-database",
-        "docs/api/authentication/login/enterprise-saml-and-others",
-        "docs/api/authentication/login/start-back-channel-login",
-        "docs/api/authentication/login/check-back-channel-login-status"
+        "docs/api/authentication/login/enterprise-saml-and-others"
       ]
     },
     {

--- a/main/config/navigation/api.authentication.fr-ca.json
+++ b/main/config/navigation/api.authentication.fr-ca.json
@@ -1,13 +1,18 @@
 {
   "pages": [
     {
+      "group": "Back-Channel Authentication",
+      "pages": [
+        "docs/fr-ca/api/authentication/login/start-back-channel-login",
+        "docs/fr-ca/api/authentication/login/check-back-channel-login-status"
+      ]
+    },
+    {
       "group": "Login",
       "pages": [
         "docs/fr-ca/api/authentication/login/index",
         "docs/fr-ca/api/authentication/login/authenticate-using-database",
-        "docs/fr-ca/api/authentication/login/enterprise-saml-and-others",
-        "docs/fr-ca/api/authentication/login/start-back-channel-login",
-        "docs/fr-ca/api/authentication/login/check-back-channel-login-status"
+        "docs/fr-ca/api/authentication/login/enterprise-saml-and-others"
       ]
     },
     {

--- a/main/config/navigation/api.authentication.fr-ca.json
+++ b/main/config/navigation/api.authentication.fr-ca.json
@@ -1,13 +1,6 @@
 {
   "pages": [
     {
-      "group": "Back-Channel Authentication",
-      "pages": [
-        "docs/fr-ca/api/authentication/login/start-back-channel-login",
-        "docs/fr-ca/api/authentication/login/check-back-channel-login-status"
-      ]
-    },
-    {
       "group": "Login",
       "pages": [
         "docs/fr-ca/api/authentication/login/index",
@@ -22,6 +15,13 @@
         "docs/fr-ca/api/authentication/logout/oidc-logout",
         "docs/fr-ca/api/authentication/logout/saml-logout",
         "docs/fr-ca/api/authentication/logout/global-token-revocation"
+      ]
+    },
+    {
+      "group": "Back-Channel Authentication",
+      "pages": [
+        "docs/fr-ca/api/authentication/login/start-back-channel-login",
+        "docs/fr-ca/api/authentication/login/check-back-channel-login-status"
       ]
     },
     {

--- a/main/config/navigation/api.authentication.ja-jp.json
+++ b/main/config/navigation/api.authentication.ja-jp.json
@@ -1,13 +1,18 @@
 {
   "pages": [
     {
+      "group": "Back-Channel Authentication",
+      "pages": [
+        "docs/ja-jp/api/authentication/login/start-back-channel-login",
+        "docs/ja-jp/api/authentication/login/check-back-channel-login-status"
+      ]
+    },
+    {
       "group": "Login",
       "pages": [
         "docs/ja-jp/api/authentication/login/index",
         "docs/ja-jp/api/authentication/login/authenticate-using-database",
-        "docs/ja-jp/api/authentication/login/enterprise-saml-and-others",
-        "docs/ja-jp/api/authentication/login/start-back-channel-login",
-        "docs/ja-jp/api/authentication/login/check-back-channel-login-status"
+        "docs/ja-jp/api/authentication/login/enterprise-saml-and-others"
       ]
     },
     {

--- a/main/config/navigation/api.authentication.ja-jp.json
+++ b/main/config/navigation/api.authentication.ja-jp.json
@@ -1,13 +1,6 @@
 {
   "pages": [
     {
-      "group": "Back-Channel Authentication",
-      "pages": [
-        "docs/ja-jp/api/authentication/login/start-back-channel-login",
-        "docs/ja-jp/api/authentication/login/check-back-channel-login-status"
-      ]
-    },
-    {
       "group": "Login",
       "pages": [
         "docs/ja-jp/api/authentication/login/index",
@@ -22,6 +15,13 @@
         "docs/ja-jp/api/authentication/logout/oidc-logout",
         "docs/ja-jp/api/authentication/logout/saml-logout",
         "docs/ja-jp/api/authentication/logout/global-token-revocation"
+      ]
+    },
+    {
+      "group": "Back-Channel Authentication",
+      "pages": [
+        "docs/ja-jp/api/authentication/login/start-back-channel-login",
+        "docs/ja-jp/api/authentication/login/check-back-channel-login-status"
       ]
     },
     {


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

Adds new Back-Channel Authentication group to Authentication API Explorer, and moves two docs related to back-channel authentication into that group from the Login nav group.

### Testing

Before:
<img width="344" height="276" alt="Screenshot 2026-08-03 at 12 39 01 PM" src="https://github.com/user-attachments/assets/137612ff-8cfc-4989-8e67-dd168e309767" />

After:
<img width="324" height="333" alt="Screenshot 2026-08-03 at 12 32 40 PM" src="https://github.com/user-attachments/assets/403531de-31e0-47f2-93fc-03bd852da4bb" />

## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
