### PR TITLE
fix: remove org name from organization member event schema and examples

### DIFF
--- a/main/docs/oas/events/events-schema.json
+++ b/main/docs/oas/events/events-schema.json
@@ -4699,14 +4699,6 @@
                     "description": "The organization the member belongs to.",
                     "type": "object",
                     "properties": {
-                      "name": {
-                        "description": "The human-readable identifier for the organization that will be used by end-users to direct them to their organization in your application..",
-                        "type": "string",
-                        "examples": [
-                          "my-organization"
-                        ],
-                        "pattern": "^(?:(?!org_))[a-z0-9]([a-z0-9-_]*[a-z0-9])?$"
-                      },
                       "id": {
                         "description": "ID of the organization.",
                         "type": "string",
@@ -4993,7 +4985,6 @@
           "data": {
             "object": {
               "organization": {
-                "name": "my-organization",
                 "id": "org_1234567890abcdef"
               },
               "user": {
@@ -5090,14 +5081,6 @@
                     "description": "The organization the member belongs to.",
                     "type": "object",
                     "properties": {
-                      "name": {
-                        "description": "The human-readable identifier for the organization that will be used by end-users to direct them to their organization in your application..",
-                        "type": "string",
-                        "examples": [
-                          "my-organization"
-                        ],
-                        "pattern": "^(?:(?!org_))[a-z0-9]([a-z0-9-_]*[a-z0-9])?$"
-                      },
                       "id": {
                         "description": "ID of the organization.",
                         "type": "string",
@@ -5384,7 +5367,6 @@
           "data": {
             "object": {
               "organization": {
-                "name": "my-organization",
                 "id": "org_1234567890abcdef"
               },
               "user": {


### PR DESCRIPTION
## Description

fix: remove org name from organization member event schema and examples

### References

https://auth0team.atlassian.net/jira/servicedesk/projects/DR/queues/custom/99/DR-2830
https://auth0team.atlassian.net/jira/servicedesk/projects/ESD/queues/custom/314/ESD-64947

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [x ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ x] I've tested the site build for this change locally.
- [ x] I've made appropriate docs updates for any code or config changes.
- [ x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
