### PR TITLE
docs: address feedback on quickstart/webapp/hono.mdx (Triage Agent)

### DIFF
--- a/main/docs/quickstart/webapp/hono.mdx
+++ b/main/docs/quickstart/webapp/hono.mdx
@@ -3,6 +3,7 @@ title: "Add Login to Your Hono Application"
 mode: wide
 sidebarTitle: Hono
 description: "This Quickstart demonstrates how to secure your Hono applications using Auth0 authentication. Follow the steps to add login, logout, and protected routes to a Hono app."
+validatedOn: 2026-08-12
 ---
 
 import {AuthCodeGroup} from "/snippets/AuthCodeGroup.jsx";
@@ -25,7 +26,7 @@ import {HowToSchema} from "/snippets/HowToSchema.jsx";
 
 ## Get Started
 
-This quickstart shows the minimal, recommended way to secure a Hono application using `@auth0/auth0-hono`. It follows the repository's recommended patterns: environment-driven configuration, `app.use(auth0(...))` middleware, and `requiresAuth()` for selective protection.
+This quickstart shows the minimal, recommended way to secure a Hono application using `@auth0/auth0-hono`. It follows the repository's recommended patterns: environment-driven configuration, `app.use(auth(...))` middleware, and `requiresAuth()` for selective protection.
 
 <Steps>
   <Step title="Create a new Hono application" stepNumber={1}>
@@ -121,7 +122,7 @@ This quickstart shows the minimal, recommended way to secure a Hono application 
           AUTH0_DOMAIN=YOUR_AUTH0_DOMAIN
           AUTH0_CLIENT_ID=YOUR_AUTH0_CLIENT_ID
           AUTH0_CLIENT_SECRET=YOUR_AUTH0_CLIENT_SECRET
-          APP_BASE_URL=http://localhost:3000
+          BASE_URL=http://localhost:3000
           AUTH0_SESSION_ENCRYPTION_KEY=your_32_char_min_secret
           # Optional for APIs
           AUTH0_AUDIENCE=YOUR_API_IDENTIFIER
@@ -133,20 +134,20 @@ This quickstart shows the minimal, recommended way to secure a Hono application 
   </Step>
 
   <Step title="Setup Hono web server with Auth0 middleware" stepNumber={4}>
-    Replace the initial template in `index.ts` file with the following example. The code demonstrates zero-config setup where environment variables are automatically read, creating an `auth0()` middleware with public routes by default and protected routes using `requiresAuth()`.
+    Replace the initial template in `index.ts` file with the following example. The code demonstrates zero-config setup where environment variables are automatically read, creating an `auth()` middleware with public routes by default and protected routes using `requiresAuth()`.
 
     ```typescript ./src/index.ts wrap lines
     // src/index.ts
     import { serve } from '@hono/node-server';
     import { Hono } from 'hono';
-    import { auth0, requiresAuth, Auth0Error, type OIDCEnv } from '@auth0/auth0-hono';
+    import { auth, requiresAuth, Auth0Error, type OIDCEnv } from '@auth0/auth0-hono';
 
     const app = new Hono<OIDCEnv>();
 
     // Zero-config: reads AUTH0_DOMAIN, AUTH0_CLIENT_ID, AUTH0_CLIENT_SECRET,
-    // APP_BASE_URL, AUTH0_SESSION_ENCRYPTION_KEY from environment
+    // BASE_URL, AUTH0_SESSION_ENCRYPTION_KEY from environment
     app.use(
-      auth0({
+      auth({
         authRequired: false, // Public by default, protect specific routes
       })
     );
@@ -197,10 +198,10 @@ This quickstart shows the minimal, recommended way to secure a Hono application 
 <Accordion title="Common issues" >
 
   <Accordion title="Callback or Redirect Mismatch" >
-    Cause: The callback URL configured in the Auth0 Dashboard does not exactly match `APP_BASE_URL` + the callback route (e.g., `http://localhost:3000/auth/callback`).
+    Cause: The callback URL configured in the Auth0 Dashboard does not exactly match `BASE_URL` + the callback route (e.g., `http://localhost:3000/auth/callback`).
 
     Fix:
-    1. Verify `.env` `APP_BASE_URL` value.
+    1. Verify `.env` `BASE_URL` value.
     2. Ensure Allowed Callback URLs in Auth0 Dashboard contain `http://localhost:3000/auth/callback`.
     3. Restart dev server after changes.
   </Accordion>
@@ -218,7 +219,7 @@ This quickstart shows the minimal, recommended way to secure a Hono application 
     Cause: Middleware not installed or placed after route registration.
 
     Fix:
-    - Ensure `app.use(auth0(...))` runs before routes that depend on authentication.
+    - Ensure `app.use(auth(...))` runs before routes that depend on authentication.
     - Confirm package installed: `npm ls @auth0/auth0-hono`.
   </Accordion>
 
@@ -234,7 +235,7 @@ This quickstart shows the minimal, recommended way to secure a Hono application 
 
 ## Advanced Usage
 
-- Selective protection: use `app.use(auth0({ authRequired: false }))` to make routes public by default and `app.use('/private/*', requiresAuth())` to protect specific paths.
+- Selective protection: use `app.use(auth({ authRequired: false }))` to make routes public by default and `app.use('/private/*', requiresAuth())` to protect specific paths.
 - Silent login: use `attemptSilentLogin()` middleware to try silent authentication for better UX.
 - Custom login flow: call `login({...})` to customize forwarded query params, `redirectAfterLogin`, or silent login options.
 - Token management: the middleware exposes access and ID tokens via the session; follow least-privilege for scopes and rotate refresh tokens safely.


### PR DESCRIPTION
## Summary

The Triage Agent clustered 1 user-feedback item across 1 source (mintlify) and identified a single underlying issue.

**Cluster:** Feedback on /docs/quickstart/webapp/hono
**Rationale:** Path-based fallback: 1 item on /docs/quickstart/webapp/hono.

## Diagnosis

Hono quickstart uses the outdated `auth0` import from `@auth0/auth0-hono` (renamed to `auth`) and inconsistently references `APP_BASE_URL` vs `BASE_URL` when only `BASE_URL` is required — content fix: update the import name and standardize on `BASE_URL`.

## Suggestions applied (8)

1. **[high]** Updates the middleware reference from the outdated `auth0` name to the current `auth` name.
2. **[high]** Standardizes the env var to `BASE_URL`, matching what the middleware actually requires.
3. **[high]** Renames the imported middleware from `auth0` to `auth`.
4. **[high]** Updates the middleware call to `auth` and the comment to reference `BASE_URL`.
5. **[high]** Standardizes the troubleshooting section on `BASE_URL` instead of `APP_BASE_URL`.
6. **[high]** Updates the descriptive prose to reference the current `auth()` middleware name.
7. **[high]** Updates the Advanced Usage example to the current `auth` middleware name.
8. **[high]** Updates the troubleshooting reference to the current `auth` middleware name.

---

Generated by the Triage Agent. The writer reviewed and approved the selected suggestions before opening this PR.