### PR TITLE
replace innacurate language with correct flow

### DIFF
--- a/main/docs/troubleshoot/customer-support/open-and-manage-support-tickets.mdx
+++ b/main/docs/troubleshoot/customer-support/open-and-manage-support-tickets.mdx
@@ -5,7 +5,7 @@ description: Describes how to open and manage tickets with Support Center.
 
 Use [Auth0 Support Center](https://support.auth0.com) to create tickets for questions or issues. All tenant member roles can access Support Center.
 
-If you are a Private Cloud customer, Auth0 provisions a public cloud-based Support Tenant for you as part of onboarding. Use this tenant to log in to Support Center and open tickets for your Private Cloud deployment. If you have not received an invitation to your Support Tenant, contact your Technical Account Manager.
+If you are a Private Cloud customer, Auth0 provisions a public cloud-based Support Tenant for you as part of onboarding. Invitees must have an Auth0 account to accept the invitation. You can create an Auth0 account by visiting [manage.auth0.com/login](https://manage.auth0.com/login) and selecting **Sign up**. Use this tenant to log in to Support Center and open tickets for your Private Cloud deployment. If you have not received an invitation to your Support Tenant, contact your Technical Account Manager.
 
 <Frame>![Open and Manage Tickets Open Ticket Screen](/docs/images/cdy7uua7fh8z/1cqZ8DSdSYMuEV7putldj8/7addb485c07802ab65b656d113660991/openticket1.png)</Frame>
 

--- a/main/docs/troubleshoot/customer-support/open-and-manage-support-tickets.mdx
+++ b/main/docs/troubleshoot/customer-support/open-and-manage-support-tickets.mdx
@@ -5,7 +5,7 @@ description: Describes how to open and manage tickets with Support Center.
 
 Use [Auth0 Support Center](https://support.auth0.com) to create tickets for questions or issues. All tenant member roles can access Support Center.
 
-If you are an existing Private Cloud customer, you need to create an Auth0 public cloud-based tenant, also known as the "Support Tenant", to log in to the Support Center. This tenant can also be used for development and test purposes at no additional cost. Please contact your Technical Account Manager or Sales Executive to associate your public cloud-based tenant to your existing Private Cloud subscription.
+If you are a Private Cloud customer, Auth0 provisions a public cloud-based Support Tenant for you as part of onboarding. Use this tenant to log in to Support Center and open tickets for your Private Cloud deployment. If you have not received an invitation to your Support Tenant, contact your Technical Account Manager.
 
 <Frame>![Open and Manage Tickets Open Ticket Screen](/docs/images/cdy7uua7fh8z/1cqZ8DSdSYMuEV7putldj8/7addb485c07802ab65b656d113660991/openticket1.png)</Frame>
 


### PR DESCRIPTION
## Description
Replaced the inaccurate "you need to create" language with the correct flow: Auth0 provisions it during onboarding, the customer just accepts the invitation. Removed the "development and test" line since that was specific to the old self-created tenant model. Kept the TAM contact as the fallback if the invitation wasn't received.

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [ x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ x] I've tested the site build for this change locally.
- [ x] I've made appropriate docs updates for any code or config changes.
- [ x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
