### PR TITLE
Fix/ss log app metadata user metadata clarification

### DIFF
--- a/main/docs/oas/tenant-logs/logs-schema.json
+++ b/main/docs/oas/tenant-logs/logs-schema.json
@@ -33495,7 +33495,8 @@
               "body": {
                 "properties": {
                   "app_metadata": {
-                    "type": "object"
+                    "type": "object",
+                    "description": "App metadata included directly in the signup request body by the calling client. This field is not populated from metadata set by pre-registration Actions; app_metadata applied by Actions is written to the user record but does not appear in the log body."
                   },
                   "blocked": {
                     "type": "boolean"
@@ -33655,6 +33656,7 @@
                     "type": "string"
                   },
                   "user_metadata": {
+                    "description": "User metadata included directly in the signup request body by the calling client. This field is not populated from metadata set by pre-registration Actions and does not reflect the final user record.",
                     "anyOf": [
                       {
                         "type": "string"


### PR DESCRIPTION
## Description

  Clarifies when `app_metadata` and `user_metadata` appear in the `ss` (Successful Signup) tenant log schema.

  The schema listed both fields without explaining that `details.body` reflects the raw signup request payload — not the final user
  record. Customers using pre-registration Actions to set `app_metadata` or `user_metadata` expected to see those values in the log,
  but they were absent because Action-applied metadata is written to the user record only, and never echoed back into the log body.
  
  Added descriptions to both fields clarifying:
  - Fields only populate when included directly in the signup request body by the calling client
  - `app_metadata` set by pre-registration Actions is applied to the user record but does not appear in the log
  - Neither field reflects the final user record state

### References

https://auth0team.atlassian.net/browse/ESD-65342
https://auth0team.atlassian.net/jira/servicedesk/projects/DR/queues/custom/98/DR-2834

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [ x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ x] I've tested the site build for this change locally.
- [ x] I've made appropriate docs updates for any code or config changes.
- [ x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
