### PR TITLE
docs: address feedback on authenticate/database-connections/passkeys.mdx (Triage Agent)

### DIFF
--- a/main/docs/authenticate/database-connections/passkeys.mdx
+++ b/main/docs/authenticate/database-connections/passkeys.mdx
@@ -2,6 +2,7 @@
 title: Passkey Authentication for Database Connections
 sidebarTitle: Passkeys
 description: Learn about Auth0's implementation of passkeys, a phishing-resistant WebAuthn device credential with advantages over traditional authentication methods.
+validatedOn: 2026-08-13
 ---
 import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
 
@@ -91,6 +92,18 @@ When you enable passkeys for your database connection, passkeys become available
 </AccordionGroup>
 
 Passkeys do not replace or invalidate a user's existing credentials. When a user creates their passkey, it is added to their account as an authentication method, but any existing email/username and password credentials remain valid.
+
+### Offer passwords alongside passkeys at login
+
+Passkeys and passwords can coexist in the same login experience, so you can let users choose either method. When you enable passkeys on a database connection, password sign-in remains available as long as your connection still allows password authentication.
+
+Your database connection's passkey policy controls how passkeys appear at login:
+
+* **Autofill (conditional UI):** When the user focuses the email or username field, their credential manager suggests stored passkeys alongside other saved credentials, such as passwords. Users who prefer a password can ignore the suggestion and type their credentials as usual.
+
+* **Passkey button:** The login screen shows a **Continue with a passkey** button in addition to the standard identifier and password fields, so users can pick passkeys or fall back to their password.
+
+You can enable autofill, the passkey button, or both. To keep password sign-in available, ensure the connection permits password authentication and configure these options in your connection's passkey policy. To learn how, read [Configure Passkey Policy](/docs/authenticate/database-connections/passkeys/configure-passkey-policy).
 
 ### Passkeys with MFA enabled
 

--- a/main/docs/authenticate/database-connections/passkeys.mdx
+++ b/main/docs/authenticate/database-connections/passkeys.mdx
@@ -93,17 +93,17 @@ When you enable passkeys for your database connection, passkeys become available
 
 Passkeys do not replace or invalidate a user's existing credentials. When a user creates their passkey, it is added to their account as an authentication method, but any existing email/username and password credentials remain valid.
 
-### Offer passwords alongside passkeys at login
+### Offer passwords and passkeys at login
 
-Passkeys and passwords can coexist in the same login experience, so you can let users choose either method. When you enable passkeys on a database connection, password sign-in remains available as long as your connection still allows password authentication.
+Passkeys and passwords can coexist in the same login experience; you can allow end users choose either method. When you enable passkeys on a database connection, password sign-in remains available as long as your connection still allows password authentication.
 
 Your database connection's passkey policy controls how passkeys appear at login:
 
-* **Autofill (conditional UI):** When the user focuses the email or username field, their credential manager suggests stored passkeys alongside other saved credentials, such as passwords. Users who prefer a password can ignore the suggestion and type their credentials as usual.
+* Autofill (conditional UI): When the end user focuses the email or username field, their credential manager suggests stored passkeys alongside other saved credentials, such as passwords. Users who prefer a password can ignore the suggestion and type their credentials as usual.
 
-* **Passkey button:** The login screen shows a **Continue with a passkey** button in addition to the standard identifier and password fields, so users can pick passkeys or fall back to their password.
+* Passkey button: The login screen shows a **Continue with a passkey** button in addition to the standard identifier and password fields, so end users can pick passkeys or fall back to their password.
 
-You can enable autofill, the passkey button, or both. To keep password sign-in available, ensure the connection permits password authentication and configure these options in your connection's passkey policy. To learn how, read [Configure Passkey Policy](/docs/authenticate/database-connections/passkeys/configure-passkey-policy).
+You can enable autofill, the passkey button, or both. To keep password sign-in available, ensure the connection permits password authentication and configure these options in your connection's passkey policy. To learn more, read [Configure Passkey Policy](/docs/authenticate/database-connections/passkeys/configure-passkey-policy).
 
 ### Passkeys with MFA enabled
 


### PR DESCRIPTION
## Summary

The Triage Agent clustered 1 user-feedback item across 1 source (mintlify) and identified a single underlying issue.

**Cluster:** Feedback on /docs/authenticate/database-connections/passkeys
**Rationale:** Path-based fallback: 1 item on /docs/authenticate/database-connections/passkeys.

## Diagnosis

Missing information — the passkeys page doesn't explain how to offer password sign-in alongside passkeys at login; content fix: document the mixed passkey + password sign-in configuration.

## Suggestions applied (1)

1. **[medium]** Adds a section documenting how to offer password sign-in alongside passkeys at login, including autofill vs. passkey button options.

---

Generated by the Triage Agent. The writer reviewed and approved the selected suggestions before opening this PR.