### PR TITLE
fix: outdated updated instructions for ad/ldap connector 

### DIFF
--- a/main/docs/authenticate/identity-providers/enterprise-identity-providers/active-directory-ldap/ad-ldap-connector/update-ad-ldap-connectors.mdx
+++ b/main/docs/authenticate/identity-providers/enterprise-identity-providers/active-directory-ldap/ad-ldap-connector/update-ad-ldap-connectors.mdx
@@ -4,36 +4,9 @@ title: Update AD/LDAP Connectors
 ---
 If there are multiple instances of the AD/LDAP Connector in your deployment, Auth0 recommends that you perform the steps below for each instance one at a time, so that only one instance is down at any point.
 
-## Admin console (Windows)
-
-1. Open the Admin Console by navigating to `http://localhost:8357/`. If the Admin Console has outbound access to the internet it will verify if a new version is available and show this on top of the page:
-
-   <Frame>![Update AD/LDAP Connectors Admin Console Screen](/docs/images/cdy7uua7fh8z/6Yp2uRnEU3RMeCqgHa6Ztl/b9c04ab83b9fd725910291b01ac9d05d/connector-update-available.png)</Frame>
-2. Go to the **Update** tab to update the installation on the current machine to the latest version. The update will take about 2 minutes and the updater logs will be displayed in the Admin Console.
-
-## Updater script (Windows)
-
-The updater script will update the AD/LDAP Connector from the command line by running the following steps:
-
-1. Verify if an update is available.
-2. Backup the existing configuration, certificates and profileMapper.js.
-3. Uninstall the AD/LDAP Connector.
-4. Download the update.
-5. Install the AD/LDAP Connector.
-6. Restore the existing configuration, certificates and profileMapper.js.
-7. Start the Windows Service.
-8. To run the updater script execute the following statement in the command line:
-   `@powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((new-object net.webclient).DownloadString('https://cdn.auth0.com/connector/windows/update-connector.ps1'))"`
-
-The updater script uses specific PowerShell commands that are only available in Windows PowerShell 3.0 and higher. If you're running on Windows 2008 and Windows 2008 R2 you might need to update your PowerShell version first.
-
-To learn more, see [Download Window Management Framework](https://www.microsoft.com/en-us/download/details.aspx?id=34595).
-
-## Manual update (Windows/Linux)
-
-1. Verify the version you have installed. Hover over the Connector status indicator on the console. The tooltip will indicate the current status and the installed version.
-2. Download the latest version of the [installer](https://cdn.auth0.com/connector/windows/adldap-5.0.10.msi?_ga=2.58973869.1675886805.1589821069-1123834949.1586212750).
-   Use the GitHub repository [version](https://github.com/auth0/ad-ldap-connector/releases/tag/v5.0.10) for other platforms.
+1. Verify the version you have installed. The current version is displayed in the admin console.
+2. Download the latest version of the [installer](https://github.com/auth0/ad-ldap-connector/releases/latest).
+   For other platforms, download the .zip or .tar.gz files.
 3. Backup your current configuration from the Admin Console or manually.
 
    1. From the Admin Console, click the **Download** button to generate a .zip file which contains the `config.json` file, the `certs` folder and the `lib\\profileMapper.js` file.

--- a/main/docs/authenticate/identity-providers/enterprise-identity-providers/active-directory-ldap/ad-ldap-connector/update-ad-ldap-connectors.mdx
+++ b/main/docs/authenticate/identity-providers/enterprise-identity-providers/active-directory-ldap/ad-ldap-connector/update-ad-ldap-connectors.mdx
@@ -4,7 +4,7 @@ title: Update AD/LDAP Connectors
 ---
 If there are multiple instances of the AD/LDAP Connector in your deployment, Auth0 recommends that you perform the steps below for each instance one at a time, so that only one instance is down at any point.
 
-1. Verify the version you have installed. The current version is displayed in the admin console.
+1. Open the Admin Console by navigating to `http://localhost:8357/`. Verify the version you have installed.
 2. Download the latest version of the [installer](https://github.com/auth0/ad-ldap-connector/releases/latest).
    For other platforms, download the .zip or .tar.gz files.
 3. Backup your current configuration from the Admin Console or manually.


### PR DESCRIPTION

## Description
* Removed some outdated instructions for updating the AD/LDAP connector. 
* We are discouraging using the in built update functionality or directly calling the powershell script with admin rights so those directions have been removed.


### References
https://auth0team.atlassian.net/browse/IUM-4251

## Checklist

- [✅ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [✅ ] I've tested the site build for this change locally.
- [✅ ] I've made appropriate docs updates for any code or config changes.
- [N/A] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
