### PR TITLE
docs: update universal components docs

### DIFF
--- a/main/docs/get-started/universal-components/android/components/my-account-overview.mdx
+++ b/main/docs/get-started/universal-components/android/components/my-account-overview.mdx
@@ -68,7 +68,7 @@ The `AuthenticatorSettingsComponent` uses the access token to call the My Accoun
     `update:me:authentication_methods`
     `delete:me:authentication_methods`
 
-8. Select **Save** to save the permissions.
+8. Select **Grant Access** to grant the selected permissions.
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 * The user's access token only includes permissions they were granted during login.

--- a/main/docs/get-started/universal-components/ios/components/my-account-overview.mdx
+++ b/main/docs/get-started/universal-components/ios/components/my-account-overview.mdx
@@ -68,7 +68,7 @@ The `MyAccountAuthMethodsView` component uses the access token to call the My Ac
     `update:me:authentication_methods`
     `delete:me:authentication_methods`
 
-8. Select **Save** to save the permissions.
+8. Select **Grant Access** to grant the selected permissions.
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 * The user's access token only includes permissions that were granted during login.

--- a/main/docs/get-started/universal-components/web/auth0-component-provider.mdx
+++ b/main/docs/get-started/universal-components/web/auth0-component-provider.mdx
@@ -48,7 +48,7 @@ Nest `Auth0ComponentProvider` in your authentication provider (`Auth0Provider`).
           authorizationParams={{ redirect_uri: window.location.origin }}
           interactiveErrorHandler='popup' // Required to handle step-up auth challenges via Universal Login popup
         >
-          <Auth0ComponentProvider domain="your-tenant.auth0.com">
+          <Auth0ComponentProvider>
             {/* Your app with Auth0 Universal Components */}
           </Auth0ComponentProvider>
         </Auth0Provider>
@@ -991,7 +991,7 @@ All custom methods are optional. Only implement the ones you need. Methods recei
           authorizationParams={{ redirect_uri: window.location.origin }}
           interactiveErrorHandler='popup' // Required to handle step-up auth challenges via Universal Login popup
         >
-          <Auth0ComponentProvider domain="your-tenant.auth0.com">
+          <Auth0ComponentProvider>
             {/* Your app with Auth0 Universal Components */}
           </Auth0ComponentProvider>
         </Auth0Provider>

--- a/main/docs/get-started/universal-components/web/components/configure-org-domains.mdx
+++ b/main/docs/get-started/universal-components/web/components/configure-org-domains.mdx
@@ -63,7 +63,7 @@ export function DomainsPage() {
 ```
 
 <Accordion title="Full integration example">
-```tsx wrap lines
+```tsx lines
 import React from "react";
 import { DomainTable } from "@auth0/universal-components-react";
 import { Auth0Provider } from "@auth0/auth0-react";
@@ -463,6 +463,7 @@ Customize appearance with CSS variables and class overrides. Supports theme-awar
 
 - `DomainTable-header`
 - `DomainTable-table`
+- `DomainTable-tableActions`
 - `DomainTable-createModal`
 - `DomainTable-configureModal`
 - `DomainTable-deleteModal`
@@ -488,28 +489,13 @@ Customize appearance with CSS variables and class overrides. Supports theme-awar
 
 ## Advanced customization
 
-The `DomainTable` component is composed of smaller subcomponents and hooks. You can import them individually to build custom domain workflows if you use shadcn.
-
-### Available subcomponents
-
-For advanced use cases, you can import individual subcomponents to build custom domain management interfaces. This is useful when you need to embed specific modals in different contexts or customize the table layout beyond what props allow.
-
-| Component                       | Description                        |
-| :------------------------------ | :--------------------------------- |
-| `DomainCreateModal`             | Modal for creating a domain        |
-| `DomainVerifyModal`             | Modal for verification flow        |
-| `DomainDeleteModal`             | Confirmation modal for deletion    |
-| `DomainConfigureProvidersModal` | Manage provider associations       |
-| `DomainTableActionsColumn`      | Action buttons for each domain row |
-
 ### Available hooks
 
 These hooks provide the underlying logic without any UI. Use them to build completely custom interfaces while leveraging the Auth0 API integration.
 
-| Hook                  | Description                                                 |
-| :-------------------- | :---------------------------------------------------------- |
-| `useDomainTable`      | Data + API layer (fetch, create, verify, delete, associate) |
-| `useDomainTableLogic` | UI interaction state + handlers (modals, notifications)     |
+| Hook             | Description                                                 |
+| :--------------- | :---------------------------------------------------------- |
+| `useDomainTable` | Data + API layer (fetch, create, verify, delete, associate) |
 
 </Tab>
 
@@ -565,7 +551,7 @@ export function DomainsPage() {
 ```
 
 <Accordion title="Full integration example">
-```tsx wrap lines
+```tsx lines
 import React from "react";
 import { DomainTable } from "@auth0/universal-components-react";
 import { useRouter } from "next/navigation";
@@ -990,7 +976,7 @@ Customization props let you adapt the component to your brand, locale, and valid
 Set custom validation rules for domain URL input.
 
 <Accordion title="Available Schema Fields">
-  **create.domain**—Domain URL validation—`regex`—Custom regex pattern -
+  **create.domainUrl**—Domain URL validation—`regex`—Custom regex pattern -
   `errorMessage`—Custom error message
 </Accordion>
 
@@ -1092,6 +1078,7 @@ Customize appearance with CSS variables and class overrides. Supports theme-awar
 
 - `DomainTable-header`
 - `DomainTable-table`
+- `DomainTable-tableActions`
 - `DomainTable-createModal`
 - `DomainTable-configureModal`
 - `DomainTable-deleteModal`
@@ -1117,53 +1104,6 @@ Customize appearance with CSS variables and class overrides. Supports theme-awar
 
 ## Advanced customization
 
-The `DomainTable` component is composed of smaller subcomponents and hooks. You can import them individually to build custom domain workflows.
-
-### Available subcomponents
-
-For advanced use cases, you can import individual subcomponents to build custom domain management interfaces. This is useful when you need to embed specific modals in different contexts or customize the table layout beyond what props allow.
-
-<table class="table">
-  <thead>
-    <tr>
-      <th>Component</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>DomainCreateModal</code>
-      </td>
-      <td>Modal for creating a domain</td>
-    </tr>
-    <tr>
-      <td>
-        <code>DomainVerifyModal</code>
-      </td>
-      <td>Modal for verification flow</td>
-    </tr>
-    <tr>
-      <td>
-        <code>DomainDeleteModal</code>
-      </td>
-      <td>Confirmation modal for deletion</td>
-    </tr>
-    <tr>
-      <td>
-        <code>DomainConfigureProvidersModal</code>
-      </td>
-      <td>Manage provider associations</td>
-    </tr>
-    <tr>
-      <td>
-        <code>DomainTableActionsColumn</code>
-      </td>
-      <td>Action buttons for each domain row</td>
-    </tr>
-  </tbody>
-</table>
-
 ### Available hooks
 
 These hooks provide the underlying logic without any UI. Use them to build completely custom interfaces while leveraging the Auth0 API integration.
@@ -1181,12 +1121,6 @@ These hooks provide the underlying logic without any UI. Use them to build compl
         <code>useDomainTable</code>
       </td>
       <td>Data + API layer (fetch, create, verify, delete, associate)</td>
-    </tr>
-    <tr>
-      <td>
-        <code>useDomainTableLogic</code>
-      </td>
-      <td>UI interaction state + handlers (modals, notifications)</td>
     </tr>
   </tbody>
 </table>
@@ -1242,7 +1176,7 @@ export function DomainsPage() {
 ```
 
 <Accordion title="Full integration example">
-```tsx wrap lines
+```tsx lines
 import React from "react";
 import { DomainTable } from "@/components/auth0/my-organization/domain-table";
 import { Auth0Provider } from "@auth0/auth0-react";
@@ -1789,6 +1723,7 @@ Customize appearance with CSS variables and class overrides. Supports theme-awar
 
 - `DomainTable-header`
 - `DomainTable-table`
+- `DomainTable-tableActions`
 - `DomainTable-createModal`
 - `DomainTable-configureModal`
 - `DomainTable-deleteModal`
@@ -1814,53 +1749,6 @@ Customize appearance with CSS variables and class overrides. Supports theme-awar
 
 ## Advanced customization
 
-The `DomainTable` component is composed of smaller subcomponents and hooks. You can import them individually to build custom domain workflows if you use shadcn.
-
-### Available subcomponents
-
-For advanced use cases, you can import individual subcomponents to build custom domain management interfaces. This is useful when you need to embed specific modals in different contexts or customize the table layout beyond what props allow.
-
-<table class="table">
-  <thead>
-    <tr>
-      <th>Component</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>DomainCreateModal</code>
-      </td>
-      <td>Modal for creating a domain</td>
-    </tr>
-    <tr>
-      <td>
-        <code>DomainVerifyModal</code>
-      </td>
-      <td>Modal for verification flow</td>
-    </tr>
-    <tr>
-      <td>
-        <code>DomainDeleteModal</code>
-      </td>
-      <td>Confirmation modal for deletion</td>
-    </tr>
-    <tr>
-      <td>
-        <code>DomainConfigureProvidersModal</code>
-      </td>
-      <td>Manage provider associations</td>
-    </tr>
-    <tr>
-      <td>
-        <code>DomainTableActionsColumn</code>
-      </td>
-      <td>Action buttons for each domain row</td>
-    </tr>
-  </tbody>
-</table>
-
 ### Available hooks
 
 These hooks provide the underlying logic without any UI. Use them to build completely custom interfaces while leveraging the Auth0 API integration.
@@ -1878,12 +1766,6 @@ These hooks provide the underlying logic without any UI. Use them to build compl
         <code>useDomainTable</code>
       </td>
       <td>Data + API layer (fetch, create, verify, delete, associate)</td>
-    </tr>
-    <tr>
-      <td>
-        <code>useDomainTableLogic</code>
-      </td>
-      <td>UI interaction state + handlers (modals, notifications)</td>
     </tr>
   </tbody>
 </table>

--- a/main/docs/get-started/universal-components/web/components/configure-org-domains.mdx
+++ b/main/docs/get-started/universal-components/web/components/configure-org-domains.mdx
@@ -1155,7 +1155,7 @@ npx shadcn@latest add auth0/auth0-ui-components/react/my-organization/domain-tab
 <details>
 <summary>Legacy Vercel registry (deprecated)</summary>
 
-Existing consumers can continue using the Vercel-hosted path until **December 31, 2026**:
+Existing consumers can continue using the Vercel-hosted path until **September 17, 2026**:
 
 ```bash wrap lines
 npx shadcn@latest add https://auth0-universal-components.vercel.app/r/my-organization/domain-table.json

--- a/main/docs/get-started/universal-components/web/components/configure-org-domains.mdx
+++ b/main/docs/get-started/universal-components/web/components/configure-org-domains.mdx
@@ -143,7 +143,7 @@ export default function App() {
       }}
       interactiveErrorHandler="popup" // Required to handle step-up auth challenges via Universal Login popup
     >
-      <Auth0ComponentProvider domain={domain}>
+      <Auth0ComponentProvider>
         <DomainsManagementPage />
       </Auth0ComponentProvider>
     </Auth0Provider>
@@ -1206,14 +1206,30 @@ These hooks provide the underlying logic without any UI. Use them to build compl
 
 ## Install the component
 
+Install the component via the shadcn CLI using the GitHub Registry:
+
+```bash wrap lines
+npx shadcn@latest add auth0/auth0-ui-components/react/my-organization/domain-table
+```
+
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+  The shadcn CLI also installs the `@auth0/universal-components-core`
+  dependency for shared utilities and Auth0 integration.
+  Requires **shadcn CLI v2.5.0+**.
+</Callout>
+
+<details>
+<summary>Legacy Vercel registry (deprecated)</summary>
+
+Existing consumers can continue using the Vercel-hosted path until **December 31, 2026**:
+
 ```bash wrap lines
 npx shadcn@latest add https://auth0-universal-components.vercel.app/r/my-organization/domain-table.json
 ```
 
-<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-  Running the shadcn command also installs the @auth0/universal-components-core
-  dependency for shared utilities and Auth0 integration.
-</Callout>
+New projects should use the GitHub Registry path above.
+
+</details>
 
 ## Get started
 
@@ -1306,7 +1322,7 @@ export default function App() {
       }}
       interactiveErrorHandler="popup" // Required to handle step-up auth challenges via Universal Login popup
     >
