### PR TITLE
docs: add scope parameter documentation for Token Vault token exchange

### DIFF
--- a/main/docs/api/authentication/token-vault-token-exchange/get-token.mdx
+++ b/main/docs/api/authentication/token-vault-token-exchange/get-token.mdx
@@ -70,6 +70,10 @@ To learn more, read the [Token Vault documentation](/docs/secure/call-apis-on-us
   (Optional) Only use `login_hint` if the user has several accounts from the same connection, such as a work Google account and a personal Google account. When you pass a value for `login_hint` during the token exchange, you explicitly identify which of the user's linked accounts the request is for.
 </ParamField>
 
+<ParamField body="scope" type="string">
+  <Badge color="yellow">Early Access</Badge> (Optional) A space-delimited list of scopes to request for the external provider's access token. Use this to request a subset of the scopes originally granted. If not provided, the token is issued with all originally granted scopes. For Privileged Worker Token Exchange (`subject_token_type` is `urn:ietf:params:oauth:token-type:jwt`), the requested scopes are intersected with the scopes configured in `token_vault_privileged_access.grants` for the specified connection.
+</ParamField>
+
 ## Response
 
 | Status | Description |

--- a/main/docs/secure/call-apis-on-users-behalf/token-vault/access-token-exchange-with-token-vault.mdx
+++ b/main/docs/secure/call-apis-on-users-behalf/token-vault/access-token-exchange-with-token-vault.mdx
@@ -87,6 +87,7 @@ curl --request POST 'https://{yourDomain}/oauth/token' \
 | `subject_token` | The Auth0 access token that the Auth0 Authorization Server validates to identify the user. |
 | `requested_token_type` | The requested token type. For Token Vault, set to the external provider's access token or `http://auth0.com/oauth/token-type/federated-connection-access-token` |
 | `connection` | The connection name, in this case, `google-oauth2`. |
+| `scope` | <Badge color="yellow">Early Access</Badge> (Optional) A space-delimited list of scopes to request for the external provider's access token. Use this to request a subset of the scopes originally granted during the Connected Accounts flow. If not provided, the token is issued with all originally granted scopes. |
 | `login_hint` | (Optional) Only use `login_hint` if the user has several accounts from the same connection, such as a work Google account and personal Google account. When you pass in a value for the `login_hint` during the token exchange, you are explicitly identifying which of the user's multiple linked accounts the request is for. |
 
 ## Step 4: Auth0 Authorization Server validates access token

--- a/main/docs/secure/call-apis-on-users-behalf/token-vault/privileged-worker-token-exchange-with-token-vault.mdx
+++ b/main/docs/secure/call-apis-on-users-behalf/token-vault/privileged-worker-token-exchange-with-token-vault.mdx
@@ -240,6 +240,7 @@ curl --request POST 'https://{yourDomain}.auth0.com/oauth/token' \
 | `subject_token` | The signed JWT bearer token that the Auth0 Authorization Server validates to identify the user. |
 | `requested_token_type` | The requested token type. For Privileged Worker Token Exchange, this should always be `http://auth0.com/oauth/token-type/token-vault-access-token`. |
 | `connection` | The connection name, in this case, `google-oauth2`. |
+| `scope` | <Badge color="yellow">Early Access</Badge> (Optional) A space-delimited list of scopes to request for the external provider's access token. The requested scopes are intersected with the scopes configured in the `token_vault_privileged_access.grants` for this connection on the client. If not provided, the token is issued with all scopes configured in the grants for this connection. |
 
 
 

--- a/main/docs/secure/call-apis-on-users-behalf/token-vault/refresh-token-exchange-with-token-vault.mdx
+++ b/main/docs/secure/call-apis-on-users-behalf/token-vault/refresh-token-exchange-with-token-vault.mdx
@@ -64,6 +64,7 @@ curl --request POST 'https://{yourDomain}/oauth/token' \
 | `subject_token` | The Auth0 refresh token that the Auth0 Authorization Server validates to identify the user. |
 | `requested_token_type` | The requested token type. For Token Vault, set to the external provider's access token or `http://auth0.com/oauth/token-type/federated-connection-access-token` |
 | `connection` | The connection name, in this case, `google-oauth2`. |
+| `scope` | <Badge color="yellow">Early Access</Badge> (Optional) A space-delimited list of scopes to request for the external provider's access token. Use this to request a subset of the scopes originally granted during the Connected Accounts flow. If not provided, the token is issued with all originally granted scopes. |
 | `login_hint` | (Optional) Only use `login_hint` if the user has several accounts from the same connection, such as a work Google account and personal Google account. When you pass in a value for the `login_hint` during the token exchange, you are explicitly identifying which of the user's multiple linked accounts the request is for. |
 
 ## Step 3: Auth0 Authorization Server validates refresh token


### PR DESCRIPTION
## Description

  This PR adds documentation for the new `scope` parameter in Token Vault token exchange endpoints, enabling runtime downscoping for all exchange types.

  ### Changes Made

  Updated four documentation files to include the `scope` parameter.

<img width="581" height="245" alt="Screenshot 2026-08-19 at 15 55 10" src="https://github.com/user-attachments/assets/744f4e8d-90cf-4814-8497-897fca906900" />
<img width="719" height="111" alt="Screenshot 2026-08-19 at 15 54 30" src="https://github.com/user-attachments/assets/2479e5e3-c2ed-4cfa-897e-fc7c5249ef1a" />



  ## Checklist

  - [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
  - [x] I've tested the site build for this change locally.
  - [x] I've made appropriate docs updates for any code or config changes.
  - [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.