### PR TITLE
feat: add SPA JS SDK reference artifact

### DIFF
--- a/main/.mintignore
+++ b/main/.mintignore
@@ -1,1 +1,4 @@
 _metadata.json
+
+# TypeDoc JSON consumed by Mintlify's SDK reference generator.
+sdk-artifacts/

--- a/main/config/nav.en.json
+++ b/main/config/nav.en.json
@@ -82,6 +82,15 @@
           "$ref": "./navigation/universal-components.json"
         }
       ]
+    },
+    {
+      "tab": "SDK Reference",
+      "icon": "book",
+      "sdk": {
+        "format": "typedoc",
+        "source": "sdk-artifacts/auth0-spa-js.json",
+        "directory": "docs/sdk/typescript"
+      }
     }
   ]
 }

--- a/main/sdk-artifacts/auth0-spa-js.json
+++ b/main/sdk-artifacts/auth0-spa-js.json
@@ -1,0 +1,3720 @@
+{
+	"id": 0,
+	"name": "@auth0/auth0-spa-js",
+	"variant": "project",
+	"kind": 1,
+	"flags": {},
+	"children": [
+		{
+			"id": 1,
+			"name": "Auth0Client",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Auth0 SDK for Single Page Applications using [Authorization Code Grant Flow with PKCE](https://auth0.com/docs/api-auth/tutorials/authorization-code-grant-pkce)."
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 25,
+					"name": "myAccount",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true,
+						"isReadonly": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 163,
+							"character": 18,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L163"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": {
+							"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+							"qualifiedName": "MyAccountApiClient"
+						},
+						"name": "MyAccountApiClient",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 26,
+					"name": "mfa",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true,
+						"isReadonly": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "MFA API client for multi-factor authentication operations.\n\nProvides methods for:\n- Listing enrolled authenticators\n- Enrolling new authenticators (OTP, SMS, Voice, Push, Email)\n- Initiating MFA challenges\n- Verifying MFA challenges"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 174,
+							"character": 18,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L174"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": {
+							"sourceFileName": "src/mfa/MfaApiClient.ts",
+							"qualifiedName": "MfaApiClient"
+						},
+						"name": "MfaApiClient",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 27,
+					"name": "passkey",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true,
+						"isReadonly": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Passkey API client for passwordless authentication.\n\nProvides two single-call methods that handle the full WebAuthn flow internally:\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`signup(options)`"
+							},
+							{
+								"kind": "text",
+								"text": " — register a new user with a passkey\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`login(options?)`"
+							},
+							{
+								"kind": "text",
+								"text": " — authenticate an existing user with a passkey"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 183,
+							"character": 18,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L183"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": {
+							"sourceFileName": "src/passkey/PasskeyApiClient.ts",
+							"qualifiedName": "PasskeyApiClient"
+						},
+						"name": "PasskeyApiClient",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 2,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 220,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L220"
+						}
+					],
+					"signatures": [
+						{
+							"id": 3,
+							"name": "new Auth0Client",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 220,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L220"
+								}
+							],
+							"parameters": [
+								{
+									"id": 4,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reference",
+										"target": {
+											"sourceFileName": "src/global.ts",
+											"qualifiedName": "Auth0ClientOptions"
+										},
+										"name": "Auth0ClientOptions",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 1,
+								"name": "Auth0Client",
+								"package": "@auth0/auth0-spa-js"
+							}
+						}
+					]
+				},
+				{
+					"id": 34,
+					"name": "getConfiguration",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 382,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L382"
+						}
+					],
+					"signatures": [
+						{
+							"id": 35,
+							"name": "getConfiguration",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Returns a readonly copy of the initialization configuration."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "An object containing domain and clientId"
+											}
+										]
+									},
+									{
+										"tag": "@example",
+										"content": [
+											{
+												"kind": "code",
+												"text": "```typescript\nconst auth0 = new Auth0Client({\n  domain: 'tenant.auth0.com',\n  clientId: 'abc123'\n});\n\nconst config = auth0.getConfiguration();\n// { domain: 'tenant.auth0.com', clientId: 'abc123' }\n```"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 382,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L382"
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Readonly"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": {
+											"sourceFileName": "src/global.ts",
+											"qualifiedName": "ClientConfiguration"
+										},
+										"name": "ClientConfiguration",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Readonly",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 81,
+					"name": "loginWithPopup",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 556,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L556"
+						}
+					],
+					"signatures": [
+						{
+							"id": 82,
+							"name": "loginWithPopup",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "code",
+										"text": "```js\ntry {\n await auth0.loginWithPopup(options);\n} catch(e) {\n if (e instanceof PopupCancelledError) {\n   // Popup was closed before login completed\n }\n}\n```"
+									},
+									{
+										"kind": "text",
+										"text": "\n\nOpens a popup with the "
+									},
+									{
+										"kind": "code",
+										"text": "`/authorize`"
+									},
+									{
+										"kind": "text",
+										"text": " URL using the parameters\nprovided as arguments. Random and secure "
+									},
+									{
+										"kind": "code",
+										"text": "`state`"
+									},
+									{
+										"kind": "text",
+										"text": " and "
+									},
+									{
+										"kind": "code",
+										"text": "`nonce`"
+									},
+									{
+										"kind": "text",
+										"text": "\nparameters will be auto-generated. If the response is successful,\nresults will be valid according to their expiration times.\n\nIMPORTANT: This method has to be called from an event handler\nthat was started by the user like a button click, for example,\notherwise the popup will be blocked in most browsers."
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 556,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L556"
+								}
+							],
+							"parameters": [
+								{
+									"id": 83,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {
+										"isOptional": true
+									},
+									"type": {
+										"type": "reference",
+										"target": {
+											"sourceFileName": "src/global.ts",
+											"qualifiedName": "PopupLoginOptions"
+										},
+										"name": "PopupLoginOptions",
+										"package": "@auth0/auth0-spa-js"
+									}
+								},
+								{
+									"id": 84,
+									"name": "config",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {
+										"isOptional": true
+									},
+									"type": {
+										"type": "reference",
+										"target": {
+											"sourceFileName": "src/global.ts",
+											"qualifiedName": "PopupConfigOptions"
+										},
+										"name": "PopupConfigOptions",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "intrinsic",
+										"name": "void"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 85,
+					"name": "getUser",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 626,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L626"
+						}
+					],
+					"signatures": [
+						{
+							"id": 86,
+							"name": "getUser",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "code",
+										"text": "```js\nconst user = await auth0.getUser();\n```"
+									},
+									{
+										"kind": "text",
+										"text": "\n\nReturns the user information if available (decoded\nfrom the "
+									},
+									{
+										"kind": "code",
+										"text": "`id_token`"
+									},
+									{
+										"kind": "text",
+										"text": ")."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@typeparam",
+										"content": [
+											{
+												"kind": "text",
+												"text": "TUser The type to return, has to extend "
+											},
+											{
+												"kind": "inline-tag",
+												"tag": "@link",
+												"text": "User",
+												"target": {
+													"sourceFileName": "src/global.ts",
+													"qualifiedName": "User"
+												},
+												"tsLinkText": ""
+											},
+											{
+												"kind": "text",
+												"text": "."
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 626,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L626"
+								}
+							],
+							"typeParameter": [
+								{
+									"id": 87,
+									"name": "TUser",
+									"variant": "typeParam",
+									"kind": 131072,
+									"flags": {},
+									"type": {
+										"type": "reference",
+										"target": {
+											"sourceFileName": "src/global.ts",
+											"qualifiedName": "User"
+										},
+										"typeArguments": [
+											{
+												"type": "reference",
+												"target": 87,
+												"name": "TUser",
+												"package": "@auth0/auth0-spa-js",
+												"refersToTypeParameter": true
+											}
+										],
+										"name": "User",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "union",
+										"types": [
+											{
+												"type": "intrinsic",
+												"name": "undefined"
+											},
+											{
+												"type": "reference",
+												"target": 87,
+												"name": "TUser",
+												"package": "@auth0/auth0-spa-js",
+												"refersToTypeParameter": true
+											}
+										]
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 88,
+					"name": "getIdTokenClaims",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 643,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L643"
+						}
+					],
+					"signatures": [
+						{
+							"id": 89,
+							"name": "getIdTokenClaims",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "code",
+										"text": "```js\nconst claims = await auth0.getIdTokenClaims();\n```"
+									},
+									{
+										"kind": "text",
+										"text": "\n\nReturns all claims from the id_token if available."
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 643,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L643"
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "union",
+										"types": [
+											{
+												"type": "intrinsic",
+												"name": "undefined"
+											},
+											{
+												"type": "reference",
+												"target": {
+													"sourceFileName": "src/global.ts",
+													"qualifiedName": "IdToken"
+												},
+												"name": "IdToken",
+												"package": "@auth0/auth0-spa-js"
+											}
+										]
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 90,
+					"name": "loginWithRedirect",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 664,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L664"
+						}
+					],
+					"signatures": [
+						{
+							"id": 91,
+							"name": "loginWithRedirect",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "code",
+										"text": "```js\nawait auth0.loginWithRedirect(options);\n```"
+									},
+									{
+										"kind": "text",
+										"text": "\n\nPerforms a redirect to "
+									},
+									{
+										"kind": "code",
+										"text": "`/authorize`"
+									},
+									{
+										"kind": "text",
+										"text": " using the parameters\nprovided as arguments. Random and secure "
+									},
+									{
+										"kind": "code",
+										"text": "`state`"
+									},
+									{
+										"kind": "text",
+										"text": " and "
+									},
+									{
+										"kind": "code",
+										"text": "`nonce`"
+									},
+									{
+										"kind": "text",
+										"text": "\nparameters will be auto-generated."
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 664,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L664"
+								}
+							],
+							"typeParameter": [
+								{
+									"id": 92,
+									"name": "TAppState",
+									"variant": "typeParam",
+									"kind": 131072,
+									"flags": {},
+									"default": {
+										"type": "intrinsic",
+										"name": "any"
+									}
+								}
+							],
+							"parameters": [
+								{
+									"id": 93,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reference",
+										"target": {
+											"sourceFileName": "src/global.ts",
+											"qualifiedName": "RedirectLoginOptions"
+										},
+										"typeArguments": [
+											{
+												"type": "reference",
+												"target": 92,
+												"name": "TAppState",
+												"package": "@auth0/auth0-spa-js",
+												"refersToTypeParameter": true
+											}
+										],
+										"name": "RedirectLoginOptions",
+										"package": "@auth0/auth0-spa-js"
+									},
+									"defaultValue": "{}"
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "intrinsic",
+										"name": "void"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 94,
+					"name": "handleRedirectCallback",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 702,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L702"
+						}
+					],
+					"signatures": [
+						{
+							"id": 95,
+							"name": "handleRedirectCallback",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "After the browser redirects back to the callback page,\ncall "
+									},
+									{
+										"kind": "code",
+										"text": "`handleRedirectCallback`"
+									},
+									{
+										"kind": "text",
+										"text": " to handle success and error\nresponses from Auth0. If the response is successful, results\nwill be valid according to their expiration times."
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 702,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L702"
+								}
+							],
+							"typeParameter": [
+								{
+									"id": 96,
+									"name": "TAppState",
+									"variant": "typeParam",
+									"kind": 131072,
+									"flags": {},
+									"default": {
+										"type": "intrinsic",
+										"name": "any"
+									}
+								}
+							],
+							"parameters": [
+								{
+									"id": 97,
+									"name": "url",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									},
+									"defaultValue": "window.location.href"
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "union",
+										"types": [
+											{
+												"type": "reference",
+												"target": {
+													"sourceFileName": "src/global.ts",
+													"qualifiedName": "RedirectLoginResult"
+												},
+												"typeArguments": [
+													{
+														"type": "reference",
+														"target": 96,
+														"name": "TAppState",
+														"package": "@auth0/auth0-spa-js",
+														"refersToTypeParameter": true
+													}
+												],
+												"name": "RedirectLoginResult",
+												"package": "@auth0/auth0-spa-js"
+											},
+											{
+												"type": "reference",
+												"target": {
+													"sourceFileName": "src/global.ts",
+													"qualifiedName": "ConnectAccountRedirectResult"
+												},
+												"typeArguments": [
+													{
+														"type": "reference",
+														"target": 96,
+														"name": "TAppState",
+														"package": "@auth0/auth0-spa-js",
+														"refersToTypeParameter": true
+													}
+												],
+												"name": "ConnectAccountRedirectResult",
+												"package": "@auth0/auth0-spa-js"
+											}
+										]
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 108,
+					"name": "checkSession",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 874,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L874"
+						}
+					],
+					"signatures": [
+						{
+							"id": 109,
+							"name": "checkSession",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "code",
+										"text": "```js\nawait auth0.checkSession();\n```"
+									},
+									{
+										"kind": "text",
+										"text": "\n\nCheck if the user is logged in using "
+									},
+									{
+										"kind": "code",
+										"text": "`getTokenSilently`"
+									},
+									{
+										"kind": "text",
+										"text": ". The difference\nwith "
+									},
+									{
+										"kind": "code",
+										"text": "`getTokenSilently`"
+									},
+									{
+										"kind": "text",
+										"text": " is that this doesn't return a token, but it will\npre-fill the token cache.\n\nThis method also heeds the "
+									},
+									{
+										"kind": "code",
+										"text": "`auth0.{clientId}.is.authenticated`"
+									},
+									{
+										"kind": "text",
+										"text": " cookie, as an optimization\n to prevent calling Auth0 unnecessarily. If the cookie is not present because\nthere was no previous login (or it has expired) then tokens will not be refreshed.\n\nIt should be used for silently logging in the user when you instantiate the\n"
+									},
+									{
+										"kind": "code",
+										"text": "`Auth0Client`"
+									},
+									{
+										"kind": "text",
+										"text": " constructor. You should not need this if you are using the\n"
+									},
+									{
+										"kind": "code",
+										"text": "`createAuth0Client`"
+									},
+									{
+										"kind": "text",
+										"text": " factory.\n\n**Note:** the cookie **may not** be present if running an app using a private tab, as some\nbrowsers clear JS cookie data and local storage when the tab or page is closed, or on page reload. This effectively\nmeans that "
+									},
+									{
+										"kind": "code",
+										"text": "`checkSession`"
+									},
+									{
+										"kind": "text",
+										"text": " could silently return without authenticating the user on page refresh when\nusing a private tab, despite having previously logged in. As a workaround, use "
+									},
+									{
+										"kind": "code",
+										"text": "`getTokenSilently`"
+									},
+									{
+										"kind": "text",
+										"text": " instead\nand handle the possible "
+									},
+									{
+										"kind": "code",
+										"text": "`login_required`"
+									},
+									{
+										"kind": "text",
+										"text": " error [as shown in the readme](https://github.com/auth0/auth0-spa-js#creating-the-client)."
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 874,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L874"
+								}
+							],
+							"parameters": [
+								{
+									"id": 110,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {
+										"isOptional": true
+									},
+									"type": {
+										"type": "reference",
+										"target": {
+											"sourceFileName": "src/global.ts",
+											"qualifiedName": "GetTokenSilentlyOptions"
+										},
+										"name": "GetTokenSilentlyOptions",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "intrinsic",
+										"name": "void"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 111,
+					"name": "getTokenSilently",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 899,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L899"
+						},
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 908,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L908"
+						},
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 948,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L948"
+						}
+					],
+					"signatures": [
+						{
+							"id": 112,
+							"name": "getTokenSilently",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Fetches a new access token and returns the response from the /oauth/token endpoint, omitting the refresh token."
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 899,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L899"
+								}
+							],
+							"parameters": [
+								{
+									"id": 113,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intersection",
+										"types": [
+											{
+												"type": "reference",
+												"target": {
+													"sourceFileName": "src/global.ts",
+													"qualifiedName": "GetTokenSilentlyOptions"
+												},
+												"name": "GetTokenSilentlyOptions",
+												"package": "@auth0/auth0-spa-js"
+											},
+											{
+												"type": "reflection",
+												"declaration": {
+													"id": 114,
+													"name": "__type",
+													"variant": "declaration",
+													"kind": 65536,
+													"flags": {},
+													"children": [
+														{
+															"id": 115,
+															"name": "detailedResponse",
+															"variant": "declaration",
+															"kind": 1024,
+															"flags": {},
+															"sources": [
+																{
+																	"fileName": "src/Auth0Client.ts",
+																	"line": 900,
+																	"character": 41,
+																	"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L900"
+																}
+															],
+															"type": {
+																"type": "literal",
+																"value": true
+															}
+														}
+													],
+													"groups": [
+														{
+															"title": "Properties",
+															"children": [
+																115
+															]
+														}
+													],
+													"sources": [
+														{
+															"fileName": "src/Auth0Client.ts",
+															"line": 900,
+															"character": 39,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L900"
+														}
+													]
+												}
+											}
+										]
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": {
+											"sourceFileName": "src/global.ts",
+											"qualifiedName": "GetTokenSilentlyVerboseResponse"
+										},
+										"name": "GetTokenSilentlyVerboseResponse",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						},
+						{
+							"id": 116,
+							"name": "getTokenSilently",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Fetches a new access token and returns it."
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 908,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L908"
+								}
+							],
+							"parameters": [
+								{
+									"id": 117,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {
+										"isOptional": true
+									},
+									"type": {
+										"type": "reference",
+										"target": {
+											"sourceFileName": "src/global.ts",
+											"qualifiedName": "GetTokenSilentlyOptions"
+										},
+										"name": "GetTokenSilentlyOptions",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "intrinsic",
+										"name": "string"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 138,
+					"name": "getTokenWithPopup",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 1127,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L1127"
+						}
+					],
+					"signatures": [
+						{
+							"id": 139,
+							"name": "getTokenWithPopup",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "code",
+										"text": "```js\nconst token = await auth0.getTokenWithPopup(options);\n```"
+									},
+									{
+										"kind": "text",
+										"text": "\nOpens a popup with the "
+									},
+									{
+										"kind": "code",
+										"text": "`/authorize`"
+									},
+									{
+										"kind": "text",
+										"text": " URL using the parameters\nprovided as arguments. Random and secure "
+									},
+									{
+										"kind": "code",
+										"text": "`state`"
+									},
+									{
+										"kind": "text",
+										"text": " and "
+									},
+									{
+										"kind": "code",
+										"text": "`nonce`"
+									},
+									{
+										"kind": "text",
+										"text": "\nparameters will be auto-generated. If the response is successful,\nresults will be valid according to their expiration times."
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 1127,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L1127"
+								}
+							],
+							"parameters": [
+								{
+									"id": 140,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reference",
+										"target": {
+											"sourceFileName": "src/global.ts",
+											"qualifiedName": "GetTokenWithPopupOptions"
+										},
+										"name": "GetTokenWithPopupOptions",
+										"package": "@auth0/auth0-spa-js"
+									},
+									"defaultValue": "{}"
+								},
+								{
+									"id": 141,
+									"name": "config",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reference",
+										"target": {
+											"sourceFileName": "src/global.ts",
+											"qualifiedName": "PopupConfigOptions"
+										},
+										"name": "PopupConfigOptions",
+										"package": "@auth0/auth0-spa-js"
+									},
+									"defaultValue": "{}"
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "union",
+										"types": [
+											{
+												"type": "intrinsic",
+												"name": "undefined"
+											},
+											{
+												"type": "intrinsic",
+												"name": "string"
+											}
+										]
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 142,
+					"name": "isAuthenticated",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 1173,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L1173"
+						}
+					],
+					"signatures": [
+						{
+							"id": 143,
+							"name": "isAuthenticated",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "code",
+										"text": "```js\nconst isAuthenticated = await auth0.isAuthenticated();\n```"
+									},
+									{
+										"kind": "text",
+										"text": "\n\nReturns "
+									},
+									{
+										"kind": "code",
+										"text": "`true`"
+									},
+									{
+										"kind": "text",
+										"text": " if there's valid information stored,\notherwise returns "
+									},
+									{
+										"kind": "code",
+										"text": "`false`"
+									},
+									{
+										"kind": "text",
+										"text": "."
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 1173,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L1173"
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "intrinsic",
+										"name": "boolean"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 147,
+					"name": "revokeRefreshToken",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 1251,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L1251"
+						}
+					],
+					"signatures": [
+						{
+							"id": 148,
+							"name": "revokeRefreshToken",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "code",
+										"text": "```js\nawait auth0.revokeRefreshToken();\n```"
+									},
+									{
+										"kind": "text",
+										"text": "\n\nRevokes the refresh token using the "
+									},
+									{
+										"kind": "code",
+										"text": "`/oauth/revoke`"
+									},
+									{
+										"kind": "text",
+										"text": " endpoint.\nThis invalidates the refresh token so it can no longer be used to obtain new access tokens.\n\nThe method works with both memory and localStorage cache modes:\n- For memory storage with worker: The refresh token never leaves the worker thread,\n  maintaining security isolation\n- For localStorage: The token is retrieved from cache and revoked\n\nIf "
+									},
+									{
+										"kind": "code",
+										"text": "`useRefreshTokens`"
+									},
+									{
+										"kind": "text",
+										"text": " is disabled, this method does nothing.\n\n**Online mode:** when "
+									},
+									{
+										"kind": "code",
+										"text": "`refreshTokenMode`"
+									},
+									{
+										"kind": "text",
+										"text": " is "
+									},
+									{
+										"kind": "code",
+										"text": "`'online'`"
+									},
+									{
+										"kind": "text",
+										"text": ", revoking the ORT via\n"
+									},
+									{
+										"kind": "code",
+										"text": "`/oauth/revoke`"
+									},
+									{
+										"kind": "text",
+										"text": " **also terminates the Auth0 session** and **clears the entire local\ncache** (access token, ID token, user profile). Because Online Refresh Tokens are\nsession-bound, the authorization server ties the token directly to the session —\nrevoking the ORT invalidates the session server-side. The local cache is cleared\nimmediately so that "
+									},
+									{
+										"kind": "code",
+										"text": "`isAuthenticated()`"
+									},
+									{
+										"kind": "text",
+										"text": " returns "
+									},
+									{
+										"kind": "code",
+										"text": "`false`"
+									},
+									{
+										"kind": "text",
+										"text": " and "
+									},
+									{
+										"kind": "code",
+										"text": "`getUser()`"
+									},
+									{
+										"kind": "text",
+										"text": " returns\n"
+									},
+									{
+										"kind": "code",
+										"text": "`undefined`"
+									},
+									{
+										"kind": "text",
+										"text": " right away, without waiting for the access token to expire.\nUse this when you need to force a sign-out without a redirect (e.g. background\nrevocation). For a redirect-based sign-out, prefer "
+									},
+									{
+										"kind": "code",
+										"text": "`logout()`"
+									},
+									{
+										"kind": "text",
+										"text": ".\n\n**Important:** This method revokes the refresh token for a single audience. If your\napplication requests tokens for multiple audiences, each audience may have its own\nrefresh token. To fully revoke all refresh tokens, call this method once per audience.\nIf you want to terminate the user's session with a redirect, use "
+									},
+									{
+										"kind": "code",
+										"text": "`logout()`"
+									},
+									{
+										"kind": "text",
+										"text": " instead.\n\nWhen using Multi-Resource Refresh Tokens (MRRT), a single refresh token may cover\nmultiple audiences. In that case, revoking it will affect all cache entries that\nshare the same token."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@example",
+										"content": [
+											{
+												"kind": "code",
+												"text": "```ts\n// Revoke the default refresh token\nawait auth0.revokeRefreshToken();\n```"
+											}
+										]
+									},
+									{
+										"tag": "@example",
+										"content": [
+											{
+												"kind": "code",
+												"text": "```ts\n// Revoke refresh tokens for each audience individually\nawait auth0.revokeRefreshToken({ audience: 'https://api.example.com' });\nawait auth0.revokeRefreshToken({ audience: 'https://api2.example.com' });\n```"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 1251,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L1251"
+								}
+							],
+							"parameters": [
+								{
+									"id": 149,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Optional parameters to identify which refresh token to revoke.\n  Defaults to the audience configured in "
+											},
+											{
+												"kind": "code",
+												"text": "`authorizationParams`"
+											},
+											{
+												"kind": "text",
+												"text": "."
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": {
+											"sourceFileName": "src/global.ts",
+											"qualifiedName": "RevokeRefreshTokenOptions"
+										},
+										"name": "RevokeRefreshTokenOptions",
+										"package": "@auth0/auth0-spa-js"
+									},
+									"defaultValue": "{}"
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "intrinsic",
+										"name": "void"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 150,
+					"name": "logout",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 1306,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L1306"
+						}
+					],
+					"signatures": [
+						{
+							"id": 151,
+							"name": "logout",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "code",
+										"text": "```js\nawait auth0.logout(options);\n```"
+									},
+									{
+										"kind": "text",
+										"text": "\n\nClears the application session and performs a redirect to "
+									},
+									{
+										"kind": "code",
+										"text": "`/v2/logout`"
+									},
+									{
+										"kind": "text",
+										"text": ", using\nthe parameters provided as arguments, to clear the Auth0 session.\n\nIf the "
+									},
+									{
+										"kind": "code",
+										"text": "`federated`"
+									},
+									{
+										"kind": "text",
+										"text": " option is specified it also clears the Identity Provider session.\n[Read more about how Logout works at Auth0](https://auth0.com/docs/logout)."
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 1306,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L1306"
+								}
+							],
+							"parameters": [
+								{
+									"id": 152,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reference",
+										"target": {
+											"sourceFileName": "src/global.ts",
+											"qualifiedName": "LogoutOptions"
+										},
+										"name": "LogoutOptions",
+										"package": "@auth0/auth0-spa-js"
+									},
+									"defaultValue": "{}"
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "intrinsic",
+										"name": "void"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 217,
+					"name": "loginWithCustomTokenExchange",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 1933,
+							"character": 8,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L1933"
+						}
+					],
+					"signatures": [
+						{
+							"id": 218,
+							"name": "loginWithCustomTokenExchange",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 1933,
+									"character": 8,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L1933"
+								}
+							],
+							"parameters": [
+								{
+									"id": 219,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reference",
+										"target": {
+											"sourceFileName": "src/TokenExchange.ts",
+											"qualifiedName": "CustomTokenExchangeOptions"
+										},
+										"name": "CustomTokenExchangeOptions",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": {
+											"sourceFileName": "src/global.ts",
+											"qualifiedName": "TokenEndpointResponse"
+										},
+										"name": "TokenEndpointResponse",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 220,
+					"name": "customTokenExchange",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 1973,
+							"character": 8,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L1973"
+						}
+					],
+					"signatures": [
+						{
+							"id": 221,
+							"name": "customTokenExchange",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "code",
+										"text": "```js\nawait auth0.customTokenExchange(options);\n```"
+									},
+									{
+										"kind": "text",
+										"text": "\n\nExchanges an external subject token for Auth0 tokens without affecting the current session.\n\nUnlike "
+									},
+									{
+										"kind": "code",
+										"text": "`loginWithCustomTokenExchange`"
+									},
+									{
+										"kind": "text",
+										"text": ", this method has no side effects — it does not cache\ntokens, does not update the authenticated session, and does not affect "
+									},
+									{
+										"kind": "code",
+										"text": "`isAuthenticated()`"
+									},
+									{
+										"kind": "text",
+										"text": "\nor "
+									},
+									{
+										"kind": "code",
+										"text": "`getUser()`"
+									},
+									{
+										"kind": "text",
+										"text": ". Use this for delegation or impersonation scenarios where you need a token\nfor a downstream API but do not want to change who the current user is.\n\nWhen a Web Worker is configured, the refresh_token is discarded inside the worker and\nnever reaches the main thread. When no Web Worker is configured, the raw authorization\nserver response is returned — if a refresh_token is present, discard it; this method\nintentionally does not store it."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A promise that resolves to the token endpoint response.\n\n**Example:**\n"
+											},
+											{
+												"kind": "code",
+												"text": "```js\nconst tokenResponse = await auth0.customTokenExchange({\n  subject_token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6Ikp...',\n  subject_token_type: 'urn:acme:legacy-system-token',\n  actor_token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6Ikp...',\n  actor_token_type: 'https://idp.example.com/token-type/agent',\n  audience: 'https://api.example.com',\n});\n\n// Use tokenResponse.access_token to call downstream API\n// Current user session is unchanged\n```"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 1973,
+									"character": 8,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L1973"
+								}
+							],
+							"parameters": [
+								{
+									"id": 222,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The options required to perform the token exchange."
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": {
+											"sourceFileName": "src/TokenExchange.ts",
+											"qualifiedName": "CustomTokenExchangeOptions"
+										},
+										"name": "CustomTokenExchangeOptions",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": {
+											"sourceFileName": "src/global.ts",
+											"qualifiedName": "TokenEndpointResponse"
+										},
+										"name": "TokenEndpointResponse",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 223,
+					"name": "exchangeToken",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 2020,
+							"character": 8,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L2020"
+						}
+					],
+					"signatures": [
+						{
+							"id": 224,
+							"name": "exchangeToken",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [],
+								"blockTags": [
+									{
+										"tag": "@deprecated",
+										"content": [
+											{
+												"kind": "text",
+												"text": "Use "
+											},
+											{
+												"kind": "code",
+												"text": "`loginWithCustomTokenExchange()`"
+											},
+											{
+												"kind": "text",
+												"text": " instead. This method will be removed in the next major version.\n\nExchanges an external subject token for Auth0 tokens."
+											}
+										]
+									},
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A promise that resolves to the token endpoint response.\n\n**Example:**\n"
+											},
+											{
+												"kind": "code",
+												"text": "```js\n// Instead of:\nconst tokens = await auth0.exchangeToken(options);\n\n// Use:\nconst tokens = await auth0.loginWithCustomTokenExchange(options);\n```"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 2020,
+									"character": 8,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L2020"
+								}
+							],
+							"parameters": [
+								{
+									"id": 225,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The options required to perform the token exchange."
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": {
+											"sourceFileName": "src/TokenExchange.ts",
+											"qualifiedName": "CustomTokenExchangeOptions"
+										},
+										"name": "CustomTokenExchangeOptions",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": {
+											"sourceFileName": "src/global.ts",
+											"qualifiedName": "TokenEndpointResponse"
+										},
+										"name": "TokenEndpointResponse",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 229,
+					"name": "getDpopNonce",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 2045,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L2045"
+						}
+					],
+					"signatures": [
+						{
+							"id": 230,
+							"name": "getDpopNonce",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Returns the current DPoP nonce used for making requests to Auth0.\n\nIt can return "
+									},
+									{
+										"kind": "code",
+										"text": "`undefined`"
+									},
+									{
+										"kind": "text",
+										"text": " because when starting fresh it will not\nbe populated until after the first response from the server.\n\nIt requires enabling the "
+									},
+									{
+										"kind": "inline-tag",
+										"tag": "@link",
+										"text": "Auth0ClientOptions.useDpop",
+										"target": {
+											"sourceFileName": "src/global.ts",
+											"qualifiedName": "Auth0ClientOptions.useDpop"
+										},
+										"tsLinkText": ""
+									},
+									{
+										"kind": "text",
+										"text": " option."
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 2045,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L2045"
+								}
+							],
+							"parameters": [
+								{
+									"id": 231,
+									"name": "id",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {
+										"isOptional": true
+									},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The identifier of a nonce: if absent, it will get the nonce\n             used for requests to Auth0. Otherwise, it will be used to\n             select a specific non-Auth0 nonce."
+											}
+										]
+									},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "union",
+										"types": [
+											{
+												"type": "intrinsic",
+												"name": "undefined"
+											},
+											{
+												"type": "intrinsic",
+												"name": "string"
+											}
+										]
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 232,
+					"name": "setDpopNonce",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 2061,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L2061"
+						}
+					],
+					"signatures": [
+						{
+							"id": 233,
+							"name": "setDpopNonce",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Sets the current DPoP nonce used for making requests to Auth0.\n\nIt requires enabling the "
+									},
+									{
+										"kind": "inline-tag",
+										"tag": "@link",
+										"text": "Auth0ClientOptions.useDpop",
+										"target": {
+											"sourceFileName": "src/global.ts",
+											"qualifiedName": "Auth0ClientOptions.useDpop"
+										},
+										"tsLinkText": ""
+									},
+									{
+										"kind": "text",
+										"text": " option."
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 2061,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L2061"
+								}
+							],
+							"parameters": [
+								{
+									"id": 234,
+									"name": "nonce",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The nonce value."
+											}
+										]
+									},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 235,
+									"name": "id",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {
+										"isOptional": true
+									},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The identifier of a nonce: if absent, it will set the nonce\n             used for requests to Auth0. Otherwise, it will be used to\n             select a specific non-Auth0 nonce."
+											}
+										]
+									},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "intrinsic",
+										"name": "void"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 236,
+					"name": "generateDpopProof",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 2073,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L2073"
+						}
+					],
+					"signatures": [
+						{
+							"id": 237,
+							"name": "generateDpopProof",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Returns a string to be used to demonstrate possession of the private\nkey used to cryptographically bind access tokens with DPoP.\n\nIt requires enabling the "
+									},
+									{
+										"kind": "inline-tag",
+										"tag": "@link",
+										"text": "Auth0ClientOptions.useDpop",
+										"target": {
+											"sourceFileName": "src/global.ts",
+											"qualifiedName": "Auth0ClientOptions.useDpop"
+										},
+										"tsLinkText": ""
+									},
+									{
+										"kind": "text",
+										"text": " option."
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 2073,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L2073"
+								}
+							],
+							"parameters": [
+								{
+									"id": 238,
+									"name": "params",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 239,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 240,
+													"name": "url",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/Auth0Client.ts",
+															"line": 2074,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L2074"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 241,
+													"name": "method",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/Auth0Client.ts",
+															"line": 2075,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L2075"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 242,
+													"name": "nonce",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {
+														"isOptional": true
+													},
+													"sources": [
+														{
+															"fileName": "src/Auth0Client.ts",
+															"line": 2076,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L2076"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 243,
+													"name": "accessToken",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/Auth0Client.ts",
+															"line": 2077,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L2077"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														240,
+														241,
+														242,
+														243
+													]
+												}
+											],
+											"sources": [
+												{
+													"fileName": "src/Auth0Client.ts",
+													"line": 2073,
+													"character": 35,
+													"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L2073"
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "intrinsic",
+										"name": "string"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 244,
+					"name": "createFetcher",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 2092,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L2092"
+						}
+					],
+					"signatures": [
+						{
+							"id": 245,
+							"name": "createFetcher",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Returns a new "
+									},
+									{
+										"kind": "code",
+										"text": "`Fetcher`"
+									},
+									{
+										"kind": "text",
+										"text": " class that will contain a "
+									},
+									{
+										"kind": "code",
+										"text": "`fetchWithAuth()`"
+									},
+									{
+										"kind": "text",
+										"text": " method.\nThis is a drop-in replacement for the Fetch API's "
+									},
+									{
+										"kind": "code",
+										"text": "`fetch()`"
+									},
+									{
+										"kind": "text",
+										"text": " method, but will\nhandle certain authentication logic for you, like building the proper auth\nheaders or managing DPoP nonces and retries automatically.\n\nCheck the "
+									},
+									{
+										"kind": "code",
+										"text": "`EXAMPLES.md`"
+									},
+									{
+										"kind": "text",
+										"text": " file for a deeper look into this method."
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 2092,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L2092"
+								}
+							],
+							"typeParameter": [
+								{
+									"id": 246,
+									"name": "TOutput",
+									"variant": "typeParam",
+									"kind": 131072,
+									"flags": {},
+									"type": {
+										"type": "reference",
+										"target": {
+											"sourceFileName": "src/fetcher.ts",
+											"qualifiedName": "CustomFetchMinimalOutput"
+										},
+										"name": "CustomFetchMinimalOutput",
+										"package": "@auth0/auth0-spa-js"
+									},
+									"default": {
+										"type": "reference",
+										"target": {
+											"sourceFileName": "node_modules/typescript/lib/lib.dom.d.ts",
+											"qualifiedName": "Response"
+										},
+										"name": "Response",
+										"package": "typescript"
+									}
+								}
+							],
+							"parameters": [
+								{
+									"id": 247,
+									"name": "config",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reference",
+										"target": {
+											"sourceFileName": "src/fetcher.ts",
+											"qualifiedName": "FetcherConfig"
+										},
+										"typeArguments": [
+											{
+												"type": "reference",
+												"target": 246,
+												"name": "TOutput",
+												"package": "@auth0/auth0-spa-js",
+												"refersToTypeParameter": true
+											}
+										],
+										"name": "FetcherConfig",
+										"package": "@auth0/auth0-spa-js"
+									},
+									"defaultValue": "{}"
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "src/fetcher.ts",
+									"qualifiedName": "Fetcher"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 246,
+										"name": "TOutput",
+										"package": "@auth0/auth0-spa-js",
+										"refersToTypeParameter": true
+									}
+								],
+								"name": "Fetcher",
+								"package": "@auth0/auth0-spa-js"
+							}
+						}
+					]
+				},
+				{
+					"id": 248,
+					"name": "connectAccountWithRedirect",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 2130,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L2130"
+						}
+					],
+					"signatures": [
+						{
+							"id": 249,
+							"name": "connectAccountWithRedirect",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Initiates a redirect to connect the user's account with a specified connection.\nThis method generates PKCE parameters, creates a transaction, and redirects to the /connect endpoint.\n\nYou must enable "
+									},
+									{
+										"kind": "code",
+										"text": "`Offline Access`"
+									},
+									{
+										"kind": "text",
+										"text": " from the Connection Permissions settings to be able to use the connection with Connected Accounts."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "Resolves when the redirect is initiated."
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If the connect request to the My Account API fails."
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 2130,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L2130"
+								}
+							],
+							"typeParameter": [
+								{
+									"id": 250,
+									"name": "TAppState",
+									"variant": "typeParam",
+									"kind": 131072,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The application state to persist through the transaction."
+											}
+										]
+									},
+									"default": {
+										"type": "intrinsic",
+										"name": "any"
+									}
+								}
+							],
+							"parameters": [
+								{
+									"id": 251,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Options for the connect account redirect flow."
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": {
+											"sourceFileName": "src/global.ts",
+											"qualifiedName": "RedirectConnectAccountOptions"
+										},
+										"typeArguments": [
+											{
+												"type": "reference",
+												"target": 250,
+												"name": "TAppState",
+												"package": "@auth0/auth0-spa-js",
+												"refersToTypeParameter": true
+											}
+										],
+										"name": "RedirectConnectAccountOptions",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "intrinsic",
+										"name": "void"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						2
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						34,
+						81,
+						85,
+						88,
+						90,
+						94,
+						108,
+						111,
+						138,
+						142,
+						147,
+						150,
+						217,
+						220,
+						223,
+						229,
+						232,
+						236,
+						244,
+						248
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						25,
+						26,
+						27
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/Auth0Client.ts",
+					"line": 144,
+					"character": 13,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/Auth0Client.ts#L144"
+				}
+			]
+		},
+		{
+			"id": 275,
+			"name": "createAuth0Client",
+			"variant": "declaration",
+			"kind": 64,
+			"flags": {},
+			"sources": [
+				{
+					"fileName": "src/index.ts",
+					"line": 13,
+					"character": 22,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/index.ts#L13"
+				},
+				{
+					"fileName": "src/index.ts",
+					"line": 20,
+					"character": 22,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/index.ts#L20"
+				},
+				{
+					"fileName": "src/index.ts",
+					"line": 32,
+					"character": 22,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/index.ts#L32"
+				}
+			],
+			"signatures": [
+				{
+					"id": 276,
+					"name": "createAuth0Client",
+					"variant": "signature",
+					"kind": 4096,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Online mode requires "
+							},
+							{
+								"kind": "code",
+								"text": "`useRefreshTokens: true`"
+							},
+							{
+								"kind": "text",
+								"text": " and "
+							},
+							{
+								"kind": "code",
+								"text": "`useDpop: true`"
+							},
+							{
+								"kind": "text",
+								"text": ", enforced here at\ncompile time. Dynamic values, casts, and plain JS are covered by the runtime check in\nthe "
+							},
+							{
+								"kind": "code",
+								"text": "`Auth0Client`"
+							},
+							{
+								"kind": "text",
+								"text": " constructor."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/index.ts",
+							"line": 13,
+							"character": 22,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/index.ts#L13"
+						}
+					],
+					"parameters": [
+						{
+							"id": 277,
+							"name": "options",
+							"variant": "param",
+							"kind": 32768,
+							"flags": {},
+							"type": {
+								"type": "intersection",
+								"types": [
+									{
+										"type": "reference",
+										"target": {
+											"sourceFileName": "src/global.ts",
+											"qualifiedName": "Auth0ClientOptions"
+										},
+										"name": "Auth0ClientOptions",
+										"package": "@auth0/auth0-spa-js"
+									},
+									{
+										"type": "reflection",
+										"declaration": {
+											"id": 278,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 279,
+													"name": "refreshTokenMode",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/index.ts",
+															"line": 15,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/index.ts#L15"
+														}
+													],
+													"type": {
+														"type": "literal",
+														"value": "online"
+													}
+												},
+												{
+													"id": 280,
+													"name": "useRefreshTokens",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/index.ts",
+															"line": 16,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/index.ts#L16"
+														}
+													],
+													"type": {
+														"type": "literal",
+														"value": true
+													}
+												},
+												{
+													"id": 281,
+													"name": "useDpop",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/index.ts",
+															"line": 17,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/index.ts#L17"
+														}
+													],
+													"type": {
+														"type": "literal",
+														"value": true
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														279,
+														280,
+														281
+													]
+												}
+											],
+											"sources": [
+												{
+													"fileName": "src/index.ts",
+													"line": 14,
+													"character": 32,
+													"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/index.ts#L14"
+												}
+											]
+										}
+									}
+								]
+							}
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": {
+							"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+							"qualifiedName": "Promise"
+						},
+						"typeArguments": [
+							{
+								"type": "reference",
+								"target": 1,
+								"name": "Auth0Client",
+								"package": "@auth0/auth0-spa-js"
+							}
+						],
+						"name": "Promise",
+						"package": "typescript"
+					}
+				},
+				{
+					"id": 282,
+					"name": "createAuth0Client",
+					"variant": "signature",
+					"kind": 4096,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Asynchronously creates the Auth0Client instance and calls "
+							},
+							{
+								"kind": "code",
+								"text": "`checkSession`"
+							},
+							{
+								"kind": "text",
+								"text": ".\n\n**Note:** There are caveats to using this in a private browser tab, which may not silently authenticate\na user on page refresh. Please see [the checkSession docs](https://auth0.github.io/auth0-spa-js/classes/Auth0Client.html#checksession) for more info."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@returns",
+								"content": [
+									{
+										"kind": "text",
+										"text": "An instance of Auth0Client"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/index.ts",
+							"line": 20,
+							"character": 22,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/index.ts#L20"
+						}
+					],
+					"parameters": [
+						{
+							"id": 283,
+							"name": "options",
+							"variant": "param",
+							"kind": 32768,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "The client options"
+									}
+								]
+							},
+							"type": {
+								"type": "intersection",
+								"types": [
+									{
+										"type": "reference",
+										"target": {
+											"sourceFileName": "src/global.ts",
+											"qualifiedName": "Auth0ClientOptions"
+										},
+										"name": "Auth0ClientOptions",
+										"package": "@auth0/auth0-spa-js"
+									},
+									{
+										"type": "reflection",
+										"declaration": {
+											"id": 284,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 285,
+													"name": "refreshTokenMode",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {
+														"isOptional": true
+													},
+													"sources": [
+														{
+															"fileName": "src/index.ts",
+															"line": 21,
+															"character": 34,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/index.ts#L21"
+														}
+													],
+													"type": {
+														"type": "literal",
+														"value": "offline"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														285
+													]
+												}
+											],
+											"sources": [
+												{
+													"fileName": "src/index.ts",
+													"line": 21,
+													"character": 32,
+													"url": "https://github.com/auth0/auth0-spa-js/blob/258fd9577cd224ac224cf583b1a6feefad1eb6d3/src/index.ts#L21"
+												}
+											]
+										}
+									}
+								]
+							}
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": {
+							"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+							"qualifiedName": "Promise"
+						},
+						"typeArguments": [
+							{
+								"type": "reference",
+								"target": 1,
+								"name": "Auth0Client",
+								"package": "@auth0/auth0-spa-js"
+							}
+						],
+						"name": "Promise",
+						"package": "typescript"
+					}
+				}
+			]
+		}
+	],
+	"groups": [
+		{
+			"title": "Functions",
+			"children": [
+				275
+			]
+		},
+		{
+			"title": "Classes",
+			"children": [
+				1
+			]
+		}
+	],
+	"packageName": "@auth0/auth0-spa-js",
+	"readme": [
+		{
+			"kind": "text",
+			"text": "![Auth0 SDK for Single Page Applications using Authorization Code Grant Flow with PKCE.](https://cdn.auth0.com/website/sdks/banners/spa-js-banner.png)\n\n[![npm version](https://img.shields.io/npm/v/@auth0/auth0-spa-js?style=flat-square&logo=npm&logoColor=CB3837)](https://www.npmjs.com/package/@auth0/auth0-spa-js)\n[![Codecov](https://img.shields.io/codecov/c/github/auth0/auth0-spa-js)](https://codecov.io/gh/auth0/auth0-spa-js)\n[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/auth0/auth0-spa-js)\n![Downloads](https://img.shields.io/npm/dw/@auth0/auth0-spa-js)\n[![License](https://img.shields.io/:license-mit-blue.svg?style=flat)](https://opensource.org/licenses/MIT)\n![CircleCI](https://img.shields.io/circleci/build/github/auth0/auth0-spa-js)\n\n📚 [Documentation](#documentation) - 🚀 [Getting Started](#getting-started) - 💻 [API Reference](#api-reference) - 💬 [Feedback](#feedback)\n\n## Documentation\n\n- [Quickstart](https://auth0.com/docs/quickstart/spa/vanillajs/interactive) - our interactive guide for quickly adding login, logout and user information to your app using Auth0.\n- [Sample app](https://github.com/auth0-samples/auth0-javascript-samples/tree/master/01-Login) - a full-fledged sample app integrated with Auth0.\n- [FAQs](https://github.com/auth0/auth0-spa-js/blob/main/FAQ.md) - frequently asked questions about auth0-spa-js SDK.\n- [Examples](https://github.com/auth0/auth0-spa-js/blob/main/EXAMPLES.md) - code samples for common scenarios.\n- [Docs Site](https://auth0.com/docs) - explore our Docs site and learn more about Auth0.\n\n## Getting Started\n\n### Installation\n\nUsing [npm](https://npmjs.org) in your project directory run the following command:\n\n"
+		},
+		{
+			"kind": "code",
+			"text": "```sh\nnpm install @auth0/auth0-spa-js\n```"
+		},
+		{
+			"kind": "text",
+			"text": "\n\nFrom the CDN:\n\n"
+		},
+		{
+			"kind": "code",
+			"text": "```html\n<script src=\"https://cdn.auth0.com/js/auth0-spa-js/2.24/auth0-spa-js.production.js\"></script>\n```"
+		},
+		{
+			"kind": "text",
+			"text": "\n\n### Configure Auth0\n\nCreate a **Single Page Application** in the [Auth0 Dashboard](https://manage.auth0.com/#/applications).\n\n> **If you're using an existing application**, verify that you have configured the following settings in your Single Page Application:\n>\n> - Click on the \"Settings\" tab of your application's page.\n> - Scroll down and click on the \"Show Advanced Settings\" link.\n> - Under \"Advanced Settings\", click on the \"OAuth\" tab.\n> - Ensure that \"JsonWebToken Signature Algorithm\" is set to "
+		},
+		{
+			"kind": "code",
+			"text": "`RS256`"
+		},
+		{
+			"kind": "text",
+			"text": " and that \"OIDC Conformant\" is enabled.\n\nNext, configure the following URLs for your application under the \"Application URIs\" section of the \"Settings\" page:\n\n- **Allowed Callback URLs**: "
+		},
+		{
+			"kind": "code",
+			"text": "`http://localhost:3000`"
+		},
+		{
+			"kind": "text",
+			"text": "\n- **Allowed Logout URLs**: "
+		},
+		{
+			"kind": "code",
+			"text": "`http://localhost:3000`"
+		},
+		{
+			"kind": "text",
+			"text": "\n- **Allowed Web Origins**: "
+		},
+		{
+			"kind": "code",
+			"text": "`http://localhost:3000`"
+		},
+		{
+			"kind": "text",
+			"text": "\n\n> These URLs should reflect the origins that your application is running on. **Allowed Callback URLs** may also include a path, depending on where you're handling the callback (see below).\n\nTake note of the **Client ID** and **Domain** values under the \"Basic Information\" section. You'll need these values in the next step.\n\n### Configure the SDK\n\nCreate an "
+		},
+		{
+			"kind": "code",
+			"text": "`Auth0Client`"
+		},
+		{
+			"kind": "text",
+			"text": " instance before rendering or initializing your application. You should only have one instance of the client.\n\n"
+		},
+		{
+			"kind": "code",
+			"text": "```js\nimport { createAuth0Client } from '@auth0/auth0-spa-js';\n\n//with async/await\nconst auth0 = await createAuth0Client({\n  domain: '<AUTH0_DOMAIN>',\n  clientId: '<AUTH0_CLIENT_ID>',\n  authorizationParams: {\n    redirect_uri: '<MY_CALLBACK_URL>'\n  }\n});\n\n//or, you can just instantiate the client on its own\nimport { Auth0Client } from '@auth0/auth0-spa-js';\n\nconst auth0 = new Auth0Client({\n  domain: '<AUTH0_DOMAIN>',\n  clientId: '<AUTH0_CLIENT_ID>',\n  authorizationParams: {\n    redirect_uri: '<MY_CALLBACK_URL>'\n  }\n});\n\n//if you do this, you'll need to check the session yourself\ntry {\n  await auth0.getTokenSilently();\n} catch (error) {\n  if (error.error !== 'login_required') {\n    throw error;\n  }\n}\n```"
+		},
+		{
+			"kind": "text",
+			"text": "\n\n### Logging In\n\nYou can then use login using the "
+		},
+		{
+			"kind": "code",
+			"text": "`Auth0Client`"
+		},
+		{
+			"kind": "text",
+			"text": " instance you created:\n\n"
+		},
+		{
+			"kind": "code",
+			"text": "```html\n<button id=\"login\">Click to Login</button>\n```"
+		},
+		{
+			"kind": "text",
+			"text": "\n\n"
+		},
+		{
+			"kind": "code",
+			"text": "```js\n//redirect to the Universal Login Page\ndocument.getElementById('login').addEventListener('click', async () => {\n  await auth0.loginWithRedirect();\n});\n\n//in your callback route (<MY_CALLBACK_URL>)\nwindow.addEventListener('load', async () => {\n  const redirectResult = await auth0.handleRedirectCallback();\n  //logged in. you can get the user profile like this:\n  const user = await auth0.getUser();\n  console.log(user);\n});\n```"
+		},
+		{
+			"kind": "text",
+			"text": "\n\n### Online Access\n\n> [!NOTE]\n> Online Access (Online Refresh Tokens) support via SDKs is currently in Early Access. To request access to this feature, contact your Auth0 representative.\n\n> [!WARNING]\n> Online Refresh Tokens do not currently support resource servers with **Ephemeral Sessions** enabled. Enabling both "
+		},
+		{
+			"kind": "code",
+			"text": "`allow_online_access`"
+		},
+		{
+			"kind": "text",
+			"text": " and \"Allow for Ephemeral Sessions\" on the same resource server results in the authorization server issuing an Online Refresh Token that is then rejected ("
+		},
+		{
+			"kind": "code",
+			"text": "`invalid_grant`"
+		},
+		{
+			"kind": "text",
+			"text": ") on the very next refresh. Until Ephemeral Sessions support is added for Online Refresh Tokens, disable \"Allow for Ephemeral Sessions\" on any resource server used with "
+		},
+		{
+			"kind": "code",
+			"text": "`refreshTokenMode: RefreshTokenMode.Online`"
+		},
+		{
+			"kind": "text",
+			"text": ".\n\nSet "
+		},
+		{
+			"kind": "code",
+			"text": "`refreshTokenMode`"
+		},
+		{
+			"kind": "text",
+			"text": " to "
+		},
+		{
+			"kind": "code",
+			"text": "`RefreshTokenMode.Online`"
+		},
+		{
+			"kind": "text",
+			"text": " (together with the required "
+		},
+		{
+			"kind": "code",
+			"text": "`useRefreshTokens: true`"
+		},
+		{
+			"kind": "text",
+			"text": " and "
+		},
+		{
+			"kind": "code",
+			"text": "`useDpop: true`"
+		},
+		{
+			"kind": "text",
+			"text": ") to use **Online Refresh Tokens** — non-rotating refresh tokens bound to the Auth0 session lifetime. The SDK injects the "
+		},
+		{
+			"kind": "code",
+			"text": "`online_access`"
+		},
+		{
+			"kind": "text",
+			"text": " scope and routes renewal through the refresh-token grant.\n\n"
+		},
+		{
+			"kind": "code",
+			"text": "```js\nimport { createAuth0Client, RefreshTokenMode } from '@auth0/auth0-spa-js';\n\nconst auth0 = await createAuth0Client({\n  domain: '<AUTH0_DOMAIN>',\n  clientId: '<AUTH0_CLIENT_ID>',\n  useRefreshTokens: true,\n  refreshTokenMode: RefreshTokenMode.Online,\n  useDpop: true,\n  authorizationParams: {\n    redirect_uri: '<MY_CALLBACK_URL>'\n  }\n});\n```"
+		},
+		{
+			"kind": "text",
+			"text": "\n\n"
+		},
+		{
+			"kind": "code",
+			"text": "`refreshTokenMode`"
+		},
+		{
+			"kind": "text",
+			"text": " is a sub-option of "
+		},
+		{
+			"kind": "code",
+			"text": "`useRefreshTokens`"
+		},
+		{
+			"kind": "text",
+			"text": ": it defaults to "
+		},
+		{
+			"kind": "code",
+			"text": "`RefreshTokenMode.Offline`"
+		},
+		{
+			"kind": "text",
+			"text": " (the rotating refresh tokens described above) and must be set to "
+		},
+		{
+			"kind": "code",
+			"text": "`RefreshTokenMode.Online`"
+		},
+		{
+			"kind": "text",
+			"text": " for Online Refresh Tokens. Online mode requires both "
+		},
+		{
+			"kind": "code",
+			"text": "`useRefreshTokens: true`"
+		},
+		{
+			"kind": "text",
+			"text": " and "
+		},
+		{
+			"kind": "code",
+			"text": "`useDpop: true`"
+		},
+		{
+			"kind": "text",
+			"text": ". See [Online Access](https://github.com/auth0/auth0-spa-js/blob/main/EXAMPLES.md#online-access-online-refresh-tokens) in EXAMPLES.md for the full guide.\n\n### More Examples\n\nFor comprehensive examples covering various scenarios including logging out, calling APIs, refresh tokens, online access, organizations, passkeys, MFA, DPoP, and more, see the [EXAMPLES.md](https://github.com/auth0/auth0-spa-js/blob/main/EXAMPLES.md) document.\n\n## API Reference\n\nExplore API Methods available in auth0-spa-js.\n\n- [Configuration Options](https://auth0.github.io/auth0-spa-js/interfaces/Auth0ClientOptions.html)\n\n- [Auth0Client](https://auth0.github.io/auth0-spa-js/classes/Auth0Client.html)\n- [createAuth0Client](https://auth0.github.io/auth0-spa-js/functions/createAuth0Client.html)\n\n## Feedback\n\n### Contributing\n\nWe appreciate feedback and contribution to this repo! Before you get started, please see the following:\n\n- [Auth0's general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)\n- [Auth0's code of conduct guidelines](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)\n- [This repo's contribution guide](https://github.com/auth0/auth0-spa-js/blob/main/CONTRIBUTING.md)\n\n### Raise an issue\n\nTo provide feedback or report a bug, please [raise an issue on our issue tracker](https://github.com/auth0/auth0-spa-js/issues).\n\n### Vulnerability Reporting\n\nPlease do not report security vulnerabilities on the public GitHub issue tracker. The [Responsible Disclosure Program](https://auth0.com/whitehat) details the procedure for disclosing security issues.\n\n## What is Auth0?\n\n<p align=\"center\">\n  <picture>\n    <source media=\"(prefers-color-scheme: dark)\" srcset=\"https://cdn.auth0.com/website/sdks/logos/auth0_dark_mode.png\" width=\"150\">\n    <source media=\"(prefers-color-scheme: light)\" srcset=\"https://cdn.auth0.com/website/sdks/logos/auth0_light_mode.png\" width=\"150\">\n    <img alt=\"Auth0 Logo\" src=\"https://cdn.auth0.com/website/sdks/logos/auth0_light_mode.png\" width=\"150\">\n  </picture>\n</p>\n<p align=\"center\">\n  Auth0 is an easy to implement, adaptable authentication and authorization platform. To learn more checkout <a href=\"https://auth0.com/why-auth0\">Why Auth0?</a>\n</p>\n<p align=\"center\">\n  This project is licensed under the MIT license. See the <a href=\"https://github.com/auth0/auth0-spa-js/blob/main/LICENSE\"> LICENSE</a> file for more info.\n</p>"
+		}
+	],
+	"symbolIdMap": {
+		"0": {
+			"sourceFileName": "docs/typedoc-entry-point.ts",
+			"qualifiedName": ""
+		},
+		"1": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client"
+		},
+		"2": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.__constructor"
+		},
+		"3": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client"
+		},
+		"4": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "options"
+		},
+		"25": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.myAccount"
+		},
+		"26": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.mfa"
+		},
+		"27": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.passkey"
+		},
+		"34": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.getConfiguration"
+		},
+		"35": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.getConfiguration"
+		},
+		"81": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.loginWithPopup"
+		},
+		"82": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.loginWithPopup"
+		},
+		"83": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "options"
+		},
+		"84": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "config"
+		},
+		"85": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.getUser"
+		},
+		"86": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.getUser"
+		},
+		"87": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "TUser"
+		},
+		"88": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.getIdTokenClaims"
+		},
+		"89": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.getIdTokenClaims"
+		},
+		"90": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.loginWithRedirect"
+		},
+		"91": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.loginWithRedirect"
+		},
+		"92": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "TAppState"
+		},
+		"93": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "options"
+		},
+		"94": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.handleRedirectCallback"
+		},
+		"95": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.handleRedirectCallback"
+		},
+		"96": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "TAppState"
+		},
+		"97": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "url"
+		},
+		"108": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.checkSession"
+		},
+		"109": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.checkSession"
+		},
+		"110": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "options"
+		},
+		"111": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.getTokenSilently"
+		},
+		"112": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.getTokenSilently"
+		},
+		"113": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "options"
+		},
+		"114": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "__type"
+		},
+		"115": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "__type.detailedResponse"
+		},
+		"116": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.getTokenSilently"
+		},
+		"117": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "options"
+		},
+		"138": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.getTokenWithPopup"
+		},
+		"139": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.getTokenWithPopup"
+		},
+		"140": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "options"
+		},
+		"141": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "config"
+		},
+		"142": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.isAuthenticated"
+		},
+		"143": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.isAuthenticated"
+		},
+		"147": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.revokeRefreshToken"
+		},
+		"148": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.revokeRefreshToken"
+		},
+		"149": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "options"
+		},
+		"150": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.logout"
+		},
+		"151": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.logout"
+		},
+		"152": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "options"
+		},
+		"217": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.loginWithCustomTokenExchange"
+		},
+		"218": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.loginWithCustomTokenExchange"
+		},
+		"219": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "options"
+		},
+		"220": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.customTokenExchange"
+		},
+		"221": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.customTokenExchange"
+		},
+		"222": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "options"
+		},
+		"223": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.exchangeToken"
+		},
+		"224": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.exchangeToken"
+		},
+		"225": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "options"
+		},
+		"229": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.getDpopNonce"
+		},
+		"230": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.getDpopNonce"
+		},
+		"231": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "id"
+		},
+		"232": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.setDpopNonce"
+		},
+		"233": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.setDpopNonce"
+		},
+		"234": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "nonce"
+		},
+		"235": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "id"
+		},
+		"236": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.generateDpopProof"
+		},
+		"237": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.generateDpopProof"
+		},
+		"238": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "params"
+		},
+		"239": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "__type"
+		},
+		"240": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "__type.url"
+		},
+		"241": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "__type.method"
+		},
+		"242": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "__type.nonce"
+		},
+		"243": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "__type.accessToken"
+		},
+		"244": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.createFetcher"
+		},
+		"245": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.createFetcher"
+		},
+		"246": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "TOutput"
+		},
+		"247": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "config"
+		},
+		"248": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.connectAccountWithRedirect"
+		},
+		"249": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.connectAccountWithRedirect"
+		},
+		"250": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "TAppState"
+		},
+		"251": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "options"
+		},
+		"275": {
+			"sourceFileName": "src/index.ts",
+			"qualifiedName": "createAuth0Client"
+		},
+		"276": {
+			"sourceFileName": "src/index.ts",
+			"qualifiedName": "createAuth0Client"
+		},
+		"277": {
+			"sourceFileName": "src/index.ts",
+			"qualifiedName": "options"
+		},
+		"278": {
+			"sourceFileName": "src/index.ts",
+			"qualifiedName": "__type"
+		},
+		"279": {
+			"sourceFileName": "src/index.ts",
+			"qualifiedName": "__type.refreshTokenMode"
+		},
+		"280": {
+			"sourceFileName": "src/index.ts",
+			"qualifiedName": "__type.useRefreshTokens"
+		},
+		"281": {
+			"sourceFileName": "src/index.ts",
+			"qualifiedName": "__type.useDpop"
+		},
+		"282": {
+			"sourceFileName": "src/index.ts",
+			"qualifiedName": "createAuth0Client"
+		},
+		"283": {
+			"sourceFileName": "src/index.ts",
+			"qualifiedName": "options"
+		},
+		"284": {
+			"sourceFileName": "src/index.ts",
+			"qualifiedName": "__type"
+		},
+		"285": {
+			"sourceFileName": "src/index.ts",
+			"qualifiedName": "__type.refreshTokenMode"
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Add a native Mintlify SDK Reference tab backed by the Auth0 SPA JS TypeDoc artifact.

## Preview

- `/docs/sdk/typescript/classes/Auth0Client`
- `/docs/sdk/typescript/functions/createAuth0Client`

## Validation

- Mint local preview rendered both generated routes.
- TypeDoc artifact JSON and navigation JSON validated locally.

The artifact currently documents `Auth0Client` and `createAuth0Client` only.