### PR TITLE
fix(docs): sync UserMembers interface docs between JS SDK and React SDK

### DIFF
--- a/main/docs/libraries/acul/js-sdk/Screens/interfaces/UserMembers.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/interfaces/UserMembers.mdx
@@ -15,7 +15,6 @@ export interface UserMembers {
   enrolledDevices: Array<EnrolledDevice> | null;
   organizations: Organizations[] | null; // OPT-IN 
   userMetadata: { [key: string]: string } | null; // OPT-IN
-  appMetadata: { [key: string]: string } | null; // OPT-IN
 }
 ```
 
@@ -40,14 +39,6 @@ export interface UserMembers {
 
 
 ## Properties
-
-<ParamField body='appMetadata' type='Optional | {[key: string]: string; }'>
-
-<Expandable title="Parameters">
-<ParamField body="[key]" type="string"/>
-
-</Expandable>
-</ParamField>
 
 <ParamField body='email' type='string'/>
 

--- a/main/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/UserMembers.mdx
+++ b/main/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/UserMembers.mdx
@@ -13,15 +13,32 @@ export interface UserMembers {
   enrolledEmails: Array<EnrolledEmail> | null;
   enrolledPhoneNumbers: Array<EnrolledPhoneNumber> | null;
   enrolledDevices: Array<EnrolledDevice> | null;
-  organizations: Organizations[] | null;
-  userMetadata: { [key: string]: string } | null;
-  appMetadata: { [key: string]: string } | null;
+  organizations: Organizations[] | null; // OPT-IN 
+  userMetadata: { [key: string]: string } | null; // OPT-IN
 }
 ```
 
-## Properties
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 
-<ParamField body='appMetadata' type='{[key: string]: string; }'/>
+
+* OPT-IN: You must explicitly configure these properties to make them available to the screen. To learn more, read [Configure ACUL](/docs/customize/login-pages/advanced-customizations/configure). 
+
+
+* When the Auth0 server is not aware of the current user, the `user` properties are not available in the following screens: 
+
+| Screens                  | Screens                   |  Screens                       | Screens                                 |   
+|--------------------------|---------------------------|--------------------------------|-----------------------------------------|
+| Login screens            | MFA OTP screens           | Accept Invitation screens      | InterstitialCaptcha screens             | 
+| Signup screens           | MFA Phone screens         | Device Code screens            | Reset Password screens                  | 
+| Passkey screens          | MFA Push screens          | Email Verification screens     | MFA Country Codes screens               | 
+| Challenge screens        | MFA Recovery Code screens | Logout Aborted screens         | MFA Detect Browser Capabilities screens | 
+| Email Identifier screens | MFA WebAuthn screens      | Logout Complete screens        | MFA Enroll screens                      |  
+| Phone Identifier screens | Accept Invitation screens | Brute Force Protection screens | | 
+
+</Callout>
+
+
+## Properties
 
 <ParamField body='email' type='string'/>
 


### PR DESCRIPTION
## Summary
- Ported the OPT-IN annotations and the screen-availability callout from the JS SDK `UserMembers` reference to the React SDK version, so both now document `organizations` and `userMetadata` consistently.
- Removed the unused `appMetadata` property from the `UserMembers` code example and properties list in both the JS SDK and React SDK docs.

## Test plan
- [ ] Verify the code example and Properties section render correctly for both `UserMembers.mdx` files in the Mintlify preview
- [ ] Confirm the OPT-IN callout and screen table display correctly in the React SDK page