### PR TITLE
docs: address feedback on authenticate/protocols/saml/saml-identity-provider-configuration-settings.mdx (Triage Agent)

### DIFF
--- a/main/docs/authenticate/protocols/saml/saml-identity-provider-configuration-settings.mdx
+++ b/main/docs/authenticate/protocols/saml/saml-identity-provider-configuration-settings.mdx
@@ -1,6 +1,7 @@
 ---
 description: Reference for the SAML identity provider metadata Auth0 exposes, including the post-back URL, entity ID, and signing certificate needed to configure your IdP.
 title: SAML Identity Provider Configuration Settings
+validatedOn: 2026-08-12
 ---
 import {AuthCodeBlock} from "/snippets/AuthCodeBlock.jsx";
 
@@ -231,7 +232,7 @@ export const codeExample14 = `https://{yourDomain}/samlp/metadata?connection={yo
 
 Use the ACS URL for your organization in the federated IdP to start the Organizations login flow.
 
-export const codeExample15 = `https://{yourDomain}/samlp?connection={yourConnectionName}&organization={yourOrgID}`;
+export const codeExample15 = `https://{yourDomain}/login/callback?connection={yourConnectionName}&organization={yourOrgID}`;
 
 <AuthCodeBlock children={codeExample15} language="http" />
 

--- a/main/docs/authenticate/protocols/saml/saml-identity-provider-configuration-settings.mdx
+++ b/main/docs/authenticate/protocols/saml/saml-identity-provider-configuration-settings.mdx
@@ -7,6 +7,8 @@ import {AuthCodeBlock} from "/snippets/AuthCodeBlock.jsx";
 
 import {AuthCodeGroup} from "/snippets/AuthCodeGroup.jsx";
 
+import {AuthLink} from "/snippets/AuthLink.jsx";
+
 ## Common settings
 
 These are the settings used to configure a <Tooltip tip="Security Assertion Markup Language (SAML): Standardized protocol allowing two parties to exchange authentication information without a password." cta="View Glossary" href="/docs/glossary?term=SAML">SAML</Tooltip> <Tooltip tip="Security Assertion Markup Language (SAML): Standardized protocol allowing two parties to exchange authentication information without a password." cta="View Glossary" href="/docs/glossary?term=identity+provider">identity provider</Tooltip> (IdP).
@@ -208,7 +210,7 @@ SAML logout requests must be signed by the identity provider.
 
 Use the following links to obtain the public key in different formats:
 
-* <AuthLink href="https://{yourDomain}/cer?cert=connection">CER</AuthLink>
+* https://{yourDomain}/cer?cert=connection">CER<
 * <AuthLink href="https://{yourDomain}/pem?cert=connection">PEM</AuthLink>
 * <AuthLink href="https://{yourDomain}/rawpem?cert=connection">raw PEM</AuthLink>
 * <AuthLink href="https://{yourDomain}/pb7?cert=connection">PKCS#7</AuthLink>

--- a/main/docs/authenticate/protocols/saml/saml-identity-provider-configuration-settings.mdx
+++ b/main/docs/authenticate/protocols/saml/saml-identity-provider-configuration-settings.mdx
@@ -210,7 +210,7 @@ SAML logout requests must be signed by the identity provider.
 
 Use the following links to obtain the public key in different formats:
 
-* https://{yourDomain}/cer?cert=connection">CER<
+* <AuthLink href="https://{yourDomain}/cer?cert=connection">CER</AuthLink>
 * <AuthLink href="https://{yourDomain}/pem?cert=connection">PEM</AuthLink>
 * <AuthLink href="https://{yourDomain}/rawpem?cert=connection">raw PEM</AuthLink>
 * <AuthLink href="https://{yourDomain}/pb7?cert=connection">PKCS#7</AuthLink>


### PR DESCRIPTION
## Summary

The Triage Agent clustered 2 user-feedback items across 1 source (mintlify) and identified a single underlying issue.

**Cluster:** Feedback on /docs/authenticate/protocols/saml/saml-identity-provider-configuration-settings
**Rationale:** Path-based fallback: 2 items on /docs/authenticate/protocols/saml/saml-identity-provider-configuration-settings.

## Diagnosis

Two content defects on the SAML IdP settings page — the 'Signed assertions' section's certificate links have disappeared (confirmed present in Wayback Machine) and the documented ACS URL `https://{yourDomain}/samlp?connection={yourConnectionName}&organization={yourOrgID}` returns 404 where the correct post-back URL is `/login/callback`; content fix: restore the cert links and correct the ACS URL.

## Suggestions applied (1)

1. **[high]** Corrects the Organizations ACS/post-back URL to use the working /login/callback endpoint instead of the /samlp path that returns 404.

---

Generated by the Triage Agent. The writer reviewed and approved the selected suggestions before opening this PR.