-      <Auth0ComponentProvider domain={domain}>
+      <Auth0ComponentProvider>
         <DomainsManagementPage />
       </Auth0ComponentProvider>
     </Auth0Provider>

--- a/main/docs/get-started/universal-components/web/components/configure-org-domains.mdx
+++ b/main/docs/get-started/universal-components/web/components/configure-org-domains.mdx
@@ -78,7 +78,7 @@ function DomainsManagementPage() {
       <DomainTable
         schema={{
           create: {
-            domain: {
+            domainUrl: {
               regex: /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/i,
               errorMessage: "Please enter a valid domain (e.g., example.com)",
             },
@@ -369,7 +369,7 @@ Set custom validation rules for domain URL input.
 <DomainTable
   schema={{
     create: {
-      domain: {
+      domainUrl: {
         regex: /^[a-z0-9.-]+\.[a-z]{2,}$/,
         errorMessage: "Enter a valid domain (example.com)",
       },
@@ -564,7 +564,7 @@ function DomainsManagementPage() {
       <DomainTable
         schema={{
           create: {
-            domain: {
+            domainUrl: {
               regex: /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/i,
               errorMessage: "Please enter a valid domain (e.g., example.com)",
             },
@@ -984,7 +984,7 @@ Set custom validation rules for domain URL input.
 <DomainTable
   schema={{
     create: {
-      domain: {
+      domainUrl: {
         regex: /^[a-z0-9.-]+\.[a-z]{2,}$/,
         errorMessage: "Enter a valid domain (example.com)",
       },
@@ -1191,7 +1191,7 @@ function DomainsManagementPage() {
       <DomainTable
         schema={{
           create: {
-            domain: {
+            domainUrl: {
               regex: /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/i,
               errorMessage: "Please enter a valid domain (e.g., example.com)",
             },
@@ -1629,7 +1629,7 @@ Set custom validation rules for domain URL input.
 <DomainTable
   schema={{
     create: {
-      domain: {
+      domainUrl: {
         regex: /^[a-z0-9.-]+\.[a-z]{2,}$/,
         errorMessage: "Enter a valid domain (example.com)",
       },

--- a/main/docs/get-started/universal-components/web/components/edit-organization-details.mdx
+++ b/main/docs/get-started/universal-components/web/components/edit-organization-details.mdx
@@ -75,7 +75,7 @@ export function OrganizationSettingsPage() {
 ```
 
 <Accordion title="Full integration example">
-```tsx wrap lines
+```tsx lines
 import React from "react";
 import { OrganizationDetailsEdit } from "@auth0/universal-components-react";
 import { Auth0Provider } from "@auth0/auth0-react";
@@ -116,7 +116,6 @@ function OrganizationSettingsPage() {
           onAfter: handleSaveSuccess,
         }}
         cancelAction={{
-          onBefore: () => confirm("Discard unsaved changes?"),
           onAfter: () => navigate("/organization"),
         }}
         backButton={{
@@ -137,7 +136,7 @@ function OrganizationSettingsPage() {
             },
           },
           classes: {
-            "OrganizationDetailsEdit-form": "shadow-xl rounded-lg",
+            "OrganizationDetails_Card": "shadow-xl rounded-lg",
           },
         }}
       />
@@ -319,7 +318,6 @@ Controls the cancel/discard flow. Use this action to manage discarded changes.
 **Properties:**
 
 - `disabled`—Disable the cancel button
-- `onBefore(data)`—Runs before the cancel action. Return `false` to prevent cancellation (for example, to confirm discarding unsaved changes).
 - `onAfter(data)`—Runs after the cancel is confirmed. Use this to navigate away from the form.
 
 **Example:**
@@ -327,9 +325,6 @@ Controls the cancel/discard flow. Use this action to manage discarded changes.
 ```tsx wrap lines
 <OrganizationDetailsEdit
   cancelAction={{
-    onBefore: (org) => {
-      return confirm("Discard unsaved changes?");
-    },
     onAfter: () => navigate("/organization"),
   }}
 />
@@ -524,9 +519,10 @@ Customize appearance with CSS variables and class overrides. Supports theme-awar
 
 **Classes**—Component class overrides
 
-- `OrganizationDetailsEdit-header`
-- `OrganizationDetailsEdit-form`
-- `OrganizationDetailsEdit-actions`
+- `OrganizationDetails_Card`
+- `OrganizationDetails_FormActions`
+- `OrganizationDetails_SettingsDetails`
+- `OrganizationDetails_BrandingDetails`
 
 </Accordion>
 
@@ -542,7 +538,7 @@ Customize appearance with CSS variables and class overrides. Supports theme-awar
       },
     },
     classes: {
-      "OrganizationDetailsEdit-form": "shadow-lg rounded-xl p-6",
+      "OrganizationDetails_Card": "shadow-lg rounded-xl p-6",
     },
   }}
 />
@@ -551,41 +547,6 @@ Customize appearance with CSS variables and class overrides. Supports theme-awar
 ---
 
 ## Advanced customization
-
-The `OrganizationDetailsEdit` component is composed of smaller subcomponents and hooks. You can import them individually to build custom organization editing workflows if you use shadcn.
-
-### Available subcomponents
-
-For advanced use cases, you can import individual subcomponents to build custom organization editing interfaces.
-
-<table class="table">
-  <thead>
-    <tr>
-      <th>Component</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>OrganizationForm</code>
-      </td>
-      <td>Main form component with all fields</td>
-    </tr>
-    <tr>
-      <td>
-        <code>ColorPickerField</code>
-      </td>
-      <td>Brand color selection field</td>
-    </tr>
-    <tr>
-      <td>
-        <code>LogoUploadField</code>
-      </td>
-      <td>Logo URL input with preview</td>
-    </tr>
-  </tbody>
-</table>
 
 ### Available hooks
 
@@ -661,7 +622,7 @@ export function OrganizationSettingsPage() {
 ```
 
 <Accordion title="Full integration example">
-```tsx wrap lines
+```tsx lines
 import React from "react";
 import { OrganizationDetailsEdit } from "@auth0/universal-components-react";
 import { useRouter } from "next/navigation";
@@ -700,7 +661,6 @@ function OrganizationSettingsPage() {
           onAfter: handleSaveSuccess,
         }}
         cancelAction={{
-          onBefore: () => confirm("Discard unsaved changes?"),
           onAfter: () => router.push("/organization"),
         }}
         backButton={{
@@ -721,7 +681,7 @@ function OrganizationSettingsPage() {
             },
           },
           classes: {
-            "OrganizationDetailsEdit-form": "shadow-xl rounded-lg",
+            "OrganizationDetails_Card": "shadow-xl rounded-lg",
           },
         }}
       />
@@ -884,7 +844,6 @@ Controls the cancel/discard flow. Use this action to manage discarded changes.
 **Properties:**
 
 - `disabled`—Disable the cancel button
-- `onBefore(data)`—Runs before the cancel action. Return `false` to prevent cancellation (for example, to confirm discarding unsaved changes).
 - `onAfter(data)`—Runs after the cancel is confirmed. Use this to navigate away from the form.
 
 **Example:**
@@ -892,9 +851,6 @@ Controls the cancel/discard flow. Use this action to manage discarded changes.
 ```tsx wrap lines
 <OrganizationDetailsEdit
   cancelAction={{
-    onBefore: (org) => {
-      return confirm("Discard unsaved changes?");
-    },
     onAfter: () => router.push("/organization"),
   }}
 />
@@ -1089,9 +1045,10 @@ Customize appearance with CSS variables and class overrides. Supports theme-awar
 
 **Classes**—Component class overrides
 
-- `OrganizationDetailsEdit-header`
-- `OrganizationDetailsEdit-form`
-- `OrganizationDetailsEdit-actions`
+- `OrganizationDetails_Card`
+- `OrganizationDetails_FormActions`
+- `OrganizationDetails_SettingsDetails`
+- `OrganizationDetails_BrandingDetails`
 
 </Accordion>
 
@@ -1107,7 +1064,7 @@ Customize appearance with CSS variables and class overrides. Supports theme-awar
       },
     },
     classes: {
-      "OrganizationDetailsEdit-form": "shadow-lg rounded-xl p-6",
+      "OrganizationDetails_Card": "shadow-lg rounded-xl p-6",
     },
   }}
 />
@@ -1116,41 +1073,6 @@ Customize appearance with CSS variables and class overrides. Supports theme-awar
 ---
 
 ## Advanced customization
-
-The `OrganizationDetailsEdit` component is composed of smaller subcomponents and hooks. You can import them individually to build custom organization editing workflows.
-
-### Available subcomponents
-
-For advanced use cases, you can import individual subcomponents to build custom organization editing interfaces.
-
-<table class="table">
-  <thead>
-    <tr>
-      <th>Component</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>OrganizationForm</code>
-      </td>
-      <td>Main form component with all fields</td>
-    </tr>
-    <tr>
-      <td>
-        <code>ColorPickerField</code>
-      </td>
-      <td>Brand color selection field</td>
-    </tr>
-    <tr>
-      <td>
-        <code>LogoUploadField</code>
-      </td>
-      <td>Logo URL input with preview</td>
-    </tr>
-  </tbody>
-</table>
 
 ### Available hooks
 
@@ -1235,7 +1157,7 @@ export function OrganizationSettingsPage() {
 ```
 
 <Accordion title="Full integration example">
-```tsx wrap lines
+```tsx lines
 import React from "react";
 import { OrganizationDetailsEdit } from "@/components/auth0/my-organization/organization-details-edit";
 import { Auth0Provider } from "@auth0/auth0-react";
@@ -1276,7 +1198,6 @@ function OrganizationSettingsPage() {
           onAfter: handleSaveSuccess,
         }}
         cancelAction={{
-          onBefore: () => confirm("Discard unsaved changes?"),
           onAfter: () => navigate("/organization"),
         }}
         backButton={{
@@ -1297,7 +1218,7 @@ function OrganizationSettingsPage() {
             },
           },
           classes: {
-            "OrganizationDetailsEdit-form": "shadow-xl rounded-lg",
+            "OrganizationDetails_Card": "shadow-xl rounded-lg",
           },
         }}
       />
@@ -1479,7 +1400,6 @@ Controls the cancel/discard flow. Use this action to manage discarded changes.
 **Properties:**
 
 - `disabled`—Disable the cancel button
-- `onBefore(data)`—Runs before the cancel action. Return `false` to prevent cancellation (for example, to confirm discarding unsaved changes).
 - `onAfter(data)`—Runs after the cancel is confirmed. Use this to navigate away from the form.
 
 **Example:**
@@ -1487,9 +1407,6 @@ Controls the cancel/discard flow. Use this action to manage discarded changes.
 ```tsx wrap lines
 <OrganizationDetailsEdit
   cancelAction={{
-    onBefore: (org) => {
-      return confirm("Discard unsaved changes?");
-    },
     onAfter: () => navigate("/organization"),
   }}
 />
@@ -1684,9 +1601,10 @@ Customize appearance with CSS variables and class overrides. Supports theme-awar
 
 **Classes**—Component class overrides
 
-- `OrganizationDetailsEdit-header`
-- `OrganizationDetailsEdit-form`
-- `OrganizationDetailsEdit-actions`
+- `OrganizationDetails_Card`
+- `OrganizationDetails_FormActions`
+- `OrganizationDetails_SettingsDetails`
+- `OrganizationDetails_BrandingDetails`
 
 </Accordion>
 
@@ -1702,7 +1620,7 @@ Customize appearance with CSS variables and class overrides. Supports theme-awar
       },
     },
     classes: {
-      "OrganizationDetailsEdit-form": "shadow-lg rounded-xl p-6",
+      "OrganizationDetails_Card": "shadow-lg rounded-xl p-6",
     },
   }}
 />
@@ -1711,41 +1629,6 @@ Customize appearance with CSS variables and class overrides. Supports theme-awar
 ---
 
 ## Advanced customization
-
-The `OrganizationDetailsEdit` component is composed of smaller subcomponents and hooks. You can import them individually to build custom organization editing workflows if you use shadcn.
-
-### Available subcomponents
-
-For advanced use cases, you can import individual subcomponents to build custom organization editing interfaces.
-
-<table class="table">
-  <thead>
-    <tr>
-      <th>Component</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>OrganizationForm</code>
-      </td>
-      <td>Main form component with all fields</td>
-    </tr>
-    <tr>
-      <td>
-        <code>ColorPickerField</code>
-      </td>
-      <td>Color picker for brand color selection</td>
-    </tr>
-    <tr>
-      <td>
-        <code>LogoUploadField</code>
-      </td>
-      <td>Logo upload and management field</td>
-    </tr>
-  </tbody>
-</table>
 
 ### Available hooks
 
@@ -1764,12 +1647,6 @@ These hooks provide the underlying logic without any UI. Use them to build compl
         <code>useOrganizationDetailsEdit</code>
       </td>
       <td>Organization data fetching and editing logic</td>
-    </tr>
-    <tr>
-      <td>
-        <code>useOrganizationDetailsEditLogic</code>
-      </td>
-      <td>Form state and action handlers</td>
     </tr>
   </tbody>
 </table>

--- a/main/docs/get-started/universal-components/web/components/edit-organization-details.mdx
+++ b/main/docs/get-started/universal-components/web/components/edit-organization-details.mdx
@@ -1125,7 +1125,7 @@ npx shadcn@latest add auth0/auth0-ui-components/react/my-organization/organizati
 <details>
 <summary>Legacy Vercel registry (deprecated)</summary>
 
-Existing consumers can continue using the Vercel-hosted path until **December 31, 2026**:
+Existing consumers can continue using the Vercel-hosted path until **September 17, 2026**:
 
 ```bash wrap lines
 npx shadcn@latest add https://auth0-universal-components.vercel.app/r/my-organization/organization-details-edit.json

--- a/main/docs/get-started/universal-components/web/components/edit-organization-details.mdx
+++ b/main/docs/get-started/universal-components/web/components/edit-organization-details.mdx
@@ -158,7 +158,7 @@ export default function App() {
       }}
       interactiveErrorHandler="popup" // Required to handle step-up auth challenges via Universal Login popup
     >
-      <Auth0ComponentProvider domain={domain}>
+      <Auth0ComponentProvider>
         <OrganizationSettingsPage />
       </Auth0ComponentProvider>
     </Auth0Provider>
@@ -1188,14 +1188,30 @@ These hooks provide the underlying logic without any UI. Use them to build compl
 
 ## Installation
 
+Install the component via the shadcn CLI using the GitHub Registry:
+
+```bash wrap lines
+npx shadcn@latest add auth0/auth0-ui-components/react/my-organization/organization-details-edit
+```
+
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+  The shadcn CLI also installs the `@auth0/universal-components-core`
+  dependency for shared utilities and Auth0 integration.
+  Requires **shadcn CLI v2.5.0+**.
+</Callout>
+
+<details>
+<summary>Legacy Vercel registry (deprecated)</summary>
+
+Existing consumers can continue using the Vercel-hosted path until **December 31, 2026**:
+
 ```bash wrap lines
 npx shadcn@latest add https://auth0-universal-components.vercel.app/r/my-organization/organization-details-edit.json
 ```
 
-<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-  Running the shadcn command also installs the @auth0/universal-components-core
-  dependency for shared utilities and Auth0 integration.
-</Callout>
+New projects should use the GitHub Registry path above.
+
+</details>
 
 ## Get started
 
@@ -1302,7 +1318,7 @@ export default function App() {
       }}
       interactiveErrorHandler="popup" // Required to handle step-up auth challenges via Universal Login popup
     >
-      <Auth0ComponentProvider domain={domain}>
+      <Auth0ComponentProvider>
         <OrganizationSettingsPage />
       </Auth0ComponentProvider>
     </Auth0Provider>

--- a/main/docs/get-started/universal-components/web/components/my-account-overview.mdx
+++ b/main/docs/get-started/universal-components/web/components/my-account-overview.mdx
@@ -117,7 +117,7 @@ export default function App() {
       authorizationParams={{ redirect_uri: window.location.origin }}
       interactiveErrorHandler="popup"
     >
-      <Auth0ComponentProvider domain={domain}>
+      <Auth0ComponentProvider>
         {/* your application */}
       </Auth0ComponentProvider>
     </Auth0Provider>
@@ -281,6 +281,23 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 Run the shadcn CLI to add the components directly to your project source:
 
 ```bash MFA management wrap lines
+npx shadcn@latest add auth0/auth0-ui-components/react/my-account/user-mfa-management
+```
+
+```bash Passkey management wrap lines
+npx shadcn@latest add auth0/auth0-ui-components/react/my-account/user-passkey-management
+```
+
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+The install command adds the component source into `src/components/auth0/my-account/` along with all UI dependencies and the `@auth0/universal-components-core` dependency for shared utilities and Auth0 integration.
+</Callout>
+
+<details>
+<summary>Legacy Vercel registry (deprecated)</summary>
+
+Existing consumers can continue using the Vercel-hosted path until **December 31, 2026**:
+
+```bash MFA management wrap lines
 npx shadcn@latest add https://auth0-universal-components.vercel.app/r/my-account/user-mfa-management.json
 ```
 
@@ -288,9 +305,9 @@ npx shadcn@latest add https://auth0-universal-components.vercel.app/r/my-account
 npx shadcn@latest add https://auth0-universal-components.vercel.app/r/my-account/user-passkey-management.json
 ```
 
-<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-The install command adds the component source into `src/components/auth0/my-account/` along with all UI dependencies and the `@auth0/universal-components-core` dependency for shared utilities and Auth0 integration.
-</Callout>
+New projects should use the GitHub Registry path above.
+
+</details>
 
 
 ### Configure environment variables
@@ -322,7 +339,7 @@ export default function App() {
       authorizationParams={{ redirect_uri: window.location.origin }}
       interactiveErrorHandler="popup"
     >
-      <Auth0ComponentProvider domain={domain}>
+      <Auth0ComponentProvider>
         {/* your application */}
       </Auth0ComponentProvider>
     </Auth0Provider>

--- a/main/docs/get-started/universal-components/web/components/my-account-overview.mdx
+++ b/main/docs/get-started/universal-components/web/components/my-account-overview.mdx
@@ -295,7 +295,7 @@ The install command adds the component source into `src/components/auth0/my-acco
 <details>
 <summary>Legacy Vercel registry (deprecated)</summary>
 
-Existing consumers can continue using the Vercel-hosted path until **December 31, 2026**:
+Existing consumers can continue using the Vercel-hosted path until **September 17, 2026**:
 
 ```bash MFA management wrap lines
 npx shadcn@latest add https://auth0-universal-components.vercel.app/r/my-account/user-mfa-management.json

--- a/main/docs/get-started/universal-components/web/components/sso-provider-create.mdx
+++ b/main/docs/get-started/universal-components/web/components/sso-provider-create.mdx
@@ -558,7 +558,7 @@ Control wizard step navigation. These callbacks are called when the user clicks 
 
 **Parameters:**
 
-- `stepId`—Current step identifier (`"provider-select"`, `"provider-details"`, `"provider-configure"`)
+- `stepId`—Current step identifier (`"provider_select"`, `"provider_details"`, `"provider_configure"`)
 - `values`—Current form values
 
 **Example:**

--- a/main/docs/get-started/universal-components/web/components/sso-provider-create.mdx
+++ b/main/docs/get-started/universal-components/web/components/sso-provider-create.mdx
@@ -263,7 +263,7 @@ npx shadcn@latest add auth0/auth0-ui-components/react/my-organization/sso-provid
 <details>
 <summary>Legacy Vercel registry (deprecated)</summary>
 
-Existing consumers can continue using the Vercel-hosted path until **December 31, 2026**:
+Existing consumers can continue using the Vercel-hosted path until **September 17, 2026**:
 
 ```bash wrap lines
 npx shadcn@latest add https://auth0-universal-components.vercel.app/r/my-organization/sso-provider-create.json

--- a/main/docs/get-started/universal-components/web/components/sso-provider-create.mdx
+++ b/main/docs/get-started/universal-components/web/components/sso-provider-create.mdx
@@ -75,7 +75,7 @@ export function CreateProviderPage() {
 ```
 
 <Accordion title="Full integration example">
-```tsx wrap lines
+```tsx lines
 import React from "react";
 import { SsoProviderCreate } from "@auth0/universal-components-react";
 import { Auth0Provider } from "@auth0/auth0-react";
@@ -190,7 +190,7 @@ export function CreateProviderPage() {
 ```
 
 <Accordion title="Full integration example">
-```tsx wrap lines
+```tsx lines
 import React from "react";
 import { SsoProviderCreate } from "@auth0/universal-components-react";
 import { useRouter } from "next/navigation";
@@ -295,7 +295,7 @@ export function CreateProviderPage() {
 ```
 
 <Accordion title="Full integration example">
-```tsx wrap lines
+```tsx lines
 import React from "react";
 import { SsoProviderCreate } from "@/components/auth0/my-organization/sso-provider-create";
 import { Auth0Provider } from "@auth0/auth0-react";
@@ -789,95 +789,6 @@ Customize appearance with CSS variables and class overrides. Supports theme-awar
 ---
 
 ## Advanced customization
-
-The `SsoProviderCreate` component is composed of smaller subcomponents and hooks. You can import them individually to build custom SSO provider creation workflows if you use shadcn.
-
-### Available subcomponents
-
-For advanced use cases, you can import individual subcomponents to build custom SSO provider creation workflows. This is useful when you need to embed a single step in a different UI or customize the wizard flow beyond what props allow.
-
-<table class="table">
-  <thead>
-    <tr>
-      <th>Component</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>ProviderSelect</code>
-      </td>
-      <td>Strategy selection step with provider icons</td>
-    </tr>
-    <tr>
-      <td>
-        <code>ProviderDetails</code>
-      </td>
-      <td>Name and display name configuration step</td>
-    </tr>
-    <tr>
-      <td>
-        <code>ProviderConfigure</code>
-      </td>
-      <td>Strategy-specific configuration step</td>
-    </tr>
-    <tr>
-      <td>
-        <code>ProviderConfigureFields</code>
-      </td>
-      <td>Dynamic form fields based on strategy</td>
-    </tr>
-    <tr>
-      <td>
-        <code>OktaProviderForm</code>
-      </td>
-      <td>Okta-specific configuration form</td>
-    </tr>
-    <tr>
-      <td>
-        <code>AdfsProviderForm</code>
-      </td>
-      <td>ADFS-specific configuration form</td>
-    </tr>
-    <tr>
-      <td>
-        <code>GoogleAppsProviderForm</code>
-      </td>
-      <td>Google Workspace-specific configuration form</td>
-    </tr>
-    <tr>
-      <td>
-        <code>OidcProviderForm</code>
-      </td>
-      <td>OIDC-specific configuration form</td>
-    </tr>
-    <tr>
-      <td>
-        <code>PingFederateProviderForm</code>
-      </td>
-      <td>PingFederate-specific configuration form</td>
-    </tr>
-    <tr>
-      <td>
-        <code>SamlpProviderForm</code>
-      </td>
-      <td>SAML-specific configuration form</td>
-    </tr>
-    <tr>
-      <td>
-        <code>WaadProviderForm</code>
-      </td>
-      <td>Azure AD-specific configuration form</td>
-    </tr>
-    <tr>
-      <td>
-        <code>Wizard</code>
-      </td>
-      <td>Multi-step wizard UI</td>
-    </tr>
-  </tbody>
-</table>
 
 ### Available hooks
 

--- a/main/docs/get-started/universal-components/web/components/sso-provider-create.mdx
+++ b/main/docs/get-started/universal-components/web/components/sso-provider-create.mdx
@@ -126,7 +126,7 @@ export default function App() {
       authorizationParams={{ redirect_uri: window.location.origin }}
       interactiveErrorHandler='popup' // Required to handle step-up auth challenges via Universal Login popup
     >
-      <Auth0ComponentProvider domain={domain}>
+      <Auth0ComponentProvider>
         <CreateSsoProviderPage />
       </Auth0ComponentProvider>
     </Auth0Provider>
@@ -248,14 +248,30 @@ export default CreateSsoProviderPage;
 
 ## Installation
 
+Install the component via the shadcn CLI using the GitHub Registry:
+
+```bash wrap lines
+npx shadcn@latest add auth0/auth0-ui-components/react/my-organization/sso-provider-create
+```
+
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+  The shadcn CLI also installs the `@auth0/universal-components-core`
+  dependency for shared utilities and Auth0 integration.
+  Requires **shadcn CLI v2.5.0+**.
+</Callout>
+
+<details>
+<summary>Legacy Vercel registry (deprecated)</summary>
+
+Existing consumers can continue using the Vercel-hosted path until **December 31, 2026**:
+
 ```bash wrap lines
 npx shadcn@latest add https://auth0-universal-components.vercel.app/r/my-organization/sso-provider-create.json
 ```
 
-<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-  Running the shadcn command also installs the @auth0/universal-components-core
-  dependency for shared utilities and Auth0 integration.
-</Callout>
+New projects should use the GitHub Registry path above.
+
+</details>
 
 ## Get started
 
@@ -330,7 +346,7 @@ export default function App() {
       authorizationParams={{ redirect_uri: window.location.origin }}
       interactiveErrorHandler='popup' // Required to handle step-up auth challenges via Universal Login popup
     >
-      <Auth0ComponentProvider domain={domain}>
+      <Auth0ComponentProvider>
         <CreateSsoProviderPage />
       </Auth0ComponentProvider>
     </Auth0Provider>

--- a/main/docs/get-started/universal-components/web/components/sso-provider-edit.mdx
+++ b/main/docs/get-started/universal-components/web/components/sso-provider-edit.mdx
@@ -104,14 +104,14 @@ function EditProviderPage() {
               toast.success("Provider configuration saved");
             },
           },
-          deleteAction: {
+          deleteFromOrganizationAction: {
             onBefore: (provider) => {
               return confirm(
-                `Delete "${provider.display_name}"? This cannot be undone.`,
+                `Remove "${provider.display_name}" from this organization?`,
               );
             },
             onAfter: () => {
-              toast.success("Provider deleted");
+              toast.success("Provider removed from organization");
               navigate("/providers");
             },
           },
@@ -350,13 +350,13 @@ The `sso` prop configures actions for the SSO settings tab. This tab manages the
     </tr>
     <tr>
       <td>
-        <code>deleteAction</code>
+        <code>deleteFromOrganizationAction</code>
       </td>
       <td>
         <code>ComponentAction&lt;IdentityProvider&gt;</code>
       </td>
       <td>
-        Delete provider permanently.
+        Remove provider from the organization.
       </td>
     </tr>
     <tr>
@@ -408,19 +408,19 @@ Controls saving changes to provider configuration (client ID, secrets, certifica
 ---
 
 
-**sso.deleteAction**
+**sso.deleteFromOrganizationAction**
 
 **Type:** `ComponentAction<IdentityProvider>`
 
-Controls permanent deletion of the provider from your Auth0 tenant.
+Controls removing the provider from the organization. The provider is deleted from the organization but remains in the tenant.
 
 **Example:**
 
 ```tsx wrap lines
 sso={{
-  deleteAction: {
+  deleteFromOrganizationAction: {
     onBefore: (provider) => {
-      return confirm(`Permanently delete "${provider.display_name}"? This cannot be undone.`);
+      return confirm(`Remove "${provider.display_name}" from this organization?`);
     },
     onAfter: () => navigate("/providers"),
   },
@@ -1080,14 +1080,14 @@ function EditProviderPage() {
               toast.success("Provider configuration saved");
             },
           },
-          deleteAction: {
+          deleteFromOrganizationAction: {
             onBefore: (provider) => {
               return confirm(
-                `Delete "${provider.display_name}"? This cannot be undone.`,
+                `Remove "${provider.display_name}" from this organization?`,
               );
             },
             onAfter: () => {
-              toast.success("Provider deleted");
+              toast.success("Provider removed from organization");
               router.push("/providers");
             },
           },
@@ -1308,13 +1308,13 @@ The `sso` prop configures actions for the SSO settings tab. This tab manages the
     </tr>
     <tr>
       <td>
-        <code>deleteAction</code>
+        <code>deleteFromOrganizationAction</code>
       </td>
       <td>
         <code>ComponentAction&lt;IdentityProvider&gt;</code>
       </td>
       <td>
-        Delete provider permanently.
+        Remove provider from the organization.
       </td>
     </tr>
     <tr>
@@ -1366,19 +1366,19 @@ Controls saving changes to provider configuration (client ID, secrets, certifica
 ---
 
 
-**sso.deleteAction**
+**sso.deleteFromOrganizationAction**
 
 **Type:** `ComponentAction<IdentityProvider>`
 
-Controls permanent deletion of the provider from your Auth0 tenant.
+Controls removing the provider from the organization. The provider is deleted from the organization but remains in the tenant.
 
 **Example:**
 
 ```tsx wrap lines
 sso={{
-  deleteAction: {
+  deleteFromOrganizationAction: {
     onBefore: (provider) => {
-      return confirm(`Permanently delete "${provider.display_name}"? This cannot be undone.`);
+      return confirm(`Remove "${provider.display_name}" from this organization?`);
     },
     onAfter: () => router.push("/providers"),
   },
@@ -2048,14 +2048,14 @@ function EditProviderPage() {
               toast.success("Provider configuration saved");
             },
           },
-          deleteAction: {
+          deleteFromOrganizationAction: {
             onBefore: (provider) => {
               return confirm(
-                `Delete "${provider.display_name}"? This cannot be undone.`,
+                `Remove "${provider.display_name}" from this organization?`,
               );
             },
             onAfter: () => {
-              toast.success("Provider deleted");
+              toast.success("Provider removed from organization");
               navigate("/providers");
             },
           },
@@ -2294,13 +2294,13 @@ The `sso` prop configures actions for the SSO settings tab. This tab manages the
     </tr>
     <tr>
       <td>
-        <code>deleteAction</code>
+        <code>deleteFromOrganizationAction</code>
       </td>
       <td>
         <code>ComponentAction&lt;IdentityProvider&gt;</code>
       </td>
       <td>
-        Delete provider permanently.
+        Remove provider from the organization.
       </td>
     </tr>
     <tr>
@@ -2352,19 +2352,19 @@ Controls saving changes to provider configuration (client ID, secrets, certifica
 ---
 
 
-**sso.deleteAction**
+**sso.deleteFromOrganizationAction**
 
 **Type:** `ComponentAction<IdentityProvider>`
 
-Controls permanent deletion of the provider from your Auth0 tenant.
+Controls removing the provider from the organization. The provider is deleted from the organization but remains in the tenant.
 
 **Example:**
 
 ```tsx wrap lines
 sso={{
-  deleteAction: {
+  deleteFromOrganizationAction: {
     onBefore: (provider) => {
-      return confirm(`Permanently delete "${provider.display_name}"? This cannot be undone.`);
+      return confirm(`Remove "${provider.display_name}" from this organization?`);
     },
     onAfter: () => navigate("/providers"),
   },

--- a/main/docs/get-started/universal-components/web/components/sso-provider-edit.mdx
+++ b/main/docs/get-started/universal-components/web/components/sso-provider-edit.mdx
@@ -104,6 +104,13 @@ function EditProviderPage() {
               toast.success("Provider configuration saved");
             },
           },
+          deleteAction: {
+            onBefore: (provider) => {
+              return confirm(
+                `Permanently delete "${provider.display_name}"? This cannot be undone.`,
+              );
+            },
+          },
           deleteFromOrganizationAction: {
             onBefore: (provider) => {
               return confirm(
@@ -350,24 +357,24 @@ The `sso` prop configures actions for the SSO settings tab. This tab manages the
     </tr>
     <tr>
       <td>
+        <code>deleteAction</code>
+      </td>
+      <td>
+        <code>ComponentAction&lt;IdentityProvider&gt;</code>
+      </td>
+      <td>
+        Permanently delete the provider from the tenant.
+      </td>
+    </tr>
+    <tr>
+      <td>
         <code>deleteFromOrganizationAction</code>
       </td>
       <td>
         <code>ComponentAction&lt;IdentityProvider&gt;</code>
       </td>
       <td>
-        Remove provider from the organization.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>removeFromOrganizationAction</code>
-      </td>
-      <td>
-        <code>ComponentAction&lt;IdentityProvider&gt;</code>
-      </td>
-      <td>
-        Remove from organization.
+        Remove provider from the organization without deleting it from the tenant.
       </td>
     </tr>
   </tbody>
@@ -408,19 +415,19 @@ Controls saving changes to provider configuration (client ID, secrets, certifica
 ---
 
 
-**sso.deleteFromOrganizationAction**
+**sso.deleteAction**
 
 **Type:** `ComponentAction<IdentityProvider>`
 
-Controls removing the provider from the organization. The provider is deleted from the organization but remains in the tenant.
+Controls permanent deletion of the provider from your Auth0 tenant. This action cannot be undone.
 
 **Example:**
 
 ```tsx wrap lines
 sso={{
-  deleteFromOrganizationAction: {
+  deleteAction: {
     onBefore: (provider) => {
-      return confirm(`Remove "${provider.display_name}" from this organization?`);
+      return confirm(`Permanently delete "${provider.display_name}"? This cannot be undone.`);
     },
     onAfter: () => navigate("/providers"),
   },
@@ -430,17 +437,17 @@ sso={{
 ---
 
 
-**sso.removeFromOrganizationAction**
+**sso.deleteFromOrganizationAction**
 
 **Type:** `ComponentAction<IdentityProvider>`
 
-Controls removing the provider from the organization without deleting it. The provider remains available to be re-added later.
+Controls removing the provider from the organization. The provider is detached from the organization but remains in the tenant and can be re-added later.
 
 **Example:**
 
 ```tsx wrap lines
 sso={{
-  removeFromOrganizationAction: {
+  deleteFromOrganizationAction: {
     onBefore: (provider) => {
       return confirm(`Remove "${provider.display_name}" from this organization?`);
     },
@@ -1080,6 +1087,13 @@ function EditProviderPage() {
               toast.success("Provider configuration saved");
             },
           },
+          deleteAction: {
+            onBefore: (provider) => {
+              return confirm(
+                `Permanently delete "${provider.display_name}"? This cannot be undone.`,
+              );
+            },
+          },
           deleteFromOrganizationAction: {
             onBefore: (provider) => {
               return confirm(
@@ -1308,24 +1322,24 @@ The `sso` prop configures actions for the SSO settings tab. This tab manages the
     </tr>
     <tr>
       <td>
+        <code>deleteAction</code>
+      </td>
+      <td>
+        <code>ComponentAction&lt;IdentityProvider&gt;</code>
+      </td>
+      <td>
+        Permanently delete the provider from the tenant.
+      </td>
+    </tr>
+    <tr>
+      <td>
         <code>deleteFromOrganizationAction</code>
       </td>
       <td>
         <code>ComponentAction&lt;IdentityProvider&gt;</code>
       </td>
       <td>
-        Remove provider from the organization.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>removeFromOrganizationAction</code>
-      </td>
-      <td>
-        <code>ComponentAction&lt;IdentityProvider&gt;</code>
-      </td>
-      <td>
-        Remove from organization.
+        Remove provider from the organization without deleting it from the tenant.
       </td>
     </tr>
   </tbody>
@@ -1366,19 +1380,19 @@ Controls saving changes to provider configuration (client ID, secrets, certifica
 ---
 
 
-**sso.deleteFromOrganizationAction**
+**sso.deleteAction**
 
 **Type:** `ComponentAction<IdentityProvider>`
 
-Controls removing the provider from the organization. The provider is deleted from the organization but remains in the tenant.
+Controls permanent deletion of the provider from your Auth0 tenant. This action cannot be undone.
 
 **Example:**
 
 ```tsx wrap lines
 sso={{
-  deleteFromOrganizationAction: {
+  deleteAction: {
     onBefore: (provider) => {
-      return confirm(`Remove "${provider.display_name}" from this organization?`);
+      return confirm(`Permanently delete "${provider.display_name}"? This cannot be undone.`);
     },
     onAfter: () => router.push("/providers"),
   },
@@ -1388,17 +1402,17 @@ sso={{
 ---
 
 
-**sso.removeFromOrganizationAction**
+**sso.deleteFromOrganizationAction**
 
 **Type:** `ComponentAction<IdentityProvider>`
 
-Controls removing the provider from the organization without deleting it. The provider remains available to be re-added later.
+Controls removing the provider from the organization. The provider is detached from the organization but remains in the tenant and can be re-added later.
 
 **Example:**
 
 ```tsx wrap lines
 sso={{
-  removeFromOrganizationAction: {
+  deleteFromOrganizationAction: {
     onBefore: (provider) => {
       return confirm(`Remove "${provider.display_name}" from this organization?`);
     },
@@ -2048,6 +2062,13 @@ function EditProviderPage() {
               toast.success("Provider configuration saved");
             },
           },
+          deleteAction: {
+            onBefore: (provider) => {
+              return confirm(
+                `Permanently delete "${provider.display_name}"? This cannot be undone.`,
+              );
+            },
+          },
           deleteFromOrganizationAction: {
             onBefore: (provider) => {
               return confirm(
@@ -2294,24 +2315,24 @@ The `sso` prop configures actions for the SSO settings tab. This tab manages the
     </tr>
     <tr>
       <td>
+        <code>deleteAction</code>
+      </td>
+      <td>
+        <code>ComponentAction&lt;IdentityProvider&gt;</code>
+      </td>
+      <td>
+        Permanently delete the provider from the tenant.
+      </td>
+    </tr>
+    <tr>
+      <td>
         <code>deleteFromOrganizationAction</code>
       </td>
       <td>
         <code>ComponentAction&lt;IdentityProvider&gt;</code>
       </td>
       <td>
-        Remove provider from the organization.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>removeFromOrganizationAction</code>
-      </td>
-      <td>
-        <code>ComponentAction&lt;IdentityProvider&gt;</code>
-      </td>
-      <td>
-        Remove from organization.
+        Remove provider from the organization without deleting it from the tenant.
       </td>
     </tr>
   </tbody>
@@ -2352,19 +2373,19 @@ Controls saving changes to provider configuration (client ID, secrets, certifica
 ---
 
 
-**sso.deleteFromOrganizationAction**
+**sso.deleteAction**
 
 **Type:** `ComponentAction<IdentityProvider>`
 
-Controls removing the provider from the organization. The provider is deleted from the organization but remains in the tenant.
+Controls permanent deletion of the provider from your Auth0 tenant. This action cannot be undone.
 
 **Example:**
 
 ```tsx wrap lines
 sso={{
-  deleteFromOrganizationAction: {
+  deleteAction: {
     onBefore: (provider) => {
-      return confirm(`Remove "${provider.display_name}" from this organization?`);
+      return confirm(`Permanently delete "${provider.display_name}"? This cannot be undone.`);
     },
     onAfter: () => navigate("/providers"),
   },
@@ -2374,17 +2395,17 @@ sso={{
 ---
 
 
-**sso.removeFromOrganizationAction**
+**sso.deleteFromOrganizationAction**
 
 **Type:** `ComponentAction<IdentityProvider>`
 
-Controls removing the provider from the organization without deleting it. The provider remains available to be re-added later.
+Controls removing the provider from the organization. The provider is detached from the organization but remains in the tenant and can be re-added later.
 
 **Example:**
 
 ```tsx wrap lines
 sso={{
-  removeFromOrganizationAction: {
+  deleteFromOrganizationAction: {
     onBefore: (provider) => {
       return confirm(`Remove "${provider.display_name}" from this organization?`);
     },

--- a/main/docs/get-started/universal-components/web/components/sso-provider-edit.mdx
+++ b/main/docs/get-started/universal-components/web/components/sso-provider-edit.mdx
@@ -78,7 +78,7 @@ export function EditProviderPage() {
 ```
 
 <Accordion title="Full integration example">
-```tsx wrap lines
+```tsx lines
 import React from "react";
 import { SsoProviderEdit } from "@auth0/universal-components-react";
 import { Auth0Provider } from "@auth0/auth0-react";
@@ -946,9 +946,6 @@ Customize appearance with CSS variables and class overrides. Supports theme-awar
 
 - `SsoProviderEdit-header`
 - `SsoProviderEdit-tabs`
-- `SsoProviderEdit-ssoTab`
-- `SsoProviderEdit-provisioningTab`
-- `SsoProviderEdit-domainsTab`
 
 </Accordion>
 
@@ -975,53 +972,6 @@ Customize appearance with CSS variables and class overrides. Supports theme-awar
 
 ## Advanced customization
 
-The `SsoProviderEdit` component is composed of smaller subcomponents and hooks. You can import them individually to build custom provider editing workflows if you use shadcn.
-
-### Available subcomponents
-
-For advanced use cases, you can import individual subcomponents to embed specific tabs or sections in different contexts.
-
-<table class="table">
-  <thead>
-    <tr>
-      <th>Component</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>SsoProviderSsoTab</code>
-      </td>
-      <td>SSO configuration form</td>
-    </tr>
-    <tr>
-      <td>
-        <code>SsoProviderProvisioningTab</code>
-      </td>
-      <td>SCIM provisioning management</td>
-    </tr>
-    <tr>
-      <td>
-        <code>SsoProviderDomainsTab</code>
-      </td>
-      <td>Domain association management</td>
-    </tr>
-    <tr>
-      <td>
-        <code>ProviderConfigureFields</code>
-      </td>
-      <td>Dynamic form fields by strategy</td>
-    </tr>
-    <tr>
-      <td>
-        <code>ScimTokenDisplay</code>
-      </td>
-      <td>SCIM token display with copy functionality</td>
-    </tr>
-  </tbody>
-</table>
-
 ### Available hooks
 
 These hooks provide the underlying logic without any UI. Use them to build completely custom interfaces while leveraging the Auth0 API integration.
@@ -1042,13 +992,7 @@ These hooks provide the underlying logic without any UI. Use them to build compl
     </tr>
     <tr>
       <td>
-        <code>useSsoProviderProvisioning</code>
-      </td>
-      <td>SCIM provisioning management</td>
-    </tr>
-    <tr>
-      <td>
-        <code>useSsoProviderDomains</code>
+        <code>useSsoDomainTab</code>
       </td>
       <td>Domain association management</td>
     </tr>
@@ -1111,7 +1055,7 @@ export function EditProviderPage({ providerId }) {
 ```
 
 <Accordion title="Full integration example">
-```tsx wrap lines
+```tsx lines
 import React from "react";
 import { SsoProviderEdit } from "@auth0/universal-components-react";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -1960,9 +1904,6 @@ Customize appearance with CSS variables and class overrides. Supports theme-awar
 
 - `SsoProviderEdit-header`
 - `SsoProviderEdit-tabs`
-- `SsoProviderEdit-ssoTab`
-- `SsoProviderEdit-provisioningTab`
-- `SsoProviderEdit-domainsTab`
 
 </Accordion>
 
@@ -1989,53 +1930,6 @@ Customize appearance with CSS variables and class overrides. Supports theme-awar
 
 ## Advanced customization
 
-The `SsoProviderEdit` component is composed of smaller subcomponents and hooks. You can import them individually to build custom provider editing workflows.
-
-### Available subcomponents
-
-For advanced use cases, you can import individual subcomponents to embed specific tabs or sections in different contexts.
-
-<table class="table">
-  <thead>
-    <tr>
-      <th>Component</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>SsoProviderSsoTab</code>
-      </td>
-      <td>SSO configuration form</td>
-    </tr>
-    <tr>
-      <td>
-        <code>SsoProviderProvisioningTab</code>
-      </td>
-      <td>SCIM provisioning management</td>
-    </tr>
-    <tr>
-      <td>
-        <code>SsoProviderDomainsTab</code>
-      </td>
-      <td>Domain association management</td>
-    </tr>
-    <tr>
-      <td>
-        <code>ProviderConfigureFields</code>
-      </td>
-      <td>Dynamic form fields by strategy</td>
-    </tr>
-    <tr>
-      <td>
-        <code>ScimTokenDisplay</code>
-      </td>
-      <td>SCIM token display with copy functionality</td>
-    </tr>
-  </tbody>
-</table>
-
 ### Available hooks
 
 These hooks provide the underlying logic without any UI. Use them to build completely custom interfaces while leveraging the Auth0 API integration.
@@ -2056,13 +1950,7 @@ These hooks provide the underlying logic without any UI. Use them to build compl
     </tr>
     <tr>
       <td>
-        <code>useSsoProviderProvisioning</code>
-      </td>
-      <td>SCIM provisioning management</td>
-    </tr>
-    <tr>
-      <td>
-        <code>useSsoProviderDomains</code>
+        <code>useSsoDomainTab</code>
       </td>
       <td>Domain association management</td>
     </tr>
@@ -2134,7 +2022,7 @@ export function EditProviderPage({ providerId }) {
 ```
 
 <Accordion title="Full integration example">
-```tsx wrap lines
+```tsx lines
 import React from "react";
 import { SsoProviderEdit } from "@/components/auth0/my-organization/sso-provider-edit";
 import { Auth0Provider } from "@auth0/auth0-react";
@@ -3002,9 +2890,6 @@ Customize appearance with CSS variables and class overrides. Supports theme-awar
 
 - `SsoProviderEdit-header`
 - `SsoProviderEdit-tabs`
-- `SsoProviderEdit-ssoTab`
-- `SsoProviderEdit-provisioningTab`
-- `SsoProviderEdit-domainsTab`
 
 </Accordion>
 
@@ -3031,47 +2916,6 @@ Customize appearance with CSS variables and class overrides. Supports theme-awar
 
 ## Advanced customization
 
-The `SsoProviderEdit` component is composed of smaller subcomponents and hooks. You can import them individually to build custom SSO provider management workflows if you use shadcn.
-
-### Available subcomponents
-
-For advanced use cases, you can import individual tab components to build custom provider editing interfaces.
-
-<table class="table">
-  <thead>
-    <tr>
-      <th>Component</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>SsoProviderEditTabs</code>
-      </td>
-      <td>Tab container and navigation</td>
-    </tr>
-    <tr>
-      <td>
-        <code>SsoTab</code>
-      </td>
-      <td>SSO settings configuration tab</td>
-    </tr>
-    <tr>
-      <td>
-        <code>ProvisioningTab</code>
-      </td>
-      <td>SCIM provisioning tab</td>
-    </tr>
-    <tr>
-      <td>
-        <code>DomainsTab</code>
-      </td>
-      <td>Domain associations tab</td>
-    </tr>
-  </tbody>
-</table>
-
 ### Available hooks
 
 These hooks provide the underlying logic without any UI. Use them to build completely custom interfaces while leveraging the Auth0 API integration.
@@ -3092,9 +2936,9 @@ These hooks provide the underlying logic without any UI. Use them to build compl
     </tr>
     <tr>
       <td>
-        <code>useSsoProviderEditLogic</code>
+        <code>useSsoDomainTab</code>
       </td>
-      <td>Tab state and action handlers</td>
+      <td>Domain association management</td>
     </tr>
   </tbody>
 </table>

--- a/main/docs/get-started/universal-components/web/components/sso-provider-edit.mdx
+++ b/main/docs/get-started/universal-components/web/components/sso-provider-edit.mdx
@@ -164,7 +164,7 @@ export default function App() {
       }}
       interactiveErrorHandler="popup" // Required to handle step-up auth challenges via Universal Login popup
     >
-      <Auth0ComponentProvider domain={domain}>
+      <Auth0ComponentProvider>
         <EditProviderPage />
       </Auth0ComponentProvider>
     </Auth0Provider>
@@ -2084,13 +2084,30 @@ These hooks provide the underlying logic without any UI. Use them to build compl
 
 ## Installation
 
+Install the component via the shadcn CLI using the GitHub Registry:
+
+```bash wrap lines
+npx shadcn@latest add auth0/auth0-ui-components/react/my-organization/sso-provider-edit
+```
+
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+  The shadcn CLI also installs the `@auth0/universal-components-core`
+  dependency for shared utilities and Auth0 integration.
+  Requires **shadcn CLI v2.5.0+**.
+</Callout>
+
+<details>
+<summary>Legacy Vercel registry (deprecated)</summary>
+
+Existing consumers can continue using the Vercel-hosted path until **December 31, 2026**:
+
 ```bash wrap lines
 npx shadcn@latest add https://auth0-universal-components.vercel.app/r/my-organization/sso-provider-edit.json
 ```
 
-<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-Running the shadcn command also installs the @auth0/universal-components-core dependency for shared utilities and Auth0 integration.
-</Callout>
+New projects should use the GitHub Registry path above.
+
+</details>
 
 ## Get started
 
@@ -2203,7 +2220,7 @@ export default function App() {
       }}
       interactiveErrorHandler="popup" // Required to handle step-up auth challenges via Universal Login popup
     >
-      <Auth0ComponentProvider domain={domain}>
+      <Auth0ComponentProvider>
         <EditProviderPage />
       </Auth0ComponentProvider>
     </Auth0Provider>

--- a/main/docs/get-started/universal-components/web/components/sso-provider-edit.mdx
+++ b/main/docs/get-started/universal-components/web/components/sso-provider-edit.mdx
@@ -1987,7 +1987,7 @@ npx shadcn@latest add auth0/auth0-ui-components/react/my-organization/sso-provid
 <details>
 <summary>Legacy Vercel registry (deprecated)</summary>
 
-Existing consumers can continue using the Vercel-hosted path until **December 31, 2026**:
+Existing consumers can continue using the Vercel-hosted path until **September 17, 2026**:
 
 ```bash wrap lines
 npx shadcn@latest add https://auth0-universal-components.vercel.app/r/my-organization/sso-provider-edit.json

--- a/main/docs/get-started/universal-components/web/components/sso-provider-table.mdx
+++ b/main/docs/get-started/universal-components/web/components/sso-provider-table.mdx
@@ -1367,7 +1367,7 @@ npx shadcn@latest add auth0/auth0-ui-components/react/my-organization/sso-provid
 <details>
 <summary>Legacy Vercel registry (deprecated)</summary>
 
-Existing consumers can continue using the Vercel-hosted path until **December 31, 2026**:
+Existing consumers can continue using the Vercel-hosted path until **September 17, 2026**:
 
 ```bash wrap lines
 npx shadcn@latest add https://auth0-universal-components.vercel.app/r/my-organization/sso-provider-table.json

--- a/main/docs/get-started/universal-components/web/components/sso-provider-table.mdx
+++ b/main/docs/get-started/universal-components/web/components/sso-provider-table.mdx
@@ -156,7 +156,7 @@ export default function App() {
       }}
       interactiveErrorHandler="popup" // Required to handle step-up auth challenges via Universal Login popup
     >
-      <Auth0ComponentProvider domain={domain}>
+      <Auth0ComponentProvider>
         <ProvidersManagementPage />
       </Auth0ComponentProvider>
     </Auth0Provider>
@@ -1458,14 +1458,30 @@ These hooks provide the underlying logic without any UI. Use them to build compl
 
 ## Installation
 
+Install the component via the shadcn CLI using the GitHub Registry:
+
+```bash wrap lines
+npx shadcn@latest add auth0/auth0-ui-components/react/my-organization/sso-provider-table
+```
+
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+  The shadcn CLI also installs the `@auth0/universal-components-core`
+  dependency for shared utilities and Auth0 integration.
+  Requires **shadcn CLI v2.5.0+**.
+</Callout>
+
+<details>
+<summary>Legacy Vercel registry (deprecated)</summary>
+
+Existing consumers can continue using the Vercel-hosted path until **December 31, 2026**:
+
 ```bash wrap lines
 npx shadcn@latest add https://auth0-universal-components.vercel.app/r/my-organization/sso-provider-table.json
 ```
 
-<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-  Running the shadcn command also installs the @auth0/universal-components-core
-  dependency for shared utilities and Auth0 integration.
-</Callout>
+New projects should use the GitHub Registry path above.
+
+</details>
 
 ## Get started
 
@@ -1571,7 +1587,7 @@ export default function App() {
       }}
       interactiveErrorHandler="popup" // Required to handle step-up auth challenges via Universal Login popup
     >
-      <Auth0ComponentProvider domain={domain}>
+      <Auth0ComponentProvider>
         <ProvidersManagementPage />
       </Auth0ComponentProvider>
     </Auth0Provider>

--- a/main/docs/get-started/universal-components/web/components/sso-provider-table.mdx
+++ b/main/docs/get-started/universal-components/web/components/sso-provider-table.mdx
@@ -74,7 +74,7 @@ export function ProvidersPage() {
 ```
 
 <Accordion title="Full integration example">
-```tsx wrap lines
+```tsx lines
 import React from "react";
 import { SsoProviderTable } from "@auth0/universal-components-react";
 import { Auth0Provider } from "@auth0/auth0-react";
@@ -637,9 +637,9 @@ Customize appearance with CSS variables and class overrides. Supports theme-awar
 
 - `SsoProviderTable-header`
 - `SsoProviderTable-table`
-- `SsoProviderTable-row`
-- `SsoProviderTable-deleteModal`
-- `SsoProviderTable-removeModal`
+- `SsoProviderTable-tableActions`
+- `SsoProviderTable-deleteProviderModal`
+- `SsoProviderTable-deleteProviderFromOrganizationModal`
 
 </Accordion>
 
@@ -668,53 +668,6 @@ Customize appearance with CSS variables and class overrides. Supports theme-awar
 
 ## Advanced customization
 
-The `SsoProviderTable` component is composed of smaller subcomponents and hooks. You can import them individually to build custom provider management workflows if you use shadcn.
-
-### Available subcomponents
-
-For advanced use cases, you can import individual subcomponents to build custom provider management interfaces. This is useful when you need to embed the table in a different layout or customize row rendering.
-
-<table class="table">
-  <thead>
-    <tr>
-      <th>Component</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>ProviderRow</code>
-      </td>
-      <td>Individual provider row with actions</td>
-    </tr>
-    <tr>
-      <td>
-        <code>ProviderDeleteModal</code>
-      </td>
-      <td>Confirmation modal for permanent deletion</td>
-    </tr>
-    <tr>
-      <td>
-        <code>ProviderRemoveModal</code>
-      </td>
-      <td>Confirmation modal for organization removal</td>
-    </tr>
-    <tr>
-      <td>
-        <code>ProviderStatusToggle</code>
-      </td>
-      <td>Enable/disable toggle component</td>
-    </tr>
-    <tr>
-      <td>
-        <code>ProviderStrategyIcon</code>
-      </td>
-      <td>Strategy icon renderer (Okta, SAML, etc.)</td>
-    </tr>
-  </tbody>
-</table>
-
 ### Available hooks
 
 These hooks provide the underlying logic without any UI. Use them to build completely custom interfaces while leveraging the Auth0 API integration.
@@ -732,12 +685,6 @@ These hooks provide the underlying logic without any UI. Use them to build compl
         <code>useSsoProviderTable</code>
       </td>
       <td>Provider list fetching and management</td>
-    </tr>
-    <tr>
-      <td>
-        <code>useSsoProviderTableLogic</code>
-      </td>
-      <td>UI interaction state + handlers (modals, actions)</td>
     </tr>
   </tbody>
 </table>
@@ -795,7 +742,7 @@ export function ProvidersPage() {
 ```
 
 <Accordion title="Full integration example">
-```tsx wrap lines
+```tsx lines
 import React from "react";
 import { SsoProviderTable } from "@auth0/universal-components-react";
 import { useRouter } from "next/navigation";
@@ -1338,9 +1285,9 @@ Customize appearance with CSS variables and class overrides. Supports theme-awar
 
 - `SsoProviderTable-header`
 - `SsoProviderTable-table`
-- `SsoProviderTable-row`
-- `SsoProviderTable-deleteModal`
-- `SsoProviderTable-removeModal`
+- `SsoProviderTable-tableActions`
+- `SsoProviderTable-deleteProviderModal`
+- `SsoProviderTable-deleteProviderFromOrganizationModal`
 
 </Accordion>
 
@@ -1369,53 +1316,6 @@ Customize appearance with CSS variables and class overrides. Supports theme-awar
 
 ## Advanced customization
 
-The `SsoProviderTable` component is composed of smaller subcomponents and hooks. You can import them individually to build custom provider management workflows.
-
-### Available subcomponents
-
-For advanced use cases, you can import individual subcomponents to build custom provider management interfaces. This is useful when you need to embed the table in a different layout or customize row rendering.
-
-<table class="table">
-  <thead>
-    <tr>
-      <th>Component</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>ProviderRow</code>
-      </td>
-      <td>Individual provider row with actions</td>
-    </tr>
-    <tr>
-      <td>
-        <code>ProviderDeleteModal</code>
-      </td>
-      <td>Confirmation modal for permanent deletion</td>
-    </tr>
-    <tr>
-      <td>
-        <code>ProviderRemoveModal</code>
-      </td>
-      <td>Confirmation modal for organization removal</td>
-    </tr>
-    <tr>
-      <td>
-        <code>ProviderStatusToggle</code>
-      </td>
-      <td>Enable/disable toggle component</td>
-    </tr>
-    <tr>
-      <td>
-        <code>ProviderStrategyIcon</code>
-      </td>
-      <td>Strategy icon renderer (Okta, SAML, etc.)</td>
-    </tr>
-  </tbody>
-</table>
-
 ### Available hooks
 
 These hooks provide the underlying logic without any UI. Use them to build completely custom interfaces while leveraging the Auth0 API integration.
@@ -1433,12 +1333,6 @@ These hooks provide the underlying logic without any UI. Use them to build compl
         <code>useSsoProviderTable</code>
       </td>
       <td>Provider list fetching and management</td>
-    </tr>
-    <tr>
-      <td>
-        <code>useSsoProviderTableLogic</code>
-      </td>
-      <td>UI interaction state + handlers (modals, actions)</td>
     </tr>
   </tbody>
 </table>
@@ -1505,7 +1399,7 @@ export function ProvidersPage() {
 ```
 
 <Accordion title="Full integration example">
-```tsx wrap lines
+```tsx lines
 import React from "react";
 import { SsoProviderTable } from "@/components/auth0/my-organization/sso-provider-table";
 import { Auth0Provider } from "@auth0/auth0-react";
@@ -2068,9 +1962,9 @@ Customize appearance with CSS variables and class overrides. Supports theme-awar
 
 - `SsoProviderTable-header`
 - `SsoProviderTable-table`
-- `SsoProviderTable-row`
-- `SsoProviderTable-deleteModal`
-- `SsoProviderTable-removeModal`
+- `SsoProviderTable-tableActions`
+- `SsoProviderTable-deleteProviderModal`
+- `SsoProviderTable-deleteProviderFromOrganizationModal`
 
 </Accordion>
 
@@ -2099,53 +1993,6 @@ Customize appearance with CSS variables and class overrides. Supports theme-awar
 
 ## Advanced customization
 
-The `SsoProviderTable` component is composed of smaller subcomponents and hooks. You can import them individually to build custom provider management workflows if you use shadcn.
-
-### Available subcomponents
-
-For advanced use cases, you can import individual subcomponents to build custom provider management interfaces. This is useful when you need to embed the table in a different layout or customize row rendering.
-
-<table class="table">
-  <thead>
-    <tr>
-      <th>Component</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>ProviderRow</code>
-      </td>
-      <td>Individual provider row with actions</td>
-    </tr>
-    <tr>
-      <td>
-        <code>ProviderDeleteModal</code>
-      </td>
-      <td>Confirmation modal for permanent deletion</td>
-    </tr>
-    <tr>
-      <td>
-        <code>ProviderRemoveModal</code>
-      </td>
-      <td>Confirmation modal for organization removal</td>
-    </tr>
-    <tr>
-      <td>
-        <code>ProviderStatusToggle</code>
-      </td>
-      <td>Enable/disable toggle component</td>
-    </tr>
-    <tr>
-      <td>
-        <code>ProviderStrategyIcon</code>
-      </td>
-      <td>Strategy icon renderer (Okta, SAML, etc.)</td>
-    </tr>
-  </tbody>
-</table>
-
 ### Available hooks
 
 These hooks provide the underlying logic without any UI. Use them to build completely custom interfaces while leveraging the Auth0 API integration.
@@ -2163,12 +2010,6 @@ These hooks provide the underlying logic without any UI. Use them to build compl
         <code>useSsoProviderTable</code>
       </td>
       <td>Provider list fetching and management</td>
-    </tr>
-    <tr>
-      <td>
-        <code>useSsoProviderTableLogic</code>
-      </td>
-      <td>UI interaction state + handlers (modals, actions)</td>
     </tr>
   </tbody>
 </table>

--- a/main/docs/get-started/universal-components/web/components/user-mfa-management.mdx
+++ b/main/docs/get-started/universal-components/web/components/user-mfa-management.mdx
@@ -292,7 +292,7 @@ The install command adds the component source into `src/components/auth0/my-acco
 <details>
 <summary>Legacy Vercel registry (deprecated)</summary>
 
-Existing consumers can continue using the Vercel-hosted path until **December 31, 2026**:
+Existing consumers can continue using the Vercel-hosted path until **September 17, 2026**:
 
 ```bash wrap lines
 npx shadcn@latest add https://auth0-universal-components.vercel.app/r/my-account/user-mfa-management.json

--- a/main/docs/get-started/universal-components/web/components/user-mfa-management.mdx
+++ b/main/docs/get-started/universal-components/web/components/user-mfa-management.mdx
@@ -158,7 +158,7 @@ export default function App() {
       authorizationParams={{ redirect_uri: window.location.origin }}
       interactiveErrorHandler="popup"
     >
-      <Auth0ComponentProvider domain={domain}>
+      <Auth0ComponentProvider>
         <SecurityPage />
       </Auth0ComponentProvider>
     </Auth0Provider>
@@ -282,12 +282,25 @@ Configure the My Account API User-delegated Access permissions in [Build Account
 ## Install the component
 
 ```bash wrap lines
-npx shadcn@latest add https://auth0-universal-components.vercel.app/r/my-account/user-mfa-management.json
+npx shadcn@latest add auth0/auth0-ui-components/react/my-account/user-mfa-management
 ```
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 The install command adds the component source into `src/components/auth0/my-account/` along with all UI dependencies and the `@auth0/universal-components-core` dependency for shared utilities and Auth0 integration.
 </Callout>
+
+<details>
+<summary>Legacy Vercel registry (deprecated)</summary>
+
+Existing consumers can continue using the Vercel-hosted path until **December 31, 2026**:
+
+```bash wrap lines
+npx shadcn@latest add https://auth0-universal-components.vercel.app/r/my-account/user-mfa-management.json
+```
+
+New projects should use the GitHub Registry path above.
+
+</details>
 
 ## Get started
 
@@ -356,7 +369,7 @@ export default function App() {
       authorizationParams={{ redirect_uri: window.location.origin }}
       interactiveErrorHandler="popup"
     >
-      <Auth0ComponentProvider domain={domain}>
+      <Auth0ComponentProvider>
         <SecurityPage />
       </Auth0ComponentProvider>
     </Auth0Provider>

--- a/main/docs/get-started/universal-components/web/components/user-passkey-management.mdx
+++ b/main/docs/get-started/universal-components/web/components/user-passkey-management.mdx
@@ -133,7 +133,7 @@ export default function App() {
       authorizationParams={{ redirect_uri: window.location.origin }}
       interactiveErrorHandler="popup"
     >
-      <Auth0ComponentProvider domain={domain}>
+      <Auth0ComponentProvider>
         <SecurityPage />
       </Auth0ComponentProvider>
     </Auth0Provider>
@@ -221,12 +221,25 @@ export default function PasskeysPage() {
 ## Install the component
 
 ```bash wrap lines
-npx shadcn@latest add https://auth0-universal-components.vercel.app/r/my-account/user-passkey-management.json
+npx shadcn@latest add auth0/auth0-ui-components/react/my-account/user-passkey-management
 ```
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 The install command adds the component source into `src/components/auth0/my-account/` along with all UI dependencies and the `@auth0/universal-components-core` dependency for shared utilities and Auth0 integration.
 </Callout>
+
+<details>
+<summary>Legacy Vercel registry (deprecated)</summary>
+
+Existing consumers can continue using the Vercel-hosted path until **December 31, 2026**:
+
+```bash wrap lines
+npx shadcn@latest add https://auth0-universal-components.vercel.app/r/my-account/user-passkey-management.json
+```
+
+New projects should use the GitHub Registry path above.
+
+</details>
 
 ## Get started
 
@@ -290,7 +303,7 @@ export default function App() {
       authorizationParams={{ redirect_uri: window.location.origin }}
       interactiveErrorHandler="popup"
     >
-      <Auth0ComponentProvider domain={domain}>
+      <Auth0ComponentProvider>
         <SecurityPage />
       </Auth0ComponentProvider>
     </Auth0Provider>

--- a/main/docs/get-started/universal-components/web/components/user-passkey-management.mdx
+++ b/main/docs/get-started/universal-components/web/components/user-passkey-management.mdx
@@ -231,7 +231,7 @@ The install command adds the component source into `src/components/auth0/my-acco
 <details>
 <summary>Legacy Vercel registry (deprecated)</summary>
 
-Existing consumers can continue using the Vercel-hosted path until **December 31, 2026**:
+Existing consumers can continue using the Vercel-hosted path until **September 17, 2026**:
 
 ```bash wrap lines
 npx shadcn@latest add https://auth0-universal-components.vercel.app/r/my-account/user-passkey-management.json

--- a/main/docs/get-started/universal-components/web/web-overview.mdx
+++ b/main/docs/get-started/universal-components/web/web-overview.mdx
@@ -65,7 +65,7 @@ function App() {
       }}
       interactiveErrorHandler='popup' // Required to handle step-up auth challenges via Universal Login popup
     >
-      <Auth0ComponentProvider domain={domain}>
+      <Auth0ComponentProvider>
         {/* Your app components */}
       </Auth0ComponentProvider>
     </Auth0Provider>
@@ -235,16 +235,23 @@ Universal Components use `@/...` imports. Start by configuring the path alias an
 npx shadcn@latest init
 ```
 
-Next, install Universal Components individually via the Shadcn CLI. For example:
+Next, install Universal Components individually via the shadcn CLI using the GitHub Registry:
 
 ```bash wrap lines
-npx shadcn@latest add @auth0/organization-details-edit
+npx shadcn@latest add auth0/auth0-ui-components/react/my-organization/organization-details-edit
 ```
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-  Shadcn CLI installs the component source code and the
+  The shadcn CLI installs the component source code and the
   `@auth0/universal-components-core` dependency for shared utilities and Auth0
-  integration.
+  integration. Requires **shadcn CLI v2.5.0+** (GitHub Registry support).
+</Callout>
+
+<Callout icon="clock" color="#f59e0b" iconType="regular">
+  **Legacy Vercel registry**: Existing consumers using the Vercel-hosted path
+  (`https://auth0-universal-components.vercel.app/r/...`) do not need to migrate
+  immediately. The Vercel registry remains available until **December 31, 2026**.
+  New projects should use the GitHub Registry path above.
 </Callout>
 
 ## Configure your application
@@ -267,7 +274,7 @@ function App() {
       }}
       interactiveErrorHandler='popup' // Required to handle step-up auth challenges via Universal Login popup
     >
-      <Auth0ComponentProvider domain={domain}>
+      <Auth0ComponentProvider>
         {/* Your app components */}
       </Auth0ComponentProvider>
     </Auth0Provider>

--- a/main/docs/get-started/universal-components/web/web-overview.mdx
+++ b/main/docs/get-started/universal-components/web/web-overview.mdx
@@ -250,7 +250,7 @@ npx shadcn@latest add auth0/auth0-ui-components/react/my-organization/organizati
 <Callout icon="clock" color="#f59e0b" iconType="regular">
   **Legacy Vercel registry**: Existing consumers using the Vercel-hosted path
   (`https://auth0-universal-components.vercel.app/r/...`) do not need to migrate
-  immediately. The Vercel registry remains available until **December 31, 2026**.
+  immediately. The Vercel registry remains available until **September 17, 2026**.
   New projects should use the GitHub Registry path above.
 </Callout>
 


### PR DESCRIPTION
### Summary

Updates Universal Components documentation to reflect the GitHub Registry migration and fix inaccuracies:

- Update shadcn install commands to use GitHub Registry — replaces the old Vercel-hosted registry path with the correct auth0/auth0-ui-components/react/... format, adds a legacy registry deprecation note, and notes the shadcn CLI v2.5.0+ requirement.
- Remove domain prop from Auth0ComponentProvider in direct SPA examples — the prop is only required for mode="proxy"; in direct mode the domain is already supplied to Auth0Provider.
- Replace "Select Save" with "Select Grant Access" in My Account setup instructions (iOS & Android) to match the first-time Dashboard experience.

### References

- [UIC-1328](https://auth0team.atlassian.net/browse/UIC-1328)
- [UIC-1348](https://auth0team.atlassian.net/browse/UIC-1348)
- [UIC-1349](https://auth0team.atlassian.net/browse/UIC-1349)
- [UIC-1370](https://auth0team.atlassian.net/browse/UIC-1370)
- [UIC-1369](https://auth0team.atlassian.net/browse/UIC-1369)

Testing

- Verified all shadcn install commands use the GitHub Registry path
- Verified no remaining domain={domain} in direct-mode Auth0ComponentProvider usage
- Confirmed proxy-mode examples in auth0-component-provider.mdx were not affected

Checklist

-  I've read and followed [CONTRIBUTING.md](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
-  I've tested the site build for this change locally.
-  I've made appropriate docs updates for any code or config changes.
-  I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
