### PR TITLE
docs(portals): add Homebrew alias note for shadowed auth0-beta binary

### DIFF
--- a/main/docs/customize/portals/quickstart.mdx
+++ b/main/docs/customize/portals/quickstart.mdx
@@ -31,7 +31,7 @@ You can create a portal using:
     Follow the [installation instructions](https://github.com/auth0/auth0-cli/#linux-and-macos-1) for your platform, then authenticate with your tenant:
 
     <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-      Homebrew users with the stable `auth0` CLI already installed: the beta binary is shadowed by your existing install. Add the following alias to your shell configuration so the commands in this guide work as written:
+      Homebrew users with the stable `auth0` CLI already installed: the beta binary is shadowed by your existing install. Add the following alias to your shell configuration for the commands in this guide to work as written:
 
       ```bash
       alias auth0-beta="$(brew --prefix auth0-beta)/bin/auth0"

--- a/main/docs/customize/portals/quickstart.mdx
+++ b/main/docs/customize/portals/quickstart.mdx
@@ -31,10 +31,10 @@ You can create a portal using:
     Follow the [installation instructions](https://github.com/auth0/auth0-cli/#linux-and-macos-1) for your platform, then authenticate with your tenant:
 
     <Note>
-      **Homebrew users with the stable `auth0` CLI already installed:** the beta binary is shadowed by your existing install. Add an alias so the commands in this guide work as written:
+      **Homebrew users with the stable `auth0` CLI already installed:** the beta binary is shadowed by your existing install. Add the following alias to your shell configuration so the commands in this guide work as written:
 
       ```bash
-      echo "alias auth0-beta=\"$(brew --prefix auth0-beta)/bin/auth0\"" >> ~/.zshrc && source ~/.zshrc
+      alias auth0-beta="$(brew --prefix auth0-beta)/bin/auth0"
       ```
     </Note>
 

--- a/main/docs/customize/portals/quickstart.mdx
+++ b/main/docs/customize/portals/quickstart.mdx
@@ -30,6 +30,14 @@ You can create a portal using:
 
     Follow the [installation instructions](https://github.com/auth0/auth0-cli/#linux-and-macos-1) for your platform, then authenticate with your tenant:
 
+    <Note>
+      **Homebrew users with the stable `auth0` CLI already installed:** the beta binary is shadowed by your existing install. Add an alias so the commands in this guide work as written:
+
+      ```bash
+      echo "alias auth0-beta=\"$(brew --prefix auth0-beta)/bin/auth0\"" >> ~/.zshrc && source ~/.zshrc
+      ```
+    </Note>
+
     ```bash
     auth0-beta login
     ```

--- a/main/docs/customize/portals/quickstart.mdx
+++ b/main/docs/customize/portals/quickstart.mdx
@@ -30,13 +30,13 @@ You can create a portal using:
 
     Follow the [installation instructions](https://github.com/auth0/auth0-cli/#linux-and-macos-1) for your platform, then authenticate with your tenant:
 
-    <Note>
-      **Homebrew users with the stable `auth0` CLI already installed:** the beta binary is shadowed by your existing install. Add the following alias to your shell configuration so the commands in this guide work as written:
+    <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+      Homebrew users with the stable `auth0` CLI already installed: the beta binary is shadowed by your existing install. Add the following alias to your shell configuration so the commands in this guide work as written:
 
       ```bash
       alias auth0-beta="$(brew --prefix auth0-beta)/bin/auth0"
       ```
-    </Note>
+    </Callout>
 
     ```bash
     auth0-beta login


### PR DESCRIPTION
## Description

  Users who already have the stable `auth0` CLI installed encounter a silent PATH shadowing issue after `brew install auth0-beta` - the beta binary is installed but
  unreachable by name. Adds a note in the CLI tab of the quickstart with the alias to fix it.

  ## Checklist

  - [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
  - [ ] I've tested the site build for this change locally.
  - [ ] I've made appropriate docs updates for any code or config changes.
  - [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.