### PR TITLE
docs: address feedback on deploy-monitor/deploy-cli-tool.mdx (Triage Agent)

### DIFF
--- a/main/docs/deploy-monitor/deploy-cli-tool.mdx
+++ b/main/docs/deploy-monitor/deploy-cli-tool.mdx
@@ -2,6 +2,7 @@
 title: Auth0 Deploy CLI
 description: Learn how to use the Auth0 Deploy CLI to manage you tenant configuration and resources and intregate it into your development workflows. 
 sidebarTitle: Overview
+validatedOn: 2026-08-12
 ---
 <Card title="Before you start">
 
@@ -12,6 +13,8 @@ Set up an [Auth0 Tenant](https://manage.auth0.com/).
 The [Auth0 Deploy CLI](https://github.com/auth0/auth0-deploy-cli) is a tool that helps you manage your Auth0 tenant configuration. It integrates into your development workflows as a standalone CLI or as a node module.
 
 Supported resource types: `actions`, `branding`, `client grants`, `clients (applications)`, `connections`, `custom domains`, `email templates`, `emails`, `grants`, `guardian`, `hook secrets`, `log streams`, `migrations`, `organizations`, `pages`, `prompts`, `resource servers (APIs)`, `roles`, `tenant settings`, `themes`.
+
+Because `client grants` and `resource servers (APIs)` are supported resource types, the Deploy CLI can synchronize API permissions (scopes defined on your APIs) and the client grants that authorize applications to access those APIs across tenants. When you export from one tenant and import into another, the `resource servers (APIs)` resource carries the API definitions and their scopes, while the `client grants` resource carries which applications are granted access to which APIs and at what scopes. This means you can apply the same Client Access levels your Dev-tenant applications have to your Staging tenant. Note that client grants reference applications and APIs by identifier, so the corresponding `clients (applications)` and `resource servers (APIs)` must also exist (or be created) in the target tenant for the grants to resolve correctly.
 
 ## Highlights
 

--- a/main/docs/deploy-monitor/deploy-cli-tool.mdx
+++ b/main/docs/deploy-monitor/deploy-cli-tool.mdx
@@ -1,6 +1,6 @@
 ---
 title: Auth0 Deploy CLI
-description: Learn how to use the Auth0 Deploy CLI to manage you tenant configuration and resources and intregate it into your development workflows. 
+description: Learn how to use the Auth0 Deploy CLI to manage your tenant configuration and resources and integrate it into your development workflows. 
 sidebarTitle: Overview
 validatedOn: 2026-08-12
 ---
@@ -14,7 +14,11 @@ The [Auth0 Deploy CLI](https://github.com/auth0/auth0-deploy-cli) is a tool that
 
 Supported resource types: `actions`, `branding`, `client grants`, `clients (applications)`, `connections`, `custom domains`, `email templates`, `emails`, `grants`, `guardian`, `hook secrets`, `log streams`, `migrations`, `organizations`, `pages`, `prompts`, `resource servers (APIs)`, `roles`, `tenant settings`, `themes`.
 
-Because `client grants` and `resource servers (APIs)` are supported resource types, the Deploy CLI can synchronize API permissions (scopes defined on your APIs) and the client grants that authorize applications to access those APIs across tenants. When you export from one tenant and import into another, the `resource servers (APIs)` resource carries the API definitions and their scopes, while the `client grants` resource carries which applications are granted access to which APIs and at what scopes. This means you can apply the same Client Access levels your Dev-tenant applications have to your Staging tenant. Note that client grants reference applications and APIs by identifier, so the corresponding `clients (applications)` and `resource servers (APIs)` must also exist (or be created) in the target tenant for the grants to resolve correctly.
+Because `client grants` and `resource servers (APIs)` are supported resource types, the Deploy CLI can synchronize API permissions (scopes defined on your APIs) and the client grants that authorize applications to access those APIs across tenants. When you export from one tenant and import into another, the `resource servers (APIs)` resource carries the API definitions and their scopes, while the `client grants` resource carries which applications are granted access to which APIs and at what scopes. This means you can apply the same access levels your Dev-tenant applications have to your Staging tenant. 
+
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+Client grants reference applications and APIs by identifier: client name for applications and `audience` for APIs. The corresponding `clients (applications)` and `resource servers (APIs)` must also exist (or be created) in the target tenant for the grants to resolve correctly.
+</Callout>
 
 ## Highlights
 


### PR DESCRIPTION
## Summary

The Triage Agent clustered 1 user-feedback item across 1 source (auth0_community) and identified a single underlying issue.

**Cluster:** Feedback on /docs/deploy-monitor/deploy-cli-tool
**Rationale:** Path-based fallback: 1 item on /docs/deploy-monitor/deploy-cli-tool.

## Diagnosis

Missing information — the Deploy CLI page lists supported resource types but doesn't explain whether API client grants / Client Access levels can be synced across tenants; content fix: document how (or whether) client_grants and API permissions are handled by the Deploy CLI.

## Suggestions applied (1)

1. **[medium]** Documents that client_grants and API permissions are supported resource types and explains how they sync across tenants, directly answering the missing-information gap.

---

Generated by the Triage Agent. The writer reviewed and approved the selected suggestions before opening this PR.