### PR TITLE
docs: add SuperSend TX SMTP and Custom Email Action examples

### DIFF
--- a/main/docs/customize/email/smtp-email-providers/custom/configure-action.mdx
+++ b/main/docs/customize/email/smtp-email-providers/custom/configure-action.mdx
@@ -120,19 +120,17 @@ In this code sample, the function `onExecuteCustomEmailProvider` takes two argum
  */
 exports.onExecuteCustomEmailProvider = async (event, api) => {
   // Define the email payload
+  // Example: deliver with SuperSend TX (https://docs.supersendtx.com)
+  // Store SUPERSENDTX_API_KEY as an Action secret named api_key.
   const emailPayload = {
-    from: {
-      name: "Test Sender",
-      email: "sender@example.com"
-    },
-    to: [{ email: event.user.email }],
-    subject: event.notification.message_type,
+    from: event.notification.from || "noreply@yourdomain.com",
+    to: event.user.email,
+    subject: event.notification.subject || event.notification.message_type,
     html: event.notification.html,
     text: event.notification.text,
   };
   try {
-    // Make the API call to send the email
-    const response = await fetch('https://api.example.com/send-email', {
+    const response = await fetch('https://api.supersendtx.com/emails', {
       method: 'POST',
       headers: {
         'Authorization': `Bearer ${event.secrets.api_key}`,

--- a/main/docs/customize/email/smtp-email-providers/smtp-server.mdx
+++ b/main/docs/customize/email/smtp-email-providers/smtp-server.mdx
@@ -45,6 +45,23 @@ To configure your tenant with an SMTP server using the Management API, use the `
 
 * To update an existing email provider, send a [`PATCH` request to `/api/v2/emails/provider`](/docs/api/management/v2/emails/patch-provider). When changing the host, port, or username, you [must supply a password](/docs/troubleshoot/product-lifecycle/deprecations-and-migrations#allow-omitting-password-on-smtp-email-provider-host-related-changes).
 
+
+
+## Example: SuperSend TX
+
+[SuperSend TX](https://supersendtx.com) provides an SMTP relay for transactional email. Create an SMTP credential in the SuperSend TX dashboard, then use these settings in Auth0:
+
+| Setting | Value |
+|---------|-------|
+| Host | `smtp.supersendtx.com` |
+| Port | `587` |
+| Username | `supersendtx` |
+| Password | Your SuperSend TX SMTP credential (`stxsmtp_…`) |
+
+Allow inbound connections from [Auth0 IP addresses](/docs/secure/security-guidance/data-security/allowlist). The **From** address must use a domain you have verified in SuperSend TX.
+
+Guide: [https://docs.supersendtx.com/smtp](https://docs.supersendtx.com/smtp)
+
 ## Additional considerations
 
 * If you need support for authentication protocols other than LOGIN, you can [write an Action to connect to your SMTP server](/docs/customize/email/configure-a-custom-email-provider).


### PR DESCRIPTION
## Summary
Adds SuperSend TX as a concrete option for Auth0 production email delivery:

1. **SMTP Server** — host/port/username/password for `smtp.supersendtx.com` on the SMTP provider guide
2. **Custom Email Provider Action** — worked example posting to `https://api.supersendtx.com/emails` (replaces the placeholder `api.example.com` sample)

This does **not** claim a first-party dashboard logo integration (Resend/SendGrid style). Those require Auth0 product partnership. SMTP + Custom Action are the supported paths today.

Docs: https://docs.supersendtx.com/smtp · https://docs.supersendtx.com/guides/auth-provider-email

## Checklist
- [ ] SMTP table values are accurate
- [ ] Action example uses Action secrets for the API key
- [ ] Auth0 IP allowlist note retained


Made with [Cursor](https://cursor.com)