### PR TITLE
chore: CODEOWNERS for generated/non-generated content

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,20 +13,18 @@ snippets/**/*.jsx     @auth0/project-docs-management-codeowner
 **/CLAUDE.md          @auth0/project-docs-management-codeowner
 
 # Docs Management ownership for generated API & Schema references
-main/docs/api           @auth0/project-docs-management-codeowner
-main/docs/fr-ca/api     @auth0/project-docs-management-codeowner
-main/docs/ja-jp/api     @auth0/project-docs-management-codeowner
-main/docs/oas           @auth0/project-docs-management-codeowner
-main/docs/events        @auth0/project-docs-management-codeowner
-main/docs/fr-ca/events  @auth0/project-docs-management-codeowner
-main/docs/ja-jp/events  @auth0/project-docs-management-codeowner
-main/docs/tenant-logs        @auth0/project-docs-management-codeowner
-main/docs/fr-ca/tenant-logs  @auth0/project-docs-management-codeowner
-main/docs/ja-jp/tenant-logs  @auth0/project-docs-management-codeowner
-main/docs/actions/reference        @auth0/project-docs-management-codeowner
-main/docs/fr-ca/actions/reference  @auth0/project-docs-management-codeowner
-main/docs/ja-jp/actions/reference  @auth0/project-docs-management-codeowner
-main/config/navigation/generated   @auth0/project-docs-management-codeowner
+/main/docs/api/management         @auth0/project-docs-management-codeowner
+/main/docs/api/myaccount          @auth0/project-docs-management-codeowner
+/main/docs/api/organization       @auth0/project-docs-management-codeowner
+/main/docs/oas                    @auth0/project-docs-management-codeowner
+/main/docs/events                 @auth0/project-docs-management-codeowner
+/main/docs/tenant-logs            @auth0/project-docs-management-codeowner
+/main/docs/actions/reference      @auth0/project-docs-management-codeowner
+/main/config/navigation/generated @auth0/project-docs-management-codeowner
+
+# Translations will be generated; for now, share ownership
+/main/docs/fr-ca @auth0/project-docs-writers-codeowner @auth0/project-docs-management-codeowner
+/main/docs/ja-jp @auth0/project-docs-writers-codeowner @auth0/project-docs-management-codeowner
 
 # Shared ownership for shared config files
 .github         @auth0/project-docs-writers-codeowner @auth0/project-docs-management-codeowner


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

* specifies only generated API docs files for docs management codeowners, removing authentication api and manual landing pages
* changes translations to shared ownership ahead of GT automation

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

### References

https://auth0.slack.com/archives/C09UBR8CWRL/p1786036779252639?thread_ts=1786035723.319859&cid=C09UBR8CWRL

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
