### PR TITLE
feat: add SDK reference docs for auth0-react and auth0-spa-js

### DIFF
--- a/main/.mintignore
+++ b/main/.mintignore
@@ -1,1 +1,4 @@
 _metadata.json
+
+# TypeDoc JSON consumed by Mintlify's SDK reference generator.
+sdk-artifacts/

--- a/main/config/nav.en.json
+++ b/main/config/nav.en.json
@@ -97,6 +97,21 @@
         "source": "sdk-artifacts/auth0-react.json",
         "directory": "docs/sdk/react"
       }
+    },
+    {
+      "tab": "JavaScript SDK Reference",
+      "icon": "book",
+      "hidden": true,
+      "$ref": "./navigation/generated/spa-js-reference.en.json"
+    },
+    {
+      "tab": "JavaScript SDK Reference (generated)",
+      "hidden": true,
+      "sdk": {
+        "format": "typedoc",
+        "source": "sdk-artifacts/auth0-spa-js.json",
+        "directory": "docs/sdk/typescript"
+      }
     }
   ]
 }

--- a/main/config/nav.en.json
+++ b/main/config/nav.en.json
@@ -82,6 +82,21 @@
           "$ref": "./navigation/universal-components.json"
         }
       ]
+    },
+    {
+      "tab": "React SDK Reference",
+      "icon": "book",
+      "hidden": true,
+      "$ref": "./navigation/generated/react-reference.en.json"
+    },
+    {
+      "tab": "React SDK Reference (generated)",
+      "hidden": true,
+      "sdk": {
+        "format": "typedoc",
+        "source": "sdk-artifacts/auth0-react.json",
+        "directory": "docs/sdk/react"
+      }
     }
   ]
 }

--- a/main/config/navigation/generated/react-reference.en.json
+++ b/main/config/navigation/generated/react-reference.en.json
@@ -1,0 +1,155 @@
+{
+  "pages": [
+    {
+      "group": "Getting Started",
+      "pages": [
+        "docs/sdk/react/functions/Auth0Provider",
+        "docs/sdk/react/types/AppState",
+        "docs/sdk/react/types/Auth0ProviderOptions",
+        "docs/sdk/react/types/Auth0ProviderWithClientOptions",
+        "docs/sdk/react/types/Auth0ProviderWithConfigOptions"
+      ]
+    },
+    {
+      "group": "Hooks & HOCs",
+      "pages": [
+        "docs/sdk/react/functions/useAuth0",
+        "docs/sdk/react/functions/useAuth0Suspense",
+        "docs/sdk/react/functions/withAuth0",
+        "docs/sdk/react/functions/withAuthenticationRequired",
+        "docs/sdk/react/interfaces/WithAuth0Props",
+        "docs/sdk/react/interfaces/WithAuthenticationRequiredOptions"
+      ]
+    },
+    {
+      "group": "Context",
+      "pages": [
+        "docs/sdk/react/interfaces/Auth0ContextInterface",
+        "docs/sdk/react/types/Auth0SuspenseContextInterface",
+        "docs/sdk/react/variables/Auth0Context"
+      ]
+    },
+    {
+      "group": "Reference",
+      "pages": [
+        {
+          "group": "Configuration",
+          "pages": [
+            "docs/sdk/react/interfaces/AuthorizationParams",
+            "docs/sdk/react/interfaces/ClientConfiguration",
+            "docs/sdk/react/types/CacheLocation",
+            "docs/sdk/react/types/InteractiveErrorHandler",
+            "docs/sdk/react/types/RefreshTokenMode",
+            "docs/sdk/react/enums/ResponseType",
+            "docs/sdk/react/variables/RefreshTokenMode"
+          ]
+        },
+        {
+          "group": "Login & Logout",
+          "pages": [
+            "docs/sdk/react/interfaces/LogoutOptions",
+            "docs/sdk/react/interfaces/LogoutUrlOptions",
+            "docs/sdk/react/interfaces/PopupConfigOptions",
+            "docs/sdk/react/interfaces/PopupLoginOptions",
+            "docs/sdk/react/interfaces/RedirectConnectAccountOptions",
+            "docs/sdk/react/interfaces/RedirectLoginOptions",
+            "docs/sdk/react/types/ConnectAccountRedirectResult",
+            "docs/sdk/react/types/ConnectedAccount"
+          ]
+        },
+        {
+          "group": "Tokens & Users",
+          "pages": [
+            "docs/sdk/react/classes/User",
+            "docs/sdk/react/interfaces/ActClaim",
+            "docs/sdk/react/interfaces/GetTokenSilentlyOptions",
+            "docs/sdk/react/interfaces/GetTokenWithPopupOptions",
+            "docs/sdk/react/interfaces/IdToken",
+            "docs/sdk/react/interfaces/RevokeRefreshTokenOptions",
+            "docs/sdk/react/types/CustomTokenExchangeOptions",
+            "docs/sdk/react/types/FetcherConfig",
+            "docs/sdk/react/types/TokenEndpointResponse"
+          ]
+        },
+        {
+          "group": "Multi-Factor Authentication",
+          "pages": [
+            "docs/sdk/react/interfaces/Authenticator",
+            "docs/sdk/react/interfaces/ChallengeAuthenticatorParams",
+            "docs/sdk/react/interfaces/ChallengeResponse",
+            "docs/sdk/react/interfaces/EnrollEmailParams",
+            "docs/sdk/react/interfaces/EnrollmentFactor",
+            "docs/sdk/react/interfaces/EnrollOtpParams",
+            "docs/sdk/react/interfaces/EnrollPushParams",
+            "docs/sdk/react/interfaces/EnrollSmsParams",
+            "docs/sdk/react/interfaces/EnrollVoiceParams",
+            "docs/sdk/react/interfaces/MfaApiClient",
+            "docs/sdk/react/interfaces/VerifyParams",
+            "docs/sdk/react/types/EnrollmentResponse",
+            "docs/sdk/react/types/EnrollParams",
+            "docs/sdk/react/types/MfaFactorType"
+          ]
+        },
+        {
+          "group": "Passkeys",
+          "pages": [
+            "docs/sdk/react/interfaces/PasskeyApiClient",
+            "docs/sdk/react/types/PasskeyLoginOptions",
+            "docs/sdk/react/types/PasskeySignupOptions"
+          ]
+        },
+        {
+          "group": "My Account",
+          "pages": [
+            "docs/sdk/react/interfaces/Factor",
+            "docs/sdk/react/interfaces/MyAccountApiClient",
+            "docs/sdk/react/interfaces/UpdateAuthenticationMethodRequest",
+            "docs/sdk/react/types/AuthenticationMethod",
+            "docs/sdk/react/types/AuthenticationMethodType",
+            "docs/sdk/react/types/EnrollmentChallengeOptions",
+            "docs/sdk/react/types/EnrollmentChallengeResponse",
+            "docs/sdk/react/types/EnrollmentVerifyOptions"
+          ]
+        },
+        {
+          "group": "Errors",
+          "pages": [
+            "docs/sdk/react/classes/AuthenticationError",
+            "docs/sdk/react/classes/ConnectError",
+            "docs/sdk/react/classes/GenericError",
+            "docs/sdk/react/classes/InvalidConfigurationError",
+            "docs/sdk/react/classes/MfaChallengeError",
+            "docs/sdk/react/classes/MfaEnrollmentError",
+            "docs/sdk/react/classes/MfaEnrollmentFactorsError",
+            "docs/sdk/react/classes/MfaError",
+            "docs/sdk/react/classes/MfaListAuthenticatorsError",
+            "docs/sdk/react/classes/MfaRequiredError",
+            "docs/sdk/react/classes/MfaVerifyError",
+            "docs/sdk/react/classes/MissingRefreshTokenError",
+            "docs/sdk/react/classes/MissingScopesError",
+            "docs/sdk/react/classes/MyAccountApiError",
+            "docs/sdk/react/classes/OAuthError",
+            "docs/sdk/react/classes/PasskeyChallengeError",
+            "docs/sdk/react/classes/PasskeyError",
+            "docs/sdk/react/classes/PasskeyGetTokenError",
+            "docs/sdk/react/classes/PasskeyRegisterError",
+            "docs/sdk/react/classes/PopupCancelledError",
+            "docs/sdk/react/classes/PopupOpenError",
+            "docs/sdk/react/classes/PopupTimeoutError",
+            "docs/sdk/react/classes/TimeoutError",
+            "docs/sdk/react/classes/UseDpopNonceError"
+          ]
+        },
+        {
+          "group": "Caching",
+          "pages": [
+            "docs/sdk/react/classes/InMemoryCache",
+            "docs/sdk/react/classes/LocalStorageCache",
+            "docs/sdk/react/interfaces/ICache",
+            "docs/sdk/react/types/Cacheable"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/main/config/navigation/generated/spa-js-reference.en.json
+++ b/main/config/navigation/generated/spa-js-reference.en.json
@@ -1,0 +1,207 @@
+{
+  "pages": [
+    {
+      "group": "Getting Started",
+      "pages": [
+        "docs/sdk/typescript/functions/createAuth0Client"
+      ]
+    },
+    {
+      "group": "Clients",
+      "pages": [
+        "docs/sdk/typescript/classes/Auth0Client",
+        "docs/sdk/typescript/classes/Fetcher",
+        "docs/sdk/typescript/classes/MfaApiClient",
+        "docs/sdk/typescript/classes/MyAccountApiClient",
+        "docs/sdk/typescript/classes/PasskeyApiClient"
+      ]
+    },
+    {
+      "group": "Reference",
+      "pages": [
+        {
+          "group": "Configuration",
+          "pages": [
+            "docs/sdk/typescript/interfaces/Auth0ClientOptions",
+            "docs/sdk/typescript/interfaces/AuthorizationParams",
+            "docs/sdk/typescript/interfaces/ClientAuthorizationParams",
+            "docs/sdk/typescript/interfaces/ClientConfiguration",
+            "docs/sdk/typescript/types/CacheLocation",
+            "docs/sdk/typescript/types/InteractiveErrorHandler",
+            "docs/sdk/typescript/types/RefreshTokenMode",
+            "docs/sdk/typescript/variables/RefreshTokenMode"
+          ]
+        },
+        {
+          "group": "Login & Logout",
+          "pages": [
+            "docs/sdk/typescript/interfaces/LogoutOptions",
+            "docs/sdk/typescript/interfaces/LogoutUrlOptions",
+            "docs/sdk/typescript/interfaces/PopupConfigOptions",
+            "docs/sdk/typescript/interfaces/PopupLoginOptions",
+            "docs/sdk/typescript/interfaces/RedirectConnectAccountOptions",
+            "docs/sdk/typescript/interfaces/RedirectLoginOptions",
+            "docs/sdk/typescript/interfaces/RedirectLoginResult",
+            "docs/sdk/typescript/types/ConnectAccountRedirectResult"
+          ]
+        },
+        {
+          "group": "Tokens & Users",
+          "pages": [
+            "docs/sdk/typescript/classes/User",
+            "docs/sdk/typescript/interfaces/ActClaim",
+            "docs/sdk/typescript/interfaces/GetTokenSilentlyOptions",
+            "docs/sdk/typescript/interfaces/GetTokenWithPopupOptions",
+            "docs/sdk/typescript/interfaces/IdToken",
+            "docs/sdk/typescript/interfaces/RevokeRefreshTokenOptions",
+            "docs/sdk/typescript/types/CustomFetchMinimalOutput",
+            "docs/sdk/typescript/types/CustomTokenExchangeOptions",
+            "docs/sdk/typescript/types/FetcherConfig",
+            "docs/sdk/typescript/types/GetTokenSilentlyVerboseResponse",
+            "docs/sdk/typescript/types/TokenEndpointResponse"
+          ]
+        },
+        {
+          "group": "Multi-Factor Authentication",
+          "pages": [
+            "docs/sdk/typescript/interfaces/Authenticator",
+            "docs/sdk/typescript/interfaces/ChallengeAuthenticatorParams",
+            "docs/sdk/typescript/interfaces/ChallengeResponse",
+            "docs/sdk/typescript/interfaces/EnrollEmailParams",
+            "docs/sdk/typescript/interfaces/EnrollOtpParams",
+            "docs/sdk/typescript/interfaces/EnrollPushParams",
+            "docs/sdk/typescript/interfaces/EnrollSmsParams",
+            "docs/sdk/typescript/interfaces/EnrollVoiceParams",
+            "docs/sdk/typescript/interfaces/EnrollmentFactor",
+            "docs/sdk/typescript/interfaces/OobEnrollmentResponse",
+            "docs/sdk/typescript/interfaces/OtpEnrollmentResponse",
+            "docs/sdk/typescript/interfaces/VerifyParams",
+            "docs/sdk/typescript/types/AuthenticatorType",
+            "docs/sdk/typescript/types/EnrollParams",
+            "docs/sdk/typescript/types/EnrollmentResponse",
+            "docs/sdk/typescript/types/MfaFactorType",
+            "docs/sdk/typescript/types/MfaGrantType",
+            "docs/sdk/typescript/types/OobChannel"
+          ]
+        },
+        {
+          "group": "Passkeys",
+          "pages": [
+            "docs/sdk/typescript/interfaces/PasskeyCreationOptions",
+            "docs/sdk/typescript/interfaces/PasskeyCredentialResponse",
+            "docs/sdk/typescript/interfaces/PasskeyErrorResponse",
+            "docs/sdk/typescript/interfaces/PasskeyLoginChallengeOptions",
+            "docs/sdk/typescript/interfaces/PasskeyLoginChallengeResponse",
+            "docs/sdk/typescript/interfaces/PasskeyRequestOptions",
+            "docs/sdk/typescript/interfaces/PasskeySignupChallengeResponse",
+            "docs/sdk/typescript/types/PasskeyGetTokenOptions",
+            "docs/sdk/typescript/types/PasskeyLoginChallenge",
+            "docs/sdk/typescript/types/PasskeyLoginOptions",
+            "docs/sdk/typescript/types/PasskeySignupChallenge",
+            "docs/sdk/typescript/types/PasskeySignupChallengeOptions",
+            "docs/sdk/typescript/types/PasskeySignupOptions"
+          ]
+        },
+        {
+          "group": "My Account",
+          "pages": [
+            "docs/sdk/typescript/interfaces/CompleteRequest",
+            "docs/sdk/typescript/interfaces/CompleteResponse",
+            "docs/sdk/typescript/interfaces/ConnectRequest",
+            "docs/sdk/typescript/interfaces/ConnectResponse",
+            "docs/sdk/typescript/interfaces/EmailAuthenticationMethod",
+            "docs/sdk/typescript/interfaces/EmailEnrollmentChallengeOptions",
+            "docs/sdk/typescript/interfaces/EmailEnrollmentChallengeResponse",
+            "docs/sdk/typescript/interfaces/EmailEnrollmentVerifyOptions",
+            "docs/sdk/typescript/interfaces/ErrorResponse",
+            "docs/sdk/typescript/interfaces/Factor",
+            "docs/sdk/typescript/interfaces/PasskeyAuthenticationMethod",
+            "docs/sdk/typescript/interfaces/PasskeyEnrollmentChallengeOptions",
+            "docs/sdk/typescript/interfaces/PasskeyEnrollmentChallengeResponse",
+            "docs/sdk/typescript/interfaces/PasskeyEnrollmentVerifyOptions",
+            "docs/sdk/typescript/interfaces/PasswordAuthenticationMethod",
+            "docs/sdk/typescript/interfaces/PasswordEnrollmentChallengeOptions",
+            "docs/sdk/typescript/interfaces/PasswordEnrollmentChallengeResponse",
+            "docs/sdk/typescript/interfaces/PasswordEnrollmentVerifyOptions",
+            "docs/sdk/typescript/interfaces/PasswordPolicy",
+            "docs/sdk/typescript/interfaces/PhoneAuthenticationMethod",
+            "docs/sdk/typescript/interfaces/PhoneEnrollmentChallengeOptions",
+            "docs/sdk/typescript/interfaces/PhoneEnrollmentChallengeResponse",
+            "docs/sdk/typescript/interfaces/PhoneEnrollmentVerifyOptions",
+            "docs/sdk/typescript/interfaces/PushNotificationAuthenticationMethod",
+            "docs/sdk/typescript/interfaces/PushNotificationEnrollmentChallengeOptions",
+            "docs/sdk/typescript/interfaces/PushNotificationEnrollmentChallengeResponse",
+            "docs/sdk/typescript/interfaces/PushNotificationEnrollmentVerifyOptions",
+            "docs/sdk/typescript/interfaces/RecoveryCodeAuthenticationMethod",
+            "docs/sdk/typescript/interfaces/RecoveryCodeEnrollmentChallengeOptions",
+            "docs/sdk/typescript/interfaces/RecoveryCodeEnrollmentChallengeResponse",
+            "docs/sdk/typescript/interfaces/RecoveryCodeEnrollmentVerifyOptions",
+            "docs/sdk/typescript/interfaces/TotpAuthenticationMethod",
+            "docs/sdk/typescript/interfaces/TotpEnrollmentChallengeOptions",
+            "docs/sdk/typescript/interfaces/TotpEnrollmentChallengeResponse",
+            "docs/sdk/typescript/interfaces/TotpEnrollmentVerifyOptions",
+            "docs/sdk/typescript/interfaces/UpdateAuthenticationMethodRequest",
+            "docs/sdk/typescript/interfaces/WebAuthnPlatformAuthenticationMethod",
+            "docs/sdk/typescript/interfaces/WebAuthnRoamingAuthenticationMethod",
+            "docs/sdk/typescript/types/AuthenticationMethod",
+            "docs/sdk/typescript/types/AuthenticationMethodType",
+            "docs/sdk/typescript/types/EnrollmentChallengeOptions",
+            "docs/sdk/typescript/types/EnrollmentChallengeResponse",
+            "docs/sdk/typescript/types/EnrollmentVerifyOptions"
+          ]
+        },
+        {
+          "group": "Errors",
+          "pages": [
+            "docs/sdk/typescript/classes/AuthenticationError",
+            "docs/sdk/typescript/classes/ConnectError",
+            "docs/sdk/typescript/classes/GenericError",
+            "docs/sdk/typescript/classes/InvalidConfigurationError",
+            "docs/sdk/typescript/classes/MfaChallengeError",
+            "docs/sdk/typescript/classes/MfaEnrollmentError",
+            "docs/sdk/typescript/classes/MfaEnrollmentFactorsError",
+            "docs/sdk/typescript/classes/MfaError",
+            "docs/sdk/typescript/classes/MfaListAuthenticatorsError",
+            "docs/sdk/typescript/classes/MfaRequiredError",
+            "docs/sdk/typescript/classes/MfaVerifyError",
+            "docs/sdk/typescript/classes/MissingRefreshTokenError",
+            "docs/sdk/typescript/classes/MissingScopesError",
+            "docs/sdk/typescript/classes/MyAccountApiError",
+            "docs/sdk/typescript/classes/PasskeyChallengeError",
+            "docs/sdk/typescript/classes/PasskeyError",
+            "docs/sdk/typescript/classes/PasskeyGetTokenError",
+            "docs/sdk/typescript/classes/PasskeyRegisterError",
+            "docs/sdk/typescript/classes/PopupCancelledError",
+            "docs/sdk/typescript/classes/PopupOpenError",
+            "docs/sdk/typescript/classes/PopupTimeoutError",
+            "docs/sdk/typescript/classes/TimeoutError",
+            "docs/sdk/typescript/classes/UseDpopNonceError",
+            "docs/sdk/typescript/interfaces/MfaRequirements"
+          ]
+        },
+        {
+          "group": "Caching",
+          "pages": [
+            "docs/sdk/typescript/classes/CacheKey",
+            "docs/sdk/typescript/classes/InMemoryCache",
+            "docs/sdk/typescript/classes/LocalStorageCache",
+            "docs/sdk/typescript/interfaces/DecodedToken",
+            "docs/sdk/typescript/interfaces/ICache",
+            "docs/sdk/typescript/types/CacheEntry",
+            "docs/sdk/typescript/types/CacheKeyData",
+            "docs/sdk/typescript/types/Cacheable",
+            "docs/sdk/typescript/types/KeyManifestEntry",
+            "docs/sdk/typescript/types/MaybePromise",
+            "docs/sdk/typescript/types/WrappedCacheEntry"
+          ]
+        },
+        {
+          "group": "Other Types",
+          "pages": [
+            "docs/sdk/typescript/enums/ResponseType"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/main/sdk-artifacts/auth0-react.json
+++ b/main/sdk-artifacts/auth0-react.json
@@ -1,0 +1,28853 @@
+{
+	"schemaVersion": "2.0",
+	"id": 0,
+	"name": "Auth0 React SDK",
+	"variant": "project",
+	"kind": 1,
+	"flags": {},
+	"children": [
+		{
+			"id": 1,
+			"name": "Auth0Provider",
+			"variant": "declaration",
+			"kind": 64,
+			"flags": {},
+			"sources": [
+				{
+					"fileName": "src/auth0-provider.tsx",
+					"line": 203,
+					"character": 6
+				}
+			],
+			"signatures": [
+				{
+					"id": 2,
+					"name": "Auth0Provider",
+					"variant": "signature",
+					"kind": 4096,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "code",
+								"text": "```jsx\n<Auth0Provider\n  domain={domain}\n  clientId={clientId}\n  authorizationParams={{ redirect_uri: window.location.origin }}>\n  <MyApp />\n</Auth0Provider>\n```"
+							},
+							{
+								"kind": "text",
+								"text": "\n\nProvides the Auth0Context to its child components.\n\nThe SDK is a client-only module (its published ESM and CommonJS bundles ship the\n"
+							},
+							{
+								"kind": "code",
+								"text": "`'use client'`"
+							},
+							{
+								"kind": "text",
+								"text": " directive), so in a Next.js App Router app you can import and render\n"
+							},
+							{
+								"kind": "code",
+								"text": "`Auth0Provider`"
+							},
+							{
+								"kind": "text",
+								"text": " directly from a Server Component such as "
+							},
+							{
+								"kind": "code",
+								"text": "`app/layout.tsx`"
+							},
+							{
+								"kind": "text",
+								"text": ".\nComponents that call hooks like "
+							},
+							{
+								"kind": "code",
+								"text": "`useAuth0`"
+							},
+							{
+								"kind": "text",
+								"text": " must still be Client Components."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Getting Started"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/auth0-provider.tsx",
+							"line": 203,
+							"character": 22
+						}
+					],
+					"typeParameters": [
+						{
+							"id": 3,
+							"name": "TUser",
+							"variant": "typeParam",
+							"kind": 131072,
+							"flags": {},
+							"type": {
+								"type": "reference",
+								"target": 326,
+								"name": "User",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"default": {
+								"type": "reference",
+								"target": 326,
+								"name": "User",
+								"package": "@auth0/auth0-spa-js"
+							}
+						}
+					],
+					"parameters": [
+						{
+							"id": 4,
+							"name": "opts",
+							"variant": "param",
+							"kind": 32768,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Type: [Auth0ProviderOptions](/docs/sdk/react/types/Auth0ProviderOptions)"
+									}
+								]
+							},
+							"type": {
+								"type": "reference",
+								"target": 5,
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 3,
+										"name": "TUser",
+										"package": "@auth0/auth0-react",
+										"refersToTypeParameter": true
+									}
+								],
+								"name": "Auth0ProviderOptions",
+								"package": "@auth0/auth0-react"
+							}
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": {
+							"packageName": "@types/react",
+							"packagePath": "index.d.ts",
+							"qualifiedName": "React.JSX.Element"
+						},
+						"name": "Element",
+						"package": "@types/react",
+						"qualifiedName": "React.JSX.Element"
+					}
+				}
+			]
+		},
+		{
+			"id": 23,
+			"name": "useAuth0",
+			"variant": "declaration",
+			"kind": 64,
+			"flags": {},
+			"sources": [
+				{
+					"fileName": "src/use-auth0.tsx",
+					"line": 29,
+					"character": 6
+				}
+			],
+			"signatures": [
+				{
+					"id": 24,
+					"name": "useAuth0",
+					"variant": "signature",
+					"kind": 4096,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "code",
+								"text": "```js\nconst {\n  // Auth state:\n  error,\n  isAuthenticated,\n  isLoading,\n  user,\n  // Auth methods:\n  getAccessTokenSilently,\n  getAccessTokenWithPopup,\n  getIdTokenClaims,\n  loginWithCustomTokenExchange,\n  exchangeToken, // deprecated - use loginWithCustomTokenExchange\n  loginWithRedirect,\n  loginWithPopup,\n  logout,\n} = useAuth0<TUser>();\n```"
+							},
+							{
+								"kind": "text",
+								"text": "\n\nUse the "
+							},
+							{
+								"kind": "code",
+								"text": "`useAuth0`"
+							},
+							{
+								"kind": "text",
+								"text": " hook in your components to access the auth state and methods.\n\nTUser is an optional type param to provide a type to the "
+							},
+							{
+								"kind": "code",
+								"text": "`user`"
+							},
+							{
+								"kind": "text",
+								"text": " field."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Hooks & HOCs"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/use-auth0.tsx",
+							"line": 29,
+							"character": 17
+						}
+					],
+					"typeParameters": [
+						{
+							"id": 25,
+							"name": "TUser",
+							"variant": "typeParam",
+							"kind": 131072,
+							"flags": {},
+							"type": {
+								"type": "reference",
+								"target": 326,
+								"name": "User",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"default": {
+								"type": "reference",
+								"target": 326,
+								"name": "User",
+								"package": "@auth0/auth0-spa-js"
+							}
+						}
+					],
+					"parameters": [
+						{
+							"id": 26,
+							"name": "context",
+							"variant": "param",
+							"kind": 32768,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Type: [Auth0ContextInterface](/docs/sdk/react/interfaces/Auth0ContextInterface), [User](/docs/sdk/react/classes/User)"
+									}
+								]
+							},
+							"type": {
+								"type": "reference",
+								"target": {
+									"packageName": "@types/react",
+									"packagePath": "index.d.ts",
+									"qualifiedName": "React.Context"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 58,
+										"typeArguments": [
+											{
+												"type": "reference",
+												"target": 326,
+												"name": "User",
+												"package": "@auth0/auth0-spa-js"
+											}
+										],
+										"name": "Auth0ContextInterface",
+										"package": "@auth0/auth0-react"
+									}
+								],
+								"name": "Context",
+								"package": "@types/react",
+								"qualifiedName": "React.Context"
+							},
+							"defaultValue": "Auth0Context"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 58,
+						"typeArguments": [
+							{
+								"type": "reference",
+								"target": 25,
+								"name": "TUser",
+								"package": "@auth0/auth0-react",
+								"refersToTypeParameter": true
+							}
+						],
+						"name": "Auth0ContextInterface",
+						"package": "@auth0/auth0-react"
+					}
+				}
+			]
+		},
+		{
+			"id": 27,
+			"name": "useAuth0Suspense",
+			"variant": "declaration",
+			"kind": 64,
+			"flags": {},
+			"sources": [
+				{
+					"fileName": "src/use-auth0-suspense.tsx",
+					"line": 43,
+					"character": 6
+				}
+			],
+			"signatures": [
+				{
+					"id": 28,
+					"name": "useAuth0Suspense",
+					"variant": "signature",
+					"kind": 4096,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "code",
+								"text": "```jsx\n<Suspense fallback={<Spinner />}>\n  <Profile />\n</Suspense>\n\nfunction Profile() {\n  const { user, isAuthenticated } = useAuth0Suspense();\n  return isAuthenticated ? <p>Hello {user.name}</p> : <p>Please log in</p>;\n}\n```"
+							},
+							{
+								"kind": "text",
+								"text": "\n\nSuspense-enabled variant of "
+							},
+							{
+								"kind": "code",
+								"text": "`useAuth0`"
+							},
+							{
+								"kind": "text",
+								"text": ". Suspends the component until Auth0\ninitialization completes (letting the nearest "
+							},
+							{
+								"kind": "code",
+								"text": "`<Suspense>`"
+							},
+							{
+								"kind": "text",
+								"text": " fallback render),\nand throws initialization errors so the nearest Error Boundary can handle\nthem. Requires React 19 or later.\n\nIf initialization fails and the app later becomes authenticated by other\nmeans, the session is re-checked once; retrying the Error Boundary then\nrenders if that check succeeded, or throws again if it did not.\n\nTUser is an optional type param to provide a type to the "
+							},
+							{
+								"kind": "code",
+								"text": "`user`"
+							},
+							{
+								"kind": "text",
+								"text": " field."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Hooks & HOCs"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/use-auth0-suspense.tsx",
+							"line": 43,
+							"character": 25
+						}
+					],
+					"typeParameters": [
+						{
+							"id": 29,
+							"name": "TUser",
+							"variant": "typeParam",
+							"kind": 131072,
+							"flags": {},
+							"type": {
+								"type": "reference",
+								"target": 326,
+								"name": "User",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"default": {
+								"type": "reference",
+								"target": 326,
+								"name": "User",
+								"package": "@auth0/auth0-spa-js"
+							}
+						}
+					],
+					"parameters": [
+						{
+							"id": 30,
+							"name": "context",
+							"variant": "param",
+							"kind": 32768,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Type: [Auth0ContextInterface](/docs/sdk/react/interfaces/Auth0ContextInterface), [User](/docs/sdk/react/classes/User)"
+									}
+								]
+							},
+							"type": {
+								"type": "reference",
+								"target": {
+									"packageName": "@types/react",
+									"packagePath": "index.d.ts",
+									"qualifiedName": "React.Context"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 58,
+										"typeArguments": [
+											{
+												"type": "reference",
+												"target": 326,
+												"name": "User",
+												"package": "@auth0/auth0-spa-js"
+											}
+										],
+										"name": "Auth0ContextInterface",
+										"package": "@auth0/auth0-react"
+									}
+								],
+								"name": "Context",
+								"package": "@types/react",
+								"qualifiedName": "React.Context"
+							},
+							"defaultValue": "Auth0Context"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 31,
+						"typeArguments": [
+							{
+								"type": "reference",
+								"target": 29,
+								"name": "TUser",
+								"package": "@auth0/auth0-react",
+								"refersToTypeParameter": true
+							}
+						],
+						"name": "Auth0SuspenseContextInterface",
+						"package": "@auth0/auth0-react"
+					}
+				}
+			]
+		},
+		{
+			"id": 33,
+			"name": "withAuth0",
+			"variant": "declaration",
+			"kind": 64,
+			"flags": {},
+			"sources": [
+				{
+					"fileName": "src/with-auth0.tsx",
+					"line": 29,
+					"character": 6
+				}
+			],
+			"signatures": [
+				{
+					"id": 34,
+					"name": "withAuth0",
+					"variant": "signature",
+					"kind": 4096,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "code",
+								"text": "```jsx\nclass MyComponent extends Component {\n  render() {\n    // Access the auth context from the `auth0` prop\n    const { user } = this.props.auth0;\n    return <div>Hello {user.name}!</div>\n  }\n}\n// Wrap your class component in withAuth0\nexport default withAuth0(MyComponent);\n```"
+							},
+							{
+								"kind": "text",
+								"text": "\n\nWrap your class components in this Higher Order Component to give them access to the Auth0Context.\n\nProviding a context as the second argument allows you to configure the Auth0Provider the Auth0Context\nshould come from f you have multiple within your application."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Hooks & HOCs"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/with-auth0.tsx",
+							"line": 29,
+							"character": 18
+						}
+					],
+					"typeParameters": [
+						{
+							"id": 35,
+							"name": "P",
+							"variant": "typeParam",
+							"kind": 131072,
+							"flags": {},
+							"type": {
+								"type": "reference",
+								"target": 38,
+								"name": "WithAuth0Props",
+								"package": "@auth0/auth0-react"
+							}
+						}
+					],
+					"parameters": [
+						{
+							"id": 36,
+							"name": "Component",
+							"variant": "param",
+							"kind": 32768,
+							"flags": {},
+							"type": {
+								"type": "reference",
+								"target": {
+									"packageName": "@types/react",
+									"packagePath": "index.d.ts",
+									"qualifiedName": "React.ComponentType"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 35,
+										"name": "P",
+										"package": "@auth0/auth0-react",
+										"refersToTypeParameter": true
+									}
+								],
+								"name": "ComponentType",
+								"package": "@types/react",
+								"qualifiedName": "React.ComponentType"
+							}
+						},
+						{
+							"id": 37,
+							"name": "context",
+							"variant": "param",
+							"kind": 32768,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Type: [Auth0ContextInterface](/docs/sdk/react/interfaces/Auth0ContextInterface), [User](/docs/sdk/react/classes/User)"
+									}
+								]
+							},
+							"type": {
+								"type": "reference",
+								"target": {
+									"packageName": "@types/react",
+									"packagePath": "index.d.ts",
+									"qualifiedName": "React.Context"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 58,
+										"typeArguments": [
+											{
+												"type": "reference",
+												"target": 326,
+												"name": "User",
+												"package": "@auth0/auth0-spa-js"
+											}
+										],
+										"name": "Auth0ContextInterface",
+										"package": "@auth0/auth0-react"
+									}
+								],
+								"name": "Context",
+								"package": "@types/react",
+								"qualifiedName": "React.Context"
+							},
+							"defaultValue": "Auth0Context"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": {
+							"packageName": "@types/react",
+							"packagePath": "index.d.ts",
+							"qualifiedName": "React.ComponentType"
+						},
+						"typeArguments": [
+							{
+								"type": "reference",
+								"target": {
+									"packageName": "typescript",
+									"packagePath": "lib/lib.es5.d.ts",
+									"qualifiedName": "Omit"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 35,
+										"name": "P",
+										"package": "@auth0/auth0-react",
+										"refersToTypeParameter": true
+									},
+									{
+										"type": "literal",
+										"value": "auth0"
+									}
+								],
+								"name": "Omit",
+								"package": "typescript"
+							}
+						],
+						"name": "ComponentType",
+						"package": "@types/react",
+						"qualifiedName": "React.ComponentType"
+					}
+				}
+			]
+		},
+		{
+			"id": 40,
+			"name": "withAuthenticationRequired",
+			"variant": "declaration",
+			"kind": 64,
+			"flags": {},
+			"sources": [
+				{
+					"fileName": "src/with-authentication-required.tsx",
+					"line": 103,
+					"character": 6
+				}
+			],
+			"signatures": [
+				{
+					"id": 41,
+					"name": "withAuthenticationRequired",
+					"variant": "signature",
+					"kind": 4096,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "code",
+								"text": "```js\nconst MyProtectedComponent = withAuthenticationRequired(MyComponent);\n```"
+							},
+							{
+								"kind": "text",
+								"text": "\n\nWhen you wrap your components in this Higher Order Component and an anonymous user visits your component\nthey will be redirected to the login page; after login they will be returned to the page they were redirected from."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Hooks & HOCs"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/with-authentication-required.tsx",
+							"line": 103,
+							"character": 35
+						}
+					],
+					"typeParameters": [
+						{
+							"id": 42,
+							"name": "P",
+							"variant": "typeParam",
+							"kind": 131072,
+							"flags": {},
+							"type": {
+								"type": "intrinsic",
+								"name": "object"
+							}
+						}
+					],
+					"parameters": [
+						{
+							"id": 43,
+							"name": "Component",
+							"variant": "param",
+							"kind": 32768,
+							"flags": {},
+							"type": {
+								"type": "reference",
+								"target": {
+									"packageName": "@types/react",
+									"packagePath": "index.d.ts",
+									"qualifiedName": "React.ComponentType"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 42,
+										"name": "P",
+										"package": "@auth0/auth0-react",
+										"refersToTypeParameter": true
+									}
+								],
+								"name": "ComponentType",
+								"package": "@types/react",
+								"qualifiedName": "React.ComponentType"
+							}
+						},
+						{
+							"id": 44,
+							"name": "options",
+							"variant": "param",
+							"kind": 32768,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Type: [WithAuthenticationRequiredOptions](/docs/sdk/react/interfaces/WithAuthenticationRequiredOptions)"
+									}
+								]
+							},
+							"type": {
+								"type": "reference",
+								"target": 45,
+								"name": "WithAuthenticationRequiredOptions",
+								"package": "@auth0/auth0-react"
+							},
+							"defaultValue": "{}"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": {
+							"packageName": "@types/react",
+							"packagePath": "index.d.ts",
+							"qualifiedName": "React.FC"
+						},
+						"typeArguments": [
+							{
+								"type": "reference",
+								"target": 42,
+								"name": "P",
+								"package": "@auth0/auth0-react",
+								"refersToTypeParameter": true
+							}
+						],
+						"name": "FC",
+						"package": "@types/react",
+						"qualifiedName": "React.FC"
+					}
+				}
+			]
+		},
+		{
+			"id": 454,
+			"name": "AuthenticationError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Thrown when handling the redirect callback fails, will be one of Auth0's\r\nAuthentication API's Standard Error Responses: https://auth0.com/docs/api/authentication?javascript#standard-error-responses"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Errors"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 461,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 41,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 462,
+							"name": "AuthenticationError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+									"line": 41,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 463,
+									"name": "error",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 464,
+									"name": "error_description",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 465,
+									"name": "state",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 466,
+									"name": "appState",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {
+										"isOptional": true
+									},
+									"type": {
+										"type": "intrinsic",
+										"name": "any"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 454,
+								"name": "AuthenticationError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 523,
+								"name": "GenericError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 522,
+						"name": "GenericError.constructor"
+					}
+				},
+				{
+					"id": 468,
+					"name": "appState",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 40,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "any"
+					}
+				},
+				{
+					"id": 469,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 18,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 526,
+						"name": "GenericError.error"
+					}
+				},
+				{
+					"id": 470,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 19,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 527,
+						"name": "GenericError.error_description"
+					}
+				},
+				{
+					"id": 467,
+					"name": "state",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 39,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 455,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true,
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 21,
+							"character": 11
+						}
+					],
+					"signatures": [
+						{
+							"id": 456,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {
+								"isInherited": true
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+									"line": 21,
+									"character": 11
+								}
+							],
+							"parameters": [
+								{
+									"id": 457,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 458,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 459,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+															"line": 22,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 460,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+															"line": 23,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														459,
+														460
+													]
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 515,
+								"name": "GenericError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"inheritedFrom": {
+								"type": "reference",
+								"target": 517,
+								"name": "GenericError.fromPayload"
+							}
+						}
+					],
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 516,
+						"name": "GenericError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						461
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						468,
+						469,
+						470,
+						467
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						455
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+					"line": 38,
+					"character": 21
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 515,
+					"name": "GenericError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 560,
+			"name": "ConnectError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Thrown when handling the redirect callback for the connect flow fails, will be one of Auth0's\r\nAuthentication API's Standard Error Responses: https://auth0.com/docs/api/authentication?javascript#standard-error-responses"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Errors"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 567,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 51,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 568,
+							"name": "ConnectError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+									"line": 51,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 569,
+									"name": "error",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 570,
+									"name": "error_description",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 571,
+									"name": "connection",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 572,
+									"name": "state",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 573,
+									"name": "appState",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {
+										"isOptional": true
+									},
+									"type": {
+										"type": "intrinsic",
+										"name": "any"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 560,
+								"name": "ConnectError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 523,
+								"name": "GenericError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 522,
+						"name": "GenericError.constructor"
+					}
+				},
+				{
+					"id": 576,
+					"name": "appState",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 50,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "any"
+					}
+				},
+				{
+					"id": 574,
+					"name": "connection",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 48,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 577,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 18,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 526,
+						"name": "GenericError.error"
+					}
+				},
+				{
+					"id": 578,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 19,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 527,
+						"name": "GenericError.error_description"
+					}
+				},
+				{
+					"id": 575,
+					"name": "state",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 49,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 561,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true,
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 21,
+							"character": 11
+						}
+					],
+					"signatures": [
+						{
+							"id": 562,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {
+								"isInherited": true
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+									"line": 21,
+									"character": 11
+								}
+							],
+							"parameters": [
+								{
+									"id": 563,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 564,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 565,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+															"line": 22,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 566,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+															"line": 23,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														565,
+														566
+													]
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 515,
+								"name": "GenericError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"inheritedFrom": {
+								"type": "reference",
+								"target": 517,
+								"name": "GenericError.fromPayload"
+							}
+						}
+					],
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 516,
+						"name": "GenericError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						567
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						576,
+						574,
+						577,
+						578,
+						575
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						561
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+					"line": 47,
+					"character": 21
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 515,
+					"name": "GenericError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 515,
+			"name": "GenericError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Thrown when network requests to the Auth server fail."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Errors"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 522,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 20,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 523,
+							"name": "GenericError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+									"line": 20,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 524,
+									"name": "error",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 525,
+									"name": "error_description",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 515,
+								"name": "GenericError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": -1,
+								"name": "Error.constructor",
+								"package": "typescript"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": -1,
+						"name": "Error.constructor",
+						"package": "typescript"
+					}
+				},
+				{
+					"id": 526,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 18,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 527,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 19,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 516,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 21,
+							"character": 11
+						}
+					],
+					"signatures": [
+						{
+							"id": 517,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+									"line": 21,
+									"character": 11
+								}
+							],
+							"parameters": [
+								{
+									"id": 518,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 519,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 520,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+															"line": 22,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 521,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+															"line": 23,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														520,
+														521
+													]
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 515,
+								"name": "GenericError",
+								"package": "@auth0/auth0-spa-js"
+							}
+						}
+					]
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						522
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						526,
+						527
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						516
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+					"line": 17,
+					"character": 21
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"packageName": "typescript",
+						"packagePath": "lib/lib.es5.d.ts",
+						"qualifiedName": "Error"
+					},
+					"name": "Error",
+					"package": "typescript"
+				}
+			],
+			"extendedBy": [
+				{
+					"type": "reference",
+					"target": 389,
+					"name": "TimeoutError"
+				},
+				{
+					"type": "reference",
+					"target": 400,
+					"name": "MfaRequiredError"
+				},
+				{
+					"type": "reference",
+					"target": 417,
+					"name": "PopupCancelledError"
+				},
+				{
+					"type": "reference",
+					"target": 443,
+					"name": "PopupOpenError"
+				},
+				{
+					"type": "reference",
+					"target": 454,
+					"name": "AuthenticationError"
+				},
+				{
+					"type": "reference",
+					"target": 471,
+					"name": "MissingRefreshTokenError"
+				},
+				{
+					"type": "reference",
+					"target": 486,
+					"name": "MissingScopesError"
+				},
+				{
+					"type": "reference",
+					"target": 501,
+					"name": "InvalidConfigurationError"
+				},
+				{
+					"type": "reference",
+					"target": 528,
+					"name": "UseDpopNonceError"
+				},
+				{
+					"type": "reference",
+					"target": 560,
+					"name": "ConnectError"
+				},
+				{
+					"type": "reference",
+					"target": 610,
+					"name": "MfaError"
+				}
+			]
+		},
+		{
+			"id": 367,
+			"name": "InMemoryCache",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Caching"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 368,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"signatures": [
+						{
+							"id": 369,
+							"name": "InMemoryCache",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"type": {
+								"type": "reference",
+								"target": 367,
+								"name": "InMemoryCache",
+								"package": "@auth0/auth0-spa-js"
+							}
+						}
+					]
+				},
+				{
+					"id": 370,
+					"name": "enclosedCache",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Type: [ICache](/docs/sdk/react/interfaces/ICache)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/cache/cache-memory.d.ts",
+							"line": 3,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 352,
+						"name": "ICache",
+						"package": "@auth0/auth0-spa-js"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						368
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						370
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/cache/cache-memory.d.ts",
+					"line": 2,
+					"character": 21
+				}
+			]
+		},
+		{
+			"id": 501,
+			"name": "InvalidConfigurationError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Thrown at construction time for an invalid option combination (e.g.\r\n"
+					},
+					{
+						"kind": "code",
+						"text": "`refreshTokenMode: 'online'`"
+					},
+					{
+						"kind": "text",
+						"text": " without "
+					},
+					{
+						"kind": "code",
+						"text": "`useDpop: true`"
+					},
+					{
+						"kind": "text",
+						"text": "). The "
+					},
+					{
+						"kind": "code",
+						"text": "`suggestion`"
+					},
+					{
+						"kind": "text",
+						"text": " names the fix."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Errors"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 508,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 32,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 509,
+							"name": "InvalidConfigurationError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+									"line": 32,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 510,
+									"name": "message",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 511,
+									"name": "suggestion",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 501,
+								"name": "InvalidConfigurationError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 523,
+								"name": "GenericError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 522,
+						"name": "GenericError.constructor"
+					}
+				},
+				{
+					"id": 513,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 18,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 526,
+						"name": "GenericError.error"
+					}
+				},
+				{
+					"id": 514,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 19,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 527,
+						"name": "GenericError.error_description"
+					}
+				},
+				{
+					"id": 512,
+					"name": "suggestion",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 31,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 502,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true,
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 21,
+							"character": 11
+						}
+					],
+					"signatures": [
+						{
+							"id": 503,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {
+								"isInherited": true
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+									"line": 21,
+									"character": 11
+								}
+							],
+							"parameters": [
+								{
+									"id": 504,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 505,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 506,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+															"line": 22,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 507,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+															"line": 23,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														506,
+														507
+													]
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 515,
+								"name": "GenericError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"inheritedFrom": {
+								"type": "reference",
+								"target": 517,
+								"name": "GenericError.fromPayload"
+							}
+						}
+					],
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 516,
+						"name": "GenericError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						508
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						513,
+						514,
+						512
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						502
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+					"line": 30,
+					"character": 21
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 515,
+					"name": "GenericError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 371,
+			"name": "LocalStorageCache",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Caching"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 372,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"signatures": [
+						{
+							"id": 373,
+							"name": "LocalStorageCache",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"type": {
+								"type": "reference",
+								"target": 371,
+								"name": "LocalStorageCache",
+								"package": "@auth0/auth0-spa-js"
+							}
+						}
+					]
+				},
+				{
+					"id": 386,
+					"name": "allKeys",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/cache/cache-localstorage.d.ts",
+							"line": 6,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 387,
+							"name": "allKeys",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/cache/cache-localstorage.d.ts",
+									"line": 6,
+									"character": 4
+								}
+							],
+							"type": {
+								"type": "array",
+								"elementType": {
+									"type": "intrinsic",
+									"name": "string"
+								}
+							},
+							"implementationOf": {
+								"type": "reference",
+								"target": 366,
+								"name": "ICache.allKeys"
+							}
+						}
+					],
+					"implementationOf": {
+						"type": "reference",
+						"target": 365,
+						"name": "ICache.allKeys"
+					}
+				},
+				{
+					"id": 379,
+					"name": "get",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/cache/cache-localstorage.d.ts",
+							"line": 4,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 380,
+							"name": "get",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/cache/cache-localstorage.d.ts",
+									"line": 4,
+									"character": 4
+								}
+							],
+							"typeParameters": [
+								{
+									"id": 381,
+									"name": "T",
+									"variant": "typeParam",
+									"kind": 131072,
+									"flags": {},
+									"default": {
+										"type": "reference",
+										"target": 388,
+										"name": "Cacheable",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"parameters": [
+								{
+									"id": 382,
+									"name": "key",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"packageName": "@auth0/auth0-spa-js",
+									"packagePath": "dist/typings/cache/shared.d.ts",
+									"qualifiedName": "MaybePromise"
+								},
+								"typeArguments": [
+									{
+										"type": "union",
+										"types": [
+											{
+												"type": "reference",
+												"target": 381,
+												"name": "T",
+												"package": "@auth0/auth0-spa-js",
+												"refersToTypeParameter": true
+											},
+											{
+												"type": "intrinsic",
+												"name": "undefined"
+											}
+										]
+									}
+								],
+								"name": "MaybePromise",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"implementationOf": {
+								"type": "reference",
+								"target": 359,
+								"name": "ICache.get"
+							}
+						}
+					],
+					"implementationOf": {
+						"type": "reference",
+						"target": 358,
+						"name": "ICache.get"
+					}
+				},
+				{
+					"id": 383,
+					"name": "remove",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/cache/cache-localstorage.d.ts",
+							"line": 5,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 384,
+							"name": "remove",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/cache/cache-localstorage.d.ts",
+									"line": 5,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 385,
+									"name": "key",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "void"
+							},
+							"implementationOf": {
+								"type": "reference",
+								"target": 363,
+								"name": "ICache.remove"
+							}
+						}
+					],
+					"implementationOf": {
+						"type": "reference",
+						"target": 362,
+						"name": "ICache.remove"
+					}
+				},
+				{
+					"id": 374,
+					"name": "set",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/cache/cache-localstorage.d.ts",
+							"line": 3,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 375,
+							"name": "set",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/cache/cache-localstorage.d.ts",
+									"line": 3,
+									"character": 4
+								}
+							],
+							"typeParameters": [
+								{
+									"id": 376,
+									"name": "T",
+									"variant": "typeParam",
+									"kind": 131072,
+									"flags": {},
+									"default": {
+										"type": "reference",
+										"target": 388,
+										"name": "Cacheable",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"parameters": [
+								{
+									"id": 377,
+									"name": "key",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 378,
+									"name": "entry",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reference",
+										"target": 376,
+										"name": "T",
+										"package": "@auth0/auth0-spa-js",
+										"refersToTypeParameter": true
+									}
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "void"
+							},
+							"implementationOf": {
+								"type": "reference",
+								"target": 354,
+								"name": "ICache.set"
+							}
+						}
+					],
+					"implementationOf": {
+						"type": "reference",
+						"target": 353,
+						"name": "ICache.set"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						372
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						386,
+						379,
+						383,
+						374
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/cache/cache-localstorage.d.ts",
+					"line": 2,
+					"character": 21
+				}
+			],
+			"implementedTypes": [
+				{
+					"type": "reference",
+					"target": 352,
+					"name": "ICache",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 649,
+			"name": "MfaChallengeError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Error thrown when initiating an MFA challenge fails."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@example",
+						"content": [
+							{
+								"kind": "code",
+								"text": "```typescript\r\ntry {\r\n  const challenge = await mfa.challenge({\r\n    mfaToken: mfaToken,\r\n    challengeType: 'otp',\r\n    authenticatorId: 'otp|dev_123'\r\n  });\r\n} catch (error) {\r\n  if (error instanceof MfaChallengeError) {\r\n    console.log(error.error); // 'too_many_attempts'\r\n    console.log(error.error_description); // 'Rate limit exceeded'\r\n  }\r\n}\r\n```"
+							}
+						]
+					},
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Errors"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 656,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+							"line": 72,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 657,
+							"name": "MfaChallengeError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+									"line": 72,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 658,
+									"name": "error",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 659,
+									"name": "error_description",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 649,
+								"name": "MfaChallengeError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 618,
+								"name": "MfaError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 617,
+						"name": "MfaError.constructor"
+					}
+				},
+				{
+					"id": 660,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 18,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 621,
+						"name": "MfaError.error"
+					}
+				},
+				{
+					"id": 661,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 19,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 622,
+						"name": "MfaError.error_description"
+					}
+				},
+				{
+					"id": 650,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true,
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+							"line": 9,
+							"character": 11
+						}
+					],
+					"signatures": [
+						{
+							"id": 651,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {
+								"isInherited": true
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+									"line": 9,
+									"character": 11
+								}
+							],
+							"parameters": [
+								{
+									"id": 652,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 653,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 654,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+															"line": 10,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 655,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+															"line": 11,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														654,
+														655
+													]
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 610,
+								"name": "MfaError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"inheritedFrom": {
+								"type": "reference",
+								"target": 612,
+								"name": "MfaError.fromPayload"
+							}
+						}
+					],
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 611,
+						"name": "MfaError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						656
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						660,
+						661
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						650
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+					"line": 71,
+					"character": 21
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 610,
+					"name": "MfaError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 636,
+			"name": "MfaEnrollmentError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Error thrown when enrolling an MFA authenticator fails."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@example",
+						"content": [
+							{
+								"kind": "code",
+								"text": "```typescript\r\ntry {\r\n  const enrollment = await mfa.enroll({\r\n    authenticator_types: ['otp']\r\n  });\r\n} catch (error) {\r\n  if (error instanceof MfaEnrollmentError) {\r\n    console.log(error.error); // 'invalid_phone_number'\r\n    console.log(error.error_description); // 'Invalid phone number format'\r\n  }\r\n}\r\n```"
+							}
+						]
+					},
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Errors"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 643,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+							"line": 50,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 644,
+							"name": "MfaEnrollmentError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+									"line": 50,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 645,
+									"name": "error",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 646,
+									"name": "error_description",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 636,
+								"name": "MfaEnrollmentError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 618,
+								"name": "MfaError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 617,
+						"name": "MfaError.constructor"
+					}
+				},
+				{
+					"id": 647,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 18,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 621,
+						"name": "MfaError.error"
+					}
+				},
+				{
+					"id": 648,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 19,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 622,
+						"name": "MfaError.error_description"
+					}
+				},
+				{
+					"id": 637,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true,
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+							"line": 9,
+							"character": 11
+						}
+					],
+					"signatures": [
+						{
+							"id": 638,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {
+								"isInherited": true
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+									"line": 9,
+									"character": 11
+								}
+							],
+							"parameters": [
+								{
+									"id": 639,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 640,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 641,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+															"line": 10,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 642,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+															"line": 11,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														641,
+														642
+													]
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 610,
+								"name": "MfaError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"inheritedFrom": {
+								"type": "reference",
+								"target": 612,
+								"name": "MfaError.fromPayload"
+							}
+						}
+					],
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 611,
+						"name": "MfaError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						643
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						647,
+						648
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						637
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+					"line": 49,
+					"character": 21
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 610,
+					"name": "MfaError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 675,
+			"name": "MfaEnrollmentFactorsError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Error thrown when getting enrollment factors fails."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@example",
+						"content": [
+							{
+								"kind": "code",
+								"text": "```typescript\r\ntry {\r\n  const factors = await mfa.getEnrollmentFactors(mfaToken);\r\n} catch (error) {\r\n  if (error instanceof MfaEnrollmentFactorsError) {\r\n    console.log(error.error); // 'mfa_context_not_found'\r\n    console.log(error.error_description); // 'MFA context not found...'\r\n  }\r\n}\r\n```"
+							}
+						]
+					},
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Errors"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 682,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+							"line": 112,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 683,
+							"name": "MfaEnrollmentFactorsError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+									"line": 112,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 684,
+									"name": "error",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 685,
+									"name": "error_description",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 675,
+								"name": "MfaEnrollmentFactorsError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 618,
+								"name": "MfaError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 617,
+						"name": "MfaError.constructor"
+					}
+				},
+				{
+					"id": 686,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 18,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 621,
+						"name": "MfaError.error"
+					}
+				},
+				{
+					"id": 687,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 19,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 622,
+						"name": "MfaError.error_description"
+					}
+				},
+				{
+					"id": 676,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true,
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+							"line": 9,
+							"character": 11
+						}
+					],
+					"signatures": [
+						{
+							"id": 677,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {
+								"isInherited": true
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+									"line": 9,
+									"character": 11
+								}
+							],
+							"parameters": [
+								{
+									"id": 678,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 679,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 680,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+															"line": 10,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 681,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+															"line": 11,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														680,
+														681
+													]
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 610,
+								"name": "MfaError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"inheritedFrom": {
+								"type": "reference",
+								"target": 612,
+								"name": "MfaError.fromPayload"
+							}
+						}
+					],
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 611,
+						"name": "MfaError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						682
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						686,
+						687
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						676
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+					"line": 111,
+					"character": 21
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 610,
+					"name": "MfaError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 610,
+			"name": "MfaError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Base class for MFA-related errors in auth0-spa-js.\r\nExtends GenericError for unified error hierarchy across the SDK."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Errors"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 617,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+							"line": 8,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 618,
+							"name": "MfaError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+									"line": 8,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 619,
+									"name": "error",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 620,
+									"name": "error_description",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 610,
+								"name": "MfaError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 523,
+								"name": "GenericError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 522,
+						"name": "GenericError.constructor"
+					}
+				},
+				{
+					"id": 621,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 18,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 526,
+						"name": "GenericError.error"
+					}
+				},
+				{
+					"id": 622,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 19,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 527,
+						"name": "GenericError.error_description"
+					}
+				},
+				{
+					"id": 611,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+							"line": 9,
+							"character": 11
+						}
+					],
+					"signatures": [
+						{
+							"id": 612,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+									"line": 9,
+									"character": 11
+								}
+							],
+							"parameters": [
+								{
+									"id": 613,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 614,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 615,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+															"line": 10,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 616,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+															"line": 11,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														615,
+														616
+													]
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 610,
+								"name": "MfaError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 517,
+								"name": "GenericError.fromPayload"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 516,
+						"name": "GenericError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						617
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						621,
+						622
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						611
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+					"line": 7,
+					"character": 21
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 515,
+					"name": "GenericError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			],
+			"extendedBy": [
+				{
+					"type": "reference",
+					"target": 623,
+					"name": "MfaListAuthenticatorsError"
+				},
+				{
+					"type": "reference",
+					"target": 636,
+					"name": "MfaEnrollmentError"
+				},
+				{
+					"type": "reference",
+					"target": 649,
+					"name": "MfaChallengeError"
+				},
+				{
+					"type": "reference",
+					"target": 662,
+					"name": "MfaVerifyError"
+				},
+				{
+					"type": "reference",
+					"target": 675,
+					"name": "MfaEnrollmentFactorsError"
+				}
+			]
+		},
+		{
+			"id": 623,
+			"name": "MfaListAuthenticatorsError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Error thrown when listing MFA authenticators fails."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@example",
+						"content": [
+							{
+								"kind": "code",
+								"text": "```typescript\r\ntry {\r\n  const authenticators = await mfa.getAuthenticators();\r\n} catch (error) {\r\n  if (error instanceof MfaListAuthenticatorsError) {\r\n    console.log(error.error); // 'access_denied'\r\n    console.log(error.error_description); // 'Unauthorized'\r\n  }\r\n}\r\n```"
+							}
+						]
+					},
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Errors"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 630,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+							"line": 30,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 631,
+							"name": "MfaListAuthenticatorsError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+									"line": 30,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 632,
+									"name": "error",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 633,
+									"name": "error_description",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 623,
+								"name": "MfaListAuthenticatorsError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 618,
+								"name": "MfaError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 617,
+						"name": "MfaError.constructor"
+					}
+				},
+				{
+					"id": 634,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 18,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 621,
+						"name": "MfaError.error"
+					}
+				},
+				{
+					"id": 635,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 19,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 622,
+						"name": "MfaError.error_description"
+					}
+				},
+				{
+					"id": 624,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true,
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+							"line": 9,
+							"character": 11
+						}
+					],
+					"signatures": [
+						{
+							"id": 625,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {
+								"isInherited": true
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+									"line": 9,
+									"character": 11
+								}
+							],
+							"parameters": [
+								{
+									"id": 626,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 627,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 628,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+															"line": 10,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 629,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+															"line": 11,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														628,
+														629
+													]
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 610,
+								"name": "MfaError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"inheritedFrom": {
+								"type": "reference",
+								"target": 612,
+								"name": "MfaError.fromPayload"
+							}
+						}
+					],
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 611,
+						"name": "MfaError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						630
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						634,
+						635
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						624
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+					"line": 29,
+					"character": 21
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 610,
+					"name": "MfaError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 400,
+			"name": "MfaRequiredError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Error thrown when the token exchange results in a "
+					},
+					{
+						"kind": "code",
+						"text": "`mfa_required`"
+					},
+					{
+						"kind": "text",
+						"text": " error"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Errors"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 407,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 80,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 408,
+							"name": "MfaRequiredError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+									"line": 80,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 409,
+									"name": "error",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 410,
+									"name": "error_description",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 411,
+									"name": "mfa_token",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 412,
+									"name": "mfa_requirements",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "@auth0/auth0-spa-js",
+											"packagePath": "dist/typings/errors.d.ts",
+											"qualifiedName": "MfaRequirements"
+										},
+										"name": "MfaRequirements",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 400,
+								"name": "MfaRequiredError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 523,
+								"name": "GenericError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 522,
+						"name": "GenericError.constructor"
+					}
+				},
+				{
+					"id": 415,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 18,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 526,
+						"name": "GenericError.error"
+					}
+				},
+				{
+					"id": 416,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 19,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 527,
+						"name": "GenericError.error_description"
+					}
+				},
+				{
+					"id": 414,
+					"name": "mfa_requirements",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 79,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/errors.d.ts",
+							"qualifiedName": "MfaRequirements"
+						},
+						"name": "MfaRequirements",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 413,
+					"name": "mfa_token",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 78,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 401,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true,
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 21,
+							"character": 11
+						}
+					],
+					"signatures": [
+						{
+							"id": 402,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {
+								"isInherited": true
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+									"line": 21,
+									"character": 11
+								}
+							],
+							"parameters": [
+								{
+									"id": 403,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 404,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 405,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+															"line": 22,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 406,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+															"line": 23,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														405,
+														406
+													]
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 515,
+								"name": "GenericError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"inheritedFrom": {
+								"type": "reference",
+								"target": 517,
+								"name": "GenericError.fromPayload"
+							}
+						}
+					],
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 516,
+						"name": "GenericError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						407
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						415,
+						416,
+						414,
+						413
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						401
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+					"line": 77,
+					"character": 21
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 515,
+					"name": "GenericError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 662,
+			"name": "MfaVerifyError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Error thrown when verifying an MFA challenge fails."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@example",
+						"content": [
+							{
+								"kind": "code",
+								"text": "```typescript\r\ntry {\r\n  const tokens = await mfa.verify({\r\n    mfaToken: mfaToken,\r\n    grant_type: 'http://auth0.com/oauth/grant-type/mfa-otp',\r\n    otp: '123456'\r\n  });\r\n} catch (error) {\r\n  if (error instanceof MfaVerifyError) {\r\n    console.log(error.error); // 'invalid_otp' or 'context_not_found'\r\n    console.log(error.error_description); // Error details\r\n  }\r\n}\r\n```"
+							}
+						]
+					},
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Errors"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 669,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+							"line": 94,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 670,
+							"name": "MfaVerifyError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+									"line": 94,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 671,
+									"name": "error",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 672,
+									"name": "error_description",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 662,
+								"name": "MfaVerifyError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 618,
+								"name": "MfaError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 617,
+						"name": "MfaError.constructor"
+					}
+				},
+				{
+					"id": 673,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 18,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 621,
+						"name": "MfaError.error"
+					}
+				},
+				{
+					"id": 674,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 19,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 622,
+						"name": "MfaError.error_description"
+					}
+				},
+				{
+					"id": 663,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true,
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+							"line": 9,
+							"character": 11
+						}
+					],
+					"signatures": [
+						{
+							"id": 664,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {
+								"isInherited": true
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+									"line": 9,
+									"character": 11
+								}
+							],
+							"parameters": [
+								{
+									"id": 665,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 666,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 667,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+															"line": 10,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 668,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+															"line": 11,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														667,
+														668
+													]
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 610,
+								"name": "MfaError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"inheritedFrom": {
+								"type": "reference",
+								"target": 612,
+								"name": "MfaError.fromPayload"
+							}
+						}
+					],
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 611,
+						"name": "MfaError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						669
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						673,
+						674
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						663
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/errors.d.ts",
+					"line": 93,
+					"character": 21
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 610,
+					"name": "MfaError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 471,
+			"name": "MissingRefreshTokenError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Error thrown when there is no refresh token to use"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Errors"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 478,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 88,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 479,
+							"name": "MissingRefreshTokenError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+									"line": 88,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 480,
+									"name": "audience",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 481,
+									"name": "scope",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 471,
+								"name": "MissingRefreshTokenError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 523,
+								"name": "GenericError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 522,
+						"name": "GenericError.constructor"
+					}
+				},
+				{
+					"id": 482,
+					"name": "audience",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 86,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 484,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 18,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 526,
+						"name": "GenericError.error"
+					}
+				},
+				{
+					"id": 485,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 19,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 527,
+						"name": "GenericError.error_description"
+					}
+				},
+				{
+					"id": 483,
+					"name": "scope",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 87,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 472,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true,
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 21,
+							"character": 11
+						}
+					],
+					"signatures": [
+						{
+							"id": 473,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {
+								"isInherited": true
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+									"line": 21,
+									"character": 11
+								}
+							],
+							"parameters": [
+								{
+									"id": 474,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 475,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 476,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+															"line": 22,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 477,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+															"line": 23,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														476,
+														477
+													]
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 515,
+								"name": "GenericError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"inheritedFrom": {
+								"type": "reference",
+								"target": 517,
+								"name": "GenericError.fromPayload"
+							}
+						}
+					],
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 516,
+						"name": "GenericError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						478
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						482,
+						484,
+						485,
+						483
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						472
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+					"line": 85,
+					"character": 21
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 515,
+					"name": "GenericError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 486,
+			"name": "MissingScopesError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Error thrown when there are missing scopes after refreshing a token"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Errors"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 493,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 96,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 494,
+							"name": "MissingScopesError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+									"line": 96,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 495,
+									"name": "audience",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 496,
+									"name": "scope",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 486,
+								"name": "MissingScopesError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 523,
+								"name": "GenericError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 522,
+						"name": "GenericError.constructor"
+					}
+				},
+				{
+					"id": 497,
+					"name": "audience",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 94,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 499,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 18,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 526,
+						"name": "GenericError.error"
+					}
+				},
+				{
+					"id": 500,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 19,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 527,
+						"name": "GenericError.error_description"
+					}
+				},
+				{
+					"id": 498,
+					"name": "scope",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 95,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 487,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true,
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 21,
+							"character": 11
+						}
+					],
+					"signatures": [
+						{
+							"id": 488,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {
+								"isInherited": true
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+									"line": 21,
+									"character": 11
+								}
+							],
+							"parameters": [
+								{
+									"id": 489,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 490,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 491,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+															"line": 22,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 492,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+															"line": 23,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														491,
+														492
+													]
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 515,
+								"name": "GenericError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"inheritedFrom": {
+								"type": "reference",
+								"target": 517,
+								"name": "GenericError.fromPayload"
+							}
+						}
+					],
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 516,
+						"name": "GenericError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						493
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						497,
+						499,
+						500,
+						498
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						487
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+					"line": 93,
+					"character": 21
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 515,
+					"name": "GenericError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 717,
+			"name": "MyAccountApiError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Error thrown when the MyAccount API returns a non-2xx response."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@example",
+						"content": [
+							{
+								"kind": "code",
+								"text": "```typescript\r\ntry {\r\n  await myAccount.getAuthenticationMethods();\r\n} catch (err) {\r\n  if (err instanceof MyAccountApiError) {\r\n    console.error(err.status, err.title, err.detail);\r\n  }\r\n}\r\n```"
+							}
+						]
+					},
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Errors"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 718,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/MyAccountApiClient.d.ts",
+							"line": 108,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 719,
+							"name": "MyAccountApiError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/MyAccountApiClient.d.ts",
+									"line": 108,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 720,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "@auth0/auth0-spa-js",
+											"packagePath": "dist/typings/myaccount/types.d.ts",
+											"qualifiedName": "ErrorResponse"
+										},
+										"name": "ErrorResponse",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 717,
+								"name": "MyAccountApiError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": -1,
+								"name": "Error.constructor",
+								"package": "typescript"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": -1,
+						"name": "Error.constructor",
+						"package": "typescript"
+					}
+				},
+				{
+					"id": 724,
+					"name": "detail",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isReadonly": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Human-readable explanation specific to this occurrence"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/MyAccountApiClient.d.ts",
+							"line": 105,
+							"character": 13
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 722,
+					"name": "status",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isReadonly": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "HTTP status code"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/MyAccountApiClient.d.ts",
+							"line": 101,
+							"character": 13
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "number"
+					}
+				},
+				{
+					"id": 723,
+					"name": "title",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isReadonly": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Short human-readable summary of the error"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/MyAccountApiClient.d.ts",
+							"line": 103,
+							"character": 13
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 721,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isReadonly": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "RFC 7807 error type identifier"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/MyAccountApiClient.d.ts",
+							"line": 99,
+							"character": 13
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 725,
+					"name": "validation_errors",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true,
+						"isReadonly": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Field-level validation errors, if present"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/MyAccountApiClient.d.ts",
+							"line": 107,
+							"character": 13
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "reflection",
+							"declaration": {
+								"id": 726,
+								"name": "__type",
+								"variant": "declaration",
+								"kind": 65536,
+								"flags": {},
+								"children": [
+									{
+										"id": 727,
+										"name": "detail",
+										"variant": "declaration",
+										"kind": 1024,
+										"flags": {},
+										"sources": [
+											{
+												"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/types.d.ts",
+												"line": 40,
+												"character": 8
+											}
+										],
+										"type": {
+											"type": "intrinsic",
+											"name": "string"
+										}
+									},
+									{
+										"id": 728,
+										"name": "field",
+										"variant": "declaration",
+										"kind": 1024,
+										"flags": {
+											"isOptional": true
+										},
+										"sources": [
+											{
+												"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/types.d.ts",
+												"line": 41,
+												"character": 8
+											}
+										],
+										"type": {
+											"type": "intrinsic",
+											"name": "string"
+										}
+									},
+									{
+										"id": 729,
+										"name": "pointer",
+										"variant": "declaration",
+										"kind": 1024,
+										"flags": {
+											"isOptional": true
+										},
+										"sources": [
+											{
+												"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/types.d.ts",
+												"line": 42,
+												"character": 8
+											}
+										],
+										"type": {
+											"type": "intrinsic",
+											"name": "string"
+										}
+									},
+									{
+										"id": 730,
+										"name": "source",
+										"variant": "declaration",
+										"kind": 1024,
+										"flags": {
+											"isOptional": true
+										},
+										"sources": [
+											{
+												"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/types.d.ts",
+												"line": 43,
+												"character": 8
+											}
+										],
+										"type": {
+											"type": "intrinsic",
+											"name": "string"
+										}
+									}
+								],
+								"groups": [
+									{
+										"title": "Properties",
+										"children": [
+											727,
+											728,
+											729,
+											730
+										]
+									}
+								]
+							}
+						}
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						718
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						724,
+						722,
+						723,
+						721,
+						725
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/MyAccountApiClient.d.ts",
+					"line": 97,
+					"character": 21
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"packageName": "typescript",
+						"packagePath": "lib/lib.es5.d.ts",
+						"qualifiedName": "Error"
+					},
+					"name": "Error",
+					"package": "typescript"
+				}
+			]
+		},
+		{
+			"id": 878,
+			"name": "OAuthError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "An OAuth2 error will come from the authorization server and will have at least an "
+					},
+					{
+						"kind": "code",
+						"text": "`error`"
+					},
+					{
+						"kind": "text",
+						"text": " property which will\nbe the error code. And possibly an "
+					},
+					{
+						"kind": "code",
+						"text": "`error_description`"
+					},
+					{
+						"kind": "text",
+						"text": " property\n\nSee: https://openid.net/specs/openid-connect-core-1_0.html#rfc.section.3.1.2.6"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Errors"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 879,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/errors.tsx",
+							"line": 8,
+							"character": 2
+						}
+					],
+					"signatures": [
+						{
+							"id": 880,
+							"name": "OAuthError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/errors.tsx",
+									"line": 8,
+									"character": 2
+								}
+							],
+							"parameters": [
+								{
+									"id": 881,
+									"name": "error",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 882,
+									"name": "error_description",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {
+										"isOptional": true
+									},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 878,
+								"name": "OAuthError",
+								"package": "@auth0/auth0-react"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": -1,
+								"name": "Error.constructor",
+								"package": "typescript"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": -1,
+						"name": "Error.constructor",
+						"package": "typescript"
+					}
+				},
+				{
+					"id": 883,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.tsx",
+							"line": 8,
+							"character": 21
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 884,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true,
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.tsx",
+							"line": 8,
+							"character": 43
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						879
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						883,
+						884
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/errors.tsx",
+					"line": 7,
+					"character": 13
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"packageName": "typescript",
+						"packagePath": "lib/lib.es5.d.ts",
+						"qualifiedName": "Error"
+					},
+					"name": "Error",
+					"package": "typescript"
+				}
+			]
+		},
+		{
+			"id": 703,
+			"name": "PasskeyChallengeError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Error thrown when requesting a passkey login challenge fails."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Errors"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 704,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 2029,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 705,
+							"name": "PasskeyChallengeError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+									"line": 2029,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 706,
+									"name": "message",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 707,
+									"name": "cause",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {
+										"isOptional": true
+									},
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "@auth0/auth0-auth-js",
+											"packagePath": "dist/index.d.ts",
+											"qualifiedName": "PasskeyApiErrorResponse"
+										},
+										"name": "PasskeyApiErrorResponse",
+										"package": "@auth0/auth0-auth-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 703,
+								"name": "PasskeyChallengeError",
+								"package": "@auth0/auth0-auth-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": -1,
+								"name": "PasskeyError.constructor",
+								"package": "@auth0/auth0-auth-js"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": -1,
+						"name": "PasskeyError.constructor",
+						"package": "@auth0/auth0-auth-js"
+					}
+				},
+				{
+					"id": 708,
+					"name": "cause",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true,
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 2015,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-auth-js",
+							"packagePath": "dist/index.d.ts",
+							"qualifiedName": "PasskeyApiErrorResponse"
+						},
+						"name": "PasskeyApiErrorResponse",
+						"package": "@auth0/auth0-auth-js"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "PasskeyError.cause"
+					}
+				},
+				{
+					"id": 709,
+					"name": "code",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 2016,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "PasskeyError.code"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						704
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						708,
+						709
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+					"line": 2028,
+					"character": 14
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"packageName": "@auth0/auth0-auth-js",
+						"packagePath": "dist/index.d.ts",
+						"qualifiedName": "PasskeyError"
+					},
+					"name": "PasskeyError",
+					"package": "@auth0/auth0-auth-js"
+				}
+			]
+		},
+		{
+			"id": 688,
+			"name": "PasskeyError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Errors"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 689,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/passkey/errors.d.ts",
+							"line": 10,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 690,
+							"name": "PasskeyError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/passkey/errors.d.ts",
+									"line": 10,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 691,
+									"name": "code",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 692,
+									"name": "message",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 693,
+									"name": "cause",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {
+										"isOptional": true
+									},
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "@auth0/auth0-spa-js",
+											"packagePath": "dist/typings/passkey/errors.d.ts",
+											"qualifiedName": "PasskeyErrorResponse"
+										},
+										"name": "PasskeyErrorResponse",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 688,
+								"name": "PasskeyError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": -1,
+								"name": "Error.constructor",
+								"package": "typescript"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": -1,
+						"name": "Error.constructor",
+						"package": "typescript"
+					}
+				},
+				{
+					"id": 695,
+					"name": "cause",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true,
+						"isReadonly": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/passkey/errors.d.ts",
+							"line": 9,
+							"character": 13
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/passkey/errors.d.ts",
+							"qualifiedName": "PasskeyErrorResponse"
+						},
+						"name": "PasskeyErrorResponse",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 694,
+					"name": "code",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isReadonly": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/passkey/errors.d.ts",
+							"line": 8,
+							"character": 13
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						689
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						695,
+						694
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/passkey/errors.d.ts",
+					"line": 7,
+					"character": 21
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"packageName": "typescript",
+						"packagePath": "lib/lib.es5.d.ts",
+						"qualifiedName": "Error"
+					},
+					"name": "Error",
+					"package": "typescript"
+				}
+			]
+		},
+		{
+			"id": 710,
+			"name": "PasskeyGetTokenError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Error thrown when exchanging a passkey credential for tokens fails.\n\nUnlike the challenge errors, this carries "
+					},
+					{
+						"kind": "code",
+						"text": "`mfa_token`"
+					},
+					{
+						"kind": "text",
+						"text": " / "
+					},
+					{
+						"kind": "code",
+						"text": "`mfa_requirements`"
+					},
+					{
+						"kind": "text",
+						"text": " on\nits "
+					},
+					{
+						"kind": "code",
+						"text": "`cause`"
+					},
+					{
+						"kind": "text",
+						"text": " when the server responds with "
+					},
+					{
+						"kind": "code",
+						"text": "`mfa_required`"
+					},
+					{
+						"kind": "text",
+						"text": "."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Errors"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 711,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 2039,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 712,
+							"name": "PasskeyGetTokenError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+									"line": 2039,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 713,
+									"name": "message",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 714,
+									"name": "cause",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {
+										"isOptional": true
+									},
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "@auth0/auth0-auth-js",
+											"packagePath": "dist/index.d.ts",
+											"qualifiedName": "PasskeyGetTokenApiErrorResponse"
+										},
+										"name": "PasskeyGetTokenApiErrorResponse",
+										"package": "@auth0/auth0-auth-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 710,
+								"name": "PasskeyGetTokenError",
+								"package": "@auth0/auth0-auth-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": -1,
+								"name": "PasskeyError.constructor",
+								"package": "@auth0/auth0-auth-js"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": -1,
+						"name": "PasskeyError.constructor",
+						"package": "@auth0/auth0-auth-js"
+					}
+				},
+				{
+					"id": 715,
+					"name": "cause",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 2038,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-auth-js",
+							"packagePath": "dist/index.d.ts",
+							"qualifiedName": "PasskeyGetTokenApiErrorResponse"
+						},
+						"name": "PasskeyGetTokenApiErrorResponse",
+						"package": "@auth0/auth0-auth-js"
+					},
+					"overwrites": {
+						"type": "reference",
+						"target": -1,
+						"name": "PasskeyError.cause"
+					}
+				},
+				{
+					"id": 716,
+					"name": "code",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 2016,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "PasskeyError.code"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						711
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						715,
+						716
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+					"line": 2037,
+					"character": 14
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"packageName": "@auth0/auth0-auth-js",
+						"packagePath": "dist/index.d.ts",
+						"qualifiedName": "PasskeyError"
+					},
+					"name": "PasskeyError",
+					"package": "@auth0/auth0-auth-js"
+				}
+			]
+		},
+		{
+			"id": 696,
+			"name": "PasskeyRegisterError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Error thrown when requesting a passkey register challenge fails."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Errors"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 697,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 2023,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 698,
+							"name": "PasskeyRegisterError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+									"line": 2023,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 699,
+									"name": "message",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 700,
+									"name": "cause",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {
+										"isOptional": true
+									},
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "@auth0/auth0-auth-js",
+											"packagePath": "dist/index.d.ts",
+											"qualifiedName": "PasskeyApiErrorResponse"
+										},
+										"name": "PasskeyApiErrorResponse",
+										"package": "@auth0/auth0-auth-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 696,
+								"name": "PasskeyRegisterError",
+								"package": "@auth0/auth0-auth-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": -1,
+								"name": "PasskeyError.constructor",
+								"package": "@auth0/auth0-auth-js"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": -1,
+						"name": "PasskeyError.constructor",
+						"package": "@auth0/auth0-auth-js"
+					}
+				},
+				{
+					"id": 701,
+					"name": "cause",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true,
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 2015,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-auth-js",
+							"packagePath": "dist/index.d.ts",
+							"qualifiedName": "PasskeyApiErrorResponse"
+						},
+						"name": "PasskeyApiErrorResponse",
+						"package": "@auth0/auth0-auth-js"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "PasskeyError.cause"
+					}
+				},
+				{
+					"id": 702,
+					"name": "code",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 2016,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "PasskeyError.code"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						697
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						701,
+						702
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+					"line": 2022,
+					"character": 14
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"packageName": "@auth0/auth0-auth-js",
+						"packagePath": "dist/index.d.ts",
+						"qualifiedName": "PasskeyError"
+					},
+					"name": "PasskeyError",
+					"package": "@auth0/auth0-auth-js"
+				}
+			]
+		},
+		{
+			"id": 417,
+			"name": "PopupCancelledError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Thrown when network requests to the Auth server fail."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Errors"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 424,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 69,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 425,
+							"name": "PopupCancelledError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+									"line": 69,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 426,
+									"name": "popup",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "typescript",
+											"packagePath": "lib/lib.dom.d.ts",
+											"qualifiedName": "Window"
+										},
+										"name": "Window",
+										"package": "typescript"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 417,
+								"name": "PopupCancelledError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 523,
+								"name": "GenericError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 522,
+						"name": "GenericError.constructor"
+					}
+				},
+				{
+					"id": 428,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 18,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 526,
+						"name": "GenericError.error"
+					}
+				},
+				{
+					"id": 429,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 19,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 527,
+						"name": "GenericError.error_description"
+					}
+				},
+				{
+					"id": 427,
+					"name": "popup",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 68,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": {
+							"packageName": "typescript",
+							"packagePath": "lib/lib.dom.d.ts",
+							"qualifiedName": "Window"
+						},
+						"name": "Window",
+						"package": "typescript"
+					}
+				},
+				{
+					"id": 418,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true,
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 21,
+							"character": 11
+						}
+					],
+					"signatures": [
+						{
+							"id": 419,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {
+								"isInherited": true
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+									"line": 21,
+									"character": 11
+								}
+							],
+							"parameters": [
+								{
+									"id": 420,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 421,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 422,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+															"line": 22,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 423,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+															"line": 23,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														422,
+														423
+													]
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 515,
+								"name": "GenericError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"inheritedFrom": {
+								"type": "reference",
+								"target": 517,
+								"name": "GenericError.fromPayload"
+							}
+						}
+					],
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 516,
+						"name": "GenericError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						424
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						428,
+						429,
+						427
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						418
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+					"line": 67,
+					"character": 21
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 515,
+					"name": "GenericError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 443,
+			"name": "PopupOpenError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Thrown when network requests to the Auth server fail."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Errors"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 450,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 72,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 451,
+							"name": "PopupOpenError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+									"line": 72,
+									"character": 4
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 443,
+								"name": "PopupOpenError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 523,
+								"name": "GenericError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 522,
+						"name": "GenericError.constructor"
+					}
+				},
+				{
+					"id": 452,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 18,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 526,
+						"name": "GenericError.error"
+					}
+				},
+				{
+					"id": 453,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 19,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 527,
+						"name": "GenericError.error_description"
+					}
+				},
+				{
+					"id": 444,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true,
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 21,
+							"character": 11
+						}
+					],
+					"signatures": [
+						{
+							"id": 445,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {
+								"isInherited": true
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+									"line": 21,
+									"character": 11
+								}
+							],
+							"parameters": [
+								{
+									"id": 446,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 447,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 448,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+															"line": 22,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 449,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+															"line": 23,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														448,
+														449
+													]
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 515,
+								"name": "GenericError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"inheritedFrom": {
+								"type": "reference",
+								"target": 517,
+								"name": "GenericError.fromPayload"
+							}
+						}
+					],
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 516,
+						"name": "GenericError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						450
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						452,
+						453
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						444
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+					"line": 71,
+					"character": 21
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 515,
+					"name": "GenericError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 430,
+			"name": "PopupTimeoutError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Error thrown when the login popup times out (if the user does not complete auth)"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Errors"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 437,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 65,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 438,
+							"name": "PopupTimeoutError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+									"line": 65,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 439,
+									"name": "popup",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "typescript",
+											"packagePath": "lib/lib.dom.d.ts",
+											"qualifiedName": "Window"
+										},
+										"name": "Window",
+										"package": "typescript"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 430,
+								"name": "PopupTimeoutError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 397,
+								"name": "TimeoutError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 396,
+						"name": "TimeoutError.constructor"
+					}
+				},
+				{
+					"id": 441,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 18,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 398,
+						"name": "TimeoutError.error"
+					}
+				},
+				{
+					"id": 442,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 19,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 399,
+						"name": "TimeoutError.error_description"
+					}
+				},
+				{
+					"id": 440,
+					"name": "popup",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 64,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": {
+							"packageName": "typescript",
+							"packagePath": "lib/lib.dom.d.ts",
+							"qualifiedName": "Window"
+						},
+						"name": "Window",
+						"package": "typescript"
+					}
+				},
+				{
+					"id": 431,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true,
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 21,
+							"character": 11
+						}
+					],
+					"signatures": [
+						{
+							"id": 432,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {
+								"isInherited": true
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+									"line": 21,
+									"character": 11
+								}
+							],
+							"parameters": [
+								{
+									"id": 433,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 434,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 435,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+															"line": 22,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 436,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+															"line": 23,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														435,
+														436
+													]
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 515,
+								"name": "GenericError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"inheritedFrom": {
+								"type": "reference",
+								"target": 391,
+								"name": "TimeoutError.fromPayload"
+							}
+						}
+					],
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 390,
+						"name": "TimeoutError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						437
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						441,
+						442,
+						440
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						431
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+					"line": 63,
+					"character": 21
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 389,
+					"name": "TimeoutError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 389,
+			"name": "TimeoutError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Thrown when silent auth times out (usually due to a configuration issue) or\r\nwhen network requests to the Auth server timeout."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Errors"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 396,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 58,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 397,
+							"name": "TimeoutError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+									"line": 58,
+									"character": 4
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 389,
+								"name": "TimeoutError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 523,
+								"name": "GenericError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 522,
+						"name": "GenericError.constructor"
+					}
+				},
+				{
+					"id": 398,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 18,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 526,
+						"name": "GenericError.error"
+					}
+				},
+				{
+					"id": 399,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 19,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 527,
+						"name": "GenericError.error_description"
+					}
+				},
+				{
+					"id": 390,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true,
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 21,
+							"character": 11
+						}
+					],
+					"signatures": [
+						{
+							"id": 391,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {
+								"isInherited": true
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+									"line": 21,
+									"character": 11
+								}
+							],
+							"parameters": [
+								{
+									"id": 392,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 393,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 394,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+															"line": 22,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 395,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+															"line": 23,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														394,
+														395
+													]
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 515,
+								"name": "GenericError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"inheritedFrom": {
+								"type": "reference",
+								"target": 517,
+								"name": "GenericError.fromPayload"
+							}
+						}
+					],
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 516,
+						"name": "GenericError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						396
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						398,
+						399
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						390
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+					"line": 57,
+					"character": 21
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 515,
+					"name": "GenericError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			],
+			"extendedBy": [
+				{
+					"type": "reference",
+					"target": 430,
+					"name": "PopupTimeoutError"
+				}
+			]
+		},
+		{
+			"id": 528,
+			"name": "UseDpopNonceError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Error thrown when the wrong DPoP nonce is used and a potential subsequent retry wasn't able to fix it."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Errors"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 535,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 103,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 536,
+							"name": "UseDpopNonceError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+									"line": 103,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 537,
+									"name": "newDpopNonce",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "union",
+										"types": [
+											{
+												"type": "intrinsic",
+												"name": "string"
+											},
+											{
+												"type": "intrinsic",
+												"name": "undefined"
+											}
+										]
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 528,
+								"name": "UseDpopNonceError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 523,
+								"name": "GenericError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 522,
+						"name": "GenericError.constructor"
+					}
+				},
+				{
+					"id": 539,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 18,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 526,
+						"name": "GenericError.error"
+					}
+				},
+				{
+					"id": 540,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 19,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 527,
+						"name": "GenericError.error_description"
+					}
+				},
+				{
+					"id": 538,
+					"name": "newDpopNonce",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 102,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "union",
+						"types": [
+							{
+								"type": "intrinsic",
+								"name": "string"
+							},
+							{
+								"type": "intrinsic",
+								"name": "undefined"
+							}
+						]
+					}
+				},
+				{
+					"id": 529,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true,
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+							"line": 21,
+							"character": 11
+						}
+					],
+					"signatures": [
+						{
+							"id": 530,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {
+								"isInherited": true
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+									"line": 21,
+									"character": 11
+								}
+							],
+							"parameters": [
+								{
+									"id": 531,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 532,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 533,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+															"line": 22,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 534,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+															"line": 23,
+															"character": 8
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														533,
+														534
+													]
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 515,
+								"name": "GenericError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"inheritedFrom": {
+								"type": "reference",
+								"target": 517,
+								"name": "GenericError.fromPayload"
+							}
+						}
+					],
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 516,
+						"name": "GenericError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						535
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						539,
+						540,
+						538
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						529
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/errors.d.ts",
+					"line": 101,
+					"character": 21
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 515,
+					"name": "GenericError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 326,
+			"name": "User",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Tokens & Users"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 327,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"signatures": [
+						{
+							"id": 328,
+							"name": "User",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"type": {
+								"type": "reference",
+								"target": 326,
+								"name": "User",
+								"package": "@auth0/auth0-spa-js"
+							}
+						}
+					]
+				},
+				{
+					"id": 349,
+					"name": "act",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Type: [ActClaim](/docs/sdk/react/interfaces/ActClaim)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 844,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 598,
+						"name": "ActClaim",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 346,
+					"name": "address",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 841,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 341,
+					"name": "birthdate",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 836,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 338,
+					"name": "email",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 833,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 339,
+					"name": "email_verified",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 834,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					}
+				},
+				{
+					"id": 331,
+					"name": "family_name",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 826,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 340,
+					"name": "gender",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 835,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 330,
+					"name": "given_name",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 825,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 343,
+					"name": "locale",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 838,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 332,
+					"name": "middle_name",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 827,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 329,
+					"name": "name",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 824,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 333,
+					"name": "nickname",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 828,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 344,
+					"name": "phone_number",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 839,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 345,
+					"name": "phone_number_verified",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 840,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					}
+				},
+				{
+					"id": 336,
+					"name": "picture",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 831,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 334,
+					"name": "preferred_username",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 829,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 335,
+					"name": "profile",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 830,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 348,
+					"name": "sub",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 843,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 347,
+					"name": "updated_at",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 842,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 337,
+					"name": "website",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 832,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 342,
+					"name": "zoneinfo",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 837,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						327
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						349,
+						346,
+						341,
+						338,
+						339,
+						331,
+						340,
+						330,
+						343,
+						332,
+						329,
+						333,
+						344,
+						345,
+						336,
+						334,
+						335,
+						348,
+						347,
+						337,
+						342
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+					"line": 823,
+					"character": 21
+				}
+			],
+			"indexSignatures": [
+				{
+					"id": 350,
+					"name": "__index",
+					"variant": "signature",
+					"kind": 8192,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 845,
+							"character": 4
+						}
+					],
+					"parameters": [
+						{
+							"id": 351,
+							"name": "key",
+							"variant": "param",
+							"kind": 32768,
+							"flags": {},
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "any"
+					}
+				}
+			]
+		},
+		{
+			"id": 598,
+			"name": "ActClaim",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Represents the actor claim ("
+					},
+					{
+						"kind": "code",
+						"text": "`act`"
+					},
+					{
+						"kind": "text",
+						"text": ") in an ID token returned via a token exchange response.\r\n\r\nThe "
+					},
+					{
+						"kind": "code",
+						"text": "`act`"
+					},
+					{
+						"kind": "text",
+						"text": " claim identifies the acting party — the entity that has been delegated authority\r\nto act on behalf of the subject. It is set via Auth0 Actions using the "
+					},
+					{
+						"kind": "code",
+						"text": "`setActor`"
+					},
+					{
+						"kind": "text",
+						"text": " command."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@see",
+						"content": [
+							{
+								"kind": "inline-tag",
+								"tag": "@link",
+								"text": "RFC 8693 Section 4.1",
+								"target": "https://www.rfc-editor.org/rfc/rfc8693#section-4.1"
+							}
+						]
+					},
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Tokens & Users"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 599,
+					"name": "sub",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The identifier of the acting party."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 768,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						599
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+					"line": 766,
+					"character": 17
+				}
+			],
+			"indexSignatures": [
+				{
+					"id": 600,
+					"name": "__index",
+					"variant": "signature",
+					"kind": 8192,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 769,
+							"character": 4
+						}
+					],
+					"parameters": [
+						{
+							"id": 601,
+							"name": "key",
+							"variant": "param",
+							"kind": 32768,
+							"flags": {},
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "any"
+					}
+				}
+			]
+		},
+		{
+			"id": 58,
+			"name": "Auth0ContextInterface",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Contains the authenticated state and authentication methods provided by the "
+					},
+					{
+						"kind": "code",
+						"text": "`useAuth0`"
+					},
+					{
+						"kind": "text",
+						"text": " hook."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Context"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 99,
+					"name": "connectAccountWithRedirect",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "code",
+								"text": "```js\nawait connectAccountWithRedirect({\n  connection: 'google-oauth2',\n  scopes: ['openid', 'profile', 'email', 'https://www.googleapis.com/auth/drive.readonly'],\n  authorization_params: {\n    // additional authorization params to forward to the authorization server\n  }\n});\n```"
+							},
+							{
+								"kind": "text",
+								"text": "\n\nRedirects to the "
+							},
+							{
+								"kind": "code",
+								"text": "`/connect`"
+							},
+							{
+								"kind": "text",
+								"text": " URL using the parameters\nprovided as arguments. This then redirects to the connection's login page\nwhere the user can authenticate and authorize the account to be connected.\n\nIf connecting the account is successful "
+							},
+							{
+								"kind": "code",
+								"text": "`onRedirectCallback`"
+							},
+							{
+								"kind": "text",
+								"text": " will be called\nwith the details of the connected account."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Connected Accounts"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/auth0-context.tsx",
+							"line": 261,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 100,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"signatures": [
+								{
+									"id": 101,
+									"name": "__type",
+									"variant": "signature",
+									"kind": 4096,
+									"flags": {},
+									"parameters": [
+										{
+											"id": 102,
+											"name": "options",
+											"variant": "param",
+											"kind": 32768,
+											"flags": {},
+											"comment": {
+												"summary": [
+													{
+														"kind": "text",
+														"text": "Type: [RedirectConnectAccountOptions](/docs/sdk/react/interfaces/RedirectConnectAccountOptions)"
+													}
+												]
+											},
+											"type": {
+												"type": "reference",
+												"target": 541,
+												"name": "RedirectConnectAccountOptions",
+												"package": "@auth0/auth0-spa-js"
+											}
+										}
+									],
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "typescript",
+											"packagePath": "lib/lib.es5.d.ts",
+											"qualifiedName": "Promise"
+										},
+										"typeArguments": [
+											{
+												"type": "intrinsic",
+												"name": "void"
+											}
+										],
+										"name": "Promise",
+										"package": "typescript"
+									}
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": 133,
+					"name": "createFetcher",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Returns a new "
+							},
+							{
+								"kind": "code",
+								"text": "`Fetcher`"
+							},
+							{
+								"kind": "text",
+								"text": " class that will contain a "
+							},
+							{
+								"kind": "code",
+								"text": "`fetchWithAuth()`"
+							},
+							{
+								"kind": "text",
+								"text": " method.\nThis is a drop-in replacement for the Fetch API's "
+							},
+							{
+								"kind": "code",
+								"text": "`fetch()`"
+							},
+							{
+								"kind": "text",
+								"text": " method, but will\nhandle certain authentication logic for you, like building the proper auth\nheaders or managing DPoP nonces and retries automatically.\n\nCheck the "
+							},
+							{
+								"kind": "code",
+								"text": "`EXAMPLES.md`"
+							},
+							{
+								"kind": "text",
+								"text": " file for a deeper look into this method."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Advanced"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/auth0-context.tsx",
+							"line": 359,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 134,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"signatures": [
+								{
+									"id": 135,
+									"name": "__type",
+									"variant": "signature",
+									"kind": 4096,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Returns a new "
+											},
+											{
+												"kind": "code",
+												"text": "`Fetcher`"
+											},
+											{
+												"kind": "text",
+												"text": " class that will contain a "
+											},
+											{
+												"kind": "code",
+												"text": "`fetchWithAuth()`"
+											},
+											{
+												"kind": "text",
+												"text": " method.\r\nThis is a drop-in replacement for the Fetch API's "
+											},
+											{
+												"kind": "code",
+												"text": "`fetch()`"
+											},
+											{
+												"kind": "text",
+												"text": " method, but will\r\nhandle certain authentication logic for you, like building the proper auth\r\nheaders or managing DPoP nonces and retries automatically.\r\n\r\nCheck the "
+											},
+											{
+												"kind": "code",
+												"text": "`EXAMPLES.md`"
+											},
+											{
+												"kind": "text",
+												"text": " file for a deeper look into this method."
+											}
+										]
+									},
+									"typeParameters": [
+										{
+											"id": 136,
+											"name": "TOutput",
+											"variant": "typeParam",
+											"kind": 131072,
+											"flags": {},
+											"type": {
+												"type": "reference",
+												"target": {
+													"packageName": "@auth0/auth0-spa-js",
+													"packagePath": "dist/typings/fetcher.d.ts",
+													"qualifiedName": "CustomFetchMinimalOutput"
+												},
+												"name": "CustomFetchMinimalOutput",
+												"package": "@auth0/auth0-spa-js"
+											},
+											"default": {
+												"type": "reference",
+												"target": {
+													"packageName": "typescript",
+													"packagePath": "lib/lib.dom.d.ts",
+													"qualifiedName": "Response"
+												},
+												"name": "Response",
+												"package": "typescript"
+											}
+										}
+									],
+									"parameters": [
+										{
+											"id": 137,
+											"name": "config",
+											"variant": "param",
+											"kind": 32768,
+											"flags": {
+												"isOptional": true
+											},
+											"comment": {
+												"summary": [
+													{
+														"kind": "text",
+														"text": "Type: [FetcherConfig](/docs/sdk/react/types/FetcherConfig)"
+													}
+												]
+											},
+											"type": {
+												"type": "reference",
+												"target": 733,
+												"typeArguments": [
+													{
+														"type": "reference",
+														"target": 136,
+														"name": "TOutput",
+														"package": "@auth0/auth0-spa-js",
+														"refersToTypeParameter": true
+													}
+												],
+												"name": "FetcherConfig",
+												"package": "@auth0/auth0-spa-js"
+											}
+										}
+									],
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "@auth0/auth0-spa-js",
+											"packagePath": "dist/typings/fetcher.d.ts",
+											"qualifiedName": "Fetcher"
+										},
+										"typeArguments": [
+											{
+												"type": "reference",
+												"target": 136,
+												"name": "TOutput",
+												"package": "@auth0/auth0-spa-js",
+												"refersToTypeParameter": true
+											}
+										],
+										"name": "Fetcher",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": 82,
+					"name": "customTokenExchange",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "code",
+								"text": "```js\nconst tokenResponse = await customTokenExchange({\n  subject_token: 'ey...',\n  subject_token_type: 'urn:acme:legacy-system-token',\n  actor_token: 'ey...',\n  actor_token_type: 'https://idp.example.com/token-type/agent',\n});\n```"
+							},
+							{
+								"kind": "text",
+								"text": "\n\nExchanges an external subject token for Auth0 tokens without affecting the current session.\n\nUnlike "
+							},
+							{
+								"kind": "code",
+								"text": "`loginWithCustomTokenExchange`"
+							},
+							{
+								"kind": "text",
+								"text": ", this method has no side effects — it does not cache\ntokens, does not update the authenticated session, and does not affect "
+							},
+							{
+								"kind": "code",
+								"text": "`isAuthenticated`"
+							},
+							{
+								"kind": "text",
+								"text": "\nor "
+							},
+							{
+								"kind": "code",
+								"text": "`user`"
+							},
+							{
+								"kind": "text",
+								"text": ". Use this for delegation or impersonation scenarios where you need a downstream\nAPI token without changing who the current user is.\n\nWhen "
+							},
+							{
+								"kind": "code",
+								"text": "`actor_token`"
+							},
+							{
+								"kind": "text",
+								"text": " is present Auth0 suppresses refresh token issuance; a missing\n"
+							},
+							{
+								"kind": "code",
+								"text": "`refresh_token`"
+							},
+							{
+								"kind": "text",
+								"text": " in the response is expected and will not cause an error."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Tokens"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/auth0-context.tsx",
+							"line": 174,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 83,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"signatures": [
+								{
+									"id": 84,
+									"name": "__type",
+									"variant": "signature",
+									"kind": 4096,
+									"flags": {},
+									"comment": {
+										"summary": [],
+										"blockTags": [
+											{
+												"tag": "@returns",
+												"content": [
+													{
+														"kind": "text",
+														"text": "A promise that resolves to the token endpoint response."
+													}
+												]
+											}
+										]
+									},
+									"parameters": [
+										{
+											"id": 85,
+											"name": "options",
+											"variant": "param",
+											"kind": 32768,
+											"flags": {},
+											"comment": {
+												"summary": [
+													{
+														"kind": "text",
+														"text": "The options required to perform the token exchange."
+													},
+													{
+														"kind": "text",
+														"text": "\n\nType: [CustomTokenExchangeOptions](/docs/sdk/react/types/CustomTokenExchangeOptions)"
+													}
+												]
+											},
+											"type": {
+												"type": "reference",
+												"target": 579,
+												"name": "CustomTokenExchangeOptions",
+												"package": "@auth0/auth0-spa-js"
+											}
+										}
+									],
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "typescript",
+											"packagePath": "lib/lib.es5.d.ts",
+											"qualifiedName": "Promise"
+										},
+										"typeArguments": [
+											{
+												"type": "reference",
+												"target": 590,
+												"name": "TokenEndpointResponse",
+												"package": "@auth0/auth0-spa-js"
+											}
+										],
+										"name": "Promise",
+										"package": "typescript"
+									}
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": 145,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"comment": {
+						"summary": [],
+						"blockTags": [
+							{
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Auth State"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/auth-state.tsx",
+							"line": 7,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "union",
+						"types": [
+							{
+								"type": "reference",
+								"target": {
+									"packageName": "typescript",
+									"packagePath": "lib/lib.es5.d.ts",
+									"qualifiedName": "Error"
+								},
+								"name": "Error",
+								"package": "typescript"
+							},
+							{
+								"type": "intrinsic",
+								"name": "undefined"
+							}
+						]
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthState.error"
+					}
+				},
+				{
+					"id": 86,
+					"name": "exchangeToken",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [],
+						"blockTags": [
+							{
+								"tag": "@deprecated",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Use "
+									},
+									{
+										"kind": "code",
+										"text": "`loginWithCustomTokenExchange()`"
+									},
+									{
+										"kind": "text",
+										"text": " instead. This method will be removed in the next major version.\n\n"
+									},
+									{
+										"kind": "code",
+										"text": "```js\nconst tokenResponse = await exchangeToken({\n  subject_token: 'external_token_value',\n  subject_token_type: 'urn:acme:legacy-system-token',\n  scope: 'openid profile email'\n});\n```"
+									},
+									{
+										"kind": "text",
+										"text": "\n\nExchanges an external subject token for Auth0 tokens and logs the user in.\n\nThis method implements the token exchange grant as specified in RFC 8693.\nIt performs a token exchange by sending a request to the "
+									},
+									{
+										"kind": "code",
+										"text": "`/oauth/token`"
+									},
+									{
+										"kind": "text",
+										"text": " endpoint\nwith the external token and returns Auth0 tokens (access token, ID token, etc.).\n\n**Example:**\n"
+									},
+									{
+										"kind": "code",
+										"text": "```js\n// Instead of:\nconst tokens = await exchangeToken(options);\n\n// Use:\nconst tokens = await loginWithCustomTokenExchange(options);\n```"
+									}
+								]
+							},
+							{
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Tokens"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/auth0-context.tsx",
+							"line": 207,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 87,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"signatures": [
+								{
+									"id": 88,
+									"name": "__type",
+									"variant": "signature",
+									"kind": 4096,
+									"flags": {},
+									"comment": {
+										"summary": [],
+										"blockTags": [
+											{
+												"tag": "@returns",
+												"content": [
+													{
+														"kind": "text",
+														"text": "A promise that resolves to the token endpoint response containing Auth0 tokens"
+													}
+												]
+											}
+										]
+									},
+									"parameters": [
+										{
+											"id": 89,
+											"name": "options",
+											"variant": "param",
+											"kind": 32768,
+											"flags": {},
+											"comment": {
+												"summary": [
+													{
+														"kind": "text",
+														"text": "The options required to perform the token exchange"
+													},
+													{
+														"kind": "text",
+														"text": "\n\nType: [CustomTokenExchangeOptions](/docs/sdk/react/types/CustomTokenExchangeOptions)"
+													}
+												]
+											},
+											"type": {
+												"type": "reference",
+												"target": 579,
+												"name": "CustomTokenExchangeOptions",
+												"package": "@auth0/auth0-spa-js"
+											}
+										}
+									],
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "typescript",
+											"packagePath": "lib/lib.es5.d.ts",
+											"qualifiedName": "Promise"
+										},
+										"typeArguments": [
+											{
+												"type": "reference",
+												"target": 590,
+												"name": "TokenEndpointResponse",
+												"package": "@auth0/auth0-spa-js"
+											}
+										],
+										"name": "Promise",
+										"package": "typescript"
+									}
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": 124,
+					"name": "generateDpopProof",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Returns a string to be used to demonstrate possession of the private\nkey used to cryptographically bind access tokens with DPoP.\n\nIt requires enabling the "
+							},
+							{
+								"kind": "inline-tag",
+								"tag": "@link",
+								"text": "Auth0ClientOptions.useDpop"
+							},
+							{
+								"kind": "text",
+								"text": " option."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Advanced"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/auth0-context.tsx",
+							"line": 349,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 125,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"signatures": [
+								{
+									"id": 126,
+									"name": "__type",
+									"variant": "signature",
+									"kind": 4096,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Returns a string to be used to demonstrate possession of the private\r\nkey used to cryptographically bind access tokens with DPoP.\r\n\r\nIt requires enabling the "
+											},
+											{
+												"kind": "inline-tag",
+												"tag": "@link",
+												"text": "Auth0ClientOptions.useDpop",
+												"target": {
+													"packageName": "@auth0/auth0-spa-js",
+													"packagePath": "dist/typings/global.d.ts",
+													"qualifiedName": "Auth0ClientOptions.useDpop"
+												}
+											},
+											{
+												"kind": "text",
+												"text": " option."
+											}
+										]
+									},
+									"parameters": [
+										{
+											"id": 127,
+											"name": "params",
+											"variant": "param",
+											"kind": 32768,
+											"flags": {},
+											"type": {
+												"type": "reflection",
+												"declaration": {
+													"id": 128,
+													"name": "__type",
+													"variant": "declaration",
+													"kind": 65536,
+													"flags": {},
+													"children": [
+														{
+															"id": 132,
+															"name": "accessToken",
+															"variant": "declaration",
+															"kind": 1024,
+															"flags": {},
+															"sources": [
+																{
+																	"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/Auth0Client.d.ts",
+																	"line": 488,
+																	"character": 8
+																}
+															],
+															"type": {
+																"type": "intrinsic",
+																"name": "string"
+															}
+														},
+														{
+															"id": 130,
+															"name": "method",
+															"variant": "declaration",
+															"kind": 1024,
+															"flags": {},
+															"sources": [
+																{
+																	"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/Auth0Client.d.ts",
+																	"line": 486,
+																	"character": 8
+																}
+															],
+															"type": {
+																"type": "intrinsic",
+																"name": "string"
+															}
+														},
+														{
+															"id": 131,
+															"name": "nonce",
+															"variant": "declaration",
+															"kind": 1024,
+															"flags": {
+																"isOptional": true
+															},
+															"sources": [
+																{
+																	"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/Auth0Client.d.ts",
+																	"line": 487,
+																	"character": 8
+																}
+															],
+															"type": {
+																"type": "intrinsic",
+																"name": "string"
+															}
+														},
+														{
+															"id": 129,
+															"name": "url",
+															"variant": "declaration",
+															"kind": 1024,
+															"flags": {},
+															"sources": [
+																{
+																	"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/Auth0Client.d.ts",
+																	"line": 485,
+																	"character": 8
+																}
+															],
+															"type": {
+																"type": "intrinsic",
+																"name": "string"
+															}
+														}
+													],
+													"groups": [
+														{
+															"title": "Properties",
+															"children": [
+																132,
+																130,
+																131,
+																129
+															]
+														}
+													]
+												}
+											}
+										}
+									],
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "typescript",
+											"packagePath": "lib/lib.es5.d.ts",
+											"qualifiedName": "Promise"
+										},
+										"typeArguments": [
+											{
+												"type": "intrinsic",
+												"name": "string"
+											}
+										],
+										"name": "Promise",
+										"package": "typescript"
+									}
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": 60,
+					"name": "getAccessTokenSilently",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "code",
+								"text": "```js\nconst token = await getAccessTokenSilently(options);\n```"
+							},
+							{
+								"kind": "text",
+								"text": "\n\nIf there's a valid token stored, return it. Otherwise, opens an\niframe with the "
+							},
+							{
+								"kind": "code",
+								"text": "`/authorize`"
+							},
+							{
+								"kind": "text",
+								"text": " URL using the parameters provided\nas arguments. Random and secure "
+							},
+							{
+								"kind": "code",
+								"text": "`state`"
+							},
+							{
+								"kind": "text",
+								"text": " and "
+							},
+							{
+								"kind": "code",
+								"text": "`nonce`"
+							},
+							{
+								"kind": "text",
+								"text": " parameters\nwill be auto-generated. If the response is successful, results\nwill be valid according to their expiration times.\n\nIf refresh tokens are used, the token endpoint is called directly with the\n'refresh_token' grant. If no refresh token is available to make this call,\nthe SDK will only fall back to using an iframe to the '/authorize' URL if \nthe "
+							},
+							{
+								"kind": "code",
+								"text": "`useRefreshTokensFallback`"
+							},
+							{
+								"kind": "text",
+								"text": " setting has been set to "
+							},
+							{
+								"kind": "code",
+								"text": "`true`"
+							},
+							{
+								"kind": "text",
+								"text": ". By default this\nsetting is "
+							},
+							{
+								"kind": "code",
+								"text": "`false`"
+							},
+							{
+								"kind": "text",
+								"text": ".\n\nThis method may use a web worker to perform the token call if the in-memory\ncache is used.\n\nIf an "
+							},
+							{
+								"kind": "code",
+								"text": "`audience`"
+							},
+							{
+								"kind": "text",
+								"text": " value is given to this function, the SDK always falls\nback to using an iframe to make the token exchange.\n\nNote that in all cases, falling back to an iframe requires access to\nthe "
+							},
+							{
+								"kind": "code",
+								"text": "`auth0`"
+							},
+							{
+								"kind": "text",
+								"text": " cookie."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Tokens"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/auth0-context.tsx",
+							"line": 63,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 61,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"signatures": [
+								{
+									"id": 62,
+									"name": "__type",
+									"variant": "signature",
+									"kind": 4096,
+									"flags": {},
+									"parameters": [
+										{
+											"id": 63,
+											"name": "options",
+											"variant": "param",
+											"kind": 32768,
+											"flags": {},
+											"comment": {
+												"summary": [
+													{
+														"kind": "text",
+														"text": "Type: [GetTokenSilentlyOptions](/docs/sdk/react/interfaces/GetTokenSilentlyOptions)"
+													}
+												]
+											},
+											"type": {
+												"type": "intersection",
+												"types": [
+													{
+														"type": "reference",
+														"target": 272,
+														"name": "GetTokenSilentlyOptions",
+														"package": "@auth0/auth0-spa-js"
+													},
+													{
+														"type": "reflection",
+														"declaration": {
+															"id": 64,
+															"name": "__type",
+															"variant": "declaration",
+															"kind": 65536,
+															"flags": {},
+															"children": [
+																{
+																	"id": 65,
+																	"name": "detailedResponse",
+																	"variant": "declaration",
+																	"kind": 1024,
+																	"flags": {},
+																	"sources": [
+																		{
+																			"fileName": "src/auth0-context.tsx",
+																			"line": 65,
+																			"character": 43
+																		}
+																	],
+																	"type": {
+																		"type": "literal",
+																		"value": true
+																	}
+																}
+															],
+															"groups": [
+																{
+																	"title": "Properties",
+																	"children": [
+																		65
+																	]
+																}
+															]
+														}
+													}
+												]
+											}
+										}
+									],
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "typescript",
+											"packagePath": "lib/lib.es5.d.ts",
+											"qualifiedName": "Promise"
+										},
+										"typeArguments": [
+											{
+												"type": "reference",
+												"target": {
+													"packageName": "@auth0/auth0-spa-js",
+													"packagePath": "dist/typings/global.d.ts",
+													"qualifiedName": "GetTokenSilentlyVerboseResponse"
+												},
+												"name": "GetTokenSilentlyVerboseResponse",
+												"package": "@auth0/auth0-spa-js"
+											}
+										],
+										"name": "Promise",
+										"package": "typescript"
+									}
+								},
+								{
+									"id": 66,
+									"name": "__type",
+									"variant": "signature",
+									"kind": 4096,
+									"flags": {},
+									"parameters": [
+										{
+											"id": 67,
+											"name": "options",
+											"variant": "param",
+											"kind": 32768,
+											"flags": {
+												"isOptional": true
+											},
+											"comment": {
+												"summary": [
+													{
+														"kind": "text",
+														"text": "Type: [GetTokenSilentlyOptions](/docs/sdk/react/interfaces/GetTokenSilentlyOptions)"
+													}
+												]
+											},
+											"type": {
+												"type": "reference",
+												"target": 272,
+												"name": "GetTokenSilentlyOptions",
+												"package": "@auth0/auth0-spa-js"
+											}
+										}
+									],
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "typescript",
+											"packagePath": "lib/lib.es5.d.ts",
+											"qualifiedName": "Promise"
+										},
+										"typeArguments": [
+											{
+												"type": "intrinsic",
+												"name": "string"
+											}
+										],
+										"name": "Promise",
+										"package": "typescript"
+									}
+								},
+								{
+									"id": 68,
+									"name": "__type",
+									"variant": "signature",
+									"kind": 4096,
+									"flags": {},
+									"parameters": [
+										{
+											"id": 69,
+											"name": "options",
+											"variant": "param",
+											"kind": 32768,
+											"flags": {},
+											"comment": {
+												"summary": [
+													{
+														"kind": "text",
+														"text": "Type: [GetTokenSilentlyOptions](/docs/sdk/react/interfaces/GetTokenSilentlyOptions)"
+													}
+												]
+											},
+											"type": {
+												"type": "reference",
+												"target": 272,
+												"name": "GetTokenSilentlyOptions",
+												"package": "@auth0/auth0-spa-js"
+											}
+										}
+									],
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "typescript",
+											"packagePath": "lib/lib.es5.d.ts",
+											"qualifiedName": "Promise"
+										},
+										"typeArguments": [
+											{
+												"type": "union",
+												"types": [
+													{
+														"type": "intrinsic",
+														"name": "string"
+													},
+													{
+														"type": "reference",
+														"target": {
+															"packageName": "@auth0/auth0-spa-js",
+															"packagePath": "dist/typings/global.d.ts",
+															"qualifiedName": "GetTokenSilentlyVerboseResponse"
+														},
+														"name": "GetTokenSilentlyVerboseResponse",
+														"package": "@auth0/auth0-spa-js"
+													}
+												]
+											}
+										],
+										"name": "Promise",
+										"package": "typescript"
+									}
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": 70,
+					"name": "getAccessTokenWithPopup",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "code",
+								"text": "```js\nconst token = await getTokenWithPopup(options, config);\n```"
+							},
+							{
+								"kind": "text",
+								"text": "\n\nGet an access token interactively.\n\nOpens a popup with the "
+							},
+							{
+								"kind": "code",
+								"text": "`/authorize`"
+							},
+							{
+								"kind": "text",
+								"text": " URL using the parameters\nprovided as arguments. Random and secure "
+							},
+							{
+								"kind": "code",
+								"text": "`state`"
+							},
+							{
+								"kind": "text",
+								"text": " and "
+							},
+							{
+								"kind": "code",
+								"text": "`nonce`"
+							},
+							{
+								"kind": "text",
+								"text": "\nparameters will be auto-generated. If the response is successful,\nresults will be valid according to their expiration times."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Tokens"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/auth0-context.tsx",
+							"line": 85,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 71,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"signatures": [
+								{
+									"id": 72,
+									"name": "__type",
+									"variant": "signature",
+									"kind": 4096,
+									"flags": {},
+									"parameters": [
+										{
+											"id": 73,
+											"name": "options",
+											"variant": "param",
+											"kind": 32768,
+											"flags": {
+												"isOptional": true
+											},
+											"comment": {
+												"summary": [
+													{
+														"kind": "text",
+														"text": "Type: [GetTokenWithPopupOptions](/docs/sdk/react/interfaces/GetTokenWithPopupOptions)"
+													}
+												]
+											},
+											"type": {
+												"type": "reference",
+												"target": 260,
+												"name": "GetTokenWithPopupOptions",
+												"package": "@auth0/auth0-spa-js"
+											}
+										},
+										{
+											"id": 74,
+											"name": "config",
+											"variant": "param",
+											"kind": 32768,
+											"flags": {
+												"isOptional": true
+											},
+											"comment": {
+												"summary": [
+													{
+														"kind": "text",
+														"text": "Type: [PopupConfigOptions](/docs/sdk/react/interfaces/PopupConfigOptions)"
+													}
+												]
+											},
+											"type": {
+												"type": "reference",
+												"target": 256,
+												"name": "PopupConfigOptions",
+												"package": "@auth0/auth0-spa-js"
+											}
+										}
+									],
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "typescript",
+											"packagePath": "lib/lib.es5.d.ts",
+											"qualifiedName": "Promise"
+										},
+										"typeArguments": [
+											{
+												"type": "union",
+												"types": [
+													{
+														"type": "intrinsic",
+														"name": "string"
+													},
+													{
+														"type": "intrinsic",
+														"name": "undefined"
+													}
+												]
+											}
+										],
+										"name": "Promise",
+										"package": "typescript"
+									}
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": 138,
+					"name": "getConfiguration",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "code",
+								"text": "```js\nconst config = getConfiguration();\n// { domain: 'tenant.auth0.com', clientId: 'abc123' }\n```"
+							},
+							{
+								"kind": "text",
+								"text": "\n\nReturns a readonly copy of the initialization configuration\ncontaining the domain and clientId."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Advanced"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/auth0-context.tsx",
+							"line": 370,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 139,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"signatures": [
+								{
+									"id": 140,
+									"name": "__type",
+									"variant": "signature",
+									"kind": 4096,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Returns a readonly copy of the initialization configuration."
+											}
+										],
+										"blockTags": [
+											{
+												"tag": "@returns",
+												"content": [
+													{
+														"kind": "text",
+														"text": "An object containing domain and clientId"
+													}
+												]
+											},
+											{
+												"tag": "@example",
+												"content": [
+													{
+														"kind": "code",
+														"text": "```typescript\r\nconst auth0 = new Auth0Client({\r\n  domain: 'tenant.auth0.com',\r\n  clientId: 'abc123'\r\n});\r\n\r\nconst config = auth0.getConfiguration();\r\n// { domain: 'tenant.auth0.com', clientId: 'abc123' }\r\n```"
+													}
+												]
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "typescript",
+											"packagePath": "lib/lib.es5.d.ts",
+											"qualifiedName": "Readonly"
+										},
+										"typeArguments": [
+											{
+												"type": "reference",
+												"target": 602,
+												"name": "ClientConfiguration",
+												"package": "@auth0/auth0-spa-js"
+											}
+										],
+										"name": "Readonly",
+										"package": "typescript"
+									}
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": 115,
+					"name": "getDpopNonce",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Returns the current DPoP nonce used for making requests to Auth0.\n\nIt can return "
+							},
+							{
+								"kind": "code",
+								"text": "`undefined`"
+							},
+							{
+								"kind": "text",
+								"text": " because when starting fresh it will not\nbe populated until after the first response from the server.\n\nIt requires enabling the "
+							},
+							{
+								"kind": "inline-tag",
+								"tag": "@link",
+								"text": "Auth0ClientOptions.useDpop"
+							},
+							{
+								"kind": "text",
+								"text": " option."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@param",
+								"name": "nonce",
+								"content": [
+									{
+										"kind": "text",
+										"text": "The nonce value."
+									}
+								]
+							},
+							{
+								"tag": "@param",
+								"name": "id",
+								"content": [
+									{
+										"kind": "text",
+										"text": "The identifier of a nonce: if absent, it will get the nonce\n             used for requests to Auth0. Otherwise, it will be used to\n             select a specific non-Auth0 nonce."
+									}
+								]
+							},
+							{
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Advanced"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/auth0-context.tsx",
+							"line": 329,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 116,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"signatures": [
+								{
+									"id": 117,
+									"name": "__type",
+									"variant": "signature",
+									"kind": 4096,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Returns the current DPoP nonce used for making requests to Auth0.\r\n\r\nIt can return "
+											},
+											{
+												"kind": "code",
+												"text": "`undefined`"
+											},
+											{
+												"kind": "text",
+												"text": " because when starting fresh it will not\r\nbe populated until after the first response from the server.\r\n\r\nIt requires enabling the "
+											},
+											{
+												"kind": "inline-tag",
+												"tag": "@link",
+												"text": "Auth0ClientOptions.useDpop",
+												"target": {
+													"packageName": "@auth0/auth0-spa-js",
+													"packagePath": "dist/typings/global.d.ts",
+													"qualifiedName": "Auth0ClientOptions.useDpop"
+												}
+											},
+											{
+												"kind": "text",
+												"text": " option."
+											}
+										]
+									},
+									"parameters": [
+										{
+											"id": 118,
+											"name": "id",
+											"variant": "param",
+											"kind": 32768,
+											"flags": {
+												"isOptional": true
+											},
+											"comment": {
+												"summary": [
+													{
+														"kind": "text",
+														"text": "The identifier of a nonce: if absent, it will get the nonce\r\n             used for requests to Auth0. Otherwise, it will be used to\r\n             select a specific non-Auth0 nonce."
+													}
+												]
+											},
+											"type": {
+												"type": "intrinsic",
+												"name": "string"
+											}
+										}
+									],
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "typescript",
+											"packagePath": "lib/lib.es5.d.ts",
+											"qualifiedName": "Promise"
+										},
+										"typeArguments": [
+											{
+												"type": "union",
+												"types": [
+													{
+														"type": "intrinsic",
+														"name": "string"
+													},
+													{
+														"type": "intrinsic",
+														"name": "undefined"
+													}
+												]
+											}
+										],
+										"name": "Promise",
+										"package": "typescript"
+									}
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": 75,
+					"name": "getIdTokenClaims",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "code",
+								"text": "```js\nconst claims = await getIdTokenClaims();\n```"
+							},
+							{
+								"kind": "text",
+								"text": "\n\nReturns all claims from the id_token if available."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Tokens"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/auth0-context.tsx",
+							"line": 97,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 76,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"signatures": [
+								{
+									"id": 77,
+									"name": "__type",
+									"variant": "signature",
+									"kind": 4096,
+									"flags": {},
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "typescript",
+											"packagePath": "lib/lib.es5.d.ts",
+											"qualifiedName": "Promise"
+										},
+										"typeArguments": [
+											{
+												"type": "union",
+												"types": [
+													{
+														"type": "reference",
+														"target": 283,
+														"name": "IdToken",
+														"package": "@auth0/auth0-spa-js"
+													},
+													{
+														"type": "intrinsic",
+														"name": "undefined"
+													}
+												]
+											}
+										],
+										"name": "Promise",
+										"package": "typescript"
+									}
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": 111,
+					"name": "handleRedirectCallback",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "After the browser redirects back to the callback page,\ncall "
+							},
+							{
+								"kind": "code",
+								"text": "`handleRedirectCallback`"
+							},
+							{
+								"kind": "text",
+								"text": " to handle success and error\nresponses from Auth0. If the response is successful, results\nwill be valid according to their expiration times."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Authentication"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/auth0-context.tsx",
+							"line": 314,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 112,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"signatures": [
+								{
+									"id": 113,
+									"name": "__type",
+									"variant": "signature",
+									"kind": 4096,
+									"flags": {},
+									"parameters": [
+										{
+											"id": 114,
+											"name": "url",
+											"variant": "param",
+											"kind": 32768,
+											"flags": {
+												"isOptional": true
+											},
+											"comment": {
+												"summary": [
+													{
+														"kind": "text",
+														"text": "The URL to that should be used to retrieve the "
+													},
+													{
+														"kind": "code",
+														"text": "`state`"
+													},
+													{
+														"kind": "text",
+														"text": " and "
+													},
+													{
+														"kind": "code",
+														"text": "`code`"
+													},
+													{
+														"kind": "text",
+														"text": " values. Defaults to "
+													},
+													{
+														"kind": "code",
+														"text": "`window.location.href`"
+													},
+													{
+														"kind": "text",
+														"text": " if not given."
+													}
+												]
+											},
+											"type": {
+												"type": "intrinsic",
+												"name": "string"
+											}
+										}
+									],
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "typescript",
+											"packagePath": "lib/lib.es5.d.ts",
+											"qualifiedName": "Promise"
+										},
+										"typeArguments": [
+											{
+												"type": "union",
+												"types": [
+													{
+														"type": "reference",
+														"target": 552,
+														"name": "ConnectAccountRedirectResult",
+														"package": "@auth0/auth0-spa-js"
+													},
+													{
+														"type": "reference",
+														"target": {
+															"packageName": "@auth0/auth0-spa-js",
+															"packagePath": "dist/typings/global.d.ts",
+															"qualifiedName": "RedirectLoginResult"
+														},
+														"typeArguments": [
+															{
+																"type": "intrinsic",
+																"name": "any"
+															}
+														],
+														"name": "RedirectLoginResult",
+														"package": "@auth0/auth0-spa-js"
+													}
+												]
+											}
+										],
+										"name": "Promise",
+										"package": "typescript"
+									}
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": 146,
+					"name": "isAuthenticated",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"comment": {
+						"summary": [],
+						"blockTags": [
+							{
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Auth State"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/auth-state.tsx",
+							"line": 8,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthState.isAuthenticated"
+					}
+				},
+				{
+					"id": 147,
+					"name": "isLoading",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"comment": {
+						"summary": [],
+						"blockTags": [
+							{
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Auth State"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/auth-state.tsx",
+							"line": 9,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthState.isLoading"
+					}
+				},
+				{
+					"id": 78,
+					"name": "loginWithCustomTokenExchange",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "code",
+								"text": "```js\nawait loginWithCustomTokenExchange(options);\n```"
+							},
+							{
+								"kind": "text",
+								"text": "\n\nExchanges an external subject token for Auth0 tokens and logs the user in.\nThis method implements the Custom Token Exchange grant as specified in RFC 8693.\n\nThe exchanged tokens are automatically cached, establishing an authenticated session.\nAfter calling this method, you can use "
+							},
+							{
+								"kind": "code",
+								"text": "`getUser()`"
+							},
+							{
+								"kind": "text",
+								"text": ", "
+							},
+							{
+								"kind": "code",
+								"text": "`getIdTokenClaims()`"
+							},
+							{
+								"kind": "text",
+								"text": ", and\n"
+							},
+							{
+								"kind": "code",
+								"text": "`getTokenSilently()`"
+							},
+							{
+								"kind": "text",
+								"text": " to access the user's information and tokens."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Tokens"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/auth0-context.tsx",
+							"line": 147,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 79,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"signatures": [
+								{
+									"id": 80,
+									"name": "__type",
+									"variant": "signature",
+									"kind": 4096,
+									"flags": {},
+									"comment": {
+										"summary": [],
+										"blockTags": [
+											{
+												"tag": "@returns",
+												"content": [
+													{
+														"kind": "text",
+														"text": "A promise that resolves to the token endpoint response,\nwhich contains the issued Auth0 tokens (access_token, id_token, etc.).\n\nThe request includes the following parameters:\n- "
+													},
+													{
+														"kind": "code",
+														"text": "`grant_type`"
+													},
+													{
+														"kind": "text",
+														"text": ": \"urn:ietf:params:oauth:grant-type:token-exchange\"\n- "
+													},
+													{
+														"kind": "code",
+														"text": "`subject_token`"
+													},
+													{
+														"kind": "text",
+														"text": ": The external token to exchange\n- "
+													},
+													{
+														"kind": "code",
+														"text": "`subject_token_type`"
+													},
+													{
+														"kind": "text",
+														"text": ": The type identifier of the external token\n- "
+													},
+													{
+														"kind": "code",
+														"text": "`scope`"
+													},
+													{
+														"kind": "text",
+														"text": ": Merged scopes from the request and SDK defaults\n- "
+													},
+													{
+														"kind": "code",
+														"text": "`audience`"
+													},
+													{
+														"kind": "text",
+														"text": ": Target audience (defaults to SDK configuration)\n- "
+													},
+													{
+														"kind": "code",
+														"text": "`organization`"
+													},
+													{
+														"kind": "text",
+														"text": ": Optional organization ID/name for org-scoped authentication\n\n**Example Usage:**\n\n"
+													},
+													{
+														"kind": "code",
+														"text": "```js\nconst options = {\n  subject_token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6Ikp...',\n  subject_token_type: 'urn:acme:legacy-system-token',\n  scope: 'openid profile email',\n  audience: 'https://api.example.com',\n  organization: 'org_12345'\n};\n\ntry {\n  const tokenResponse = await loginWithCustomTokenExchange(options);\n  console.log('Access token:', tokenResponse.access_token);\n\n  // User is now logged in - access user info\n  const user = await getUser();\n  console.log('Logged in user:', user);\n} catch (error) {\n  console.error('Token exchange failed:', error);\n}\n```"
+													}
+												]
+											}
+										]
+									},
+									"parameters": [
+										{
+											"id": 81,
+											"name": "options",
+											"variant": "param",
+											"kind": 32768,
+											"flags": {},
+											"comment": {
+												"summary": [
+													{
+														"kind": "text",
+														"text": "The options required to perform the token exchange."
+													},
+													{
+														"kind": "text",
+														"text": "\n\nType: [CustomTokenExchangeOptions](/docs/sdk/react/types/CustomTokenExchangeOptions)"
+													}
+												]
+											},
+											"type": {
+												"type": "reference",
+												"target": 579,
+												"name": "CustomTokenExchangeOptions",
+												"package": "@auth0/auth0-spa-js"
+											}
+										}
+									],
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "typescript",
+											"packagePath": "lib/lib.es5.d.ts",
+											"qualifiedName": "Promise"
+										},
+										"typeArguments": [
+											{
+												"type": "reference",
+												"target": 590,
+												"name": "TokenEndpointResponse",
+												"package": "@auth0/auth0-spa-js"
+											}
+										],
+										"name": "Promise",
+										"package": "typescript"
+									}
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": 94,
+					"name": "loginWithPopup",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "code",
+								"text": "```js\nawait loginWithPopup(options, config);\n```"
+							},
+							{
+								"kind": "text",
+								"text": "\n\nOpens a popup with the "
+							},
+							{
+								"kind": "code",
+								"text": "`/authorize`"
+							},
+							{
+								"kind": "text",
+								"text": " URL using the parameters\nprovided as arguments. Random and secure "
+							},
+							{
+								"kind": "code",
+								"text": "`state`"
+							},
+							{
+								"kind": "text",
+								"text": " and "
+							},
+							{
+								"kind": "code",
+								"text": "`nonce`"
+							},
+							{
+								"kind": "text",
+								"text": "\nparameters will be auto-generated. If the response is successful,\nresults will be valid according to their expiration times.\n\nIMPORTANT: This method has to be called from an event handler\nthat was started by the user like a button click, for example,\notherwise the popup will be blocked in most browsers."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Authentication"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/auth0-context.tsx",
+							"line": 238,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 95,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"signatures": [
+								{
+									"id": 96,
+									"name": "__type",
+									"variant": "signature",
+									"kind": 4096,
+									"flags": {},
+									"parameters": [
+										{
+											"id": 97,
+											"name": "options",
+											"variant": "param",
+											"kind": 32768,
+											"flags": {
+												"isOptional": true
+											},
+											"comment": {
+												"summary": [
+													{
+														"kind": "text",
+														"text": "Type: [PopupLoginOptions](/docs/sdk/react/interfaces/PopupLoginOptions)"
+													}
+												]
+											},
+											"type": {
+												"type": "reference",
+												"target": 254,
+												"name": "PopupLoginOptions",
+												"package": "@auth0/auth0-spa-js"
+											}
+										},
+										{
+											"id": 98,
+											"name": "config",
+											"variant": "param",
+											"kind": 32768,
+											"flags": {
+												"isOptional": true
+											},
+											"comment": {
+												"summary": [
+													{
+														"kind": "text",
+														"text": "Type: [PopupConfigOptions](/docs/sdk/react/interfaces/PopupConfigOptions)"
+													}
+												]
+											},
+											"type": {
+												"type": "reference",
+												"target": 256,
+												"name": "PopupConfigOptions",
+												"package": "@auth0/auth0-spa-js"
+											}
+										}
+									],
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "typescript",
+											"packagePath": "lib/lib.es5.d.ts",
+											"qualifiedName": "Promise"
+										},
+										"typeArguments": [
+											{
+												"type": "intrinsic",
+												"name": "void"
+											}
+										],
+										"name": "Promise",
+										"package": "typescript"
+									}
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": 90,
+					"name": "loginWithRedirect",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "code",
+								"text": "```js\nawait loginWithRedirect(options);\n```"
+							},
+							{
+								"kind": "text",
+								"text": "\n\nPerforms a redirect to "
+							},
+							{
+								"kind": "code",
+								"text": "`/authorize`"
+							},
+							{
+								"kind": "text",
+								"text": " using the parameters\nprovided as arguments. Random and secure "
+							},
+							{
+								"kind": "code",
+								"text": "`state`"
+							},
+							{
+								"kind": "text",
+								"text": " and "
+							},
+							{
+								"kind": "code",
+								"text": "`nonce`"
+							},
+							{
+								"kind": "text",
+								"text": "\nparameters will be auto-generated."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Authentication"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/auth0-context.tsx",
+							"line": 220,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 91,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"signatures": [
+								{
+									"id": 92,
+									"name": "__type",
+									"variant": "signature",
+									"kind": 4096,
+									"flags": {},
+									"parameters": [
+										{
+											"id": 93,
+											"name": "options",
+											"variant": "param",
+											"kind": 32768,
+											"flags": {
+												"isOptional": true
+											},
+											"comment": {
+												"summary": [
+													{
+														"kind": "text",
+														"text": "Type: [AppState](/docs/sdk/react/types/AppState), [RedirectLoginOptions](/docs/sdk/react/interfaces/RedirectLoginOptions)"
+													}
+												]
+											},
+											"type": {
+												"type": "reference",
+												"target": 227,
+												"typeArguments": [
+													{
+														"type": "reference",
+														"target": 15,
+														"name": "AppState",
+														"package": "@auth0/auth0-react"
+													}
+												],
+												"name": "RedirectLoginOptions",
+												"package": "@auth0/auth0-react"
+											}
+										}
+									],
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "typescript",
+											"packagePath": "lib/lib.es5.d.ts",
+											"qualifiedName": "Promise"
+										},
+										"typeArguments": [
+											{
+												"type": "intrinsic",
+												"name": "void"
+											}
+										],
+										"name": "Promise",
+										"package": "typescript"
+									}
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": 103,
+					"name": "logout",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "code",
+								"text": "```js\nauth0.logout({ logoutParams: { returnTo: window.location.origin } });\n```"
+							},
+							{
+								"kind": "text",
+								"text": "\n\nClears the application session and performs a redirect to "
+							},
+							{
+								"kind": "code",
+								"text": "`/v2/logout`"
+							},
+							{
+								"kind": "text",
+								"text": ", using\nthe parameters provided as arguments, to clear the Auth0 session.\nIf the "
+							},
+							{
+								"kind": "code",
+								"text": "`logoutParams.federated`"
+							},
+							{
+								"kind": "text",
+								"text": " option is specified, it also clears the Identity Provider session.\n[Read more about how Logout works at Auth0](https://auth0.com/docs/logout)."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Authentication"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/auth0-context.tsx",
+							"line": 275,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 104,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"signatures": [
+								{
+									"id": 105,
+									"name": "__type",
+									"variant": "signature",
+									"kind": 4096,
+									"flags": {},
+									"parameters": [
+										{
+											"id": 106,
+											"name": "options",
+											"variant": "param",
+											"kind": 32768,
+											"flags": {
+												"isOptional": true
+											},
+											"comment": {
+												"summary": [
+													{
+														"kind": "text",
+														"text": "Type: [LogoutOptions](/docs/sdk/react/interfaces/LogoutOptions)"
+													}
+												]
+											},
+											"type": {
+												"type": "reference",
+												"target": 215,
+												"name": "LogoutOptions",
+												"package": "@auth0/auth0-react"
+											}
+										}
+									],
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "typescript",
+											"packagePath": "lib/lib.es5.d.ts",
+											"qualifiedName": "Promise"
+										},
+										"typeArguments": [
+											{
+												"type": "intrinsic",
+												"name": "void"
+											}
+										],
+										"name": "Promise",
+										"package": "typescript"
+									}
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": 141,
+					"name": "mfa",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "code",
+								"text": "```js\nconst { mfa } = useAuth0();\nconst authenticators = await mfa.getAuthenticators(mfaToken);\n```"
+							},
+							{
+								"kind": "text",
+								"text": "\n\nMFA API client for Multi-Factor Authentication operations.\n\nProvides access to all MFA-related methods:\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`getAuthenticators(mfaToken)`"
+							},
+							{
+								"kind": "text",
+								"text": " - List enrolled authenticators\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`enroll(params)`"
+							},
+							{
+								"kind": "text",
+								"text": " - Enroll new authenticators (OTP, SMS, Voice, Email, Push)\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`challenge(params)`"
+							},
+							{
+								"kind": "text",
+								"text": " - Initiate MFA challenges\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`verify(params)`"
+							},
+							{
+								"kind": "text",
+								"text": " - Verify MFA challenges and complete authentication\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`getEnrollmentFactors(mfaToken)`"
+							},
+							{
+								"kind": "text",
+								"text": " - Get available enrollment factors"
+							},
+							{
+								"kind": "text",
+								"text": "\n\nType: [MfaApiClient](/docs/sdk/react/interfaces/MfaApiClient)"
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@example",
+								"content": [
+									{
+										"kind": "code",
+										"text": "```js\nconst { mfa, getAccessTokenSilently } = useAuth0();\n\ntry {\n  await getAccessTokenSilently();\n} catch (error) {\n  if (error.error === 'mfa_required') {\n    // Check if enrollment is needed\n    const factors = await mfa.getEnrollmentFactors(error.mfa_token);\n\n    if (factors.length > 0) {\n      // Enroll in OTP\n      const enrollment = await mfa.enroll({\n        mfaToken: error.mfa_token,\n        factorType: 'otp'\n      });\n      console.log('QR Code:', enrollment.barcodeUri);\n    }\n\n    // Get authenticators and challenge\n    const authenticators = await mfa.getAuthenticators(error.mfa_token);\n    await mfa.challenge({\n      mfaToken: error.mfa_token,\n      challengeType: 'otp',\n      authenticatorId: authenticators[0].id\n    });\n\n    // Verify with user's code\n    const tokens = await mfa.verify({\n      mfaToken: error.mfa_token,\n      otp: userCode\n    });\n  }\n}\n```"
+									}
+								]
+							},
+							{
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Sub-clients"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/auth0-context.tsx",
+							"line": 424,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 741,
+						"name": "MfaApiClient",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 143,
+					"name": "myAccount",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "code",
+								"text": "```js\nconst { myAccount } = useAuth0();\nconst factors = await myAccount.getFactors();\n```"
+							},
+							{
+								"kind": "text",
+								"text": "\n\nMyAccount API client for self-service account management operations.\n\nProvides access to methods for managing the authenticated user's authentication\nmethods and factors:\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`getFactors()`"
+							},
+							{
+								"kind": "text",
+								"text": " - List available authentication factors\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`getAuthenticationMethods(type?)`"
+							},
+							{
+								"kind": "text",
+								"text": " - List enrolled authentication methods, optionally filtered by type\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`getAuthenticationMethod(id)`"
+							},
+							{
+								"kind": "text",
+								"text": " - Get a specific authentication method by ID\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`updateAuthenticationMethod(id, data)`"
+							},
+							{
+								"kind": "text",
+								"text": " - Update an authentication method (e.g. rename)\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`deleteAuthenticationMethod(id)`"
+							},
+							{
+								"kind": "text",
+								"text": " - Remove an enrolled authentication method\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`enrollmentChallenge(options)`"
+							},
+							{
+								"kind": "text",
+								"text": " - Initiate a two-step enrollment challenge\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`enrollmentVerify(options)`"
+							},
+							{
+								"kind": "text",
+								"text": " - Complete a two-step enrollment by verifying the challenge"
+							},
+							{
+								"kind": "text",
+								"text": "\n\nType: [MyAccountApiClient](/docs/sdk/react/interfaces/MyAccountApiClient)"
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@example",
+								"content": [
+									{
+										"kind": "code",
+										"text": "```js\nconst { myAccount } = useAuth0();\n\n// List all enrolled authentication methods\nconst methods = await myAccount.getAuthenticationMethods();\n\n// Enroll a new passkey\nconst challenge = await myAccount.enrollmentChallenge({ type: 'passkey' });\nconst credential = await navigator.credentials.create({ publicKey: challenge.authn_params_public_key });\nawait myAccount.enrollmentVerify({ type: 'passkey', auth_session: challenge.auth_session, location: challenge.location, authn_response: credential });\n\n// Remove an authentication method\nawait myAccount.deleteAuthenticationMethod('method-id');\n```"
+									}
+								]
+							},
+							{
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Sub-clients"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/auth0-context.tsx",
+							"line": 476,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 836,
+						"name": "MyAccountApiClient",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 142,
+					"name": "passkey",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "code",
+								"text": "```js\nconst { passkey } = useAuth0();\nconst tokens = await passkey.signup({ email: 'user@example.com' });\n```"
+							},
+							{
+								"kind": "text",
+								"text": "\n\nPasskey API client for WebAuthn-based passwordless authentication.\n\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`signup(options)`"
+							},
+							{
+								"kind": "text",
+								"text": " — register a new user and create a passkey credential\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`login(options?)`"
+							},
+							{
+								"kind": "text",
+								"text": " — authenticate an existing user via passkey assertion\n\nBoth methods exchange the WebAuthn credential for Auth0 tokens and update\n"
+							},
+							{
+								"kind": "code",
+								"text": "`isAuthenticated`"
+							},
+							{
+								"kind": "text",
+								"text": " / "
+							},
+							{
+								"kind": "code",
+								"text": "`user`"
+							},
+							{
+								"kind": "text",
+								"text": " in the same way as "
+							},
+							{
+								"kind": "code",
+								"text": "`loginWithPopup`"
+							},
+							{
+								"kind": "text",
+								"text": "."
+							},
+							{
+								"kind": "text",
+								"text": "\n\nType: [PasskeyApiClient](/docs/sdk/react/interfaces/PasskeyApiClient)"
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Sub-clients"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/auth0-context.tsx",
+							"line": 440,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 811,
+						"name": "PasskeyApiClient",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 107,
+					"name": "revokeRefreshToken",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "code",
+								"text": "```js\nawait revokeRefreshToken();\n// or for a specific audience:\nawait revokeRefreshToken({ audience: 'https://api.example.com' });\n```"
+							},
+							{
+								"kind": "text",
+								"text": "\n\nRevokes the refresh token via the "
+							},
+							{
+								"kind": "code",
+								"text": "`/oauth/revoke`"
+							},
+							{
+								"kind": "text",
+								"text": " endpoint. This invalidates the\nrefresh token so it can no longer be used to obtain new access tokens.\n\nIf "
+							},
+							{
+								"kind": "code",
+								"text": "`useRefreshTokens`"
+							},
+							{
+								"kind": "text",
+								"text": " is disabled, this method does nothing.\nWhen multiple audiences share the same refresh token, revoking for\none audience invalidates it for all of them.\n\n**Online mode** ("
+							},
+							{
+								"kind": "code",
+								"text": "`refreshTokenMode: RefreshTokenMode.Online`"
+							},
+							{
+								"kind": "text",
+								"text": "): revoking the Online\nRefresh Token also terminates the Auth0 session server-side and clears the entire\nlocal cache. "
+							},
+							{
+								"kind": "code",
+								"text": "`isAuthenticated`"
+							},
+							{
+								"kind": "text",
+								"text": " and "
+							},
+							{
+								"kind": "code",
+								"text": "`user`"
+							},
+							{
+								"kind": "text",
+								"text": " update immediately to reflect the\nterminated session — no redirect required. Use "
+							},
+							{
+								"kind": "code",
+								"text": "`logout()`"
+							},
+							{
+								"kind": "text",
+								"text": " instead if you want a\nredirect-based sign-out.\n\n**Offline mode**: only the refresh token is invalidated; the cached access token\nand user profile remain valid until the access token expires. "
+							},
+							{
+								"kind": "code",
+								"text": "`isAuthenticated`"
+							},
+							{
+								"kind": "text",
+								"text": "\nand "
+							},
+							{
+								"kind": "code",
+								"text": "`user`"
+							},
+							{
+								"kind": "text",
+								"text": " are unaffected until then."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Tokens"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/auth0-context.tsx",
+							"line": 304,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 108,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"signatures": [
+								{
+									"id": 109,
+									"name": "__type",
+									"variant": "signature",
+									"kind": 4096,
+									"flags": {},
+									"parameters": [
+										{
+											"id": 110,
+											"name": "options",
+											"variant": "param",
+											"kind": 32768,
+											"flags": {
+												"isOptional": true
+											},
+											"comment": {
+												"summary": [
+													{
+														"kind": "text",
+														"text": "Optional parameters to identify which refresh token to revoke.\n  Defaults to the audience configured in "
+													},
+													{
+														"kind": "code",
+														"text": "`authorizationParams`"
+													},
+													{
+														"kind": "text",
+														"text": "."
+													},
+													{
+														"kind": "text",
+														"text": "\n\nType: [RevokeRefreshTokenOptions](/docs/sdk/react/interfaces/RevokeRefreshTokenOptions)"
+													}
+												]
+											},
+											"type": {
+												"type": "reference",
+												"target": 731,
+												"name": "RevokeRefreshTokenOptions",
+												"package": "@auth0/auth0-spa-js"
+											}
+										}
+									],
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "typescript",
+											"packagePath": "lib/lib.es5.d.ts",
+											"qualifiedName": "Promise"
+										},
+										"typeArguments": [
+											{
+												"type": "intrinsic",
+												"name": "void"
+											}
+										],
+										"name": "Promise",
+										"package": "typescript"
+									}
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": 119,
+					"name": "setDpopNonce",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Sets the current DPoP nonce used for making requests to Auth0.\n\nIt requires enabling the "
+							},
+							{
+								"kind": "inline-tag",
+								"tag": "@link",
+								"text": "Auth0ClientOptions.useDpop"
+							},
+							{
+								"kind": "text",
+								"text": " option."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@param",
+								"name": "nonce",
+								"content": [
+									{
+										"kind": "text",
+										"text": "The nonce value."
+									}
+								]
+							},
+							{
+								"tag": "@param",
+								"name": "id",
+								"content": [
+									{
+										"kind": "text",
+										"text": "The identifier of a nonce: if absent, it will set the nonce\n             used for requests to Auth0. Otherwise, it will be used to\n             select a specific non-Auth0 nonce."
+									}
+								]
+							},
+							{
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Advanced"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/auth0-context.tsx",
+							"line": 341,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 120,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"signatures": [
+								{
+									"id": 121,
+									"name": "__type",
+									"variant": "signature",
+									"kind": 4096,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Sets the current DPoP nonce used for making requests to Auth0.\r\n\r\nIt requires enabling the "
+											},
+											{
+												"kind": "inline-tag",
+												"tag": "@link",
+												"text": "Auth0ClientOptions.useDpop",
+												"target": {
+													"packageName": "@auth0/auth0-spa-js",
+													"packagePath": "dist/typings/global.d.ts",
+													"qualifiedName": "Auth0ClientOptions.useDpop"
+												}
+											},
+											{
+												"kind": "text",
+												"text": " option."
+											}
+										]
+									},
+									"parameters": [
+										{
+											"id": 122,
+											"name": "nonce",
+											"variant": "param",
+											"kind": 32768,
+											"flags": {},
+											"comment": {
+												"summary": [
+													{
+														"kind": "text",
+														"text": "The nonce value."
+													}
+												]
+											},
+											"type": {
+												"type": "intrinsic",
+												"name": "string"
+											}
+										},
+										{
+											"id": 123,
+											"name": "id",
+											"variant": "param",
+											"kind": 32768,
+											"flags": {
+												"isOptional": true
+											},
+											"comment": {
+												"summary": [
+													{
+														"kind": "text",
+														"text": "The identifier of a nonce: if absent, it will set the nonce\r\n             used for requests to Auth0. Otherwise, it will be used to\r\n             select a specific non-Auth0 nonce."
+													}
+												]
+											},
+											"type": {
+												"type": "intrinsic",
+												"name": "string"
+											}
+										}
+									],
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "typescript",
+											"packagePath": "lib/lib.es5.d.ts",
+											"qualifiedName": "Promise"
+										},
+										"typeArguments": [
+											{
+												"type": "intrinsic",
+												"name": "void"
+											}
+										],
+										"name": "Promise",
+										"package": "typescript"
+									}
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": 148,
+					"name": "user",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"comment": {
+						"summary": [],
+						"blockTags": [
+							{
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Auth State"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/auth-state.tsx",
+							"line": 10,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "union",
+						"types": [
+							{
+								"type": "reference",
+								"target": 59,
+								"name": "TUser",
+								"package": "@auth0/auth0-react",
+								"qualifiedName": "Auth0ContextInterface.TUser",
+								"refersToTypeParameter": true
+							},
+							{
+								"type": "intrinsic",
+								"name": "undefined"
+							}
+						]
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthState.user",
+						"package": "@auth0/auth0-react"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						99,
+						133,
+						82,
+						145,
+						86,
+						124,
+						60,
+						70,
+						138,
+						115,
+						75,
+						111,
+						146,
+						147,
+						78,
+						94,
+						90,
+						103,
+						141,
+						143,
+						142,
+						107,
+						119,
+						148
+					]
+				}
+			],
+			"categories": [
+				{
+					"title": "Auth State",
+					"children": [
+						145,
+						146,
+						147,
+						148
+					]
+				},
+				{
+					"title": "Sub-clients",
+					"children": [
+						141,
+						143,
+						142
+					]
+				},
+				{
+					"title": "Authentication",
+					"children": [
+						111,
+						94,
+						90,
+						103
+					]
+				},
+				{
+					"title": "Tokens",
+					"children": [
+						82,
+						86,
+						60,
+						70,
+						75,
+						78,
+						107
+					]
+				},
+				{
+					"title": "Connected Accounts",
+					"children": [
+						99
+					]
+				},
+				{
+					"title": "Advanced",
+					"children": [
+						133,
+						124,
+						138,
+						115,
+						119
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/auth0-context.tsx",
+					"line": 35,
+					"character": 17
+				}
+			],
+			"typeParameters": [
+				{
+					"id": 59,
+					"name": "TUser",
+					"variant": "typeParam",
+					"kind": 131072,
+					"flags": {},
+					"type": {
+						"type": "reference",
+						"target": 326,
+						"name": "User",
+						"package": "@auth0/auth0-spa-js"
+					},
+					"default": {
+						"type": "reference",
+						"target": 326,
+						"name": "User",
+						"package": "@auth0/auth0-spa-js"
+					}
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"packageName": "@auth0/auth0-react",
+						"packagePath": "src/auth-state.tsx",
+						"qualifiedName": "AuthState"
+					},
+					"typeArguments": [
+						{
+							"type": "reference",
+							"target": 59,
+							"name": "TUser",
+							"package": "@auth0/auth0-react",
+							"qualifiedName": "Auth0ContextInterface.TUser",
+							"refersToTypeParameter": true
+						}
+					],
+					"name": "AuthState",
+					"package": "@auth0/auth0-react"
+				}
+			]
+		},
+		{
+			"id": 766,
+			"name": "Authenticator",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Represents an MFA authenticator enrolled by a user"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Multi-Factor Authentication"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 769,
+					"name": "active",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Whether the authenticator is active"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+							"line": 11,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					}
+				},
+				{
+					"id": 768,
+					"name": "authenticatorType",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Type of authenticator"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+							"line": 9,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/mfa/types.d.ts",
+							"qualifiedName": "AuthenticatorType"
+						},
+						"name": "AuthenticatorType",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 771,
+					"name": "createdAt",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "ISO 8601 timestamp when created"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+							"line": 15,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 767,
+					"name": "id",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Unique identifier for the authenticator"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+							"line": 7,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 772,
+					"name": "lastAuth",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "ISO 8601 timestamp of last authentication"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+							"line": 17,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 770,
+					"name": "name",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Optional friendly name"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+							"line": 13,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 773,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Types of MFA challenges"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+							"line": 19,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						769,
+						768,
+						771,
+						767,
+						772,
+						770,
+						773
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+					"line": 5,
+					"character": 17
+				}
+			]
+		},
+		{
+			"id": 236,
+			"name": "AuthorizationParams",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Configuration"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 244,
+					"name": "acr_values",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 67,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 246,
+					"name": "audience",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The default audience to be used for requesting API access."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 80,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 247,
+					"name": "connection",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The name of the connection configured for your application.\r\nIf null, it will redirect to the Auth0 Login Page and show\r\nthe Login Widget."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 86,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 237,
+					"name": "display",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "- "
+							},
+							{
+								"kind": "code",
+								"text": "`'page'`"
+							},
+							{
+								"kind": "text",
+								"text": ": displays the UI with a full page view\r\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`'popup'`"
+							},
+							{
+								"kind": "text",
+								"text": ": displays the UI with a popup window\r\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`'touch'`"
+							},
+							{
+								"kind": "text",
+								"text": ": displays the UI in a way that leverages a touch interface\r\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`'wap'`"
+							},
+							{
+								"kind": "text",
+								"text": ": displays the UI with a \"feature phone\" type interface"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 28,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "union",
+						"types": [
+							{
+								"type": "literal",
+								"value": "page"
+							},
+							{
+								"type": "literal",
+								"value": "popup"
+							},
+							{
+								"type": "literal",
+								"value": "touch"
+							},
+							{
+								"type": "literal",
+								"value": "wap"
+							}
+						]
+					}
+				},
+				{
+					"id": 241,
+					"name": "id_token_hint",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Previously issued ID Token."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 50,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 249,
+					"name": "invitation",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The Id of an invitation to accept. This is available from the user invitation URL that is given when participating in a user invitation flow."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 102,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 243,
+					"name": "login_hint",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The user's email address or other identifier. When your app knows\r\nwhich user is trying to authenticate, you can provide this parameter\r\nto pre-fill the email box or select the right session for sign-in.\r\n\r\nThis currently only affects the classic Lock experience."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 66,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 239,
+					"name": "max_age",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Maximum allowable elapsed time (in seconds) since authentication.\r\nIf the last time the user authenticated is greater than this value,\r\nthe user must be reauthenticated."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 41,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "union",
+						"types": [
+							{
+								"type": "intrinsic",
+								"name": "string"
+							},
+							{
+								"type": "intrinsic",
+								"name": "number"
+							}
+						]
+					}
+				},
+				{
+					"id": 248,
+					"name": "organization",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The organization to log in to.\r\n\r\nThis will specify an "
+							},
+							{
+								"kind": "code",
+								"text": "`organization`"
+							},
+							{
+								"kind": "text",
+								"text": " parameter in your user's login request.\r\n\r\n- If you provide an Organization ID (a string with the prefix "
+							},
+							{
+								"kind": "code",
+								"text": "`org_`"
+							},
+							{
+								"kind": "text",
+								"text": "), it will be validated against the "
+							},
+							{
+								"kind": "code",
+								"text": "`org_id`"
+							},
+							{
+								"kind": "text",
+								"text": " claim of your user's ID Token. The validation is case-sensitive.\r\n- If you provide an Organization Name (a string *without* the prefix "
+							},
+							{
+								"kind": "code",
+								"text": "`org_`"
+							},
+							{
+								"kind": "text",
+								"text": "), it will be validated against the "
+							},
+							{
+								"kind": "code",
+								"text": "`org_name`"
+							},
+							{
+								"kind": "text",
+								"text": " claim of your user's ID Token. The validation is case-insensitive.\r\n  To use an Organization Name you must have \"Allow Organization Names in Authentication API\" switched on in your Auth0 settings dashboard.\r\n  More information is available on the [Auth0 documentation portal](https://auth0.com/docs/manage-users/organizations/configure-organizations/use-org-name-authentication-api)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 98,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 238,
+					"name": "prompt",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "- "
+							},
+							{
+								"kind": "code",
+								"text": "`'none'`"
+							},
+							{
+								"kind": "text",
+								"text": ": do not prompt user for login or consent on reauthentication\r\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`'login'`"
+							},
+							{
+								"kind": "text",
+								"text": ": prompt user for reauthentication\r\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`'consent'`"
+							},
+							{
+								"kind": "text",
+								"text": ": prompt user for consent before processing request\r\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`'select_account'`"
+							},
+							{
+								"kind": "text",
+								"text": ": prompt user to select an account"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 35,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "union",
+						"types": [
+							{
+								"type": "literal",
+								"value": "none"
+							},
+							{
+								"type": "literal",
+								"value": "login"
+							},
+							{
+								"type": "literal",
+								"value": "consent"
+							},
+							{
+								"type": "literal",
+								"value": "select_account"
+							}
+						]
+					}
+				},
+				{
+					"id": 250,
+					"name": "redirect_uri",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The default URL where Auth0 will redirect your browser to with\r\nthe authentication result. It must be whitelisted in\r\nthe \"Allowed Callback URLs\" field in your Auth0 Application's\r\nsettings. If not provided here, it should be provided in the other\r\nmethods that provide authentication."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 110,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 245,
+					"name": "scope",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The default scope to be used on authentication requests.\r\n\r\nThis defaults to "
+							},
+							{
+								"kind": "code",
+								"text": "`profile email`"
+							},
+							{
+								"kind": "text",
+								"text": " if not set. If you are setting extra scopes and require\r\n"
+							},
+							{
+								"kind": "code",
+								"text": "`profile`"
+							},
+							{
+								"kind": "text",
+								"text": " and "
+							},
+							{
+								"kind": "code",
+								"text": "`email`"
+							},
+							{
+								"kind": "text",
+								"text": " to be included then you must include them in the provided scope.\r\n\r\nNote: The "
+							},
+							{
+								"kind": "code",
+								"text": "`openid`"
+							},
+							{
+								"kind": "text",
+								"text": " scope is **always applied** regardless of this setting."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 76,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 242,
+					"name": "screen_hint",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Provides a hint to Auth0 as to what flow should be displayed.\r\nThe default behavior is to show a login page but you can override\r\nthis by passing 'signup' to show the signup page instead.\r\n\r\nThis only affects the New Universal Login Experience."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 58,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 251,
+					"name": "session_transfer_token",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Session transfer token from a native application for Native to Web SSO.\r\nWhen "
+							},
+							{
+								"kind": "code",
+								"text": "`sessionTransferTokenQueryParamName`"
+							},
+							{
+								"kind": "text",
+								"text": " is set, this is automatically\r\nextracted from the specified URL query parameter if present."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@see",
+								"content": [
+									{
+										"kind": "text",
+										"text": "https://auth0.com/docs/authenticate/single-sign-on/native-to-web"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 118,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 240,
+					"name": "ui_locales",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The space-separated list of language tags, ordered by preference.\r\nFor example: "
+							},
+							{
+								"kind": "code",
+								"text": "`'fr-CA fr en'`"
+							},
+							{
+								"kind": "text",
+								"text": "."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 46,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						244,
+						246,
+						247,
+						237,
+						241,
+						249,
+						243,
+						239,
+						248,
+						238,
+						250,
+						245,
+						242,
+						251,
+						240
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+					"line": 21,
+					"character": 17
+				}
+			],
+			"indexSignatures": [
+				{
+					"id": 252,
+					"name": "__index",
+					"variant": "signature",
+					"kind": 8192,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "If you need to send custom parameters to the Authorization Server,\r\nmake sure to use the original parameter name."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 123,
+							"character": 4
+						}
+					],
+					"parameters": [
+						{
+							"id": 253,
+							"name": "key",
+							"variant": "param",
+							"kind": 32768,
+							"flags": {},
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "any"
+					}
+				}
+			]
+		},
+		{
+			"id": 795,
+			"name": "ChallengeAuthenticatorParams",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Parameters for initiating an MFA challenge"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Multi-Factor Authentication"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 798,
+					"name": "authenticatorId",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Specific authenticator to challenge (optional)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+							"line": 138,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 797,
+					"name": "challengeType",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Type of challenge to initiate"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+							"line": 136,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "union",
+						"types": [
+							{
+								"type": "literal",
+								"value": "otp"
+							},
+							{
+								"type": "literal",
+								"value": "oob"
+							}
+						]
+					}
+				},
+				{
+					"id": 796,
+					"name": "mfaToken",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "MFA token from mfa_required error or MFA-scoped access token"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+							"line": 134,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						798,
+						797,
+						796
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+					"line": 132,
+					"character": 17
+				}
+			]
+		},
+		{
+			"id": 799,
+			"name": "ChallengeResponse",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Response from initiating an MFA challenge"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Multi-Factor Authentication"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 802,
+					"name": "bindingMethod",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Binding method for OOB (e.g., 'prompt')"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+							"line": 149,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 800,
+					"name": "challengeType",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Type of challenge created"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+							"line": 145,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "union",
+						"types": [
+							{
+								"type": "literal",
+								"value": "otp"
+							},
+							{
+								"type": "literal",
+								"value": "oob"
+							}
+						]
+					}
+				},
+				{
+					"id": 801,
+					"name": "oobCode",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Out-of-band code (for OOB challenges)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+							"line": 147,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						802,
+						800,
+						801
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+					"line": 143,
+					"character": 17
+				}
+			]
+		},
+		{
+			"id": 602,
+			"name": "ClientConfiguration",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Configuration details exposed by the Auth0Client after initialization."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Configuration"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 604,
+					"name": "clientId",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The Auth0 client ID that was configured"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 369,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 603,
+					"name": "domain",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The Auth0 domain that was configured"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 365,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						604,
+						603
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+					"line": 361,
+					"character": 17
+				}
+			]
+		},
+		{
+			"id": 787,
+			"name": "EnrollEmailParams",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Email enrollment parameters"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Multi-Factor Authentication"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 789,
+					"name": "email",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Email address (optional, uses user's email if not provided)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+							"line": 78,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 788,
+					"name": "factorType",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The factor type for enrollment"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+							"line": 76,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "email"
+					}
+				},
+				{
+					"id": 790,
+					"name": "mfaToken",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "MFA token from mfa_required error"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+							"line": 44,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollBaseParams.mfaToken"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						789,
+						788,
+						790
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+					"line": 74,
+					"character": 17
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"packageName": "@auth0/auth0-spa-js",
+						"packagePath": "dist/typings/mfa/types.d.ts",
+						"qualifiedName": "EnrollBaseParams"
+					},
+					"name": "EnrollBaseParams",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 809,
+			"name": "EnrollmentFactor",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Enrollment factor returned by getEnrollmentFactors"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Multi-Factor Authentication"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 810,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Type of enrollment factor available"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+							"line": 180,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						810
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+					"line": 178,
+					"character": 17
+				}
+			]
+		},
+		{
+			"id": 776,
+			"name": "EnrollOtpParams",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "OTP (Time-based One-Time Password) enrollment parameters"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Multi-Factor Authentication"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 777,
+					"name": "factorType",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The factor type for enrollment"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+							"line": 51,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "otp"
+					}
+				},
+				{
+					"id": 778,
+					"name": "mfaToken",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "MFA token from mfa_required error"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+							"line": 44,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollBaseParams.mfaToken"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						777,
+						778
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+					"line": 49,
+					"character": 17
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"packageName": "@auth0/auth0-spa-js",
+						"packagePath": "dist/typings/mfa/types.d.ts",
+						"qualifiedName": "EnrollBaseParams"
+					},
+					"name": "EnrollBaseParams",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 791,
+			"name": "EnrollPushParams",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Push notification enrollment parameters"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Multi-Factor Authentication"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 792,
+					"name": "factorType",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The factor type for enrollment"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+							"line": 85,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "push"
+					}
+				},
+				{
+					"id": 793,
+					"name": "mfaToken",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "MFA token from mfa_required error"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+							"line": 44,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollBaseParams.mfaToken"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						792,
+						793
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+					"line": 83,
+					"character": 17
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"packageName": "@auth0/auth0-spa-js",
+						"packagePath": "dist/typings/mfa/types.d.ts",
+						"qualifiedName": "EnrollBaseParams"
+					},
+					"name": "EnrollBaseParams",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 779,
+			"name": "EnrollSmsParams",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "SMS enrollment parameters"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Multi-Factor Authentication"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 780,
+					"name": "factorType",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The factor type for enrollment"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+							"line": 58,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "sms"
+					}
+				},
+				{
+					"id": 782,
+					"name": "mfaToken",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "MFA token from mfa_required error"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+							"line": 44,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollBaseParams.mfaToken"
+					}
+				},
+				{
+					"id": 781,
+					"name": "phoneNumber",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Phone number in E.164 format (required for SMS)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+							"line": 60,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						780,
+						782,
+						781
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+					"line": 56,
+					"character": 17
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"packageName": "@auth0/auth0-spa-js",
+						"packagePath": "dist/typings/mfa/types.d.ts",
+						"qualifiedName": "EnrollBaseParams"
+					},
+					"name": "EnrollBaseParams",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 783,
+			"name": "EnrollVoiceParams",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Voice enrollment parameters"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Multi-Factor Authentication"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 784,
+					"name": "factorType",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The factor type for enrollment"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+							"line": 67,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "voice"
+					}
+				},
+				{
+					"id": 786,
+					"name": "mfaToken",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "MFA token from mfa_required error"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+							"line": 44,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollBaseParams.mfaToken"
+					}
+				},
+				{
+					"id": 785,
+					"name": "phoneNumber",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Phone number in E.164 format (required for voice)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+							"line": 69,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						784,
+						786,
+						785
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+					"line": 65,
+					"character": 17
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"packageName": "@auth0/auth0-spa-js",
+						"packagePath": "dist/typings/mfa/types.d.ts",
+						"qualifiedName": "EnrollBaseParams"
+					},
+					"name": "EnrollBaseParams",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 869,
+			"name": "Factor",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "My Account"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 870,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Type: [AuthenticationMethodType](/docs/sdk/react/types/AuthenticationMethodType)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/types.d.ts",
+							"line": 48,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 868,
+						"name": "AuthenticationMethodType",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 871,
+					"name": "usage",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/types.d.ts",
+							"line": 49,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "union",
+							"types": [
+								{
+									"type": "literal",
+									"value": "primary"
+								},
+								{
+									"type": "literal",
+									"value": "secondary"
+								}
+							]
+						}
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						870,
+						871
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/types.d.ts",
+					"line": 47,
+					"character": 17
+				}
+			]
+		},
+		{
+			"id": 272,
+			"name": "GetTokenSilentlyOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Tokens & Users"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 274,
+					"name": "authorizationParams",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Parameters that will be sent back to Auth0 as part of a request."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 498,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 275,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"children": [
+								{
+									"id": 278,
+									"name": "audience",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {
+										"isOptional": true
+									},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The audience that was used in the authentication request"
+											}
+										]
+									},
+									"sources": [
+										{
+											"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+											"line": 515,
+											"character": 8
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 276,
+									"name": "redirect_uri",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {
+										"isOptional": true
+									},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "There's no actual redirect when getting a token silently,\r\nbut, according to the spec, a "
+											},
+											{
+												"kind": "code",
+												"text": "`redirect_uri`"
+											},
+											{
+												"kind": "text",
+												"text": " param is required.\r\nAuth0 uses this parameter to validate that the current "
+											},
+											{
+												"kind": "code",
+												"text": "`origin`"
+											},
+											{
+												"kind": "text",
+												"text": "\r\nmatches the "
+											},
+											{
+												"kind": "code",
+												"text": "`redirect_uri`"
+											},
+											{
+												"kind": "text",
+												"text": " "
+											},
+											{
+												"kind": "code",
+												"text": "`origin`"
+											},
+											{
+												"kind": "text",
+												"text": " when sending the response.\r\nIt must be whitelisted in the \"Allowed Web Origins\" in your\r\nAuth0 Application's settings."
+											}
+										]
+									},
+									"sources": [
+										{
+											"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+											"line": 507,
+											"character": 8
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 277,
+									"name": "scope",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {
+										"isOptional": true
+									},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The scope that was used in the authentication request"
+											}
+										]
+									},
+									"sources": [
+										{
+											"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+											"line": 511,
+											"character": 8
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"groups": [
+								{
+									"title": "Properties",
+									"children": [
+										278,
+										276,
+										277
+									]
+								}
+							],
+							"indexSignatures": [
+								{
+									"id": 279,
+									"name": "__index",
+									"variant": "signature",
+									"kind": 8192,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "If you need to send custom parameters to the Authorization Server,\r\nmake sure to use the original parameter name."
+											}
+										]
+									},
+									"parameters": [
+										{
+											"id": 280,
+											"name": "key",
+											"variant": "param",
+											"kind": 32768,
+											"flags": {},
+											"type": {
+												"type": "intrinsic",
+												"name": "string"
+											}
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "any"
+									}
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": 273,
+					"name": "cacheMode",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "When "
+							},
+							{
+								"kind": "code",
+								"text": "`off`"
+							},
+							{
+								"kind": "text",
+								"text": ", ignores the cache and always sends a\r\nrequest to Auth0. Concurrent "
+							},
+							{
+								"kind": "code",
+								"text": "`off`"
+							},
+							{
+								"kind": "text",
+								"text": " calls are not deduplicated — each makes its own request.\r\nWhen "
+							},
+							{
+								"kind": "code",
+								"text": "`cache-only`"
+							},
+							{
+								"kind": "text",
+								"text": ", only reads from the cache and never sends a request to Auth0.\r\nDefaults to "
+							},
+							{
+								"kind": "code",
+								"text": "`on`"
+							},
+							{
+								"kind": "text",
+								"text": ", where it both reads from the cache and sends a request to Auth0 as needed."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 494,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "union",
+						"types": [
+							{
+								"type": "literal",
+								"value": "on"
+							},
+							{
+								"type": "literal",
+								"value": "off"
+							},
+							{
+								"type": "literal",
+								"value": "cache-only"
+							}
+						]
+					}
+				},
+				{
+					"id": 282,
+					"name": "detailedResponse",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "If true, the full response from the /oauth/token endpoint (or the cache, if the cache was used) is returned\r\n(minus "
+							},
+							{
+								"kind": "code",
+								"text": "`refresh_token`"
+							},
+							{
+								"kind": "text",
+								"text": " if one was issued). Otherwise, just the access token is returned.\r\n\r\nThe default is "
+							},
+							{
+								"kind": "code",
+								"text": "`false`"
+							},
+							{
+								"kind": "text",
+								"text": "."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 532,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					}
+				},
+				{
+					"id": 281,
+					"name": "timeoutInSeconds",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "A maximum number of seconds to wait before declaring the background /authorize call as failed for timeout\r\nDefaults to 60s."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 525,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "number"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						274,
+						273,
+						282,
+						281
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+					"line": 487,
+					"character": 17
+				}
+			]
+		},
+		{
+			"id": 260,
+			"name": "GetTokenWithPopupOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Tokens & Users"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 262,
+					"name": "authorizationParams",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true,
+						"isInherited": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "URL parameters that will be sent back to the Authorization Server. This can be known parameters\r\ndefined by Auth0 or custom parameters that you define."
+							},
+							{
+								"kind": "text",
+								"text": "\n\nType: [AuthorizationParams](/docs/sdk/react/interfaces/AuthorizationParams)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 133,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 236,
+						"name": "AuthorizationParams",
+						"package": "@auth0/auth0-spa-js"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 255,
+						"name": "PopupLoginOptions.authorizationParams"
+					}
+				},
+				{
+					"id": 261,
+					"name": "cacheMode",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "When "
+							},
+							{
+								"kind": "code",
+								"text": "`off`"
+							},
+							{
+								"kind": "text",
+								"text": ", ignores the cache and always sends a request to Auth0.\r\nWhen "
+							},
+							{
+								"kind": "code",
+								"text": "`cache-only`"
+							},
+							{
+								"kind": "text",
+								"text": ", only reads from the cache and never sends a request to Auth0.\r\nDefaults to "
+							},
+							{
+								"kind": "code",
+								"text": "`on`"
+							},
+							{
+								"kind": "text",
+								"text": ", where it both reads from the cache and sends a request to Auth0 as needed."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 540,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "union",
+						"types": [
+							{
+								"type": "literal",
+								"value": "on"
+							},
+							{
+								"type": "literal",
+								"value": "off"
+							},
+							{
+								"type": "literal",
+								"value": "cache-only"
+							}
+						]
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						262,
+						261
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+					"line": 534,
+					"character": 17
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 254,
+					"name": "PopupLoginOptions",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 352,
+			"name": "ICache",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Caching"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 365,
+					"name": "allKeys",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/cache/shared.d.ts",
+							"line": 67,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 366,
+							"name": "allKeys",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/cache/shared.d.ts",
+									"line": 67,
+									"character": 4
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"packageName": "@auth0/auth0-spa-js",
+									"packagePath": "dist/typings/cache/shared.d.ts",
+									"qualifiedName": "MaybePromise"
+								},
+								"typeArguments": [
+									{
+										"type": "array",
+										"elementType": {
+											"type": "intrinsic",
+											"name": "string"
+										}
+									}
+								],
+								"name": "MaybePromise",
+								"package": "@auth0/auth0-spa-js"
+							}
+						}
+					]
+				},
+				{
+					"id": 358,
+					"name": "get",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/cache/shared.d.ts",
+							"line": 65,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 359,
+							"name": "get",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/cache/shared.d.ts",
+									"line": 65,
+									"character": 4
+								}
+							],
+							"typeParameters": [
+								{
+									"id": 360,
+									"name": "T",
+									"variant": "typeParam",
+									"kind": 131072,
+									"flags": {},
+									"default": {
+										"type": "reference",
+										"target": 388,
+										"name": "Cacheable",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"parameters": [
+								{
+									"id": 361,
+									"name": "key",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"packageName": "@auth0/auth0-spa-js",
+									"packagePath": "dist/typings/cache/shared.d.ts",
+									"qualifiedName": "MaybePromise"
+								},
+								"typeArguments": [
+									{
+										"type": "union",
+										"types": [
+											{
+												"type": "reference",
+												"target": 360,
+												"name": "T",
+												"package": "@auth0/auth0-spa-js",
+												"refersToTypeParameter": true
+											},
+											{
+												"type": "intrinsic",
+												"name": "undefined"
+											}
+										]
+									}
+								],
+								"name": "MaybePromise",
+								"package": "@auth0/auth0-spa-js"
+							}
+						}
+					]
+				},
+				{
+					"id": 362,
+					"name": "remove",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/cache/shared.d.ts",
+							"line": 66,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 363,
+							"name": "remove",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/cache/shared.d.ts",
+									"line": 66,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 364,
+									"name": "key",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"packageName": "@auth0/auth0-spa-js",
+									"packagePath": "dist/typings/cache/shared.d.ts",
+									"qualifiedName": "MaybePromise"
+								},
+								"typeArguments": [
+									{
+										"type": "intrinsic",
+										"name": "void"
+									}
+								],
+								"name": "MaybePromise",
+								"package": "@auth0/auth0-spa-js"
+							}
+						}
+					]
+				},
+				{
+					"id": 353,
+					"name": "set",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/cache/shared.d.ts",
+							"line": 64,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 354,
+							"name": "set",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/cache/shared.d.ts",
+									"line": 64,
+									"character": 4
+								}
+							],
+							"typeParameters": [
+								{
+									"id": 355,
+									"name": "T",
+									"variant": "typeParam",
+									"kind": 131072,
+									"flags": {},
+									"default": {
+										"type": "reference",
+										"target": 388,
+										"name": "Cacheable",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"parameters": [
+								{
+									"id": 356,
+									"name": "key",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 357,
+									"name": "entry",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reference",
+										"target": 355,
+										"name": "T",
+										"package": "@auth0/auth0-spa-js",
+										"refersToTypeParameter": true
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"packageName": "@auth0/auth0-spa-js",
+									"packagePath": "dist/typings/cache/shared.d.ts",
+									"qualifiedName": "MaybePromise"
+								},
+								"typeArguments": [
+									{
+										"type": "intrinsic",
+										"name": "void"
+									}
+								],
+								"name": "MaybePromise",
+								"package": "@auth0/auth0-spa-js"
+							}
+						}
+					]
+				}
+			],
+			"groups": [
+				{
+					"title": "Methods",
+					"children": [
+						365,
+						358,
+						362,
+						353
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/cache/shared.d.ts",
+					"line": 63,
+					"character": 17
+				}
+			],
+			"implementedBy": [
+				{
+					"type": "reference",
+					"target": 371,
+					"name": "LocalStorageCache"
+				}
+			]
+		},
+		{
+			"id": 283,
+			"name": "IdToken",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Tokens & Users"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 284,
+					"name": "__raw",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 772,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 315,
+					"name": "acr",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 803,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 323,
+					"name": "act",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The actor claim, present in ID tokens returned via token exchange responses.\r\nIdentifies the acting party that has been delegated authority to act on behalf\r\nof the subject. Set via Auth0 Actions using the "
+							},
+							{
+								"kind": "code",
+								"text": "`setActor`"
+							},
+							{
+								"kind": "text",
+								"text": " command."
+							},
+							{
+								"kind": "text",
+								"text": "\n\nType: [ActClaim](/docs/sdk/react/interfaces/ActClaim)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 820,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 598,
+						"name": "ActClaim",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 302,
+					"name": "address",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 790,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 316,
+					"name": "amr",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 804,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "intrinsic",
+							"name": "string"
+						}
+					}
+				},
+				{
+					"id": 313,
+					"name": "at_hash",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 801,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 305,
+					"name": "aud",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 793,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 312,
+					"name": "auth_time",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 800,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 310,
+					"name": "azp",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 798,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 297,
+					"name": "birthdate",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 785,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 314,
+					"name": "c_hash",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 802,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 318,
+					"name": "cnf",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 806,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 294,
+					"name": "email",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 782,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 295,
+					"name": "email_verified",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 783,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					}
+				},
+				{
+					"id": 306,
+					"name": "exp",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 794,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "number"
+					}
+				},
+				{
+					"id": 287,
+					"name": "family_name",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 775,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 296,
+					"name": "gender",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 784,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 286,
+					"name": "given_name",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 774,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 308,
+					"name": "iat",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 796,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "number"
+					}
+				},
+				{
+					"id": 304,
+					"name": "iss",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 792,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 309,
+					"name": "jti",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 797,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 299,
+					"name": "locale",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 787,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 288,
+					"name": "middle_name",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 776,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 285,
+					"name": "name",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 773,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 307,
+					"name": "nbf",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 795,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "number"
+					}
+				},
+				{
+					"id": 289,
+					"name": "nickname",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 777,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 311,
+					"name": "nonce",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 799,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 320,
+					"name": "org_id",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 808,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 321,
+					"name": "org_name",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 809,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 300,
+					"name": "phone_number",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 788,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 301,
+					"name": "phone_number_verified",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 789,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					}
+				},
+				{
+					"id": 292,
+					"name": "picture",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 780,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 290,
+					"name": "preferred_username",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 778,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 291,
+					"name": "profile",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 779,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 322,
+					"name": "session_expiry",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "IPSIE session expiry ceiling (Unix timestamp in seconds).\r\nWhen present, the SDK will not return tokens after this point in time."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 814,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "number"
+					}
+				},
+				{
+					"id": 319,
+					"name": "sid",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 807,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 317,
+					"name": "sub_jwk",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 805,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 303,
+					"name": "updated_at",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 791,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 293,
+					"name": "website",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 781,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 298,
+					"name": "zoneinfo",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 786,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						284,
+						315,
+						323,
+						302,
+						316,
+						313,
+						305,
+						312,
+						310,
+						297,
+						314,
+						318,
+						294,
+						295,
+						306,
+						287,
+						296,
+						286,
+						308,
+						304,
+						309,
+						299,
+						288,
+						285,
+						307,
+						289,
+						311,
+						320,
+						321,
+						300,
+						301,
+						292,
+						290,
+						291,
+						322,
+						319,
+						317,
+						303,
+						293,
+						298
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+					"line": 771,
+					"character": 17
+				}
+			],
+			"indexSignatures": [
+				{
+					"id": 324,
+					"name": "__index",
+					"variant": "signature",
+					"kind": 8192,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 821,
+							"character": 4
+						}
+					],
+					"parameters": [
+						{
+							"id": 325,
+							"name": "key",
+							"variant": "param",
+							"kind": 32768,
+							"flags": {},
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "any"
+					}
+				}
+			]
+		},
+		{
+			"id": 215,
+			"name": "LogoutOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Login & Logout"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 216,
+					"name": "clientId",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true,
+						"isInherited": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The "
+							},
+							{
+								"kind": "code",
+								"text": "`clientId`"
+							},
+							{
+								"kind": "text",
+								"text": " of your application.\r\n\r\nIf this property is not set, then the "
+							},
+							{
+								"kind": "code",
+								"text": "`clientId`"
+							},
+							{
+								"kind": "text",
+								"text": " that was used during initialization of the SDK is sent to the logout endpoint.\r\n\r\nIf this property is set to "
+							},
+							{
+								"kind": "code",
+								"text": "`null`"
+							},
+							{
+								"kind": "text",
+								"text": ", then no client ID value is sent to the logout endpoint.\r\n\r\n[Read more about how redirecting after logout works](https://auth0.com/docs/logout/guides/redirect-users-after-logout)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 552,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "union",
+						"types": [
+							{
+								"type": "intrinsic",
+								"name": "string"
+							},
+							{
+								"type": "literal",
+								"value": null
+							}
+						]
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 264,
+						"name": "Omit.clientId",
+						"package": "@auth0/auth0-spa-js",
+						"qualifiedName": "LogoutUrlOptions.clientId"
+					}
+				},
+				{
+					"id": 221,
+					"name": "logoutParams",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true,
+						"isInherited": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Parameters to pass to the logout endpoint. This can be known parameters defined by Auth0 or custom parameters\r\nyou wish to provide."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 557,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 222,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"children": [
+								{
+									"id": 223,
+									"name": "federated",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {
+										"isOptional": true
+									},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "When supported by the upstream identity provider,\r\nforces the user to logout of their identity provider\r\nand from Auth0.\r\n[Read more about how federated logout works at Auth0](https://auth0.com/docs/logout/guides/logout-idps)"
+											}
+										]
+									},
+									"sources": [
+										{
+											"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+											"line": 564,
+											"character": 8
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "boolean"
+									}
+								},
+								{
+									"id": 224,
+									"name": "returnTo",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {
+										"isOptional": true
+									},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The URL where Auth0 will redirect your browser to after the logout.\r\n\r\n**Note**: If the "
+											},
+											{
+												"kind": "code",
+												"text": "`client_id`"
+											},
+											{
+												"kind": "text",
+												"text": " parameter is included, the\r\n"
+											},
+											{
+												"kind": "code",
+												"text": "`returnTo`"
+											},
+											{
+												"kind": "text",
+												"text": " URL that is provided must be listed in the\r\nApplication's \"Allowed Logout URLs\" in the Auth0 dashboard.\r\nHowever, if the "
+											},
+											{
+												"kind": "code",
+												"text": "`client_id`"
+											},
+											{
+												"kind": "text",
+												"text": " parameter is not included, the\r\n"
+											},
+											{
+												"kind": "code",
+												"text": "`returnTo`"
+											},
+											{
+												"kind": "text",
+												"text": " URL must be listed in the \"Allowed Logout URLs\" at\r\nthe account level in the Auth0 dashboard.\r\n\r\n[Read more about how redirecting after logout works](https://auth0.com/docs/logout/guides/redirect-users-after-logout)"
+											}
+										]
+									},
+									"sources": [
+										{
+											"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+											"line": 577,
+											"character": 8
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"groups": [
+								{
+									"title": "Properties",
+									"children": [
+										223,
+										224
+									]
+								}
+							],
+							"indexSignatures": [
+								{
+									"id": 225,
+									"name": "__index",
+									"variant": "signature",
+									"kind": 8192,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "If you need to send custom parameters to the logout endpoint, make sure to use the original parameter name."
+											}
+										]
+									},
+									"parameters": [
+										{
+											"id": 226,
+											"name": "key",
+											"variant": "param",
+											"kind": 32768,
+											"flags": {},
+											"type": {
+												"type": "intrinsic",
+												"name": "string"
+											}
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "any"
+									}
+								}
+							]
+						}
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 265,
+						"name": "Omit.logoutParams",
+						"package": "@auth0/auth0-spa-js",
+						"qualifiedName": "LogoutUrlOptions.logoutParams"
+					}
+				},
+				{
+					"id": 217,
+					"name": "openUrl",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true,
+						"isInherited": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Used to control the redirect and not rely on the SDK to do the actual redirect.\r\n\r\nSet to "
+							},
+							{
+								"kind": "code",
+								"text": "`false`"
+							},
+							{
+								"kind": "text",
+								"text": " to disable the redirect, or provide a function to handle the actual redirect yourself."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@example",
+								"content": [
+									{
+										"kind": "code",
+										"text": "```ts\nawait auth0.logout({\r\n  openUrl(url) {\r\n    window.location.replace(url);\r\n  }\r\n});\n```"
+									}
+								]
+							},
+							{
+								"tag": "@example",
+								"content": [
+									{
+										"kind": "code",
+										"text": "```ts\nimport { Browser } from '@capacitor/browser';\r\n\r\nawait auth0.logout({\r\n  async openUrl(url) {\r\n    await Browser.open({ url });\r\n  }\r\n});\n```"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 618,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "union",
+						"types": [
+							{
+								"type": "literal",
+								"value": false
+							},
+							{
+								"type": "reflection",
+								"declaration": {
+									"id": 218,
+									"name": "__type",
+									"variant": "declaration",
+									"kind": 65536,
+									"flags": {},
+									"signatures": [
+										{
+											"id": 219,
+											"name": "__type",
+											"variant": "signature",
+											"kind": 4096,
+											"flags": {},
+											"parameters": [
+												{
+													"id": 220,
+													"name": "url",
+													"variant": "param",
+													"kind": 32768,
+													"flags": {},
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"type": {
+												"type": "union",
+												"types": [
+													{
+														"type": "intrinsic",
+														"name": "void"
+													},
+													{
+														"type": "reference",
+														"target": {
+															"packageName": "typescript",
+															"packagePath": "lib/lib.es5.d.ts",
+															"qualifiedName": "Promise"
+														},
+														"typeArguments": [
+															{
+																"type": "intrinsic",
+																"name": "void"
+															}
+														],
+														"name": "Promise",
+														"package": "typescript"
+													}
+												]
+											}
+										}
+									]
+								}
+							}
+						]
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "Omit.openUrl",
+						"package": "@auth0/auth0-spa-js"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						216,
+						221,
+						217
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/auth0-context.tsx",
+					"line": 27,
+					"character": 17
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"packageName": "typescript",
+						"packagePath": "lib/lib.es5.d.ts",
+						"qualifiedName": "Omit"
+					},
+					"typeArguments": [
+						{
+							"type": "reference",
+							"target": {
+								"packageName": "@auth0/auth0-spa-js",
+								"packagePath": "dist/typings/global.d.ts",
+								"qualifiedName": "LogoutOptions"
+							},
+							"name": "SPALogoutOptions",
+							"package": "@auth0/auth0-spa-js",
+							"qualifiedName": "LogoutOptions"
+						},
+						{
+							"type": "literal",
+							"value": "onRedirect"
+						}
+					],
+					"name": "Omit",
+					"package": "typescript"
+				}
+			]
+		},
+		{
+			"id": 263,
+			"name": "LogoutUrlOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Login & Logout"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 264,
+					"name": "clientId",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The "
+							},
+							{
+								"kind": "code",
+								"text": "`clientId`"
+							},
+							{
+								"kind": "text",
+								"text": " of your application.\r\n\r\nIf this property is not set, then the "
+							},
+							{
+								"kind": "code",
+								"text": "`clientId`"
+							},
+							{
+								"kind": "text",
+								"text": " that was used during initialization of the SDK is sent to the logout endpoint.\r\n\r\nIf this property is set to "
+							},
+							{
+								"kind": "code",
+								"text": "`null`"
+							},
+							{
+								"kind": "text",
+								"text": ", then no client ID value is sent to the logout endpoint.\r\n\r\n[Read more about how redirecting after logout works](https://auth0.com/docs/logout/guides/redirect-users-after-logout)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 552,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "union",
+						"types": [
+							{
+								"type": "intrinsic",
+								"name": "string"
+							},
+							{
+								"type": "literal",
+								"value": null
+							}
+						]
+					}
+				},
+				{
+					"id": 265,
+					"name": "logoutParams",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Parameters to pass to the logout endpoint. This can be known parameters defined by Auth0 or custom parameters\r\nyou wish to provide."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 557,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 266,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"children": [
+								{
+									"id": 267,
+									"name": "federated",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {
+										"isOptional": true
+									},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "When supported by the upstream identity provider,\r\nforces the user to logout of their identity provider\r\nand from Auth0.\r\n[Read more about how federated logout works at Auth0](https://auth0.com/docs/logout/guides/logout-idps)"
+											}
+										]
+									},
+									"sources": [
+										{
+											"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+											"line": 564,
+											"character": 8
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "boolean"
+									}
+								},
+								{
+									"id": 268,
+									"name": "returnTo",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {
+										"isOptional": true
+									},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The URL where Auth0 will redirect your browser to after the logout.\r\n\r\n**Note**: If the "
+											},
+											{
+												"kind": "code",
+												"text": "`client_id`"
+											},
+											{
+												"kind": "text",
+												"text": " parameter is included, the\r\n"
+											},
+											{
+												"kind": "code",
+												"text": "`returnTo`"
+											},
+											{
+												"kind": "text",
+												"text": " URL that is provided must be listed in the\r\nApplication's \"Allowed Logout URLs\" in the Auth0 dashboard.\r\nHowever, if the "
+											},
+											{
+												"kind": "code",
+												"text": "`client_id`"
+											},
+											{
+												"kind": "text",
+												"text": " parameter is not included, the\r\n"
+											},
+											{
+												"kind": "code",
+												"text": "`returnTo`"
+											},
+											{
+												"kind": "text",
+												"text": " URL must be listed in the \"Allowed Logout URLs\" at\r\nthe account level in the Auth0 dashboard.\r\n\r\n[Read more about how redirecting after logout works](https://auth0.com/docs/logout/guides/redirect-users-after-logout)"
+											}
+										]
+									},
+									"sources": [
+										{
+											"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+											"line": 577,
+											"character": 8
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"groups": [
+								{
+									"title": "Properties",
+									"children": [
+										267,
+										268
+									]
+								}
+							],
+							"indexSignatures": [
+								{
+									"id": 269,
+									"name": "__index",
+									"variant": "signature",
+									"kind": 8192,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "If you need to send custom parameters to the logout endpoint, make sure to use the original parameter name."
+											}
+										]
+									},
+									"parameters": [
+										{
+											"id": 270,
+											"name": "key",
+											"variant": "param",
+											"kind": 32768,
+											"flags": {},
+											"type": {
+												"type": "intrinsic",
+												"name": "string"
+											}
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "any"
+									}
+								}
+							]
+						}
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						264,
+						265
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+					"line": 542,
+					"character": 17
+				}
+			]
+		},
+		{
+			"id": 741,
+			"name": "MfaApiClient",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Client for Auth0 MFA API operations\r\n\r\nManages multi-factor authentication including:\r\n- Listing enrolled authenticators\r\n- Enrolling new authenticators (OTP, SMS, Voice, Push, Email)\r\n- Initiating MFA challenges\r\n- Verifying MFA challenges\r\n\r\nThis is a wrapper around auth0-auth-js MfaClient that maintains\r\nbackward compatibility with the existing spa-js API.\r\n\r\nMFA context (scope, audience) is stored internally keyed by mfaToken,\r\nenabling concurrent MFA flows without state conflicts."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@example",
+						"content": [
+							{
+								"kind": "code",
+								"text": "```typescript\r\ntry {\r\n  await auth0.getTokenSilently({ authorizationParams: { audience: 'https://api.example.com' } });\r\n} catch (e) {\r\n  if (e instanceof MfaRequiredError) {\r\n    // SDK automatically stores context for this mfaToken\r\n    const authenticators = await auth0.mfa.getAuthenticators({ mfaToken: e.mfa_token });\r\n    // ... complete MFA flow\r\n  }\r\n}\r\n```"
+							}
+						]
+					},
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Multi-Factor Authentication"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 757,
+					"name": "challenge",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/MfaApiClient.d.ts",
+							"line": 137,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 758,
+							"name": "challenge",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Initiates an MFA challenge\r\n\r\nSends OTP via SMS, initiates push notification, or prepares for OTP entry"
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "Challenge response with oobCode if applicable"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If challenge initiation fails"
+											}
+										]
+									},
+									{
+										"tag": "@example",
+										"name": "OTP challenge",
+										"content": [
+											{
+												"kind": "code",
+												"text": "```typescript\r\nconst challenge = await mfa.challenge({\r\n  mfaToken: mfaTokenFromLogin,\r\n  challengeType: 'otp',\r\n  authenticatorId: 'otp|dev_xxx'\r\n});\r\n// User enters OTP from their authenticator app\r\n```"
+											}
+										]
+									},
+									{
+										"tag": "@example",
+										"name": "SMS challenge",
+										"content": [
+											{
+												"kind": "code",
+												"text": "```typescript\r\nconst challenge = await mfa.challenge({\r\n  mfaToken: mfaTokenFromLogin,\r\n  challengeType: 'oob',\r\n  authenticatorId: 'sms|dev_xxx'\r\n});\r\nconsole.log(challenge.oobCode); // Use for verification\r\n```"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/MfaApiClient.d.ts",
+									"line": 137,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 759,
+									"name": "params",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Challenge parameters including mfaToken"
+											},
+											{
+												"kind": "text",
+												"text": "\n\nType: [ChallengeAuthenticatorParams](/docs/sdk/react/interfaces/ChallengeAuthenticatorParams)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 795,
+										"name": "ChallengeAuthenticatorParams",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"packageName": "typescript",
+									"packagePath": "lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 799,
+										"name": "ChallengeResponse",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 754,
+					"name": "enroll",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/MfaApiClient.d.ts",
+							"line": 107,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 755,
+							"name": "enroll",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Enrolls a new MFA authenticator\r\n\r\nRequires MFA access token with 'enroll' scope"
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "Enrollment response with authenticator details"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If enrollment fails"
+											}
+										]
+									},
+									{
+										"tag": "@example",
+										"name": "OTP enrollment",
+										"content": [
+											{
+												"kind": "code",
+												"text": "```typescript\r\nconst enrollment = await mfa.enroll({\r\n  mfaToken: mfaToken,\r\n  factorType: 'otp'\r\n});\r\nconsole.log(enrollment.secret); // Base32 secret\r\nconsole.log(enrollment.barcodeUri); // QR code URI\r\n```"
+											}
+										]
+									},
+									{
+										"tag": "@example",
+										"name": "SMS enrollment",
+										"content": [
+											{
+												"kind": "code",
+												"text": "```typescript\r\nconst enrollment = await mfa.enroll({\r\n  mfaToken: mfaToken,\r\n  factorType: 'sms',\r\n  phoneNumber: '+12025551234'\r\n});\r\n```"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/MfaApiClient.d.ts",
+									"line": 107,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 756,
+									"name": "params",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Enrollment parameters including mfaToken and factorType"
+											},
+											{
+												"kind": "text",
+												"text": "\n\nType: [EnrollParams](/docs/sdk/react/types/EnrollParams)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 775,
+										"name": "EnrollParams",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"packageName": "typescript",
+									"packagePath": "lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 794,
+										"name": "EnrollmentResponse",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 751,
+					"name": "getAuthenticators",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/MfaApiClient.d.ts",
+							"line": 78,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 752,
+							"name": "getAuthenticators",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Gets enrolled MFA authenticators filtered by challenge types from context.\r\n\r\nChallenge types are automatically resolved from the stored MFA context\r\n(set when mfa_required error occurred)."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "Array of enrolled authenticators matching the challenge types"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If the request fails or context not found"
+											}
+										]
+									},
+									{
+										"tag": "@example",
+										"name": "Basic usage",
+										"content": [
+											{
+												"kind": "code",
+												"text": "```typescript\r\ntry {\r\n  await auth0.getTokenSilently();\r\n} catch (e) {\r\n  if (e instanceof MfaRequiredError) {\r\n    // SDK automatically uses challenge types from error context\r\n    const authenticators = await auth0.mfa.getAuthenticators(e.mfa_token);\r\n  }\r\n}\r\n```"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/MfaApiClient.d.ts",
+									"line": 78,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 753,
+									"name": "mfaToken",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "MFA token from mfa_required error"
+											}
+										]
+									},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"packageName": "typescript",
+									"packagePath": "lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "array",
+										"elementType": {
+											"type": "reference",
+											"target": 766,
+											"name": "Authenticator",
+											"package": "@auth0/auth0-spa-js"
+										}
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 760,
+					"name": "getEnrollmentFactors",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/MfaApiClient.d.ts",
+							"line": 180,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 761,
+							"name": "getEnrollmentFactors",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Gets available MFA enrollment factors from the stored context.\r\n\r\nThis method exposes the enrollment options from the mfa_required error's\r\nmfaRequirements.enroll array, eliminating the need for manual parsing."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "Array of enrollment factors available for the user (empty array if no enrollment required)"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If MFA context not found"
+											}
+										]
+									},
+									{
+										"tag": "@example",
+										"name": "Basic usage",
+										"content": [
+											{
+												"kind": "code",
+												"text": "```typescript\r\ntry {\r\n  await auth0.getTokenSilently();\r\n} catch (error) {\r\n  if (error.error === 'mfa_required') {\r\n    // Get enrollment options from SDK\r\n    const enrollOptions = await auth0.mfa.getEnrollmentFactors(error.mfa_token);\r\n    // [{ type: 'otp' }, { type: 'phone' }, { type: 'push-notification' }]\r\n\r\n    showEnrollmentOptions(enrollOptions);\r\n  }\r\n}\r\n```"
+											}
+										]
+									},
+									{
+										"tag": "@example",
+										"name": "Check if enrollment is required",
+										"content": [
+											{
+												"kind": "code",
+												"text": "```typescript\r\ntry {\r\n  const factors = await auth0.mfa.getEnrollmentFactors(mfaToken);\r\n  if (factors.length > 0) {\r\n    // User needs to enroll in MFA\r\n    renderEnrollmentUI(factors);\r\n  } else {\r\n    // No enrollment required, proceed with challenge\r\n  }\r\n} catch (error) {\r\n  if (error instanceof MfaEnrollmentFactorsError) {\r\n    console.error('Context not found:', error.error_description);\r\n  }\r\n}\r\n```"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/MfaApiClient.d.ts",
+									"line": 180,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 762,
+									"name": "mfaToken",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "MFA token from mfa_required error"
+											}
+										]
+									},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"packageName": "typescript",
+									"packagePath": "lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "array",
+										"elementType": {
+											"type": "reference",
+											"target": 809,
+											"name": "EnrollmentFactor",
+											"package": "@auth0/auth0-spa-js"
+										}
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 763,
+					"name": "verify",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/MfaApiClient.d.ts",
+							"line": 224,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 764,
+							"name": "verify",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Verifies an MFA challenge and completes authentication\r\n\r\nThe scope and audience are retrieved from the stored context (set when the\r\nmfa_required error occurred). The grant_type is automatically inferred from\r\nwhich verification field is provided (otp, oobCode, or recoveryCode)."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "Token response with access_token, id_token, refresh_token"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If verification fails (invalid code, expired, rate limited)"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If MFA context not found"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If grant_type cannot be inferred\r\n\r\nRate limits:\r\n- 10 verification attempts allowed\r\n- Refreshes at 1 attempt per 6 minutes"
+											}
+										]
+									},
+									{
+										"tag": "@example",
+										"name": "OTP verification (grant_type inferred from otp field)",
+										"content": [
+											{
+												"kind": "code",
+												"text": "```typescript\r\nconst tokens = await mfa.verify({\r\n  mfaToken: mfaTokenFromLogin,\r\n  otp: '123456'\r\n});\r\nconsole.log(tokens.access_token);\r\n```"
+											}
+										]
+									},
+									{
+										"tag": "@example",
+										"name": "OOB verification (grant_type inferred from oobCode field)",
+										"content": [
+											{
+												"kind": "code",
+												"text": "```typescript\r\nconst tokens = await mfa.verify({\r\n  mfaToken: mfaTokenFromLogin,\r\n  oobCode: challenge.oobCode,\r\n  bindingCode: '123456' // Code user received via SMS\r\n});\r\n```"
+											}
+										]
+									},
+									{
+										"tag": "@example",
+										"name": "Recovery code verification (grant_type inferred from recoveryCode field)",
+										"content": [
+											{
+												"kind": "code",
+												"text": "```typescript\r\nconst tokens = await mfa.verify({\r\n  mfaToken: mfaTokenFromLogin,\r\n  recoveryCode: 'XXXX-XXXX-XXXX'\r\n});\r\n```"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/MfaApiClient.d.ts",
+									"line": 224,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 765,
+									"name": "params",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Verification parameters with OTP, OOB code, or recovery code"
+											},
+											{
+												"kind": "text",
+												"text": "\n\nType: [VerifyParams](/docs/sdk/react/interfaces/VerifyParams)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 803,
+										"name": "VerifyParams",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"packageName": "typescript",
+									"packagePath": "lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 590,
+										"name": "TokenEndpointResponse",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				}
+			],
+			"groups": [
+				{
+					"title": "Methods",
+					"children": [
+						757,
+						754,
+						751,
+						760,
+						763
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/MfaApiClient.d.ts",
+					"line": 34,
+					"character": 21
+				}
+			]
+		},
+		{
+			"id": 836,
+			"name": "MyAccountApiClient",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Client for Auth0 MyAccount API operations.\r\n\r\nProvides methods for managing the current user's account:\r\n- Connected accounts (link/unlink external identity providers)\r\n- MFA factors\r\n- Authentication methods (passkeys, phone, email, TOTP) - list, get, update, delete\r\n- Authentication method enrollment (challenge and verify)"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "My Account"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 842,
+					"name": "completeAccount",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/MyAccountApiClient.d.ts",
+							"line": 30,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 843,
+							"name": "completeAccount",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Verify the redirect from the connect account flow and complete the connecting of the account."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A promise that resolves to the completed connected account details"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/MyAccountApiClient.d.ts",
+									"line": 30,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 844,
+									"name": "params",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Completion parameters including auth session, connect code, and redirect URI"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "@auth0/auth0-spa-js",
+											"packagePath": "dist/typings/myaccount/types.d.ts",
+											"qualifiedName": "CompleteRequest"
+										},
+										"name": "CompleteRequest",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"packageName": "typescript",
+									"packagePath": "lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": {
+											"packageName": "@auth0/auth0-spa-js",
+											"packagePath": "dist/typings/myaccount/types.d.ts",
+											"qualifiedName": "CompleteResponse"
+										},
+										"name": "CompleteResponse",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 839,
+					"name": "connectAccount",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/MyAccountApiClient.d.ts",
+							"line": 23,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 840,
+							"name": "connectAccount",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Get a ticket for the connect account flow."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A promise that resolves to a connect response with the redirect URI and auth session"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/MyAccountApiClient.d.ts",
+									"line": 23,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 841,
+									"name": "params",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Connection parameters including connection name and redirect URI"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "@auth0/auth0-spa-js",
+											"packagePath": "dist/typings/myaccount/types.d.ts",
+											"qualifiedName": "ConnectRequest"
+										},
+										"name": "ConnectRequest",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"packageName": "typescript",
+									"packagePath": "lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": {
+											"packageName": "@auth0/auth0-spa-js",
+											"packagePath": "dist/typings/myaccount/types.d.ts",
+											"qualifiedName": "ConnectResponse"
+										},
+										"name": "ConnectResponse",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 853,
+					"name": "deleteAuthenticationMethod",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/MyAccountApiClient.d.ts",
+							"line": 57,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 854,
+							"name": "deleteAuthenticationMethod",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Delete an authentication method by ID."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A promise that resolves when the authentication method has been deleted"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/MyAccountApiClient.d.ts",
+									"line": 57,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 855,
+									"name": "id",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The ID of the authentication method to delete"
+											}
+										]
+									},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"packageName": "typescript",
+									"packagePath": "lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "intrinsic",
+										"name": "void"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 860,
+					"name": "enrollmentChallenge",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/MyAccountApiClient.d.ts",
+							"line": 73,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 861,
+							"name": "enrollmentChallenge",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Start the enrollment of an authentication method for the current user.\r\nThe response shape varies by type."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A promise that resolves to the enrollment challenge response (shape varies by type)"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/MyAccountApiClient.d.ts",
+									"line": 73,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 862,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Enrollment challenge options specifying the factor type and any type-specific fields"
+											},
+											{
+												"kind": "text",
+												"text": "\n\nType: [EnrollmentChallengeOptions](/docs/sdk/react/types/EnrollmentChallengeOptions)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 875,
+										"name": "EnrollmentChallengeOptions",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"packageName": "typescript",
+									"packagePath": "lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 876,
+										"name": "EnrollmentChallengeResponse",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 863,
+					"name": "enrollmentVerify",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/MyAccountApiClient.d.ts",
+							"line": 80,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 864,
+							"name": "enrollmentVerify",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Confirm the enrollment of an authentication method to complete registration."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A promise that resolves to the confirmed authentication method"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/MyAccountApiClient.d.ts",
+									"line": 80,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 865,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Enrollment verify options including the auth session and type-specific verification data"
+											},
+											{
+												"kind": "text",
+												"text": "\n\nType: [EnrollmentVerifyOptions](/docs/sdk/react/types/EnrollmentVerifyOptions)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 877,
+										"name": "EnrollmentVerifyOptions",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"packageName": "typescript",
+									"packagePath": "lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 867,
+										"name": "AuthenticationMethod",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 850,
+					"name": "getAuthenticationMethod",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/MyAccountApiClient.d.ts",
+							"line": 50,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 851,
+							"name": "getAuthenticationMethod",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Get an authentication method by ID."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A promise that resolves to the authentication method"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/MyAccountApiClient.d.ts",
+									"line": 50,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 852,
+									"name": "id",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The ID of the authentication method to retrieve"
+											}
+										]
+									},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"packageName": "typescript",
+									"packagePath": "lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 867,
+										"name": "AuthenticationMethod",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 847,
+					"name": "getAuthenticationMethods",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/MyAccountApiClient.d.ts",
+							"line": 43,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 848,
+							"name": "getAuthenticationMethods",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Get a list of all authentication methods for the current user."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A promise that resolves to an array of authentication methods"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/MyAccountApiClient.d.ts",
+									"line": 43,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 849,
+									"name": "type",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {
+										"isOptional": true
+									},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Optional filter to return only methods of a specific type"
+											},
+											{
+												"kind": "text",
+												"text": "\n\nType: [AuthenticationMethodType](/docs/sdk/react/types/AuthenticationMethodType)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 868,
+										"name": "AuthenticationMethodType",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"packageName": "typescript",
+									"packagePath": "lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "array",
+										"elementType": {
+											"type": "reference",
+											"target": 867,
+											"name": "AuthenticationMethod",
+											"package": "@auth0/auth0-spa-js"
+										}
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 845,
+					"name": "getFactors",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/MyAccountApiClient.d.ts",
+							"line": 36,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 846,
+							"name": "getFactors",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Get the status of all factors for the current user."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A promise that resolves to an array of factors with their enabled/disabled status"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/MyAccountApiClient.d.ts",
+									"line": 36,
+									"character": 4
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"packageName": "typescript",
+									"packagePath": "lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "array",
+										"elementType": {
+											"type": "reference",
+											"target": 869,
+											"name": "Factor",
+											"package": "@auth0/auth0-spa-js"
+										}
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 856,
+					"name": "updateAuthenticationMethod",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/MyAccountApiClient.d.ts",
+							"line": 65,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 857,
+							"name": "updateAuthenticationMethod",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Update details of an authentication method by ID."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A promise that resolves to the updated authentication method"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/MyAccountApiClient.d.ts",
+									"line": 65,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 858,
+									"name": "id",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The ID of the authentication method to update"
+											}
+										]
+									},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 859,
+									"name": "data",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The fields to update (e.g. name, preferred_authentication_method for phone)"
+											},
+											{
+												"kind": "text",
+												"text": "\n\nType: [UpdateAuthenticationMethodRequest](/docs/sdk/react/interfaces/UpdateAuthenticationMethodRequest)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 872,
+										"name": "UpdateAuthenticationMethodRequest",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"packageName": "typescript",
+									"packagePath": "lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 867,
+										"name": "AuthenticationMethod",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				}
+			],
+			"groups": [
+				{
+					"title": "Methods",
+					"children": [
+						842,
+						839,
+						853,
+						860,
+						863,
+						850,
+						847,
+						845,
+						856
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/MyAccountApiClient.d.ts",
+					"line": 13,
+					"character": 21
+				}
+			]
+		},
+		{
+			"id": 811,
+			"name": "PasskeyApiClient",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Client for Auth0 Passkey operations.\r\n\r\nProvides 2 public methods:\r\n- "
+					},
+					{
+						"kind": "code",
+						"text": "`signup`"
+					},
+					{
+						"kind": "text",
+						"text": " — Register a new user with a passkey (full flow: challenge → WebAuthn → token exchange)\r\n- "
+					},
+					{
+						"kind": "code",
+						"text": "`login`"
+					},
+					{
+						"kind": "text",
+						"text": " — Sign in with a passkey (full flow: challenge → WebAuthn → token exchange)"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@example",
+						"content": [
+							{
+								"kind": "code",
+								"text": "```typescript\r\n// Signup — single call handles everything\r\nconst tokens = await auth0.passkey.signup({ email: 'user@example.com' });\r\n\r\n// Login — single call handles everything\r\nconst tokens = await auth0.passkey.login();\r\n```"
+							}
+						]
+					},
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Passkeys"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 822,
+					"name": "getLoginChallenge",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/passkey/PasskeyApiClient.d.ts",
+							"line": 85,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 823,
+							"name": "getLoginChallenge",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Request a passkey login challenge.\r\n\r\nStep 1 of the granular login flow. Returns the auth session and a\r\ndecoded "
+									},
+									{
+										"kind": "code",
+										"text": "`PublicKeyCredentialRequestOptions`"
+									},
+									{
+										"kind": "text",
+										"text": ". Run the WebAuthn assertion\r\nceremony with "
+									},
+									{
+										"kind": "code",
+										"text": "`publicKey`"
+									},
+									{
+										"kind": "text",
+										"text": ", then hand the resulting credential and "
+									},
+									{
+										"kind": "code",
+										"text": "`authSession`"
+									},
+									{
+										"kind": "text",
+										"text": " to\r\n"
+									},
+									{
+										"kind": "code",
+										"text": "`getTokenWithPasskey()`"
+									},
+									{
+										"kind": "text",
+										"text": "."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A promise resolving to "
+											},
+											{
+												"kind": "code",
+												"text": "`{ authSession, publicKey }`"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If WebAuthn is not supported in the browser"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If the challenge request fails"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/passkey/PasskeyApiClient.d.ts",
+									"line": 85,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 824,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {
+										"isOptional": true
+									},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Optional login challenge options (realm/organization)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "@auth0/auth0-auth-js",
+											"packagePath": "dist/index.d.ts",
+											"qualifiedName": "PasskeyLoginChallengeOptions"
+										},
+										"name": "PasskeyLoginChallengeOptions",
+										"package": "@auth0/auth0-auth-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"packageName": "typescript",
+									"packagePath": "lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": {
+											"packageName": "@auth0/auth0-spa-js",
+											"packagePath": "dist/typings/passkey/types.d.ts",
+											"qualifiedName": "PasskeyLoginChallenge"
+										},
+										"name": "PasskeyLoginChallenge",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 819,
+					"name": "getSignupChallenge",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/passkey/PasskeyApiClient.d.ts",
+							"line": 71,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 820,
+							"name": "getSignupChallenge",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Request a passkey signup challenge.\r\n\r\nStep 1 of the granular signup flow. Returns the auth session and a\r\ndecoded "
+									},
+									{
+										"kind": "code",
+										"text": "`PublicKeyCredentialCreationOptions`"
+									},
+									{
+										"kind": "text",
+										"text": ". Run the WebAuthn credential\r\ncreation ceremony with "
+									},
+									{
+										"kind": "code",
+										"text": "`publicKey`"
+									},
+									{
+										"kind": "text",
+										"text": ", then hand the resulting credential and "
+									},
+									{
+										"kind": "code",
+										"text": "`authSession`"
+									},
+									{
+										"kind": "text",
+										"text": " to\r\n"
+									},
+									{
+										"kind": "code",
+										"text": "`getTokenWithPasskey()`"
+									},
+									{
+										"kind": "text",
+										"text": "."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A promise resolving to "
+											},
+											{
+												"kind": "code",
+												"text": "`{ authSession, publicKey }`"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If WebAuthn is not supported in the browser"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If the challenge request fails"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/passkey/PasskeyApiClient.d.ts",
+									"line": 71,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 821,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Signup challenge options (user identifier, optional realm/organization/metadata)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "@auth0/auth0-auth-js",
+											"packagePath": "dist/index.d.ts",
+											"qualifiedName": "PasskeySignupChallengeOptions"
+										},
+										"name": "PasskeySignupChallengeOptions",
+										"package": "@auth0/auth0-auth-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"packageName": "typescript",
+									"packagePath": "lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": {
+											"packageName": "@auth0/auth0-spa-js",
+											"packagePath": "dist/typings/passkey/types.d.ts",
+											"qualifiedName": "PasskeySignupChallenge"
+										},
+										"name": "PasskeySignupChallenge",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 825,
+					"name": "getTokenWithPasskey",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/passkey/PasskeyApiClient.d.ts",
+							"line": 100,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 826,
+							"name": "getTokenWithPasskey",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Exchange a signed passkey credential for tokens.\r\n\r\nStep 2 of the granular flow. Serializes the raw "
+									},
+									{
+										"kind": "code",
+										"text": "`PublicKeyCredential`"
+									},
+									{
+										"kind": "text",
+										"text": "\r\nproduced by the WebAuthn ceremony — either a creation (signup) or an\r\nassertion (login) credential — and exchanges it for tokens. The credential\r\ntype (attestation vs assertion) is detected automatically."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A promise resolving to the token endpoint response"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If WebAuthn is not supported in the browser"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If the credential is not a valid attestation or assertion response"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If the token exchange fails"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/passkey/PasskeyApiClient.d.ts",
+									"line": 100,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 827,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The auth session, raw credential, and optional realm/organization/scope/audience"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "@auth0/auth0-spa-js",
+											"packagePath": "dist/typings/passkey/types.d.ts",
+											"qualifiedName": "PasskeyGetTokenOptions"
+										},
+										"name": "PasskeyGetTokenOptions",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"packageName": "typescript",
+									"packagePath": "lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 590,
+										"name": "TokenEndpointResponse",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 816,
+					"name": "login",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/passkey/PasskeyApiClient.d.ts",
+							"line": 57,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 817,
+							"name": "login",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Sign in with an existing passkey.\r\n\r\nHandles the full flow: requests a login challenge, triggers the browser\r\nWebAuthn assertion ceremony, serializes the result, and exchanges it\r\nfor tokens."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A promise that resolves to the token endpoint response containing access/ID tokens"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If WebAuthn is not supported in the browser"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If the challenge request fails"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If the token exchange fails"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If the user cancels the WebAuthn prompt"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/passkey/PasskeyApiClient.d.ts",
+									"line": 57,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 818,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {
+										"isOptional": true
+									},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Optional passkey login options (optional scope/audience/realm/organization)"
+											},
+											{
+												"kind": "text",
+												"text": "\n\nType: [PasskeyLoginOptions](/docs/sdk/react/types/PasskeyLoginOptions)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 832,
+										"name": "PasskeyLoginOptions",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"packageName": "typescript",
+									"packagePath": "lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 590,
+										"name": "TokenEndpointResponse",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 813,
+					"name": "signup",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/passkey/PasskeyApiClient.d.ts",
+							"line": 42,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 814,
+							"name": "signup",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Register a new user with a passkey.\r\n\r\nHandles the full flow: requests a signup challenge, triggers the browser\r\nWebAuthn credential creation ceremony, serializes the result, and exchanges\r\nit for tokens."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A promise that resolves to the token endpoint response containing access/ID tokens"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If WebAuthn is not supported in the browser"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If the challenge request fails"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If the token exchange fails"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If the user cancels the WebAuthn prompt"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/passkey/PasskeyApiClient.d.ts",
+									"line": 42,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 815,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Passkey signup options (user identifier, optional scope/audience)"
+											},
+											{
+												"kind": "text",
+												"text": "\n\nType: [PasskeySignupOptions](/docs/sdk/react/types/PasskeySignupOptions)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 828,
+										"name": "PasskeySignupOptions",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"packageName": "typescript",
+									"packagePath": "lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 590,
+										"name": "TokenEndpointResponse",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				}
+			],
+			"groups": [
+				{
+					"title": "Methods",
+					"children": [
+						822,
+						819,
+						825,
+						816,
+						813
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/passkey/PasskeyApiClient.d.ts",
+					"line": 21,
+					"character": 21
+				}
+			]
+		},
+		{
+			"id": 256,
+			"name": "PopupConfigOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Login & Logout"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 259,
+					"name": "closePopup",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Controls whether the SDK automatically closes the popup window.\r\n\r\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`true`"
+							},
+							{
+								"kind": "text",
+								"text": " (default): SDK closes the popup automatically after receiving the authorization response\r\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`false`"
+							},
+							{
+								"kind": "text",
+								"text": ": SDK does not close the popup. The caller is responsible for closing it, including on errors.\r\n\r\nSetting this to "
+							},
+							{
+								"kind": "code",
+								"text": "`false`"
+							},
+							{
+								"kind": "text",
+								"text": " is useful when you need full control over the popup lifecycle,\r\nsuch as in Chrome extensions where closing the popup too early can terminate the\r\nextension's service worker before authentication completes.\r\n\r\nWhen "
+							},
+							{
+								"kind": "code",
+								"text": "`closePopup: false`"
+							},
+							{
+								"kind": "text",
+								"text": ", you should close the popup in a try/finally block:\r\n"
+							},
+							{
+								"kind": "code",
+								"text": "```\r\nconst popup = window.open('', '_blank');\r\ntry {\r\n  await auth0.loginWithPopup({}, { popup, closePopup: false });\r\n} finally {\r\n  popup.close();\r\n}\r\n```"
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@default",
+								"content": [
+									{
+										"kind": "code",
+										"text": "```ts\ntrue\n```"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 485,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					}
+				},
+				{
+					"id": 258,
+					"name": "popup",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Accepts an already-created popup window to use. If not specified, the SDK\r\nwill create its own. This may be useful for platforms like iOS that have\r\nsecurity restrictions around when popups can be invoked (e.g. from a user click event)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 462,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "any"
+					}
+				},
+				{
+					"id": 257,
+					"name": "timeoutInSeconds",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The number of seconds to wait for a popup response before\r\nthrowing a timeout error. Defaults to 60s"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 456,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "number"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						259,
+						258,
+						257
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+					"line": 451,
+					"character": 17
+				}
+			]
+		},
+		{
+			"id": 254,
+			"name": "PopupLoginOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Login & Logout"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 255,
+					"name": "authorizationParams",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true,
+						"isInherited": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "URL parameters that will be sent back to the Authorization Server. This can be known parameters\r\ndefined by Auth0 or custom parameters that you define."
+							},
+							{
+								"kind": "text",
+								"text": "\n\nType: [AuthorizationParams](/docs/sdk/react/interfaces/AuthorizationParams)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 133,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 236,
+						"name": "AuthorizationParams",
+						"package": "@auth0/auth0-spa-js"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "BaseLoginOptions.authorizationParams"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						255
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+					"line": 449,
+					"character": 17
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"packageName": "@auth0/auth0-spa-js",
+						"packagePath": "dist/typings/global.d.ts",
+						"qualifiedName": "BaseLoginOptions"
+					},
+					"name": "BaseLoginOptions",
+					"package": "@auth0/auth0-spa-js"
+				}
+			],
+			"extendedBy": [
+				{
+					"type": "reference",
+					"target": 260,
+					"name": "GetTokenWithPopupOptions"
+				}
+			]
+		},
+		{
+			"id": 541,
+			"name": "RedirectConnectAccountOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Login & Logout"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 547,
+					"name": "appState",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Optional application state to persist through the transaction."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@example",
+								"content": [
+									{
+										"kind": "code",
+										"text": "```ts\nawait auth0.connectAccountWithRedirect({\r\n  connection: 'google-oauth2',\r\n  appState: { returnTo: '/settings' }\r\n});\n```"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 660,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 542,
+						"name": "TAppState",
+						"package": "@auth0/auth0-spa-js",
+						"qualifiedName": "RedirectConnectAccountOptions.TAppState",
+						"refersToTypeParameter": true
+					}
+				},
+				{
+					"id": 545,
+					"name": "authorization_params",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Additional authorization parameters for the request."
+							},
+							{
+								"kind": "text",
+								"text": "\n\nType: [AuthorizationParams](/docs/sdk/react/interfaces/AuthorizationParams)"
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@example",
+								"content": [
+									{
+										"kind": "code",
+										"text": "```ts\nawait auth0.connectAccountWithRedirect({\r\n  connection: 'github',\r\n  authorization_params: {\r\n    audience: 'https://api.github.com'\r\n  }\r\n});\n```"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 646,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 236,
+						"name": "AuthorizationParams",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 543,
+					"name": "connection",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The name of the connection to link (e.g. 'google-oauth2')."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 624,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 548,
+					"name": "openUrl",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Optional function to handle the redirect URL."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@example",
+								"content": [
+									{
+										"kind": "code",
+										"text": "```ts\nawait auth0.connectAccountWithRedirect({\r\n  connection: 'google-oauth2',\r\n  openUrl: async (url) => { myBrowserApi.open(url); }\r\n});\n```"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 670,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 549,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"signatures": [
+								{
+									"id": 550,
+									"name": "__type",
+									"variant": "signature",
+									"kind": 4096,
+									"flags": {},
+									"parameters": [
+										{
+											"id": 551,
+											"name": "url",
+											"variant": "param",
+											"kind": 32768,
+											"flags": {},
+											"type": {
+												"type": "intrinsic",
+												"name": "string"
+											}
+										}
+									],
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "typescript",
+											"packagePath": "lib/lib.es5.d.ts",
+											"qualifiedName": "Promise"
+										},
+										"typeArguments": [
+											{
+												"type": "intrinsic",
+												"name": "void"
+											}
+										],
+										"name": "Promise",
+										"package": "typescript"
+									}
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": 546,
+					"name": "redirectUri",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The URI to redirect back to after connecting the account."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 650,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 544,
+					"name": "scopes",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Array of scopes to request from the Identity Provider during the connect account flow."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@example",
+								"content": [
+									{
+										"kind": "code",
+										"text": "```ts\nawait auth0.connectAccountWithRedirect({\r\n  connection: 'google-oauth2',\r\n  scopes: ['https://www.googleapis.com/auth/calendar']\r\n});\n```"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 634,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "intrinsic",
+							"name": "string"
+						}
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						547,
+						545,
+						543,
+						548,
+						546,
+						544
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+					"line": 620,
+					"character": 17
+				}
+			],
+			"typeParameters": [
+				{
+					"id": 542,
+					"name": "TAppState",
+					"variant": "typeParam",
+					"kind": 131072,
+					"flags": {},
+					"default": {
+						"type": "intrinsic",
+						"name": "any"
+					}
+				}
+			]
+		},
+		{
+			"id": 227,
+			"name": "RedirectLoginOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Login & Logout"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 229,
+					"name": "appState",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true,
+						"isInherited": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Used to store state before doing the redirect"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 392,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 228,
+						"name": "TAppState",
+						"package": "@auth0/auth0-react",
+						"qualifiedName": "RedirectLoginOptions.TAppState",
+						"refersToTypeParameter": true
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "Omit.appState",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 230,
+					"name": "authorizationParams",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true,
+						"isInherited": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "URL parameters that will be sent back to the Authorization Server. This can be known parameters\r\ndefined by Auth0 or custom parameters that you define."
+							},
+							{
+								"kind": "text",
+								"text": "\n\nType: [AuthorizationParams](/docs/sdk/react/interfaces/AuthorizationParams)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 133,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 236,
+						"name": "AuthorizationParams",
+						"package": "@auth0/auth0-spa-js"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 255,
+						"name": "Omit.authorizationParams",
+						"package": "@auth0/auth0-spa-js",
+						"qualifiedName": "BaseLoginOptions.authorizationParams"
+					}
+				},
+				{
+					"id": 235,
+					"name": "fragment",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true,
+						"isInherited": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Used to add to the URL fragment before redirecting"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 396,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "Omit.fragment",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 231,
+					"name": "openUrl",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true,
+						"isInherited": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Used to control the redirect and not rely on the SDK to do the actual redirect."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@example",
+								"content": [
+									{
+										"kind": "code",
+										"text": "```ts\nconst client = new Auth0Client({\r\n  openUrl(url) {\r\n    window.location.replace(url);\r\n  }\r\n});\n```"
+									}
+								]
+							},
+							{
+								"tag": "@example",
+								"content": [
+									{
+										"kind": "code",
+										"text": "```ts\nimport { Browser } from '@capacitor/browser';\r\n\r\nconst client = new Auth0Client({\r\n  async openUrl(url) {\r\n    await Browser.open({ url });\r\n  }\r\n});\n```"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 428,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 232,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"signatures": [
+								{
+									"id": 233,
+									"name": "__type",
+									"variant": "signature",
+									"kind": 4096,
+									"flags": {},
+									"parameters": [
+										{
+											"id": 234,
+											"name": "url",
+											"variant": "param",
+											"kind": 32768,
+											"flags": {},
+											"type": {
+												"type": "intrinsic",
+												"name": "string"
+											}
+										}
+									],
+									"type": {
+										"type": "union",
+										"types": [
+											{
+												"type": "intrinsic",
+												"name": "void"
+											},
+											{
+												"type": "reference",
+												"target": {
+													"packageName": "typescript",
+													"packagePath": "lib/lib.es5.d.ts",
+													"qualifiedName": "Promise"
+												},
+												"typeArguments": [
+													{
+														"type": "intrinsic",
+														"name": "void"
+													}
+												],
+												"name": "Promise",
+												"package": "typescript"
+											}
+										]
+									}
+								}
+							]
+						}
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "Omit.openUrl",
+						"package": "@auth0/auth0-spa-js"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						229,
+						230,
+						235,
+						231
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/auth0-context.tsx",
+					"line": 29,
+					"character": 17
+				}
+			],
+			"typeParameters": [
+				{
+					"id": 228,
+					"name": "TAppState",
+					"variant": "typeParam",
+					"kind": 131072,
+					"flags": {},
+					"default": {
+						"type": "reference",
+						"target": 15,
+						"name": "AppState",
+						"package": "@auth0/auth0-react"
+					}
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"packageName": "typescript",
+						"packagePath": "lib/lib.es5.d.ts",
+						"qualifiedName": "Omit"
+					},
+					"typeArguments": [
+						{
+							"type": "reference",
+							"target": {
+								"packageName": "@auth0/auth0-spa-js",
+								"packagePath": "dist/typings/global.d.ts",
+								"qualifiedName": "RedirectLoginOptions"
+							},
+							"typeArguments": [
+								{
+									"type": "reference",
+									"target": 228,
+									"name": "TAppState",
+									"package": "@auth0/auth0-react",
+									"qualifiedName": "RedirectLoginOptions.TAppState",
+									"refersToTypeParameter": true
+								}
+							],
+							"name": "SPARedirectLoginOptions",
+							"package": "@auth0/auth0-spa-js",
+							"qualifiedName": "RedirectLoginOptions"
+						},
+						{
+							"type": "literal",
+							"value": "onRedirect"
+						}
+					],
+					"name": "Omit",
+					"package": "typescript"
+				}
+			]
+		},
+		{
+			"id": 731,
+			"name": "RevokeRefreshTokenOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Options for revoking a refresh token"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Tokens & Users"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 732,
+					"name": "audience",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Audience to identify which refresh token to revoke. Omit for default audience."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 871,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						732
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+					"line": 869,
+					"character": 17
+				}
+			]
+		},
+		{
+			"id": 872,
+			"name": "UpdateAuthenticationMethodRequest",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "My Account"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 873,
+					"name": "name",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/types.d.ts",
+							"line": 110,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 874,
+					"name": "preferred_authentication_method",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Only valid when updating a phone authentication method."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/types.d.ts",
+							"line": 112,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "union",
+						"types": [
+							{
+								"type": "literal",
+								"value": "sms"
+							},
+							{
+								"type": "literal",
+								"value": "voice"
+							}
+						]
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						873,
+						874
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/types.d.ts",
+					"line": 109,
+					"character": 17
+				}
+			]
+		},
+		{
+			"id": 803,
+			"name": "VerifyParams",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Parameters for verifying an MFA challenge.\r\n\r\nThe grant_type is automatically inferred from which verification field is provided:\r\n- "
+					},
+					{
+						"kind": "code",
+						"text": "`otp`"
+					},
+					{
+						"kind": "text",
+						"text": " field → MFA-OTP grant type\r\n- "
+					},
+					{
+						"kind": "code",
+						"text": "`oobCode`"
+					},
+					{
+						"kind": "text",
+						"text": " field → MFA-OOB grant type\r\n- "
+					},
+					{
+						"kind": "code",
+						"text": "`recoveryCode`"
+					},
+					{
+						"kind": "text",
+						"text": " field → MFA-RECOVERY-CODE grant type"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Multi-Factor Authentication"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 807,
+					"name": "bindingCode",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Binding code (for OOB challenges with binding)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+							"line": 171,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 804,
+					"name": "mfaToken",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "MFA token from challenge flow"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+							"line": 165,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 806,
+					"name": "oobCode",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Out-of-band code (for OOB challenges)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+							"line": 169,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 805,
+					"name": "otp",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "One-time password (for OTP challenges)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+							"line": 167,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 808,
+					"name": "recoveryCode",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Recovery code (for recovery code verification)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+							"line": 173,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						807,
+						804,
+						806,
+						805,
+						808
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+					"line": 163,
+					"character": 17
+				}
+			]
+		},
+		{
+			"id": 38,
+			"name": "WithAuth0Props",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Components wrapped in "
+					},
+					{
+						"kind": "code",
+						"text": "`withAuth0`"
+					},
+					{
+						"kind": "text",
+						"text": " will have an additional "
+					},
+					{
+						"kind": "code",
+						"text": "`auth0`"
+					},
+					{
+						"kind": "text",
+						"text": " prop"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Hooks & HOCs"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 39,
+					"name": "auth0",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Type: [Auth0ContextInterface](/docs/sdk/react/interfaces/Auth0ContextInterface)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/with-auth0.tsx",
+							"line": 8,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 58,
+						"name": "Auth0ContextInterface",
+						"package": "@auth0/auth0-react"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						39
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/with-auth0.tsx",
+					"line": 7,
+					"character": 17
+				}
+			]
+		},
+		{
+			"id": 45,
+			"name": "WithAuthenticationRequiredOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Options for the withAuthenticationRequired Higher Order Component"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Hooks & HOCs"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 56,
+					"name": "context",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The context to be used when calling useAuth0, this should only be provided if you are using multiple Auth0Providers\nwithin your application and you wish to tie a specific component to a Auth0Provider other than the Auth0Provider\nassociated with the default Auth0Context."
+							},
+							{
+								"kind": "text",
+								"text": "\n\nType: [Auth0ContextInterface](/docs/sdk/react/interfaces/Auth0ContextInterface), [User](/docs/sdk/react/classes/User)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/with-authentication-required.tsx",
+							"line": 92,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": {
+							"packageName": "@types/react",
+							"packagePath": "index.d.ts",
+							"qualifiedName": "React.Context"
+						},
+						"typeArguments": [
+							{
+								"type": "reference",
+								"target": 58,
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 326,
+										"name": "User",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Auth0ContextInterface",
+								"package": "@auth0/auth0-react"
+							}
+						],
+						"name": "Context",
+						"package": "@types/react",
+						"qualifiedName": "React.Context"
+					}
+				},
+				{
+					"id": 55,
+					"name": "loginOptions",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "code",
+								"text": "```js\nwithAuthenticationRequired(Profile, {\n  loginOptions: {\n    appState: {\n      customProp: 'foo'\n    }\n  }\n})\n```"
+							},
+							{
+								"kind": "text",
+								"text": "\n\nPass additional login options, like extra "
+							},
+							{
+								"kind": "code",
+								"text": "`appState`"
+							},
+							{
+								"kind": "text",
+								"text": " to the login page.\nThis will be merged with the "
+							},
+							{
+								"kind": "code",
+								"text": "`returnTo`"
+							},
+							{
+								"kind": "text",
+								"text": " option used by the "
+							},
+							{
+								"kind": "code",
+								"text": "`onRedirectCallback`"
+							},
+							{
+								"kind": "text",
+								"text": " handler."
+							},
+							{
+								"kind": "text",
+								"text": "\n\nType: [AppState](/docs/sdk/react/types/AppState), [RedirectLoginOptions](/docs/sdk/react/interfaces/RedirectLoginOptions)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/with-authentication-required.tsx",
+							"line": 86,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 227,
+						"typeArguments": [
+							{
+								"type": "reference",
+								"target": 15,
+								"name": "AppState",
+								"package": "@auth0/auth0-react"
+							}
+						],
+						"name": "RedirectLoginOptions",
+						"package": "@auth0/auth0-react"
+					}
+				},
+				{
+					"id": 52,
+					"name": "onBeforeAuthentication",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "code",
+								"text": "```js\nwithAuthenticationRequired(Profile, {\n  onBeforeAuthentication: () => { analyticsLibrary.track('login_triggered'); }\n})\n```"
+							},
+							{
+								"kind": "text",
+								"text": "\n\nAllows executing logic before the user is redirected to the login page."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/with-authentication-required.tsx",
+							"line": 71,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 53,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"signatures": [
+								{
+									"id": 54,
+									"name": "__type",
+									"variant": "signature",
+									"kind": 4096,
+									"flags": {},
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "typescript",
+											"packagePath": "lib/lib.es5.d.ts",
+											"qualifiedName": "Promise"
+										},
+										"typeArguments": [
+											{
+												"type": "intrinsic",
+												"name": "void"
+											}
+										],
+										"name": "Promise",
+										"package": "typescript"
+									}
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": 49,
+					"name": "onRedirecting",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "code",
+								"text": "```js\nwithAuthenticationRequired(Profile, {\n  onRedirecting: () => <div>Redirecting you to the login...</div>\n})\n```"
+							},
+							{
+								"kind": "text",
+								"text": "\n\nRender a message to show that the user is being redirected to the login."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/with-authentication-required.tsx",
+							"line": 61,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 50,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"signatures": [
+								{
+									"id": 51,
+									"name": "__type",
+									"variant": "signature",
+									"kind": 4096,
+									"flags": {},
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "@types/react",
+											"packagePath": "index.d.ts",
+											"qualifiedName": "React.JSX.Element"
+										},
+										"name": "Element",
+										"package": "@types/react",
+										"qualifiedName": "React.JSX.Element"
+									}
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": 46,
+					"name": "returnTo",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "code",
+								"text": "```js\nwithAuthenticationRequired(Profile, {\n  returnTo: '/profile'\n})\n```"
+							},
+							{
+								"kind": "text",
+								"text": "\n\nor\n\n"
+							},
+							{
+								"kind": "code",
+								"text": "```js\nwithAuthenticationRequired(Profile, {\n  returnTo: () => window.location.hash.substr(1)\n})\n```"
+							},
+							{
+								"kind": "text",
+								"text": "\n\nAdd a path for the "
+							},
+							{
+								"kind": "code",
+								"text": "`onRedirectCallback`"
+							},
+							{
+								"kind": "text",
+								"text": " handler to return the user to after login."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/with-authentication-required.tsx",
+							"line": 51,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "union",
+						"types": [
+							{
+								"type": "intrinsic",
+								"name": "string"
+							},
+							{
+								"type": "reflection",
+								"declaration": {
+									"id": 47,
+									"name": "__type",
+									"variant": "declaration",
+									"kind": 65536,
+									"flags": {},
+									"signatures": [
+										{
+											"id": 48,
+											"name": "__type",
+											"variant": "signature",
+											"kind": 4096,
+											"flags": {},
+											"type": {
+												"type": "intrinsic",
+												"name": "string"
+											}
+										}
+									]
+								}
+							}
+						]
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						56,
+						55,
+						52,
+						49,
+						46
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/with-authentication-required.tsx",
+					"line": 33,
+					"character": 17
+				}
+			]
+		},
+		{
+			"id": 15,
+			"name": "AppState",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "The state of the application before the user was redirected to the login page\nand any account that the user may have connected to."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Getting Started"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 18,
+					"name": "connectedAccount",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Type: [ConnectedAccount](/docs/sdk/react/types/ConnectedAccount)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/auth0-provider.tsx",
+							"line": 53,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 22,
+						"name": "ConnectedAccount",
+						"package": "@auth0/auth0-react"
+					}
+				},
+				{
+					"id": 19,
+					"name": "response_type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Type: [ResponseType](/docs/sdk/react/enums/ResponseType)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/auth0-provider.tsx",
+							"line": 54,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 557,
+						"name": "ResponseType",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 17,
+					"name": "returnTo",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/auth0-provider.tsx",
+							"line": 52,
+							"character": 2
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						18,
+						19,
+						17
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/auth0-provider.tsx",
+					"line": 51,
+					"character": 12
+				}
+			],
+			"indexSignatures": [
+				{
+					"id": 20,
+					"name": "__index",
+					"variant": "signature",
+					"kind": 8192,
+					"flags": {},
+					"parameters": [
+						{
+							"id": 21,
+							"name": "key",
+							"variant": "param",
+							"kind": 32768,
+							"flags": {},
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "any"
+					}
+				}
+			]
+		},
+		{
+			"id": 5,
+			"name": "Auth0ProviderOptions",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "The main configuration to instantiate the "
+					},
+					{
+						"kind": "code",
+						"text": "`Auth0Provider`"
+					},
+					{
+						"kind": "text",
+						"text": ".\n\nEither provide "
+					},
+					{
+						"kind": "code",
+						"text": "`domain`"
+					},
+					{
+						"kind": "text",
+						"text": " and "
+					},
+					{
+						"kind": "code",
+						"text": "`clientId`"
+					},
+					{
+						"kind": "text",
+						"text": " ("
+					},
+					{
+						"kind": "code",
+						"text": "`Auth0ProviderWithConfigOptions`"
+					},
+					{
+						"kind": "text",
+						"text": ")\nor a pre-configured "
+					},
+					{
+						"kind": "code",
+						"text": "`client`"
+					},
+					{
+						"kind": "text",
+						"text": " instance ("
+					},
+					{
+						"kind": "code",
+						"text": "`Auth0ProviderWithClientOptions`"
+					},
+					{
+						"kind": "text",
+						"text": ")."
+					},
+					{
+						"kind": "text",
+						"text": "\n\nType: [Auth0ProviderWithClientOptions](/docs/sdk/react/types/Auth0ProviderWithClientOptions), [Auth0ProviderWithConfigOptions](/docs/sdk/react/types/Auth0ProviderWithConfigOptions)"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Getting Started"
+							}
+						]
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "src/auth0-provider.tsx",
+					"line": 122,
+					"character": 12
+				}
+			],
+			"typeParameters": [
+				{
+					"id": 6,
+					"name": "TUser",
+					"variant": "typeParam",
+					"kind": 131072,
+					"flags": {},
+					"type": {
+						"type": "reference",
+						"target": 326,
+						"name": "User",
+						"package": "@auth0/auth0-spa-js"
+					},
+					"default": {
+						"type": "reference",
+						"target": 326,
+						"name": "User",
+						"package": "@auth0/auth0-spa-js"
+					}
+				}
+			],
+			"type": {
+				"type": "union",
+				"types": [
+					{
+						"type": "reference",
+						"target": 7,
+						"typeArguments": [
+							{
+								"type": "reference",
+								"target": 6,
+								"name": "TUser",
+								"package": "@auth0/auth0-react",
+								"refersToTypeParameter": true
+							}
+						],
+						"name": "Auth0ProviderWithConfigOptions",
+						"package": "@auth0/auth0-react"
+					},
+					{
+						"type": "reference",
+						"target": 11,
+						"typeArguments": [
+							{
+								"type": "reference",
+								"target": 6,
+								"name": "TUser",
+								"package": "@auth0/auth0-react",
+								"refersToTypeParameter": true
+							}
+						],
+						"name": "Auth0ProviderWithClientOptions",
+						"package": "@auth0/auth0-react"
+					}
+				]
+			}
+		},
+		{
+			"id": 11,
+			"name": "Auth0ProviderWithClientOptions",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Options for "
+					},
+					{
+						"kind": "code",
+						"text": "`Auth0Provider`"
+					},
+					{
+						"kind": "text",
+						"text": " when supplying a pre-configured "
+					},
+					{
+						"kind": "code",
+						"text": "`Auth0Client`"
+					},
+					{
+						"kind": "text",
+						"text": " instance."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Getting Started"
+							}
+						]
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "src/auth0-provider.tsx",
+					"line": 113,
+					"character": 12
+				}
+			],
+			"typeParameters": [
+				{
+					"id": 14,
+					"name": "TUser",
+					"variant": "typeParam",
+					"kind": 131072,
+					"flags": {},
+					"type": {
+						"type": "reference",
+						"target": 326,
+						"name": "User",
+						"package": "@auth0/auth0-spa-js"
+					},
+					"default": {
+						"type": "reference",
+						"target": 326,
+						"name": "User",
+						"package": "@auth0/auth0-spa-js"
+					}
+				}
+			],
+			"type": {
+				"type": "intersection",
+				"types": [
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-react",
+							"packagePath": "src/auth0-provider.tsx",
+							"qualifiedName": "Auth0ProviderBaseOptions"
+						},
+						"typeArguments": [
+							{
+								"type": "reference",
+								"target": 14,
+								"name": "TUser",
+								"package": "@auth0/auth0-react",
+								"refersToTypeParameter": true
+							}
+						],
+						"name": "Auth0ProviderBaseOptions",
+						"package": "@auth0/auth0-react"
+					},
+					{
+						"type": "reflection",
+						"declaration": {
+							"id": 12,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"children": [
+								{
+									"id": 13,
+									"name": "client",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {},
+									"sources": [
+										{
+											"fileName": "src/auth0-provider.tsx",
+											"line": 114,
+											"character": 38
+										}
+									],
+									"type": {
+										"type": "reference",
+										"target": {
+											"packageName": "@auth0/auth0-spa-js",
+											"packagePath": "dist/typings/Auth0Client.d.ts",
+											"qualifiedName": "Auth0Client"
+										},
+										"name": "Auth0Client",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"groups": [
+								{
+									"title": "Properties",
+									"children": [
+										13
+									]
+								}
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": 7,
+			"name": "Auth0ProviderWithConfigOptions",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Options for "
+					},
+					{
+						"kind": "code",
+						"text": "`Auth0Provider`"
+					},
+					{
+						"kind": "text",
+						"text": " when configuring Auth0 via "
+					},
+					{
+						"kind": "code",
+						"text": "`domain`"
+					},
+					{
+						"kind": "text",
+						"text": " and "
+					},
+					{
+						"kind": "code",
+						"text": "`clientId`"
+					},
+					{
+						"kind": "text",
+						"text": ".\nUse this type when building wrapper components around "
+					},
+					{
+						"kind": "code",
+						"text": "`Auth0Provider`"
+					},
+					{
+						"kind": "text",
+						"text": "."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Getting Started"
+							}
+						]
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "src/auth0-provider.tsx",
+					"line": 107,
+					"character": 12
+				}
+			],
+			"typeParameters": [
+				{
+					"id": 10,
+					"name": "TUser",
+					"variant": "typeParam",
+					"kind": 131072,
+					"flags": {},
+					"type": {
+						"type": "reference",
+						"target": 326,
+						"name": "User",
+						"package": "@auth0/auth0-spa-js"
+					},
+					"default": {
+						"type": "reference",
+						"target": 326,
+						"name": "User",
+						"package": "@auth0/auth0-spa-js"
+					}
+				}
+			],
+			"type": {
+				"type": "intersection",
+				"types": [
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-react",
+							"packagePath": "src/auth0-provider.tsx",
+							"qualifiedName": "Auth0ProviderBaseOptions"
+						},
+						"typeArguments": [
+							{
+								"type": "reference",
+								"target": 10,
+								"name": "TUser",
+								"package": "@auth0/auth0-react",
+								"refersToTypeParameter": true
+							}
+						],
+						"name": "Auth0ProviderBaseOptions",
+						"package": "@auth0/auth0-react"
+					},
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/global.d.ts",
+							"qualifiedName": "Auth0ClientOptions"
+						},
+						"name": "Auth0ClientOptions",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reflection",
+						"declaration": {
+							"id": 8,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"children": [
+								{
+									"id": 9,
+									"name": "client",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {
+										"isOptional": true
+									},
+									"sources": [
+										{
+											"fileName": "src/auth0-provider.tsx",
+											"line": 108,
+											"character": 59
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "never"
+									}
+								}
+							],
+							"groups": [
+								{
+									"title": "Properties",
+									"children": [
+										9
+									]
+								}
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": 31,
+			"name": "Auth0SuspenseContextInterface",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "The value returned by "
+					},
+					{
+						"kind": "code",
+						"text": "`useAuth0Suspense`"
+					},
+					{
+						"kind": "text",
+						"text": ": the full "
+					},
+					{
+						"kind": "code",
+						"text": "`useAuth0`"
+					},
+					{
+						"kind": "text",
+						"text": " interface minus\n"
+					},
+					{
+						"kind": "code",
+						"text": "`isLoading`"
+					},
+					{
+						"kind": "text",
+						"text": " and the internal "
+					},
+					{
+						"kind": "code",
+						"text": "`_initPromise`"
+					},
+					{
+						"kind": "text",
+						"text": ". "
+					},
+					{
+						"kind": "code",
+						"text": "`error`"
+					},
+					{
+						"kind": "text",
+						"text": " is\nretained for post-init failures such as "
+					},
+					{
+						"kind": "code",
+						"text": "`loginWithPopup`"
+					},
+					{
+						"kind": "text",
+						"text": "."
+					},
+					{
+						"kind": "text",
+						"text": "\n\nType: [Auth0ContextInterface](/docs/sdk/react/interfaces/Auth0ContextInterface)"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Context"
+							}
+						]
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "src/use-auth0-suspense.tsx",
+					"line": 15,
+					"character": 12
+				}
+			],
+			"typeParameters": [
+				{
+					"id": 32,
+					"name": "TUser",
+					"variant": "typeParam",
+					"kind": 131072,
+					"flags": {},
+					"type": {
+						"type": "reference",
+						"target": 326,
+						"name": "User",
+						"package": "@auth0/auth0-spa-js"
+					},
+					"default": {
+						"type": "reference",
+						"target": 326,
+						"name": "User",
+						"package": "@auth0/auth0-spa-js"
+					}
+				}
+			],
+			"type": {
+				"type": "reference",
+				"target": {
+					"packageName": "typescript",
+					"packagePath": "lib/lib.es5.d.ts",
+					"qualifiedName": "Omit"
+				},
+				"typeArguments": [
+					{
+						"type": "reference",
+						"target": 58,
+						"typeArguments": [
+							{
+								"type": "reference",
+								"target": 32,
+								"name": "TUser",
+								"package": "@auth0/auth0-react",
+								"refersToTypeParameter": true
+							}
+						],
+						"name": "Auth0ContextInterface",
+						"package": "@auth0/auth0-react"
+					},
+					{
+						"type": "union",
+						"types": [
+							{
+								"type": "literal",
+								"value": "isLoading"
+							},
+							{
+								"type": "literal",
+								"value": "_initPromise"
+							}
+						]
+					}
+				],
+				"name": "Omit",
+				"package": "typescript"
+			}
+		},
+		{
+			"id": 867,
+			"name": "AuthenticationMethod",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "My Account"
+							}
+						]
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/types.d.ts",
+					"line": 108,
+					"character": 12
+				}
+			],
+			"type": {
+				"type": "union",
+				"types": [
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/myaccount/types.d.ts",
+							"qualifiedName": "PasskeyAuthenticationMethod"
+						},
+						"name": "PasskeyAuthenticationMethod",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/myaccount/types.d.ts",
+							"qualifiedName": "WebAuthnPlatformAuthenticationMethod"
+						},
+						"name": "WebAuthnPlatformAuthenticationMethod",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/myaccount/types.d.ts",
+							"qualifiedName": "WebAuthnRoamingAuthenticationMethod"
+						},
+						"name": "WebAuthnRoamingAuthenticationMethod",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/myaccount/types.d.ts",
+							"qualifiedName": "PhoneAuthenticationMethod"
+						},
+						"name": "PhoneAuthenticationMethod",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/myaccount/types.d.ts",
+							"qualifiedName": "EmailAuthenticationMethod"
+						},
+						"name": "EmailAuthenticationMethod",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/myaccount/types.d.ts",
+							"qualifiedName": "PasswordAuthenticationMethod"
+						},
+						"name": "PasswordAuthenticationMethod",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/myaccount/types.d.ts",
+							"qualifiedName": "TotpAuthenticationMethod"
+						},
+						"name": "TotpAuthenticationMethod",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/myaccount/types.d.ts",
+							"qualifiedName": "PushNotificationAuthenticationMethod"
+						},
+						"name": "PushNotificationAuthenticationMethod",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/myaccount/types.d.ts",
+							"qualifiedName": "RecoveryCodeAuthenticationMethod"
+						},
+						"name": "RecoveryCodeAuthenticationMethod",
+						"package": "@auth0/auth0-spa-js"
+					}
+				]
+			}
+		},
+		{
+			"id": 868,
+			"name": "AuthenticationMethodType",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "My Account"
+							}
+						]
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/types.d.ts",
+					"line": 46,
+					"character": 12
+				}
+			],
+			"type": {
+				"type": "union",
+				"types": [
+					{
+						"type": "literal",
+						"value": "passkey"
+					},
+					{
+						"type": "literal",
+						"value": "password"
+					},
+					{
+						"type": "literal",
+						"value": "phone"
+					},
+					{
+						"type": "literal",
+						"value": "totp"
+					},
+					{
+						"type": "literal",
+						"value": "email"
+					},
+					{
+						"type": "literal",
+						"value": "push-notification"
+					},
+					{
+						"type": "literal",
+						"value": "recovery-code"
+					},
+					{
+						"type": "literal",
+						"value": "webauthn-platform"
+					},
+					{
+						"type": "literal",
+						"value": "webauthn-roaming"
+					}
+				]
+			}
+		},
+		{
+			"id": 388,
+			"name": "Cacheable",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Caching"
+							}
+						]
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/cache/shared.d.ts",
+					"line": 61,
+					"character": 12
+				}
+			],
+			"type": {
+				"type": "union",
+				"types": [
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/cache/shared.d.ts",
+							"qualifiedName": "WrappedCacheEntry"
+						},
+						"name": "WrappedCacheEntry",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/cache/shared.d.ts",
+							"qualifiedName": "KeyManifestEntry"
+						},
+						"name": "KeyManifestEntry",
+						"package": "@auth0/auth0-spa-js"
+					}
+				]
+			}
+		},
+		{
+			"id": 271,
+			"name": "CacheLocation",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "The possible locations where tokens can be stored"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Configuration"
+							}
+						]
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+					"line": 374,
+					"character": 12
+				}
+			],
+			"type": {
+				"type": "union",
+				"types": [
+					{
+						"type": "literal",
+						"value": "memory"
+					},
+					{
+						"type": "literal",
+						"value": "localstorage"
+					}
+				]
+			}
+		},
+		{
+			"id": 552,
+			"name": "ConnectAccountRedirectResult",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "The result returned after a successful account connection redirect.\r\n\r\nCombines the redirect login result (including any persisted app state)\r\nwith the complete response from the My Account API."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@example",
+						"content": [
+							{
+								"kind": "code",
+								"text": "```ts\nconst result = await auth0.connectAccountWithRedirect(options);\r\nconsole.log(result.appState); // Access persisted app state\r\nconsole.log(result.connection);   // The connection of the account you connected to.\r\nconsole.log(result.response_type === 'connect_code');   // The response type will be 'connect_code'\n```"
+							}
+						]
+					},
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Login & Logout"
+							}
+						]
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+					"line": 685,
+					"character": 12
+				}
+			],
+			"typeParameters": [
+				{
+					"id": 556,
+					"name": "TAppState",
+					"variant": "typeParam",
+					"kind": 131072,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The type of application state persisted through the transaction."
+							}
+						]
+					},
+					"default": {
+						"type": "intrinsic",
+						"name": "any"
+					}
+				}
+			],
+			"type": {
+				"type": "intersection",
+				"types": [
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/myaccount/types.d.ts",
+							"qualifiedName": "CompleteResponse"
+						},
+						"name": "CompleteResponse",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reflection",
+						"declaration": {
+							"id": 553,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"children": [
+								{
+									"id": 554,
+									"name": "appState",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {
+										"isOptional": true
+									},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "State stored when the redirect request was made"
+											}
+										]
+									},
+									"sources": [
+										{
+											"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+											"line": 689,
+											"character": 4
+										}
+									],
+									"type": {
+										"type": "reference",
+										"target": 556,
+										"name": "TAppState",
+										"package": "@auth0/auth0-spa-js",
+										"refersToTypeParameter": true
+									}
+								},
+								{
+									"id": 555,
+									"name": "response_type",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The type of response, for connect account it will be "
+											},
+											{
+												"kind": "code",
+												"text": "`connect_code`"
+											}
+										]
+									},
+									"sources": [
+										{
+											"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+											"line": 693,
+											"character": 4
+										}
+									],
+									"type": {
+										"type": "reference",
+										"target": 559,
+										"name": "ResponseType.ConnectCode",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"groups": [
+								{
+									"title": "Properties",
+									"children": [
+										554,
+										555
+									]
+								}
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": 22,
+			"name": "ConnectedAccount",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "The account that has been connected during the connect flow."
+					},
+					{
+						"kind": "text",
+						"text": "\n\nType: [ConnectAccountRedirectResult](/docs/sdk/react/types/ConnectAccountRedirectResult)"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Login & Logout"
+							}
+						]
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "src/auth0-provider.tsx",
+					"line": 45,
+					"character": 12
+				}
+			],
+			"type": {
+				"type": "reference",
+				"target": {
+					"packageName": "typescript",
+					"packagePath": "lib/lib.es5.d.ts",
+					"qualifiedName": "Omit"
+				},
+				"typeArguments": [
+					{
+						"type": "reference",
+						"target": 552,
+						"name": "ConnectAccountRedirectResult",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "union",
+						"types": [
+							{
+								"type": "literal",
+								"value": "appState"
+							},
+							{
+								"type": "literal",
+								"value": "response_type"
+							}
+						]
+					}
+				],
+				"name": "Omit",
+				"package": "typescript"
+			}
+		},
+		{
+			"id": 579,
+			"name": "CustomTokenExchangeOptions",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Represents the configuration options required for initiating a Custom Token Exchange request\r\nfollowing RFC 8693 specifications."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@see",
+						"content": [
+							{
+								"kind": "inline-tag",
+								"tag": "@link",
+								"text": "RFC 8693: OAuth 2.0 Token Exchange",
+								"target": "https://www.rfc-editor.org/rfc/rfc8693"
+							}
+						]
+					},
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Tokens & Users"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 586,
+					"name": "actor_token",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "A token representing the acting party for delegation or impersonation scenarios."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@remarks",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Used when one principal needs to act on behalf of another.\r\nFor example, an AI agent acting on behalf of a user."
+									}
+								]
+							},
+							{
+								"tag": "@example",
+								"content": [
+									{
+										"kind": "code",
+										"text": "```ts\n\"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...\"\n```"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/TokenExchange.d.ts",
+							"line": 72,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 587,
+					"name": "actor_token_type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The type identifier for the actor token."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@remarks",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Must be a URI under your organization's control, following the same\r\nrules as subject_token_type."
+									}
+								]
+							},
+							{
+								"tag": "@example",
+								"content": [
+									{
+										"kind": "code",
+										"text": "```ts\n\"https://idp.example.com/token-type/agent\"\n```"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/TokenExchange.d.ts",
+							"line": 83,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 583,
+					"name": "audience",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The target audience for the requested Auth0 token"
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@remarks",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Must match exactly with an API identifier configured in your Auth0 tenant.\r\nIf not provided, falls back to the client's default audience."
+									}
+								]
+							},
+							{
+								"tag": "@example",
+								"content": [
+									{
+										"kind": "code",
+										"text": "```ts\n\"https://api.your-service.com/v1\"\n```"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/TokenExchange.d.ts",
+							"line": 45,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 585,
+					"name": "organization",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "ID or name of the organization to use when authenticating a user.\r\nWhen provided, the user will be authenticated using the organization context.\r\nThe organization ID will be present in the access token payload."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/TokenExchange.d.ts",
+							"line": 61,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 584,
+					"name": "scope",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Space-separated list of OAuth 2.0 scopes being requested"
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@remarks",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Subject to API authorization policies configured in Auth0"
+									}
+								]
+							},
+							{
+								"tag": "@example",
+								"content": [
+									{
+										"kind": "code",
+										"text": "```ts\n\"openid profile email read:data write:data\"\n```"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/TokenExchange.d.ts",
+							"line": 55,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 582,
+					"name": "subject_token",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The opaque token value being exchanged for Auth0 tokens"
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@security",
+								"content": [
+									{
+										"kind": "text",
+										"text": "- Must be validated in Auth0 Actions using strong cryptographic verification\r\n- Implement replay attack protection\r\n- Recommended validation libraries: "
+									},
+									{
+										"kind": "code",
+										"text": "`jose`"
+									},
+									{
+										"kind": "text",
+										"text": ", "
+									},
+									{
+										"kind": "code",
+										"text": "`jsonwebtoken`"
+									}
+								]
+							},
+							{
+								"tag": "@example",
+								"content": [
+									{
+										"kind": "code",
+										"text": "```ts\n\"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\"\n```"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/TokenExchange.d.ts",
+							"line": 34,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 581,
+					"name": "subject_token_type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The type identifier for the subject token being exchanged"
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@pattern",
+								"content": [
+									{
+										"kind": "text",
+										"text": "- Must be a namespaced URI under your organization's control\r\n- Forbidden patterns:\r\n  - "
+									},
+									{
+										"kind": "code",
+										"text": "`^urn:ietf:params:oauth:*`"
+									},
+									{
+										"kind": "text",
+										"text": " (IETF reserved)\r\n  - "
+									},
+									{
+										"kind": "code",
+										"text": "`^https://auth0\\.com/*`"
+									},
+									{
+										"kind": "text",
+										"text": " (Auth0 reserved)\r\n  - "
+									},
+									{
+										"kind": "code",
+										"text": "`^urn:auth0:*`"
+									},
+									{
+										"kind": "text",
+										"text": " (Auth0 reserved)"
+									}
+								]
+							},
+							{
+								"tag": "@example",
+								"content": [
+									{
+										"kind": "code",
+										"text": "```ts\n\"urn:acme:legacy-system-token\"\r\n\"https://api.yourcompany.com/token-type/v1\"\n```"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/TokenExchange.d.ts",
+							"line": 22,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						586,
+						587,
+						583,
+						585,
+						584,
+						582,
+						581
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/TokenExchange.d.ts",
+					"line": 7,
+					"character": 12
+				}
+			],
+			"indexSignatures": [
+				{
+					"id": 588,
+					"name": "__index",
+					"variant": "signature",
+					"kind": 8192,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Additional custom parameters for Auth0 Action processing"
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@remarks",
+								"content": [
+									{
+										"kind": "text",
+										"text": "Accessible in Action code via "
+									},
+									{
+										"kind": "code",
+										"text": "`event.request.body`"
+									}
+								]
+							},
+							{
+								"tag": "@example",
+								"content": [
+									{
+										"kind": "code",
+										"text": "```typescript\r\n{\r\n  custom_parameter: \"session_context\",\r\n  device_fingerprint: \"a3d8f7...\",\r\n}\r\n```"
+									}
+								]
+							}
+						]
+					},
+					"parameters": [
+						{
+							"id": 589,
+							"name": "key",
+							"variant": "param",
+							"kind": 32768,
+							"flags": {},
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "unknown"
+					}
+				}
+			]
+		},
+		{
+			"id": 875,
+			"name": "EnrollmentChallengeOptions",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "My Account"
+							}
+						]
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/types.d.ts",
+					"line": 142,
+					"character": 12
+				}
+			],
+			"type": {
+				"type": "union",
+				"types": [
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/myaccount/types.d.ts",
+							"qualifiedName": "PasskeyEnrollmentChallengeOptions"
+						},
+						"name": "PasskeyEnrollmentChallengeOptions",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/myaccount/types.d.ts",
+							"qualifiedName": "PhoneEnrollmentChallengeOptions"
+						},
+						"name": "PhoneEnrollmentChallengeOptions",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/myaccount/types.d.ts",
+							"qualifiedName": "EmailEnrollmentChallengeOptions"
+						},
+						"name": "EmailEnrollmentChallengeOptions",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/myaccount/types.d.ts",
+							"qualifiedName": "TotpEnrollmentChallengeOptions"
+						},
+						"name": "TotpEnrollmentChallengeOptions",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/myaccount/types.d.ts",
+							"qualifiedName": "PushNotificationEnrollmentChallengeOptions"
+						},
+						"name": "PushNotificationEnrollmentChallengeOptions",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/myaccount/types.d.ts",
+							"qualifiedName": "RecoveryCodeEnrollmentChallengeOptions"
+						},
+						"name": "RecoveryCodeEnrollmentChallengeOptions",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/myaccount/types.d.ts",
+							"qualifiedName": "PasswordEnrollmentChallengeOptions"
+						},
+						"name": "PasswordEnrollmentChallengeOptions",
+						"package": "@auth0/auth0-spa-js"
+					}
+				]
+			}
+		},
+		{
+			"id": 876,
+			"name": "EnrollmentChallengeResponse",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "My Account"
+							}
+						]
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/types.d.ts",
+					"line": 198,
+					"character": 12
+				}
+			],
+			"type": {
+				"type": "union",
+				"types": [
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/myaccount/types.d.ts",
+							"qualifiedName": "PasskeyEnrollmentChallengeResponse"
+						},
+						"name": "PasskeyEnrollmentChallengeResponse",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/myaccount/types.d.ts",
+							"qualifiedName": "PhoneEnrollmentChallengeResponse"
+						},
+						"name": "PhoneEnrollmentChallengeResponse",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/myaccount/types.d.ts",
+							"qualifiedName": "EmailEnrollmentChallengeResponse"
+						},
+						"name": "EmailEnrollmentChallengeResponse",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/myaccount/types.d.ts",
+							"qualifiedName": "TotpEnrollmentChallengeResponse"
+						},
+						"name": "TotpEnrollmentChallengeResponse",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/myaccount/types.d.ts",
+							"qualifiedName": "PushNotificationEnrollmentChallengeResponse"
+						},
+						"name": "PushNotificationEnrollmentChallengeResponse",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/myaccount/types.d.ts",
+							"qualifiedName": "RecoveryCodeEnrollmentChallengeResponse"
+						},
+						"name": "RecoveryCodeEnrollmentChallengeResponse",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/myaccount/types.d.ts",
+							"qualifiedName": "PasswordEnrollmentChallengeResponse"
+						},
+						"name": "PasswordEnrollmentChallengeResponse",
+						"package": "@auth0/auth0-spa-js"
+					}
+				]
+			}
+		},
+		{
+			"id": 794,
+			"name": "EnrollmentResponse",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Union type for all enrollment response types"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Multi-Factor Authentication"
+							}
+						]
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+					"line": 128,
+					"character": 12
+				}
+			],
+			"type": {
+				"type": "union",
+				"types": [
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/mfa/types.d.ts",
+							"qualifiedName": "OtpEnrollmentResponse"
+						},
+						"name": "OtpEnrollmentResponse",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/mfa/types.d.ts",
+							"qualifiedName": "OobEnrollmentResponse"
+						},
+						"name": "OobEnrollmentResponse",
+						"package": "@auth0/auth0-spa-js"
+					}
+				]
+			}
+		},
+		{
+			"id": 877,
+			"name": "EnrollmentVerifyOptions",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "My Account"
+							}
+						]
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/myaccount/types.d.ts",
+					"line": 229,
+					"character": 12
+				}
+			],
+			"type": {
+				"type": "union",
+				"types": [
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/myaccount/types.d.ts",
+							"qualifiedName": "PasskeyEnrollmentVerifyOptions"
+						},
+						"name": "PasskeyEnrollmentVerifyOptions",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/myaccount/types.d.ts",
+							"qualifiedName": "PhoneEnrollmentVerifyOptions"
+						},
+						"name": "PhoneEnrollmentVerifyOptions",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/myaccount/types.d.ts",
+							"qualifiedName": "EmailEnrollmentVerifyOptions"
+						},
+						"name": "EmailEnrollmentVerifyOptions",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/myaccount/types.d.ts",
+							"qualifiedName": "TotpEnrollmentVerifyOptions"
+						},
+						"name": "TotpEnrollmentVerifyOptions",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/myaccount/types.d.ts",
+							"qualifiedName": "PushNotificationEnrollmentVerifyOptions"
+						},
+						"name": "PushNotificationEnrollmentVerifyOptions",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/myaccount/types.d.ts",
+							"qualifiedName": "RecoveryCodeEnrollmentVerifyOptions"
+						},
+						"name": "RecoveryCodeEnrollmentVerifyOptions",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/myaccount/types.d.ts",
+							"qualifiedName": "PasswordEnrollmentVerifyOptions"
+						},
+						"name": "PasswordEnrollmentVerifyOptions",
+						"package": "@auth0/auth0-spa-js"
+					}
+				]
+			}
+		},
+		{
+			"id": 775,
+			"name": "EnrollParams",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Union type for all enrollment parameter types"
+					},
+					{
+						"kind": "text",
+						"text": "\n\nType: [EnrollEmailParams](/docs/sdk/react/interfaces/EnrollEmailParams), [EnrollOtpParams](/docs/sdk/react/interfaces/EnrollOtpParams), [EnrollPushParams](/docs/sdk/react/interfaces/EnrollPushParams), [EnrollSmsParams](/docs/sdk/react/interfaces/EnrollSmsParams), [EnrollVoiceParams](/docs/sdk/react/interfaces/EnrollVoiceParams)"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Multi-Factor Authentication"
+							}
+						]
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+					"line": 90,
+					"character": 12
+				}
+			],
+			"type": {
+				"type": "union",
+				"types": [
+					{
+						"type": "reference",
+						"target": 776,
+						"name": "EnrollOtpParams",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 779,
+						"name": "EnrollSmsParams",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 783,
+						"name": "EnrollVoiceParams",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 787,
+						"name": "EnrollEmailParams",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 791,
+						"name": "EnrollPushParams",
+						"package": "@auth0/auth0-spa-js"
+					}
+				]
+			}
+		},
+		{
+			"id": 733,
+			"name": "FetcherConfig",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Tokens & Users"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 736,
+					"name": "baseUrl",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/fetcher.d.ts",
+							"line": 17,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 738,
+					"name": "dpopNonceId",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/fetcher.d.ts",
+							"line": 19,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 737,
+					"name": "fetch",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/fetcher.d.ts",
+							"line": 18,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/fetcher.d.ts",
+							"qualifiedName": "CustomFetchImpl"
+						},
+						"typeArguments": [
+							{
+								"type": "reference",
+								"target": 739,
+								"name": "TOutput",
+								"package": "@auth0/auth0-spa-js",
+								"refersToTypeParameter": true
+							}
+						],
+						"name": "CustomFetchImpl",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 735,
+					"name": "getAccessToken",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/fetcher.d.ts",
+							"line": 16,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/fetcher.d.ts",
+							"qualifiedName": "AccessTokenFactory"
+						},
+						"name": "AccessTokenFactory",
+						"package": "@auth0/auth0-spa-js"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						736,
+						738,
+						737,
+						735
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/fetcher.d.ts",
+					"line": 15,
+					"character": 12
+				}
+			],
+			"typeParameters": [
+				{
+					"id": 739,
+					"name": "TOutput",
+					"variant": "typeParam",
+					"kind": 131072,
+					"flags": {},
+					"type": {
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-spa-js",
+							"packagePath": "dist/typings/fetcher.d.ts",
+							"qualifiedName": "CustomFetchMinimalOutput"
+						},
+						"name": "CustomFetchMinimalOutput",
+						"package": "@auth0/auth0-spa-js"
+					}
+				}
+			]
+		},
+		{
+			"id": 740,
+			"name": "InteractiveErrorHandler",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Configuration option for automatic interactive error handling.\r\n\r\n- "
+					},
+					{
+						"kind": "code",
+						"text": "`'popup'`"
+					},
+					{
+						"kind": "text",
+						"text": ": SDK automatically opens Universal Login popup on MFA error"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Configuration"
+							}
+						]
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+					"line": 9,
+					"character": 12
+				}
+			],
+			"type": {
+				"type": "literal",
+				"value": "popup"
+			}
+		},
+		{
+			"id": 774,
+			"name": "MfaFactorType",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Supported MFA factors for enrollment"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Multi-Factor Authentication"
+							}
+						]
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/mfa/types.d.ts",
+					"line": 38,
+					"character": 12
+				}
+			],
+			"type": {
+				"type": "union",
+				"types": [
+					{
+						"type": "literal",
+						"value": "otp"
+					},
+					{
+						"type": "literal",
+						"value": "sms"
+					},
+					{
+						"type": "literal",
+						"value": "email"
+					},
+					{
+						"type": "literal",
+						"value": "push"
+					},
+					{
+						"type": "literal",
+						"value": "voice"
+					}
+				]
+			}
+		},
+		{
+			"id": 832,
+			"name": "PasskeyLoginOptions",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Options for passkey login (authenticating with an existing passkey)."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Passkeys"
+							}
+						]
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/passkey/types.d.ts",
+					"line": 13,
+					"character": 12
+				}
+			],
+			"type": {
+				"type": "intersection",
+				"types": [
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-auth-js",
+							"packagePath": "dist/index.d.ts",
+							"qualifiedName": "PasskeyLoginChallengeOptions"
+						},
+						"name": "PasskeyLoginChallengeOptions",
+						"package": "@auth0/auth0-auth-js"
+					},
+					{
+						"type": "reflection",
+						"declaration": {
+							"id": 833,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"children": [
+								{
+									"id": 835,
+									"name": "audience",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {
+										"isOptional": true
+									},
+									"sources": [
+										{
+											"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/passkey/types.d.ts",
+											"line": 15,
+											"character": 4
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 834,
+									"name": "scope",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {
+										"isOptional": true
+									},
+									"sources": [
+										{
+											"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/passkey/types.d.ts",
+											"line": 14,
+											"character": 4
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"groups": [
+								{
+									"title": "Properties",
+									"children": [
+										835,
+										834
+									]
+								}
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": 828,
+			"name": "PasskeySignupOptions",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Options for passkey signup (registering a new user with a passkey)."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Passkeys"
+							}
+						]
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/passkey/types.d.ts",
+					"line": 6,
+					"character": 12
+				}
+			],
+			"type": {
+				"type": "intersection",
+				"types": [
+					{
+						"type": "reference",
+						"target": {
+							"packageName": "@auth0/auth0-auth-js",
+							"packagePath": "dist/index.d.ts",
+							"qualifiedName": "PasskeySignupChallengeOptions"
+						},
+						"name": "PasskeySignupChallengeOptions",
+						"package": "@auth0/auth0-auth-js"
+					},
+					{
+						"type": "reflection",
+						"declaration": {
+							"id": 829,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"children": [
+								{
+									"id": 831,
+									"name": "audience",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {
+										"isOptional": true
+									},
+									"sources": [
+										{
+											"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/passkey/types.d.ts",
+											"line": 8,
+											"character": 4
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 830,
+									"name": "scope",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {
+										"isOptional": true
+									},
+									"sources": [
+										{
+											"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/passkey/types.d.ts",
+											"line": 7,
+											"character": 4
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"groups": [
+								{
+									"title": "Properties",
+									"children": [
+										831,
+										830
+									]
+								}
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": 609,
+			"name": "RefreshTokenMode",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "The refresh-token variant used when "
+					},
+					{
+						"kind": "code",
+						"text": "`useRefreshTokens: true`"
+					},
+					{
+						"kind": "text",
+						"text": ".\r\n\r\n- "
+					},
+					{
+						"kind": "inline-tag",
+						"tag": "@link",
+						"text": "RefreshTokenMode.Offline",
+						"target": 607
+					},
+					{
+						"kind": "text",
+						"text": " (default): rotating offline refresh tokens.\r\n- "
+					},
+					{
+						"kind": "inline-tag",
+						"tag": "@link",
+						"text": "RefreshTokenMode.Online",
+						"target": 608
+					},
+					{
+						"kind": "text",
+						"text": ": non-rotating Online Refresh Tokens (ORTs)."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Configuration"
+							}
+						]
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+					"line": 16,
+					"character": 21
+				},
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+					"line": 20,
+					"character": 12
+				}
+			],
+			"type": {
+				"type": "indexedAccess",
+				"indexType": {
+					"type": "typeOperator",
+					"operator": "keyof",
+					"target": {
+						"type": "query",
+						"queryType": {
+							"type": "reference",
+							"target": 605,
+							"name": "RefreshTokenMode",
+							"package": "@auth0/auth0-spa-js"
+						}
+					}
+				},
+				"objectType": {
+					"type": "query",
+					"queryType": {
+						"type": "reference",
+						"target": 605,
+						"name": "RefreshTokenMode",
+						"package": "@auth0/auth0-spa-js"
+					}
+				}
+			}
+		},
+		{
+			"id": 590,
+			"name": "TokenEndpointResponse",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Tokens & Users"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 594,
+					"name": "access_token",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 724,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 596,
+					"name": "expires_in",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 726,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "number"
+					}
+				},
+				{
+					"id": 592,
+					"name": "id_token",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 722,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 595,
+					"name": "refresh_token",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 725,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 597,
+					"name": "scope",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 727,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 593,
+					"name": "token_type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 723,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						594,
+						596,
+						592,
+						595,
+						597,
+						593
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+					"line": 721,
+					"character": 12
+				}
+			]
+		},
+		{
+			"id": 557,
+			"name": "ResponseType",
+			"variant": "declaration",
+			"kind": 8,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "The types of responses expected from the authorization server.\r\n- "
+					},
+					{
+						"kind": "code",
+						"text": "`code`"
+					},
+					{
+						"kind": "text",
+						"text": ": used for the standard login flow.\r\n- "
+					},
+					{
+						"kind": "code",
+						"text": "`connect_code`"
+					},
+					{
+						"kind": "text",
+						"text": ": used for the connect account flow."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Configuration"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 558,
+					"name": "Code",
+					"variant": "declaration",
+					"kind": 16,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 436,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "code"
+					}
+				},
+				{
+					"id": 559,
+					"name": "ConnectCode",
+					"variant": "declaration",
+					"kind": 16,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+							"line": 437,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "connect_code"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Enumeration Members",
+					"children": [
+						558,
+						559
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+					"line": 435,
+					"character": 20
+				}
+			]
+		},
+		{
+			"id": 57,
+			"name": "Auth0Context",
+			"variant": "declaration",
+			"kind": 32,
+			"flags": {
+				"isConst": true
+			},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "The Auth0 Context"
+					},
+					{
+						"kind": "text",
+						"text": "\n\nType: [Auth0ContextInterface](/docs/sdk/react/interfaces/Auth0ContextInterface), [User](/docs/sdk/react/classes/User)"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Context"
+							}
+						]
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "src/auth0-context.tsx",
+					"line": 545,
+					"character": 6
+				}
+			],
+			"type": {
+				"type": "reference",
+				"target": {
+					"packageName": "@types/react",
+					"packagePath": "index.d.ts",
+					"qualifiedName": "React.Context"
+				},
+				"typeArguments": [
+					{
+						"type": "reference",
+						"target": 58,
+						"typeArguments": [
+							{
+								"type": "reference",
+								"target": 326,
+								"name": "User",
+								"package": "@auth0/auth0-spa-js"
+							}
+						],
+						"name": "Auth0ContextInterface",
+						"package": "@auth0/auth0-react"
+					}
+				],
+				"name": "Context",
+				"package": "@types/react",
+				"qualifiedName": "React.Context"
+			},
+			"defaultValue": "..."
+		},
+		{
+			"id": 605,
+			"name": "RefreshTokenMode",
+			"variant": "declaration",
+			"kind": 32,
+			"flags": {
+				"isConst": true
+			},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "The refresh-token variant used when "
+					},
+					{
+						"kind": "code",
+						"text": "`useRefreshTokens: true`"
+					},
+					{
+						"kind": "text",
+						"text": ".\r\n\r\n- "
+					},
+					{
+						"kind": "inline-tag",
+						"tag": "@link",
+						"text": "RefreshTokenMode.Offline",
+						"target": 607
+					},
+					{
+						"kind": "text",
+						"text": " (default): rotating offline refresh tokens.\r\n- "
+					},
+					{
+						"kind": "inline-tag",
+						"tag": "@link",
+						"text": "RefreshTokenMode.Online",
+						"target": 608
+					},
+					{
+						"kind": "text",
+						"text": ": non-rotating Online Refresh Tokens (ORTs)."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Configuration"
+							}
+						]
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+					"line": 16,
+					"character": 21
+				},
+				{
+					"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+					"line": 20,
+					"character": 12
+				}
+			],
+			"type": {
+				"type": "reflection",
+				"declaration": {
+					"id": 606,
+					"name": "__type",
+					"variant": "declaration",
+					"kind": 65536,
+					"flags": {},
+					"children": [
+						{
+							"id": 607,
+							"name": "Offline",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {
+								"isReadonly": true
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+									"line": 17,
+									"character": 13
+								}
+							],
+							"type": {
+								"type": "literal",
+								"value": "offline"
+							}
+						},
+						{
+							"id": 608,
+							"name": "Online",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {
+								"isReadonly": true
+							},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-spa-js/dist/typings/global.d.ts",
+									"line": 18,
+									"character": 13
+								}
+							],
+							"type": {
+								"type": "literal",
+								"value": "online"
+							}
+						}
+					],
+					"groups": [
+						{
+							"title": "Properties",
+							"children": [
+								607,
+								608
+							]
+						}
+					]
+				}
+			}
+		}
+	],
+	"groups": [
+		{
+			"title": "Enumerations",
+			"children": [
+				557
+			]
+		},
+		{
+			"title": "Classes",
+			"children": [
+				454,
+				560,
+				515,
+				367,
+				501,
+				371,
+				649,
+				636,
+				675,
+				610,
+				623,
+				400,
+				662,
+				471,
+				486,
+				717,
+				878,
+				703,
+				688,
+				710,
+				696,
+				417,
+				443,
+				430,
+				389,
+				528,
+				326
+			]
+		},
+		{
+			"title": "Interfaces",
+			"children": [
+				598,
+				58,
+				766,
+				236,
+				795,
+				799,
+				602,
+				787,
+				809,
+				776,
+				791,
+				779,
+				783,
+				869,
+				272,
+				260,
+				352,
+				283,
+				215,
+				263,
+				741,
+				836,
+				811,
+				256,
+				254,
+				541,
+				227,
+				731,
+				872,
+				803,
+				38,
+				45
+			]
+		},
+		{
+			"title": "Type Aliases",
+			"children": [
+				15,
+				5,
+				11,
+				7,
+				31,
+				867,
+				868,
+				388,
+				271,
+				552,
+				22,
+				579,
+				875,
+				876,
+				794,
+				877,
+				775,
+				733,
+				740,
+				774,
+				832,
+				828,
+				609,
+				590
+			]
+		},
+		{
+			"title": "Variables",
+			"children": [
+				57,
+				605
+			]
+		},
+		{
+			"title": "Functions",
+			"children": [
+				1,
+				23,
+				27,
+				33,
+				40
+			]
+		}
+	],
+	"categories": [
+		{
+			"title": "Getting Started",
+			"children": [
+				1,
+				15,
+				5,
+				11,
+				7
+			]
+		},
+		{
+			"title": "Hooks & HOCs",
+			"children": [
+				23,
+				27,
+				33,
+				40,
+				38,
+				45
+			]
+		},
+		{
+			"title": "Context",
+			"children": [
+				58,
+				31,
+				57
+			]
+		},
+		{
+			"title": "Configuration",
+			"children": [
+				236,
+				602,
+				271,
+				740,
+				609,
+				557,
+				605
+			]
+		},
+		{
+			"title": "Login & Logout",
+			"children": [
+				215,
+				263,
+				256,
+				254,
+				541,
+				227,
+				552,
+				22
+			]
+		},
+		{
+			"title": "Tokens & Users",
+			"children": [
+				326,
+				598,
+				272,
+				260,
+				283,
+				731,
+				579,
+				733,
+				590
+			]
+		},
+		{
+			"title": "Multi-Factor Authentication",
+			"children": [
+				766,
+				795,
+				799,
+				787,
+				809,
+				776,
+				791,
+				779,
+				783,
+				741,
+				803,
+				794,
+				775,
+				774
+			]
+		},
+		{
+			"title": "Passkeys",
+			"children": [
+				811,
+				832,
+				828
+			]
+		},
+		{
+			"title": "My Account",
+			"children": [
+				869,
+				836,
+				872,
+				867,
+				868,
+				875,
+				876,
+				877
+			]
+		},
+		{
+			"title": "Errors",
+			"children": [
+				454,
+				560,
+				515,
+				501,
+				649,
+				636,
+				675,
+				610,
+				623,
+				400,
+				662,
+				471,
+				486,
+				717,
+				878,
+				703,
+				688,
+				710,
+				696,
+				417,
+				443,
+				430,
+				389,
+				528
+			]
+		},
+		{
+			"title": "Caching",
+			"children": [
+				367,
+				371,
+				352,
+				388
+			]
+		}
+	],
+	"packageName": "@auth0/auth0-react",
+	"readme": [
+		{
+			"kind": "text",
+			"text": "![Auth0 SDK for React Single Page Applications](https://cdn.auth0.com/website/sdks/banners/auth0-react-banner.png)\n\n[![npm](https://img.shields.io/npm/v/@auth0/auth0-react.svg?style=flat)](https://www.npmjs.com/package/@auth0/auth0-react)\n[![codecov](https://img.shields.io/codecov/c/github/auth0/auth0-react/main.svg?style=flat)](https://codecov.io/gh/auth0/auth0-react)\n[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/auth0/auth0-react)\n![Downloads](https://img.shields.io/npm/dw/@auth0/auth0-react)\n[![License](https://img.shields.io/:license-mit-blue.svg?style=flat)](https://opensource.org/licenses/MIT)\n[![CircleCI](https://img.shields.io/circleci/build/github/auth0/auth0-react.svg?branch=main&style=flat)](https://circleci.com/gh/auth0/auth0-react)\n\n📚 [Documentation](#documentation) - 🚀 [Getting Started](#getting-started) - 💻 [API Reference](#api-reference) - 💬 [Feedback](#feedback)\n\n## Documentation\n\n- [Quickstart](https://auth0.com/docs/quickstart/spa/react) - our interactive guide for quickly adding login, logout and user information to a React app using Auth0.\n- [Sample App](https://github.com/auth0-samples/auth0-react-samples/tree/master/Sample-01) - a full-fledged React application integrated with Auth0.\n- [FAQs](https://github.com/auth0/auth0-react/blob/main/FAQ.md) - frequently asked questions about the auth0-react SDK.\n- [Examples](https://github.com/auth0/auth0-react/blob/main/EXAMPLES.md) - code samples for common React authentication scenario's.\n- [Docs site](https://www.auth0.com/docs) - explore our docs site and learn more about Auth0.\n\n## Getting started\n\n### Installation\n\nUsing [npm](https://npmjs.org/)\n\n"
+		},
+		{
+			"kind": "code",
+			"text": "```bash\nnpm install @auth0/auth0-react\n```"
+		},
+		{
+			"kind": "text",
+			"text": "\n\nUsing [yarn](https://yarnpkg.com/)\n\n"
+		},
+		{
+			"kind": "code",
+			"text": "```bash\nyarn add @auth0/auth0-react\n```"
+		},
+		{
+			"kind": "text",
+			"text": "\n\n### Configure Auth0\n\nCreate a **Single Page Application** in the [Auth0 Dashboard](https://manage.auth0.com/#/applications).\n\n> **If you're using an existing application**, verify that you have configured the following settings in your Single Page Application:\n>\n> - Click on the \"Settings\" tab of your application's page.\n> - Scroll down and click on the \"Show Advanced Settings\" link.\n> - Under \"Advanced Settings\", click on the \"OAuth\" tab.\n> - Ensure that \"JsonWebToken Signature Algorithm\" is set to "
+		},
+		{
+			"kind": "code",
+			"text": "`RS256`"
+		},
+		{
+			"kind": "text",
+			"text": " and that \"OIDC Conformant\" is enabled.\n\nNext, configure the following URLs for your application under the \"Application URIs\" section of the \"Settings\" page:\n\n- **Allowed Callback URLs**: "
+		},
+		{
+			"kind": "code",
+			"text": "`http://localhost:3000`"
+		},
+		{
+			"kind": "text",
+			"text": "\n- **Allowed Logout URLs**: "
+		},
+		{
+			"kind": "code",
+			"text": "`http://localhost:3000`"
+		},
+		{
+			"kind": "text",
+			"text": "\n- **Allowed Web Origins**: "
+		},
+		{
+			"kind": "code",
+			"text": "`http://localhost:3000`"
+		},
+		{
+			"kind": "text",
+			"text": "\n\n> These URLs should reflect the origins that your application is running on. **Allowed Callback URLs** may also include a path, depending on where you're handling the callback.\n\nTake note of the **Client ID** and **Domain** values under the \"Basic Information\" section. You'll need these values in the next step.\n\n### Configure the SDK\n\nConfigure the SDK by wrapping your application in "
+		},
+		{
+			"kind": "code",
+			"text": "`Auth0Provider`"
+		},
+		{
+			"kind": "text",
+			"text": ":\n\n"
+		},
+		{
+			"kind": "code",
+			"text": "```jsx\n// src/index.js\nimport React from 'react';\nimport { createRoot } from 'react-dom/client';\nimport { Auth0Provider } from '@auth0/auth0-react';\nimport App from './App';\n\nconst root = createRoot(document.getElementById('app'));\n\nroot.render(\n  <Auth0Provider\n    domain=\"YOUR_AUTH0_DOMAIN\"\n    clientId=\"YOUR_AUTH0_CLIENT_ID\"\n    authorizationParams={{\n      redirect_uri: window.location.origin,\n    }}\n  >\n    <App />\n  </Auth0Provider>\n);\n```"
+		},
+		{
+			"kind": "text",
+			"text": "\n\n<details>\n<summary>Instructions for React <18</summary>\n<br>\n\n"
+		},
+		{
+			"kind": "code",
+			"text": "```jsx\n// src/index.js\nimport React from 'react';\nimport ReactDOM from 'react-dom';\nimport { Auth0Provider } from '@auth0/auth0-react';\nimport App from './App';\n\nReactDOM.render(\n  <Auth0Provider\n    domain=\"YOUR_AUTH0_DOMAIN\"\n    clientId=\"YOUR_AUTH0_CLIENT_ID\"\n    authorizationParams={{\n      redirect_uri: window.location.origin,\n    }}\n  >\n    <App />\n  </Auth0Provider>,\n  document.getElementById('app')\n);\n```"
+		},
+		{
+			"kind": "text",
+			"text": "\n</details>\n\nUse the "
+		},
+		{
+			"kind": "code",
+			"text": "`useAuth0`"
+		},
+		{
+			"kind": "text",
+			"text": " hook in your components to access authentication state ("
+		},
+		{
+			"kind": "code",
+			"text": "`isLoading`"
+		},
+		{
+			"kind": "text",
+			"text": ", "
+		},
+		{
+			"kind": "code",
+			"text": "`isAuthenticated`"
+		},
+		{
+			"kind": "text",
+			"text": " and "
+		},
+		{
+			"kind": "code",
+			"text": "`user`"
+		},
+		{
+			"kind": "text",
+			"text": ") and authentication methods ("
+		},
+		{
+			"kind": "code",
+			"text": "`loginWithRedirect`"
+		},
+		{
+			"kind": "text",
+			"text": " and "
+		},
+		{
+			"kind": "code",
+			"text": "`logout`"
+		},
+		{
+			"kind": "text",
+			"text": "):\n\n"
+		},
+		{
+			"kind": "code",
+			"text": "```jsx\n// src/App.js\nimport React from 'react';\nimport { useAuth0 } from '@auth0/auth0-react';\n\nfunction App() {\n  const { isLoading, isAuthenticated, error, user, loginWithRedirect, logout } =\n    useAuth0();\n\n  if (isLoading) {\n    return <div>Loading...</div>;\n  }\n  if (error) {\n    return <div>Oops... {error.message}</div>;\n  }\n\n  if (isAuthenticated) {\n    return (\n      <div>\n        Hello {user.name}{' '}\n        <button onClick={() => logout({ logoutParams: { returnTo: window.location.origin } })}>\n          Log out\n        </button>\n      </div>\n    );\n  } else {\n    return <button onClick={() => loginWithRedirect()}>Log in</button>;\n  }\n}\n\nexport default App;\n```"
+		},
+		{
+			"kind": "text",
+			"text": "\n\nFor more code samples on how to integrate **auth0-react** SDK in your **React** application, have a look at our [examples](https://github.com/auth0/auth0-react/blob/main/EXAMPLES.md).\n\n## API reference\n\nExplore public API's available in auth0-react.\n\n- [Auth0Provider](https://auth0.github.io/auth0-react/functions/Auth0Provider.html)\n- [Auth0ProviderOptions](https://auth0.github.io/auth0-react/interfaces/Auth0ProviderOptions.html)\n- [useAuth0](https://auth0.github.io/auth0-react/functions/useAuth0.html)\n- [useAuth0Suspense](https://auth0.github.io/auth0-react/functions/useAuth0Suspense.html)\n- [withAuth0](https://auth0.github.io/auth0-react/functions/withAuth0.html)\n- [withAuthenticationRequired](https://auth0.github.io/auth0-react/functions/withAuthenticationRequired.html)\n\n## Feedback\n\n### Contributing\n\nWe appreciate feedback and contribution to this repo! Before you get started, please see the following:\n\n- [Auth0's general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)\n- [Auth0's code of conduct guidelines](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)\n- [This repo's contribution guide](https://github.com/auth0/auth0-react/blob/main/CONTRIBUTING.md)\n\n### Raise an issue\n\nTo provide feedback or report a bug, please [raise an issue on our issue tracker](https://github.com/auth0/auth0-react/issues).\n\n### Vulnerability Reporting\n\nPlease do not report security vulnerabilities on the public GitHub issue tracker. The [Responsible Disclosure Program](https://auth0.com/responsible-disclosure-policy) details the procedure for disclosing security issues.\n\n---\n\n<p align=\"center\">\n  <picture>\n    <source media=\"(prefers-color-scheme: light)\" srcset=\"https://cdn.auth0.com/website/sdks/logos/auth0_light_mode.png\"   width=\"150\">\n    <source media=\"(prefers-color-scheme: dark)\" srcset=\"https://cdn.auth0.com/website/sdks/logos/auth0_dark_mode.png\" width=\"150\">\n    <img alt=\"Auth0 Logo\" src=\"https://cdn.auth0.com/website/sdks/logos/auth0_light_mode.png\" width=\"150\">\n  </picture>\n</p>\n<p align=\"center\">Auth0 is an easy to implement, adaptable authentication and authorization platform. To learn more checkout <a href=\"https://auth0.com/why-auth0\">Why Auth0?</a></p>\n<p align=\"center\">\nThis project is licensed under the MIT license. See the <a href=\"https://github.com/auth0/auth0-react/blob/main/LICENSE\"> LICENSE</a> file for more info.</p>"
+		}
+	],
+	"symbolIdMap": {
+		"0": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/index.tsx",
+			"qualifiedName": ""
+		},
+		"1": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-provider.tsx",
+			"qualifiedName": "Auth0Provider"
+		},
+		"2": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-provider.tsx",
+			"qualifiedName": "Auth0Provider"
+		},
+		"3": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-provider.tsx",
+			"qualifiedName": "TUser"
+		},
+		"4": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-provider.tsx",
+			"qualifiedName": "opts"
+		},
+		"5": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-provider.tsx",
+			"qualifiedName": "Auth0ProviderOptions"
+		},
+		"6": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-provider.tsx",
+			"qualifiedName": "TUser"
+		},
+		"7": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-provider.tsx",
+			"qualifiedName": "Auth0ProviderWithConfigOptions"
+		},
+		"8": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-provider.tsx",
+			"qualifiedName": "__type"
+		},
+		"9": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-provider.tsx",
+			"qualifiedName": "__type.client"
+		},
+		"10": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-provider.tsx",
+			"qualifiedName": "TUser"
+		},
+		"11": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-provider.tsx",
+			"qualifiedName": "Auth0ProviderWithClientOptions"
+		},
+		"12": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-provider.tsx",
+			"qualifiedName": "__type"
+		},
+		"13": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-provider.tsx",
+			"qualifiedName": "__type.client"
+		},
+		"14": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-provider.tsx",
+			"qualifiedName": "TUser"
+		},
+		"15": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-provider.tsx",
+			"qualifiedName": "AppState"
+		},
+		"17": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-provider.tsx",
+			"qualifiedName": "__type.returnTo"
+		},
+		"18": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-provider.tsx",
+			"qualifiedName": "__type.connectedAccount"
+		},
+		"19": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-provider.tsx",
+			"qualifiedName": "__type.response_type"
+		},
+		"20": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-provider.tsx",
+			"qualifiedName": "__type.__index"
+		},
+		"22": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-provider.tsx",
+			"qualifiedName": "ConnectedAccount"
+		},
+		"23": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/use-auth0.tsx",
+			"qualifiedName": "useAuth0"
+		},
+		"24": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/use-auth0.tsx",
+			"qualifiedName": "useAuth0"
+		},
+		"25": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/use-auth0.tsx",
+			"qualifiedName": "TUser"
+		},
+		"26": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/use-auth0.tsx",
+			"qualifiedName": "context"
+		},
+		"27": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/use-auth0-suspense.tsx",
+			"qualifiedName": "useAuth0Suspense"
+		},
+		"28": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/use-auth0-suspense.tsx",
+			"qualifiedName": "useAuth0Suspense"
+		},
+		"29": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/use-auth0-suspense.tsx",
+			"qualifiedName": "TUser"
+		},
+		"30": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/use-auth0-suspense.tsx",
+			"qualifiedName": "context"
+		},
+		"31": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/use-auth0-suspense.tsx",
+			"qualifiedName": "Auth0SuspenseContextInterface"
+		},
+		"32": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/use-auth0-suspense.tsx",
+			"qualifiedName": "TUser"
+		},
+		"33": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/with-auth0.tsx",
+			"qualifiedName": "withAuth0"
+		},
+		"34": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/with-auth0.tsx",
+			"qualifiedName": "withAuth0"
+		},
+		"35": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/with-auth0.tsx",
+			"qualifiedName": "P"
+		},
+		"36": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/with-auth0.tsx",
+			"qualifiedName": "Component"
+		},
+		"37": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/with-auth0.tsx",
+			"qualifiedName": "context"
+		},
+		"38": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/with-auth0.tsx",
+			"qualifiedName": "WithAuth0Props"
+		},
+		"39": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/with-auth0.tsx",
+			"qualifiedName": "WithAuth0Props.auth0"
+		},
+		"40": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/with-authentication-required.tsx",
+			"qualifiedName": "withAuthenticationRequired"
+		},
+		"41": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/with-authentication-required.tsx",
+			"qualifiedName": "withAuthenticationRequired"
+		},
+		"42": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/with-authentication-required.tsx",
+			"qualifiedName": "P"
+		},
+		"43": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/with-authentication-required.tsx",
+			"qualifiedName": "Component"
+		},
+		"44": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/with-authentication-required.tsx",
+			"qualifiedName": "options"
+		},
+		"45": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/with-authentication-required.tsx",
+			"qualifiedName": "WithAuthenticationRequiredOptions"
+		},
+		"46": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/with-authentication-required.tsx",
+			"qualifiedName": "WithAuthenticationRequiredOptions.returnTo"
+		},
+		"47": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/with-authentication-required.tsx",
+			"qualifiedName": "__type"
+		},
+		"48": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/with-authentication-required.tsx",
+			"qualifiedName": "__type"
+		},
+		"49": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/with-authentication-required.tsx",
+			"qualifiedName": "WithAuthenticationRequiredOptions.onRedirecting"
+		},
+		"50": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/with-authentication-required.tsx",
+			"qualifiedName": "__type"
+		},
+		"51": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/with-authentication-required.tsx",
+			"qualifiedName": "__type"
+		},
+		"52": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/with-authentication-required.tsx",
+			"qualifiedName": "WithAuthenticationRequiredOptions.onBeforeAuthentication"
+		},
+		"53": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/with-authentication-required.tsx",
+			"qualifiedName": "__type"
+		},
+		"54": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/with-authentication-required.tsx",
+			"qualifiedName": "__type"
+		},
+		"55": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/with-authentication-required.tsx",
+			"qualifiedName": "WithAuthenticationRequiredOptions.loginOptions"
+		},
+		"56": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/with-authentication-required.tsx",
+			"qualifiedName": "WithAuthenticationRequiredOptions.context"
+		},
+		"57": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "Auth0Context"
+		},
+		"58": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "Auth0ContextInterface"
+		},
+		"59": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "Auth0ContextInterface.TUser"
+		},
+		"60": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "Auth0ContextInterface.getAccessTokenSilently"
+		},
+		"61": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "__type"
+		},
+		"62": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "__type"
+		},
+		"63": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "options"
+		},
+		"64": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "__type"
+		},
+		"65": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "__type.detailedResponse"
+		},
+		"66": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "__type"
+		},
+		"67": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "options"
+		},
+		"68": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "__type"
+		},
+		"69": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "options"
+		},
+		"70": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "Auth0ContextInterface.getAccessTokenWithPopup"
+		},
+		"71": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "__type"
+		},
+		"72": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "__type"
+		},
+		"73": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "options"
+		},
+		"74": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "config"
+		},
+		"75": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "Auth0ContextInterface.getIdTokenClaims"
+		},
+		"76": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "__type"
+		},
+		"77": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "__type"
+		},
+		"78": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "Auth0ContextInterface.loginWithCustomTokenExchange"
+		},
+		"79": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "__type"
+		},
+		"80": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "__type"
+		},
+		"81": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "options"
+		},
+		"82": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "Auth0ContextInterface.customTokenExchange"
+		},
+		"83": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "__type"
+		},
+		"84": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "__type"
+		},
+		"85": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "options"
+		},
+		"86": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "Auth0ContextInterface.exchangeToken"
+		},
+		"87": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "__type"
+		},
+		"88": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "__type"
+		},
+		"89": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "options"
+		},
+		"90": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "Auth0ContextInterface.loginWithRedirect"
+		},
+		"91": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "__type"
+		},
+		"92": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "__type"
+		},
+		"93": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "options"
+		},
+		"94": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "Auth0ContextInterface.loginWithPopup"
+		},
+		"95": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "__type"
+		},
+		"96": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "__type"
+		},
+		"97": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "options"
+		},
+		"98": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "config"
+		},
+		"99": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "Auth0ContextInterface.connectAccountWithRedirect"
+		},
+		"100": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "__type"
+		},
+		"101": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "__type"
+		},
+		"102": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "options"
+		},
+		"103": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "Auth0ContextInterface.logout"
+		},
+		"104": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "__type"
+		},
+		"105": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "__type"
+		},
+		"106": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "options"
+		},
+		"107": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "Auth0ContextInterface.revokeRefreshToken"
+		},
+		"108": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "__type"
+		},
+		"109": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "__type"
+		},
+		"110": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "options"
+		},
+		"111": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "Auth0ContextInterface.handleRedirectCallback"
+		},
+		"112": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "__type"
+		},
+		"113": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "__type"
+		},
+		"114": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "url"
+		},
+		"115": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "Auth0ContextInterface.getDpopNonce"
+		},
+		"116": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/Auth0Client.d.ts",
+			"qualifiedName": "Auth0Client.getDpopNonce"
+		},
+		"117": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/Auth0Client.d.ts",
+			"qualifiedName": "Auth0Client.getDpopNonce"
+		},
+		"118": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/Auth0Client.d.ts",
+			"qualifiedName": "id"
+		},
+		"119": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "Auth0ContextInterface.setDpopNonce"
+		},
+		"120": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/Auth0Client.d.ts",
+			"qualifiedName": "Auth0Client.setDpopNonce"
+		},
+		"121": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/Auth0Client.d.ts",
+			"qualifiedName": "Auth0Client.setDpopNonce"
+		},
+		"122": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/Auth0Client.d.ts",
+			"qualifiedName": "nonce"
+		},
+		"123": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/Auth0Client.d.ts",
+			"qualifiedName": "id"
+		},
+		"124": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "Auth0ContextInterface.generateDpopProof"
+		},
+		"125": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/Auth0Client.d.ts",
+			"qualifiedName": "Auth0Client.generateDpopProof"
+		},
+		"126": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/Auth0Client.d.ts",
+			"qualifiedName": "Auth0Client.generateDpopProof"
+		},
+		"127": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/Auth0Client.d.ts",
+			"qualifiedName": "params"
+		},
+		"128": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/Auth0Client.d.ts",
+			"qualifiedName": "__type"
+		},
+		"129": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/Auth0Client.d.ts",
+			"qualifiedName": "__type.url"
+		},
+		"130": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/Auth0Client.d.ts",
+			"qualifiedName": "__type.method"
+		},
+		"131": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/Auth0Client.d.ts",
+			"qualifiedName": "__type.nonce"
+		},
+		"132": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/Auth0Client.d.ts",
+			"qualifiedName": "__type.accessToken"
+		},
+		"133": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "Auth0ContextInterface.createFetcher"
+		},
+		"134": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/Auth0Client.d.ts",
+			"qualifiedName": "Auth0Client.createFetcher"
+		},
+		"135": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/Auth0Client.d.ts",
+			"qualifiedName": "Auth0Client.createFetcher"
+		},
+		"136": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/Auth0Client.d.ts",
+			"qualifiedName": "TOutput"
+		},
+		"137": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/Auth0Client.d.ts",
+			"qualifiedName": "config"
+		},
+		"138": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "Auth0ContextInterface.getConfiguration"
+		},
+		"139": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/Auth0Client.d.ts",
+			"qualifiedName": "Auth0Client.getConfiguration"
+		},
+		"140": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/Auth0Client.d.ts",
+			"qualifiedName": "Auth0Client.getConfiguration"
+		},
+		"141": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "Auth0ContextInterface.mfa"
+		},
+		"142": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "Auth0ContextInterface.passkey"
+		},
+		"143": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "Auth0ContextInterface.myAccount"
+		},
+		"145": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth-state.tsx",
+			"qualifiedName": "AuthState.error"
+		},
+		"146": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth-state.tsx",
+			"qualifiedName": "AuthState.isAuthenticated"
+		},
+		"147": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth-state.tsx",
+			"qualifiedName": "AuthState.isLoading"
+		},
+		"148": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth-state.tsx",
+			"qualifiedName": "AuthState.user"
+		},
+		"215": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "LogoutOptions"
+		},
+		"216": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "clientId"
+		},
+		"217": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "openUrl"
+		},
+		"218": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "__type"
+		},
+		"219": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "__type"
+		},
+		"220": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "url"
+		},
+		"221": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "logoutParams"
+		},
+		"222": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "__type"
+		},
+		"223": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "__type.federated"
+		},
+		"224": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "__type.returnTo"
+		},
+		"225": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "__type.__index"
+		},
+		"227": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "RedirectLoginOptions"
+		},
+		"228": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/auth0-context.tsx",
+			"qualifiedName": "RedirectLoginOptions.TAppState"
+		},
+		"229": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "appState"
+		},
+		"230": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "authorizationParams"
+		},
+		"231": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "openUrl"
+		},
+		"232": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "__type"
+		},
+		"233": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "__type"
+		},
+		"234": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "url"
+		},
+		"235": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "fragment"
+		},
+		"236": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "AuthorizationParams"
+		},
+		"237": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "AuthorizationParams.display"
+		},
+		"238": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "AuthorizationParams.prompt"
+		},
+		"239": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "AuthorizationParams.max_age"
+		},
+		"240": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "AuthorizationParams.ui_locales"
+		},
+		"241": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "AuthorizationParams.id_token_hint"
+		},
+		"242": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "AuthorizationParams.screen_hint"
+		},
+		"243": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "AuthorizationParams.login_hint"
+		},
+		"244": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "AuthorizationParams.acr_values"
+		},
+		"245": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "AuthorizationParams.scope"
+		},
+		"246": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "AuthorizationParams.audience"
+		},
+		"247": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "AuthorizationParams.connection"
+		},
+		"248": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "AuthorizationParams.organization"
+		},
+		"249": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "AuthorizationParams.invitation"
+		},
+		"250": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "AuthorizationParams.redirect_uri"
+		},
+		"251": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "AuthorizationParams.session_transfer_token"
+		},
+		"252": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "AuthorizationParams.__index"
+		},
+		"254": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "PopupLoginOptions"
+		},
+		"255": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "BaseLoginOptions.authorizationParams"
+		},
+		"256": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "PopupConfigOptions"
+		},
+		"257": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "PopupConfigOptions.timeoutInSeconds"
+		},
+		"258": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "PopupConfigOptions.popup"
+		},
+		"259": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "PopupConfigOptions.closePopup"
+		},
+		"260": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "GetTokenWithPopupOptions"
+		},
+		"261": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "GetTokenWithPopupOptions.cacheMode"
+		},
+		"262": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "BaseLoginOptions.authorizationParams"
+		},
+		"263": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "LogoutUrlOptions"
+		},
+		"264": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "LogoutUrlOptions.clientId"
+		},
+		"265": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "LogoutUrlOptions.logoutParams"
+		},
+		"266": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "__type"
+		},
+		"267": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "__type.federated"
+		},
+		"268": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "__type.returnTo"
+		},
+		"269": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "__type.__index"
+		},
+		"271": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "CacheLocation"
+		},
+		"272": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "GetTokenSilentlyOptions"
+		},
+		"273": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "GetTokenSilentlyOptions.cacheMode"
+		},
+		"274": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "GetTokenSilentlyOptions.authorizationParams"
+		},
+		"275": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "__type"
+		},
+		"276": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "__type.redirect_uri"
+		},
+		"277": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "__type.scope"
+		},
+		"278": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "__type.audience"
+		},
+		"279": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "__type.__index"
+		},
+		"281": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "GetTokenSilentlyOptions.timeoutInSeconds"
+		},
+		"282": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "GetTokenSilentlyOptions.detailedResponse"
+		},
+		"283": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken"
+		},
+		"284": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.__raw"
+		},
+		"285": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.name"
+		},
+		"286": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.given_name"
+		},
+		"287": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.family_name"
+		},
+		"288": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.middle_name"
+		},
+		"289": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.nickname"
+		},
+		"290": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.preferred_username"
+		},
+		"291": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.profile"
+		},
+		"292": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.picture"
+		},
+		"293": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.website"
+		},
+		"294": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.email"
+		},
+		"295": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.email_verified"
+		},
+		"296": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.gender"
+		},
+		"297": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.birthdate"
+		},
+		"298": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.zoneinfo"
+		},
+		"299": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.locale"
+		},
+		"300": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.phone_number"
+		},
+		"301": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.phone_number_verified"
+		},
+		"302": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.address"
+		},
+		"303": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.updated_at"
+		},
+		"304": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.iss"
+		},
+		"305": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.aud"
+		},
+		"306": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.exp"
+		},
+		"307": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.nbf"
+		},
+		"308": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.iat"
+		},
+		"309": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.jti"
+		},
+		"310": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.azp"
+		},
+		"311": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.nonce"
+		},
+		"312": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.auth_time"
+		},
+		"313": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.at_hash"
+		},
+		"314": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.c_hash"
+		},
+		"315": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.acr"
+		},
+		"316": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.amr"
+		},
+		"317": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.sub_jwk"
+		},
+		"318": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.cnf"
+		},
+		"319": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.sid"
+		},
+		"320": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.org_id"
+		},
+		"321": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.org_name"
+		},
+		"322": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.session_expiry"
+		},
+		"323": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.act"
+		},
+		"324": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "IdToken.__index"
+		},
+		"326": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "User"
+		},
+		"329": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "User.name"
+		},
+		"330": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "User.given_name"
+		},
+		"331": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "User.family_name"
+		},
+		"332": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "User.middle_name"
+		},
+		"333": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "User.nickname"
+		},
+		"334": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "User.preferred_username"
+		},
+		"335": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "User.profile"
+		},
+		"336": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "User.picture"
+		},
+		"337": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "User.website"
+		},
+		"338": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "User.email"
+		},
+		"339": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "User.email_verified"
+		},
+		"340": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "User.gender"
+		},
+		"341": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "User.birthdate"
+		},
+		"342": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "User.zoneinfo"
+		},
+		"343": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "User.locale"
+		},
+		"344": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "User.phone_number"
+		},
+		"345": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "User.phone_number_verified"
+		},
+		"346": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "User.address"
+		},
+		"347": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "User.updated_at"
+		},
+		"348": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "User.sub"
+		},
+		"349": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "User.act"
+		},
+		"350": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "User.__index"
+		},
+		"352": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/shared.d.ts",
+			"qualifiedName": "ICache"
+		},
+		"353": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/shared.d.ts",
+			"qualifiedName": "ICache.set"
+		},
+		"354": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/shared.d.ts",
+			"qualifiedName": "ICache.set"
+		},
+		"355": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/shared.d.ts",
+			"qualifiedName": "T"
+		},
+		"356": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/shared.d.ts",
+			"qualifiedName": "key"
+		},
+		"357": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/shared.d.ts",
+			"qualifiedName": "entry"
+		},
+		"358": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/shared.d.ts",
+			"qualifiedName": "ICache.get"
+		},
+		"359": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/shared.d.ts",
+			"qualifiedName": "ICache.get"
+		},
+		"360": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/shared.d.ts",
+			"qualifiedName": "T"
+		},
+		"361": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/shared.d.ts",
+			"qualifiedName": "key"
+		},
+		"362": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/shared.d.ts",
+			"qualifiedName": "ICache.remove"
+		},
+		"363": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/shared.d.ts",
+			"qualifiedName": "ICache.remove"
+		},
+		"364": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/shared.d.ts",
+			"qualifiedName": "key"
+		},
+		"365": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/shared.d.ts",
+			"qualifiedName": "ICache.allKeys"
+		},
+		"366": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/shared.d.ts",
+			"qualifiedName": "ICache.allKeys"
+		},
+		"367": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/cache-memory.d.ts",
+			"qualifiedName": "InMemoryCache"
+		},
+		"370": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/cache-memory.d.ts",
+			"qualifiedName": "InMemoryCache.enclosedCache"
+		},
+		"371": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/cache-localstorage.d.ts",
+			"qualifiedName": "LocalStorageCache"
+		},
+		"374": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/cache-localstorage.d.ts",
+			"qualifiedName": "LocalStorageCache.set"
+		},
+		"375": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/cache-localstorage.d.ts",
+			"qualifiedName": "LocalStorageCache.set"
+		},
+		"376": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/cache-localstorage.d.ts",
+			"qualifiedName": "T"
+		},
+		"377": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/cache-localstorage.d.ts",
+			"qualifiedName": "key"
+		},
+		"378": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/cache-localstorage.d.ts",
+			"qualifiedName": "entry"
+		},
+		"379": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/cache-localstorage.d.ts",
+			"qualifiedName": "LocalStorageCache.get"
+		},
+		"380": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/cache-localstorage.d.ts",
+			"qualifiedName": "LocalStorageCache.get"
+		},
+		"381": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/cache-localstorage.d.ts",
+			"qualifiedName": "T"
+		},
+		"382": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/cache-localstorage.d.ts",
+			"qualifiedName": "key"
+		},
+		"383": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/cache-localstorage.d.ts",
+			"qualifiedName": "LocalStorageCache.remove"
+		},
+		"384": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/cache-localstorage.d.ts",
+			"qualifiedName": "LocalStorageCache.remove"
+		},
+		"385": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/cache-localstorage.d.ts",
+			"qualifiedName": "key"
+		},
+		"386": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/cache-localstorage.d.ts",
+			"qualifiedName": "LocalStorageCache.allKeys"
+		},
+		"387": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/cache-localstorage.d.ts",
+			"qualifiedName": "LocalStorageCache.allKeys"
+		},
+		"388": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/cache/shared.d.ts",
+			"qualifiedName": "Cacheable"
+		},
+		"389": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "TimeoutError"
+		},
+		"390": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"391": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"392": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__0"
+		},
+		"393": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type"
+		},
+		"394": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type.error"
+		},
+		"395": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"396": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "TimeoutError.__constructor"
+		},
+		"397": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "TimeoutError"
+		},
+		"398": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"399": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"400": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "MfaRequiredError"
+		},
+		"401": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"402": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"403": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__0"
+		},
+		"404": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type"
+		},
+		"405": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type.error"
+		},
+		"406": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"407": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "MfaRequiredError.__constructor"
+		},
+		"408": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "MfaRequiredError"
+		},
+		"409": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "error"
+		},
+		"410": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "error_description"
+		},
+		"411": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "mfa_token"
+		},
+		"412": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "mfa_requirements"
+		},
+		"413": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "MfaRequiredError.mfa_token"
+		},
+		"414": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "MfaRequiredError.mfa_requirements"
+		},
+		"415": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"416": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"417": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "PopupCancelledError"
+		},
+		"418": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"419": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"420": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__0"
+		},
+		"421": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type"
+		},
+		"422": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type.error"
+		},
+		"423": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"424": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "PopupCancelledError.__constructor"
+		},
+		"425": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "PopupCancelledError"
+		},
+		"426": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "popup"
+		},
+		"427": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "PopupCancelledError.popup"
+		},
+		"428": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"429": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"430": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "PopupTimeoutError"
+		},
+		"431": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"432": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"433": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__0"
+		},
+		"434": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type"
+		},
+		"435": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type.error"
+		},
+		"436": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"437": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "PopupTimeoutError.__constructor"
+		},
+		"438": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "PopupTimeoutError"
+		},
+		"439": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "popup"
+		},
+		"440": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "PopupTimeoutError.popup"
+		},
+		"441": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"442": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"443": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "PopupOpenError"
+		},
+		"444": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"445": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"446": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__0"
+		},
+		"447": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type"
+		},
+		"448": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type.error"
+		},
+		"449": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"450": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "PopupOpenError.__constructor"
+		},
+		"451": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "PopupOpenError"
+		},
+		"452": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"453": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"454": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "AuthenticationError"
+		},
+		"455": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"456": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"457": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__0"
+		},
+		"458": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type"
+		},
+		"459": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type.error"
+		},
+		"460": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"461": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "AuthenticationError.__constructor"
+		},
+		"462": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "AuthenticationError"
+		},
+		"463": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "error"
+		},
+		"464": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "error_description"
+		},
+		"465": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "state"
+		},
+		"466": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "appState"
+		},
+		"467": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "AuthenticationError.state"
+		},
+		"468": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "AuthenticationError.appState"
+		},
+		"469": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"470": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"471": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "MissingRefreshTokenError"
+		},
+		"472": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"473": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"474": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__0"
+		},
+		"475": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type"
+		},
+		"476": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type.error"
+		},
+		"477": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"478": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "MissingRefreshTokenError.__constructor"
+		},
+		"479": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "MissingRefreshTokenError"
+		},
+		"480": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "audience"
+		},
+		"481": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "scope"
+		},
+		"482": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "MissingRefreshTokenError.audience"
+		},
+		"483": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "MissingRefreshTokenError.scope"
+		},
+		"484": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"485": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"486": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "MissingScopesError"
+		},
+		"487": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"488": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"489": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__0"
+		},
+		"490": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type"
+		},
+		"491": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type.error"
+		},
+		"492": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"493": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "MissingScopesError.__constructor"
+		},
+		"494": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "MissingScopesError"
+		},
+		"495": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "audience"
+		},
+		"496": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "scope"
+		},
+		"497": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "MissingScopesError.audience"
+		},
+		"498": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "MissingScopesError.scope"
+		},
+		"499": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"500": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"501": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "InvalidConfigurationError"
+		},
+		"502": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"503": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"504": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__0"
+		},
+		"505": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type"
+		},
+		"506": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type.error"
+		},
+		"507": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"508": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "InvalidConfigurationError.__constructor"
+		},
+		"509": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "InvalidConfigurationError"
+		},
+		"510": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "message"
+		},
+		"511": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "suggestion"
+		},
+		"512": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "InvalidConfigurationError.suggestion"
+		},
+		"513": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"514": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"515": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError"
+		},
+		"516": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"517": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"518": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__0"
+		},
+		"519": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type"
+		},
+		"520": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type.error"
+		},
+		"521": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"522": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.__constructor"
+		},
+		"523": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError"
+		},
+		"524": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "error"
+		},
+		"525": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "error_description"
+		},
+		"526": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"527": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"528": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "UseDpopNonceError"
+		},
+		"529": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"530": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"531": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__0"
+		},
+		"532": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type"
+		},
+		"533": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type.error"
+		},
+		"534": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"535": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "UseDpopNonceError.__constructor"
+		},
+		"536": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "UseDpopNonceError"
+		},
+		"537": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "newDpopNonce"
+		},
+		"538": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "UseDpopNonceError.newDpopNonce"
+		},
+		"539": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"540": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"541": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "RedirectConnectAccountOptions"
+		},
+		"542": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "RedirectConnectAccountOptions.TAppState"
+		},
+		"543": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "RedirectConnectAccountOptions.connection"
+		},
+		"544": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "RedirectConnectAccountOptions.scopes"
+		},
+		"545": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "RedirectConnectAccountOptions.authorization_params"
+		},
+		"546": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "RedirectConnectAccountOptions.redirectUri"
+		},
+		"547": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "RedirectConnectAccountOptions.appState"
+		},
+		"548": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "RedirectConnectAccountOptions.openUrl"
+		},
+		"549": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "__type"
+		},
+		"550": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "__type"
+		},
+		"551": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "url"
+		},
+		"552": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "ConnectAccountRedirectResult"
+		},
+		"553": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "__type"
+		},
+		"554": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "__type.appState"
+		},
+		"555": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "__type.response_type"
+		},
+		"556": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "TAppState"
+		},
+		"557": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "ResponseType"
+		},
+		"558": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "ResponseType.Code"
+		},
+		"559": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "ResponseType.ConnectCode"
+		},
+		"560": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "ConnectError"
+		},
+		"561": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"562": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"563": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__0"
+		},
+		"564": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type"
+		},
+		"565": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type.error"
+		},
+		"566": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"567": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "ConnectError.__constructor"
+		},
+		"568": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "ConnectError"
+		},
+		"569": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "error"
+		},
+		"570": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "error_description"
+		},
+		"571": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "connection"
+		},
+		"572": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "state"
+		},
+		"573": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "appState"
+		},
+		"574": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "ConnectError.connection"
+		},
+		"575": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "ConnectError.state"
+		},
+		"576": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "ConnectError.appState"
+		},
+		"577": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"578": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"579": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/TokenExchange.d.ts",
+			"qualifiedName": "CustomTokenExchangeOptions"
+		},
+		"581": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/TokenExchange.d.ts",
+			"qualifiedName": "__type.subject_token_type"
+		},
+		"582": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/TokenExchange.d.ts",
+			"qualifiedName": "__type.subject_token"
+		},
+		"583": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/TokenExchange.d.ts",
+			"qualifiedName": "__type.audience"
+		},
+		"584": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/TokenExchange.d.ts",
+			"qualifiedName": "__type.scope"
+		},
+		"585": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/TokenExchange.d.ts",
+			"qualifiedName": "__type.organization"
+		},
+		"586": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/TokenExchange.d.ts",
+			"qualifiedName": "__type.actor_token"
+		},
+		"587": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/TokenExchange.d.ts",
+			"qualifiedName": "__type.actor_token_type"
+		},
+		"588": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/TokenExchange.d.ts",
+			"qualifiedName": "__type.__index"
+		},
+		"590": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "TokenEndpointResponse"
+		},
+		"592": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "__type.id_token"
+		},
+		"593": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "__type.token_type"
+		},
+		"594": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "__type.access_token"
+		},
+		"595": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "__type.refresh_token"
+		},
+		"596": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "__type.expires_in"
+		},
+		"597": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "__type.scope"
+		},
+		"598": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "ActClaim"
+		},
+		"599": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "ActClaim.sub"
+		},
+		"600": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "ActClaim.__index"
+		},
+		"602": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "ClientConfiguration"
+		},
+		"603": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "ClientConfiguration.domain"
+		},
+		"604": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "ClientConfiguration.clientId"
+		},
+		"605": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "RefreshTokenMode"
+		},
+		"606": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "__type"
+		},
+		"607": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "__type.Offline"
+		},
+		"608": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "__type.Online"
+		},
+		"609": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "RefreshTokenMode"
+		},
+		"610": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "MfaError"
+		},
+		"611": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "MfaError.fromPayload"
+		},
+		"612": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "MfaError.fromPayload"
+		},
+		"613": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "__0"
+		},
+		"614": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "__type"
+		},
+		"615": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "__type.error"
+		},
+		"616": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"617": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "MfaError.__constructor"
+		},
+		"618": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "MfaError"
+		},
+		"619": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "error"
+		},
+		"620": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "error_description"
+		},
+		"621": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"622": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"623": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "MfaListAuthenticatorsError"
+		},
+		"624": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "MfaError.fromPayload"
+		},
+		"625": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "MfaError.fromPayload"
+		},
+		"626": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "__0"
+		},
+		"627": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "__type"
+		},
+		"628": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "__type.error"
+		},
+		"629": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"630": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "MfaListAuthenticatorsError.__constructor"
+		},
+		"631": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "MfaListAuthenticatorsError"
+		},
+		"632": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "error"
+		},
+		"633": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "error_description"
+		},
+		"634": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"635": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"636": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "MfaEnrollmentError"
+		},
+		"637": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "MfaError.fromPayload"
+		},
+		"638": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "MfaError.fromPayload"
+		},
+		"639": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "__0"
+		},
+		"640": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "__type"
+		},
+		"641": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "__type.error"
+		},
+		"642": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"643": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "MfaEnrollmentError.__constructor"
+		},
+		"644": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "MfaEnrollmentError"
+		},
+		"645": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "error"
+		},
+		"646": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "error_description"
+		},
+		"647": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"648": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"649": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "MfaChallengeError"
+		},
+		"650": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "MfaError.fromPayload"
+		},
+		"651": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "MfaError.fromPayload"
+		},
+		"652": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "__0"
+		},
+		"653": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "__type"
+		},
+		"654": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "__type.error"
+		},
+		"655": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"656": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "MfaChallengeError.__constructor"
+		},
+		"657": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "MfaChallengeError"
+		},
+		"658": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "error"
+		},
+		"659": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "error_description"
+		},
+		"660": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"661": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"662": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "MfaVerifyError"
+		},
+		"663": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "MfaError.fromPayload"
+		},
+		"664": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "MfaError.fromPayload"
+		},
+		"665": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "__0"
+		},
+		"666": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "__type"
+		},
+		"667": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "__type.error"
+		},
+		"668": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"669": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "MfaVerifyError.__constructor"
+		},
+		"670": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "MfaVerifyError"
+		},
+		"671": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "error"
+		},
+		"672": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "error_description"
+		},
+		"673": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"674": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"675": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "MfaEnrollmentFactorsError"
+		},
+		"676": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "MfaError.fromPayload"
+		},
+		"677": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "MfaError.fromPayload"
+		},
+		"678": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "__0"
+		},
+		"679": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "__type"
+		},
+		"680": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "__type.error"
+		},
+		"681": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"682": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "MfaEnrollmentFactorsError.__constructor"
+		},
+		"683": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "MfaEnrollmentFactorsError"
+		},
+		"684": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "error"
+		},
+		"685": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/errors.d.ts",
+			"qualifiedName": "error_description"
+		},
+		"686": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"687": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/errors.d.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"688": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/passkey/errors.d.ts",
+			"qualifiedName": "PasskeyError"
+		},
+		"689": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/passkey/errors.d.ts",
+			"qualifiedName": "PasskeyError.__constructor"
+		},
+		"690": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/passkey/errors.d.ts",
+			"qualifiedName": "PasskeyError"
+		},
+		"691": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/passkey/errors.d.ts",
+			"qualifiedName": "code"
+		},
+		"692": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/passkey/errors.d.ts",
+			"qualifiedName": "message"
+		},
+		"693": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/passkey/errors.d.ts",
+			"qualifiedName": "cause"
+		},
+		"694": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/passkey/errors.d.ts",
+			"qualifiedName": "PasskeyError.code"
+		},
+		"695": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/passkey/errors.d.ts",
+			"qualifiedName": "PasskeyError.cause"
+		},
+		"696": {
+			"packageName": "@auth0/auth0-auth-js",
+			"packagePath": "dist/index.d.ts",
+			"qualifiedName": "PasskeyRegisterError"
+		},
+		"697": {
+			"packageName": "@auth0/auth0-auth-js",
+			"packagePath": "dist/index.d.ts",
+			"qualifiedName": "PasskeyRegisterError.__constructor"
+		},
+		"698": {
+			"packageName": "@auth0/auth0-auth-js",
+			"packagePath": "dist/index.d.ts",
+			"qualifiedName": "PasskeyRegisterError"
+		},
+		"699": {
+			"packageName": "@auth0/auth0-auth-js",
+			"packagePath": "dist/index.d.ts",
+			"qualifiedName": "message"
+		},
+		"700": {
+			"packageName": "@auth0/auth0-auth-js",
+			"packagePath": "dist/index.d.ts",
+			"qualifiedName": "cause"
+		},
+		"701": {
+			"packageName": "@auth0/auth0-auth-js",
+			"packagePath": "dist/index.d.ts",
+			"qualifiedName": "PasskeyError.cause"
+		},
+		"702": {
+			"packageName": "@auth0/auth0-auth-js",
+			"packagePath": "dist/index.d.ts",
+			"qualifiedName": "PasskeyError.code"
+		},
+		"703": {
+			"packageName": "@auth0/auth0-auth-js",
+			"packagePath": "dist/index.d.ts",
+			"qualifiedName": "PasskeyChallengeError"
+		},
+		"704": {
+			"packageName": "@auth0/auth0-auth-js",
+			"packagePath": "dist/index.d.ts",
+			"qualifiedName": "PasskeyChallengeError.__constructor"
+		},
+		"705": {
+			"packageName": "@auth0/auth0-auth-js",
+			"packagePath": "dist/index.d.ts",
+			"qualifiedName": "PasskeyChallengeError"
+		},
+		"706": {
+			"packageName": "@auth0/auth0-auth-js",
+			"packagePath": "dist/index.d.ts",
+			"qualifiedName": "message"
+		},
+		"707": {
+			"packageName": "@auth0/auth0-auth-js",
+			"packagePath": "dist/index.d.ts",
+			"qualifiedName": "cause"
+		},
+		"708": {
+			"packageName": "@auth0/auth0-auth-js",
+			"packagePath": "dist/index.d.ts",
+			"qualifiedName": "PasskeyError.cause"
+		},
+		"709": {
+			"packageName": "@auth0/auth0-auth-js",
+			"packagePath": "dist/index.d.ts",
+			"qualifiedName": "PasskeyError.code"
+		},
+		"710": {
+			"packageName": "@auth0/auth0-auth-js",
+			"packagePath": "dist/index.d.ts",
+			"qualifiedName": "PasskeyGetTokenError"
+		},
+		"711": {
+			"packageName": "@auth0/auth0-auth-js",
+			"packagePath": "dist/index.d.ts",
+			"qualifiedName": "PasskeyGetTokenError.__constructor"
+		},
+		"712": {
+			"packageName": "@auth0/auth0-auth-js",
+			"packagePath": "dist/index.d.ts",
+			"qualifiedName": "PasskeyGetTokenError"
+		},
+		"713": {
+			"packageName": "@auth0/auth0-auth-js",
+			"packagePath": "dist/index.d.ts",
+			"qualifiedName": "message"
+		},
+		"714": {
+			"packageName": "@auth0/auth0-auth-js",
+			"packagePath": "dist/index.d.ts",
+			"qualifiedName": "cause"
+		},
+		"715": {
+			"packageName": "@auth0/auth0-auth-js",
+			"packagePath": "dist/index.d.ts",
+			"qualifiedName": "PasskeyGetTokenError.cause"
+		},
+		"716": {
+			"packageName": "@auth0/auth0-auth-js",
+			"packagePath": "dist/index.d.ts",
+			"qualifiedName": "PasskeyError.code"
+		},
+		"717": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "MyAccountApiError"
+		},
+		"718": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "MyAccountApiError.__constructor"
+		},
+		"719": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "MyAccountApiError"
+		},
+		"720": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "__0"
+		},
+		"721": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "MyAccountApiError.type"
+		},
+		"722": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "MyAccountApiError.status"
+		},
+		"723": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "MyAccountApiError.title"
+		},
+		"724": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "MyAccountApiError.detail"
+		},
+		"725": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "MyAccountApiError.validation_errors"
+		},
+		"726": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/types.d.ts",
+			"qualifiedName": "__type"
+		},
+		"727": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/types.d.ts",
+			"qualifiedName": "__type.detail"
+		},
+		"728": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/types.d.ts",
+			"qualifiedName": "__type.field"
+		},
+		"729": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/types.d.ts",
+			"qualifiedName": "__type.pointer"
+		},
+		"730": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/types.d.ts",
+			"qualifiedName": "__type.source"
+		},
+		"731": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "RevokeRefreshTokenOptions"
+		},
+		"732": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "RevokeRefreshTokenOptions.audience"
+		},
+		"733": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/fetcher.d.ts",
+			"qualifiedName": "FetcherConfig"
+		},
+		"735": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/fetcher.d.ts",
+			"qualifiedName": "__type.getAccessToken"
+		},
+		"736": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/fetcher.d.ts",
+			"qualifiedName": "__type.baseUrl"
+		},
+		"737": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/fetcher.d.ts",
+			"qualifiedName": "__type.fetch"
+		},
+		"738": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/fetcher.d.ts",
+			"qualifiedName": "__type.dpopNonceId"
+		},
+		"739": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/fetcher.d.ts",
+			"qualifiedName": "TOutput"
+		},
+		"740": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/global.d.ts",
+			"qualifiedName": "InteractiveErrorHandler"
+		},
+		"741": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/MfaApiClient.d.ts",
+			"qualifiedName": "MfaApiClient"
+		},
+		"751": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/MfaApiClient.d.ts",
+			"qualifiedName": "MfaApiClient.getAuthenticators"
+		},
+		"752": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/MfaApiClient.d.ts",
+			"qualifiedName": "MfaApiClient.getAuthenticators"
+		},
+		"753": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/MfaApiClient.d.ts",
+			"qualifiedName": "mfaToken"
+		},
+		"754": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/MfaApiClient.d.ts",
+			"qualifiedName": "MfaApiClient.enroll"
+		},
+		"755": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/MfaApiClient.d.ts",
+			"qualifiedName": "MfaApiClient.enroll"
+		},
+		"756": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/MfaApiClient.d.ts",
+			"qualifiedName": "params"
+		},
+		"757": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/MfaApiClient.d.ts",
+			"qualifiedName": "MfaApiClient.challenge"
+		},
+		"758": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/MfaApiClient.d.ts",
+			"qualifiedName": "MfaApiClient.challenge"
+		},
+		"759": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/MfaApiClient.d.ts",
+			"qualifiedName": "params"
+		},
+		"760": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/MfaApiClient.d.ts",
+			"qualifiedName": "MfaApiClient.getEnrollmentFactors"
+		},
+		"761": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/MfaApiClient.d.ts",
+			"qualifiedName": "MfaApiClient.getEnrollmentFactors"
+		},
+		"762": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/MfaApiClient.d.ts",
+			"qualifiedName": "mfaToken"
+		},
+		"763": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/MfaApiClient.d.ts",
+			"qualifiedName": "MfaApiClient.verify"
+		},
+		"764": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/MfaApiClient.d.ts",
+			"qualifiedName": "MfaApiClient.verify"
+		},
+		"765": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/MfaApiClient.d.ts",
+			"qualifiedName": "params"
+		},
+		"766": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "Authenticator"
+		},
+		"767": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "Authenticator.id"
+		},
+		"768": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "Authenticator.authenticatorType"
+		},
+		"769": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "Authenticator.active"
+		},
+		"770": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "Authenticator.name"
+		},
+		"771": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "Authenticator.createdAt"
+		},
+		"772": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "Authenticator.lastAuth"
+		},
+		"773": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "Authenticator.type"
+		},
+		"774": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "MfaFactorType"
+		},
+		"775": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "EnrollParams"
+		},
+		"776": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "EnrollOtpParams"
+		},
+		"777": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "EnrollOtpParams.factorType"
+		},
+		"778": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "EnrollBaseParams.mfaToken"
+		},
+		"779": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "EnrollSmsParams"
+		},
+		"780": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "EnrollSmsParams.factorType"
+		},
+		"781": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "EnrollSmsParams.phoneNumber"
+		},
+		"782": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "EnrollBaseParams.mfaToken"
+		},
+		"783": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "EnrollVoiceParams"
+		},
+		"784": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "EnrollVoiceParams.factorType"
+		},
+		"785": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "EnrollVoiceParams.phoneNumber"
+		},
+		"786": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "EnrollBaseParams.mfaToken"
+		},
+		"787": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "EnrollEmailParams"
+		},
+		"788": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "EnrollEmailParams.factorType"
+		},
+		"789": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "EnrollEmailParams.email"
+		},
+		"790": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "EnrollBaseParams.mfaToken"
+		},
+		"791": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "EnrollPushParams"
+		},
+		"792": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "EnrollPushParams.factorType"
+		},
+		"793": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "EnrollBaseParams.mfaToken"
+		},
+		"794": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "EnrollmentResponse"
+		},
+		"795": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "ChallengeAuthenticatorParams"
+		},
+		"796": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "ChallengeAuthenticatorParams.mfaToken"
+		},
+		"797": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "ChallengeAuthenticatorParams.challengeType"
+		},
+		"798": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "ChallengeAuthenticatorParams.authenticatorId"
+		},
+		"799": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "ChallengeResponse"
+		},
+		"800": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "ChallengeResponse.challengeType"
+		},
+		"801": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "ChallengeResponse.oobCode"
+		},
+		"802": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "ChallengeResponse.bindingMethod"
+		},
+		"803": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "VerifyParams"
+		},
+		"804": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "VerifyParams.mfaToken"
+		},
+		"805": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "VerifyParams.otp"
+		},
+		"806": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "VerifyParams.oobCode"
+		},
+		"807": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "VerifyParams.bindingCode"
+		},
+		"808": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "VerifyParams.recoveryCode"
+		},
+		"809": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "EnrollmentFactor"
+		},
+		"810": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/mfa/types.d.ts",
+			"qualifiedName": "EnrollmentFactor.type"
+		},
+		"811": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/passkey/PasskeyApiClient.d.ts",
+			"qualifiedName": "PasskeyApiClient"
+		},
+		"813": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/passkey/PasskeyApiClient.d.ts",
+			"qualifiedName": "PasskeyApiClient.signup"
+		},
+		"814": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/passkey/PasskeyApiClient.d.ts",
+			"qualifiedName": "PasskeyApiClient.signup"
+		},
+		"815": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/passkey/PasskeyApiClient.d.ts",
+			"qualifiedName": "options"
+		},
+		"816": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/passkey/PasskeyApiClient.d.ts",
+			"qualifiedName": "PasskeyApiClient.login"
+		},
+		"817": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/passkey/PasskeyApiClient.d.ts",
+			"qualifiedName": "PasskeyApiClient.login"
+		},
+		"818": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/passkey/PasskeyApiClient.d.ts",
+			"qualifiedName": "options"
+		},
+		"819": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/passkey/PasskeyApiClient.d.ts",
+			"qualifiedName": "PasskeyApiClient.getSignupChallenge"
+		},
+		"820": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/passkey/PasskeyApiClient.d.ts",
+			"qualifiedName": "PasskeyApiClient.getSignupChallenge"
+		},
+		"821": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/passkey/PasskeyApiClient.d.ts",
+			"qualifiedName": "options"
+		},
+		"822": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/passkey/PasskeyApiClient.d.ts",
+			"qualifiedName": "PasskeyApiClient.getLoginChallenge"
+		},
+		"823": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/passkey/PasskeyApiClient.d.ts",
+			"qualifiedName": "PasskeyApiClient.getLoginChallenge"
+		},
+		"824": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/passkey/PasskeyApiClient.d.ts",
+			"qualifiedName": "options"
+		},
+		"825": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/passkey/PasskeyApiClient.d.ts",
+			"qualifiedName": "PasskeyApiClient.getTokenWithPasskey"
+		},
+		"826": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/passkey/PasskeyApiClient.d.ts",
+			"qualifiedName": "PasskeyApiClient.getTokenWithPasskey"
+		},
+		"827": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/passkey/PasskeyApiClient.d.ts",
+			"qualifiedName": "options"
+		},
+		"828": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/passkey/types.d.ts",
+			"qualifiedName": "PasskeySignupOptions"
+		},
+		"829": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/passkey/types.d.ts",
+			"qualifiedName": "__type"
+		},
+		"830": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/passkey/types.d.ts",
+			"qualifiedName": "__type.scope"
+		},
+		"831": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/passkey/types.d.ts",
+			"qualifiedName": "__type.audience"
+		},
+		"832": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/passkey/types.d.ts",
+			"qualifiedName": "PasskeyLoginOptions"
+		},
+		"833": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/passkey/types.d.ts",
+			"qualifiedName": "__type"
+		},
+		"834": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/passkey/types.d.ts",
+			"qualifiedName": "__type.scope"
+		},
+		"835": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/passkey/types.d.ts",
+			"qualifiedName": "__type.audience"
+		},
+		"836": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "MyAccountApiClient"
+		},
+		"839": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "MyAccountApiClient.connectAccount"
+		},
+		"840": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "MyAccountApiClient.connectAccount"
+		},
+		"841": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "params"
+		},
+		"842": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "MyAccountApiClient.completeAccount"
+		},
+		"843": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "MyAccountApiClient.completeAccount"
+		},
+		"844": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "params"
+		},
+		"845": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "MyAccountApiClient.getFactors"
+		},
+		"846": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "MyAccountApiClient.getFactors"
+		},
+		"847": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "MyAccountApiClient.getAuthenticationMethods"
+		},
+		"848": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "MyAccountApiClient.getAuthenticationMethods"
+		},
+		"849": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "type"
+		},
+		"850": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "MyAccountApiClient.getAuthenticationMethod"
+		},
+		"851": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "MyAccountApiClient.getAuthenticationMethod"
+		},
+		"852": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "id"
+		},
+		"853": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "MyAccountApiClient.deleteAuthenticationMethod"
+		},
+		"854": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "MyAccountApiClient.deleteAuthenticationMethod"
+		},
+		"855": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "id"
+		},
+		"856": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "MyAccountApiClient.updateAuthenticationMethod"
+		},
+		"857": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "MyAccountApiClient.updateAuthenticationMethod"
+		},
+		"858": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "id"
+		},
+		"859": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "data"
+		},
+		"860": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "MyAccountApiClient.enrollmentChallenge"
+		},
+		"861": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "MyAccountApiClient.enrollmentChallenge"
+		},
+		"862": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "options"
+		},
+		"863": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "MyAccountApiClient.enrollmentVerify"
+		},
+		"864": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "MyAccountApiClient.enrollmentVerify"
+		},
+		"865": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/MyAccountApiClient.d.ts",
+			"qualifiedName": "options"
+		},
+		"867": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/types.d.ts",
+			"qualifiedName": "AuthenticationMethod"
+		},
+		"868": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/types.d.ts",
+			"qualifiedName": "AuthenticationMethodType"
+		},
+		"869": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/types.d.ts",
+			"qualifiedName": "Factor"
+		},
+		"870": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/types.d.ts",
+			"qualifiedName": "Factor.type"
+		},
+		"871": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/types.d.ts",
+			"qualifiedName": "Factor.usage"
+		},
+		"872": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/types.d.ts",
+			"qualifiedName": "UpdateAuthenticationMethodRequest"
+		},
+		"873": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/types.d.ts",
+			"qualifiedName": "UpdateAuthenticationMethodRequest.name"
+		},
+		"874": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/types.d.ts",
+			"qualifiedName": "UpdateAuthenticationMethodRequest.preferred_authentication_method"
+		},
+		"875": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/types.d.ts",
+			"qualifiedName": "EnrollmentChallengeOptions"
+		},
+		"876": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/types.d.ts",
+			"qualifiedName": "EnrollmentChallengeResponse"
+		},
+		"877": {
+			"packageName": "@auth0/auth0-spa-js",
+			"packagePath": "dist/typings/myaccount/types.d.ts",
+			"qualifiedName": "EnrollmentVerifyOptions"
+		},
+		"878": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/errors.tsx",
+			"qualifiedName": "OAuthError"
+		},
+		"879": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/errors.tsx",
+			"qualifiedName": "OAuthError.__constructor"
+		},
+		"880": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/errors.tsx",
+			"qualifiedName": "OAuthError"
+		},
+		"881": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/errors.tsx",
+			"qualifiedName": "error"
+		},
+		"882": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/errors.tsx",
+			"qualifiedName": "error_description"
+		},
+		"883": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/errors.tsx",
+			"qualifiedName": "OAuthError.error"
+		},
+		"884": {
+			"packageName": "@auth0/auth0-react",
+			"packagePath": "src/errors.tsx",
+			"qualifiedName": "OAuthError.error_description"
+		}
+	},
+	"files": {
+		"entries": {
+			"1": "src/index.tsx",
+			"2": "README.md",
+			"3": ""
+		},
+		"reflections": {
+			"1": 0,
+			"2": 0,
+			"3": 0
+		}
+	}
+}

--- a/main/sdk-artifacts/auth0-spa-js.json
+++ b/main/sdk-artifacts/auth0-spa-js.json
@@ -1,0 +1,39098 @@
+{
+	"id": 0,
+	"name": "Auth0 SPA SDK",
+	"variant": "project",
+	"kind": 1,
+	"flags": {},
+	"children": [
+		{
+			"id": 1,
+			"name": "createAuth0Client",
+			"variant": "declaration",
+			"kind": 64,
+			"flags": {},
+			"sources": [
+				{
+					"fileName": "src/index.ts",
+					"line": 13,
+					"character": 22,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/index.ts#L13"
+				},
+				{
+					"fileName": "src/index.ts",
+					"line": 20,
+					"character": 22,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/index.ts#L20"
+				},
+				{
+					"fileName": "src/index.ts",
+					"line": 32,
+					"character": 22,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/index.ts#L32"
+				}
+			],
+			"signatures": [
+				{
+					"id": 2,
+					"name": "createAuth0Client",
+					"variant": "signature",
+					"kind": 4096,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Online mode requires "
+							},
+							{
+								"kind": "code",
+								"text": "`useRefreshTokens: true`"
+							},
+							{
+								"kind": "text",
+								"text": " and "
+							},
+							{
+								"kind": "code",
+								"text": "`useDpop: true`"
+							},
+							{
+								"kind": "text",
+								"text": ", enforced here at\ncompile time. Dynamic values, casts, and plain JS are covered by the runtime check in\nthe "
+							},
+							{
+								"kind": "code",
+								"text": "`Auth0Client`"
+							},
+							{
+								"kind": "text",
+								"text": " constructor."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/index.ts",
+							"line": 13,
+							"character": 22,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/index.ts#L13"
+						}
+					],
+					"parameters": [
+						{
+							"id": 3,
+							"name": "options",
+							"variant": "param",
+							"kind": 32768,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Type: [Auth0ClientOptions](/docs/sdk/typescript/interfaces/Auth0ClientOptions)"
+									}
+								]
+							},
+							"type": {
+								"type": "intersection",
+								"types": [
+									{
+										"type": "reference",
+										"target": 1233,
+										"name": "Auth0ClientOptions",
+										"package": "@auth0/auth0-spa-js"
+									},
+									{
+										"type": "reflection",
+										"declaration": {
+											"id": 4,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 5,
+													"name": "refreshTokenMode",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/index.ts",
+															"line": 15,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/index.ts#L15"
+														}
+													],
+													"type": {
+														"type": "literal",
+														"value": "online"
+													}
+												},
+												{
+													"id": 7,
+													"name": "useDpop",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/index.ts",
+															"line": 17,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/index.ts#L17"
+														}
+													],
+													"type": {
+														"type": "literal",
+														"value": true
+													}
+												},
+												{
+													"id": 6,
+													"name": "useRefreshTokens",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/index.ts",
+															"line": 16,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/index.ts#L16"
+														}
+													],
+													"type": {
+														"type": "literal",
+														"value": true
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														5,
+														7,
+														6
+													]
+												}
+											],
+											"sources": [
+												{
+													"fileName": "src/index.ts",
+													"line": 14,
+													"character": 32,
+													"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/index.ts#L14"
+												}
+											]
+										}
+									}
+								]
+							}
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": {
+							"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+							"qualifiedName": "Promise"
+						},
+						"typeArguments": [
+							{
+								"type": "reference",
+								"target": 12,
+								"name": "Auth0Client",
+								"package": "@auth0/auth0-spa-js"
+							}
+						],
+						"name": "Promise",
+						"package": "typescript"
+					}
+				},
+				{
+					"id": 8,
+					"name": "createAuth0Client",
+					"variant": "signature",
+					"kind": 4096,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Asynchronously creates the Auth0Client instance and calls "
+							},
+							{
+								"kind": "code",
+								"text": "`checkSession`"
+							},
+							{
+								"kind": "text",
+								"text": ".\n\n**Note:** There are caveats to using this in a private browser tab, which may not silently authenticate\na user on page refresh. Please see [the checkSession docs](https://auth0.github.io/auth0-spa-js/classes/Auth0Client.html#checksession) for more info."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@returns",
+								"content": [
+									{
+										"kind": "text",
+										"text": "An instance of Auth0Client"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/index.ts",
+							"line": 20,
+							"character": 22,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/index.ts#L20"
+						}
+					],
+					"parameters": [
+						{
+							"id": 9,
+							"name": "options",
+							"variant": "param",
+							"kind": 32768,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "The client options"
+									},
+									{
+										"kind": "text",
+										"text": "\n\nType: [Auth0ClientOptions](/docs/sdk/typescript/interfaces/Auth0ClientOptions)"
+									}
+								]
+							},
+							"type": {
+								"type": "intersection",
+								"types": [
+									{
+										"type": "reference",
+										"target": 1233,
+										"name": "Auth0ClientOptions",
+										"package": "@auth0/auth0-spa-js"
+									},
+									{
+										"type": "reflection",
+										"declaration": {
+											"id": 10,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 11,
+													"name": "refreshTokenMode",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {
+														"isOptional": true
+													},
+													"sources": [
+														{
+															"fileName": "src/index.ts",
+															"line": 21,
+															"character": 34,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/index.ts#L21"
+														}
+													],
+													"type": {
+														"type": "literal",
+														"value": "offline"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														11
+													]
+												}
+											],
+											"sources": [
+												{
+													"fileName": "src/index.ts",
+													"line": 21,
+													"character": 32,
+													"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/index.ts#L21"
+												}
+											]
+										}
+									}
+								]
+							}
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": {
+							"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+							"qualifiedName": "Promise"
+						},
+						"typeArguments": [
+							{
+								"type": "reference",
+								"target": 12,
+								"name": "Auth0Client",
+								"package": "@auth0/auth0-spa-js"
+							}
+						],
+						"name": "Promise",
+						"package": "typescript"
+					}
+				}
+			]
+		},
+		{
+			"id": 12,
+			"name": "Auth0Client",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Auth0 SDK for Single Page Applications using [Authorization Code Grant Flow with PKCE](https://auth0.com/docs/api-auth/tutorials/authorization-code-grant-pkce)."
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 13,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 221,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L221"
+						}
+					],
+					"signatures": [
+						{
+							"id": 14,
+							"name": "new Auth0Client",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 221,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L221"
+								}
+							],
+							"parameters": [
+								{
+									"id": 15,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Type: [Auth0ClientOptions](/docs/sdk/typescript/interfaces/Auth0ClientOptions)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 1233,
+										"name": "Auth0ClientOptions",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 12,
+								"name": "Auth0Client",
+								"package": "@auth0/auth0-spa-js"
+							}
+						}
+					]
+				},
+				{
+					"id": 37,
+					"name": "mfa",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true,
+						"isReadonly": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "MFA API client for multi-factor authentication operations.\n\nProvides methods for:\n- Listing enrolled authenticators\n- Enrolling new authenticators (OTP, SMS, Voice, Push, Email)\n- Initiating MFA challenges\n- Verifying MFA challenges"
+							},
+							{
+								"kind": "text",
+								"text": "\n\nType: [MfaApiClient](/docs/sdk/typescript/classes/MfaApiClient)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 175,
+							"character": 18,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L175"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 542,
+						"name": "MfaApiClient",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 36,
+					"name": "myAccount",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true,
+						"isReadonly": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "\n\nType: [MyAccountApiClient](/docs/sdk/typescript/classes/MyAccountApiClient)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 164,
+							"character": 18,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L164"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 754,
+						"name": "MyAccountApiClient",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 38,
+					"name": "passkey",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true,
+						"isReadonly": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Passkey API client for passwordless authentication.\n\nProvides two single-call methods that handle the full WebAuthn flow internally:\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`signup(options)`"
+							},
+							{
+								"kind": "text",
+								"text": " — register a new user with a passkey\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`login(options?)`"
+							},
+							{
+								"kind": "text",
+								"text": " — authenticate an existing user with a passkey"
+							},
+							{
+								"kind": "text",
+								"text": "\n\nType: [PasskeyApiClient](/docs/sdk/typescript/classes/PasskeyApiClient)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 184,
+							"character": 18,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L184"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 1057,
+						"name": "PasskeyApiClient",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 119,
+					"name": "checkSession",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 875,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L875"
+						}
+					],
+					"signatures": [
+						{
+							"id": 120,
+							"name": "checkSession",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "code",
+										"text": "```js\nawait auth0.checkSession();\n```"
+									},
+									{
+										"kind": "text",
+										"text": "\n\nCheck if the user is logged in using "
+									},
+									{
+										"kind": "code",
+										"text": "`getTokenSilently`"
+									},
+									{
+										"kind": "text",
+										"text": ". The difference\nwith "
+									},
+									{
+										"kind": "code",
+										"text": "`getTokenSilently`"
+									},
+									{
+										"kind": "text",
+										"text": " is that this doesn't return a token, but it will\npre-fill the token cache.\n\nThis method also heeds the "
+									},
+									{
+										"kind": "code",
+										"text": "`auth0.{clientId}.is.authenticated`"
+									},
+									{
+										"kind": "text",
+										"text": " cookie, as an optimization\n to prevent calling Auth0 unnecessarily. If the cookie is not present because\nthere was no previous login (or it has expired) then tokens will not be refreshed.\n\nIt should be used for silently logging in the user when you instantiate the\n"
+									},
+									{
+										"kind": "code",
+										"text": "`Auth0Client`"
+									},
+									{
+										"kind": "text",
+										"text": " constructor. You should not need this if you are using the\n"
+									},
+									{
+										"kind": "code",
+										"text": "`createAuth0Client`"
+									},
+									{
+										"kind": "text",
+										"text": " factory.\n\n**Note:** the cookie **may not** be present if running an app using a private tab, as some\nbrowsers clear JS cookie data and local storage when the tab or page is closed, or on page reload. This effectively\nmeans that "
+									},
+									{
+										"kind": "code",
+										"text": "`checkSession`"
+									},
+									{
+										"kind": "text",
+										"text": " could silently return without authenticating the user on page refresh when\nusing a private tab, despite having previously logged in. As a workaround, use "
+									},
+									{
+										"kind": "code",
+										"text": "`getTokenSilently`"
+									},
+									{
+										"kind": "text",
+										"text": " instead\nand handle the possible "
+									},
+									{
+										"kind": "code",
+										"text": "`login_required`"
+									},
+									{
+										"kind": "text",
+										"text": " error [as shown in the readme](https://github.com/auth0/auth0-spa-js#creating-the-client)."
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 875,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L875"
+								}
+							],
+							"parameters": [
+								{
+									"id": 121,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {
+										"isOptional": true
+									},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "\n\nType: [GetTokenSilentlyOptions](/docs/sdk/typescript/interfaces/GetTokenSilentlyOptions)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 1319,
+										"name": "GetTokenSilentlyOptions",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "intrinsic",
+										"name": "void"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 259,
+					"name": "connectAccountWithRedirect",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 2132,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L2132"
+						}
+					],
+					"signatures": [
+						{
+							"id": 260,
+							"name": "connectAccountWithRedirect",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Initiates a redirect to connect the user's account with a specified connection.\nThis method generates PKCE parameters, creates a transaction, and redirects to the /connect endpoint.\n\nYou must enable "
+									},
+									{
+										"kind": "code",
+										"text": "`Offline Access`"
+									},
+									{
+										"kind": "text",
+										"text": " from the Connection Permissions settings to be able to use the connection with Connected Accounts."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "Resolves when the redirect is initiated."
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If the connect request to the My Account API fails."
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 2132,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L2132"
+								}
+							],
+							"typeParameter": [
+								{
+									"id": 261,
+									"name": "TAppState",
+									"variant": "typeParam",
+									"kind": 131072,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The application state to persist through the transaction."
+											}
+										]
+									},
+									"default": {
+										"type": "intrinsic",
+										"name": "any"
+									}
+								}
+							],
+							"parameters": [
+								{
+									"id": 262,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Options for the connect account redirect flow."
+											},
+											{
+												"kind": "text",
+												"text": "\n\nType: [RedirectConnectAccountOptions](/docs/sdk/typescript/interfaces/RedirectConnectAccountOptions)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 1357,
+										"typeArguments": [
+											{
+												"type": "reference",
+												"target": 261,
+												"name": "TAppState",
+												"package": "@auth0/auth0-spa-js",
+												"refersToTypeParameter": true
+											}
+										],
+										"name": "RedirectConnectAccountOptions",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "intrinsic",
+										"name": "void"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 255,
+					"name": "createFetcher",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 2094,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L2094"
+						}
+					],
+					"signatures": [
+						{
+							"id": 256,
+							"name": "createFetcher",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Returns a new "
+									},
+									{
+										"kind": "code",
+										"text": "`Fetcher`"
+									},
+									{
+										"kind": "text",
+										"text": " class that will contain a "
+									},
+									{
+										"kind": "code",
+										"text": "`fetchWithAuth()`"
+									},
+									{
+										"kind": "text",
+										"text": " method.\nThis is a drop-in replacement for the Fetch API's "
+									},
+									{
+										"kind": "code",
+										"text": "`fetch()`"
+									},
+									{
+										"kind": "text",
+										"text": " method, but will\nhandle certain authentication logic for you, like building the proper auth\nheaders or managing DPoP nonces and retries automatically.\n\nCheck the "
+									},
+									{
+										"kind": "code",
+										"text": "`EXAMPLES.md`"
+									},
+									{
+										"kind": "text",
+										"text": " file for a deeper look into this method."
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 2094,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L2094"
+								}
+							],
+							"typeParameter": [
+								{
+									"id": 257,
+									"name": "TOutput",
+									"variant": "typeParam",
+									"kind": 131072,
+									"flags": {},
+									"type": {
+										"type": "reference",
+										"target": 750,
+										"name": "CustomFetchMinimalOutput",
+										"package": "@auth0/auth0-spa-js"
+									},
+									"default": {
+										"type": "reference",
+										"target": {
+											"sourceFileName": "node_modules/typescript/lib/lib.dom.d.ts",
+											"qualifiedName": "Response"
+										},
+										"name": "Response",
+										"package": "typescript"
+									}
+								}
+							],
+							"parameters": [
+								{
+									"id": 258,
+									"name": "config",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Type: [FetcherConfig](/docs/sdk/typescript/types/FetcherConfig)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 682,
+										"typeArguments": [
+											{
+												"type": "reference",
+												"target": 257,
+												"name": "TOutput",
+												"package": "@auth0/auth0-spa-js",
+												"refersToTypeParameter": true
+											}
+										],
+										"name": "FetcherConfig",
+										"package": "@auth0/auth0-spa-js"
+									},
+									"defaultValue": "{}"
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 689,
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 257,
+										"name": "TOutput",
+										"package": "@auth0/auth0-spa-js",
+										"refersToTypeParameter": true
+									}
+								],
+								"name": "Fetcher",
+								"package": "@auth0/auth0-spa-js"
+							}
+						}
+					]
+				},
+				{
+					"id": 231,
+					"name": "customTokenExchange",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 1975,
+							"character": 8,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L1975"
+						}
+					],
+					"signatures": [
+						{
+							"id": 232,
+							"name": "customTokenExchange",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "code",
+										"text": "```js\nawait auth0.customTokenExchange(options);\n```"
+									},
+									{
+										"kind": "text",
+										"text": "\n\nExchanges an external subject token for Auth0 tokens without affecting the current session.\n\nUnlike "
+									},
+									{
+										"kind": "code",
+										"text": "`loginWithCustomTokenExchange`"
+									},
+									{
+										"kind": "text",
+										"text": ", this method has no side effects — it does not cache\ntokens, does not update the authenticated session, and does not affect "
+									},
+									{
+										"kind": "code",
+										"text": "`isAuthenticated()`"
+									},
+									{
+										"kind": "text",
+										"text": "\nor "
+									},
+									{
+										"kind": "code",
+										"text": "`getUser()`"
+									},
+									{
+										"kind": "text",
+										"text": ". Use this for delegation or impersonation scenarios where you need a token\nfor a downstream API but do not want to change who the current user is.\n\nWhen a Web Worker is configured, the refresh_token is discarded inside the worker and\nnever reaches the main thread. When no Web Worker is configured, the raw authorization\nserver response is returned — if a refresh_token is present, discard it; this method\nintentionally does not store it."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A promise that resolves to the token endpoint response.\n\n**Example:**\n"
+											},
+											{
+												"kind": "code",
+												"text": "```js\nconst tokenResponse = await auth0.customTokenExchange({\n  subject_token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6Ikp...',\n  subject_token_type: 'urn:acme:legacy-system-token',\n  actor_token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6Ikp...',\n  actor_token_type: 'https://idp.example.com/token-type/agent',\n  audience: 'https://api.example.com',\n});\n\n// Use tokenResponse.access_token to call downstream API\n// Current user session is unchanged\n```"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 1975,
+									"character": 8,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L1975"
+								}
+							],
+							"parameters": [
+								{
+									"id": 233,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The options required to perform the token exchange."
+											},
+											{
+												"kind": "text",
+												"text": "\n\nType: [CustomTokenExchangeOptions](/docs/sdk/typescript/types/CustomTokenExchangeOptions)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 1196,
+										"name": "CustomTokenExchangeOptions",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 1389,
+										"name": "TokenEndpointResponse",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 234,
+					"name": "exchangeToken",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 2022,
+							"character": 8,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L2022"
+						}
+					],
+					"signatures": [
+						{
+							"id": 235,
+							"name": "exchangeToken",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [],
+								"blockTags": [
+									{
+										"tag": "@deprecated",
+										"content": [
+											{
+												"kind": "text",
+												"text": "Use "
+											},
+											{
+												"kind": "code",
+												"text": "`loginWithCustomTokenExchange()`"
+											},
+											{
+												"kind": "text",
+												"text": " instead. This method will be removed in the next major version.\n\nExchanges an external subject token for Auth0 tokens."
+											}
+										]
+									},
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A promise that resolves to the token endpoint response.\n\n**Example:**\n"
+											},
+											{
+												"kind": "code",
+												"text": "```js\n// Instead of:\nconst tokens = await auth0.exchangeToken(options);\n\n// Use:\nconst tokens = await auth0.loginWithCustomTokenExchange(options);\n```"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 2022,
+									"character": 8,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L2022"
+								}
+							],
+							"parameters": [
+								{
+									"id": 236,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The options required to perform the token exchange."
+											},
+											{
+												"kind": "text",
+												"text": "\n\nType: [CustomTokenExchangeOptions](/docs/sdk/typescript/types/CustomTokenExchangeOptions)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 1196,
+										"name": "CustomTokenExchangeOptions",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 1389,
+										"name": "TokenEndpointResponse",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 247,
+					"name": "generateDpopProof",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 2075,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L2075"
+						}
+					],
+					"signatures": [
+						{
+							"id": 248,
+							"name": "generateDpopProof",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Returns a string to be used to demonstrate possession of the private\nkey used to cryptographically bind access tokens with DPoP.\n\nIt requires enabling the "
+									},
+									{
+										"kind": "inline-tag",
+										"tag": "@link",
+										"text": "Auth0ClientOptions.useDpop",
+										"target": 1262,
+										"tsLinkText": ""
+									},
+									{
+										"kind": "text",
+										"text": " option."
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 2075,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L2075"
+								}
+							],
+							"parameters": [
+								{
+									"id": 249,
+									"name": "params",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 250,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 254,
+													"name": "accessToken",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/Auth0Client.ts",
+															"line": 2079,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L2079"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 252,
+													"name": "method",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/Auth0Client.ts",
+															"line": 2077,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L2077"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 253,
+													"name": "nonce",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {
+														"isOptional": true
+													},
+													"sources": [
+														{
+															"fileName": "src/Auth0Client.ts",
+															"line": 2078,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L2078"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 251,
+													"name": "url",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/Auth0Client.ts",
+															"line": 2076,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L2076"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														254,
+														252,
+														253,
+														251
+													]
+												}
+											],
+											"sources": [
+												{
+													"fileName": "src/Auth0Client.ts",
+													"line": 2075,
+													"character": 35,
+													"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L2075"
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "intrinsic",
+										"name": "string"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 45,
+					"name": "getConfiguration",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 383,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L383"
+						}
+					],
+					"signatures": [
+						{
+							"id": 46,
+							"name": "getConfiguration",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Returns a readonly copy of the initialization configuration."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "An object containing domain and clientId"
+											}
+										]
+									},
+									{
+										"tag": "@example",
+										"content": [
+											{
+												"kind": "code",
+												"text": "```typescript\nconst auth0 = new Auth0Client({\n  domain: 'tenant.auth0.com',\n  clientId: 'abc123'\n});\n\nconst config = auth0.getConfiguration();\n// { domain: 'tenant.auth0.com', clientId: 'abc123' }\n```"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 383,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L383"
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Readonly"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 1267,
+										"name": "ClientConfiguration",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Readonly",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 240,
+					"name": "getDpopNonce",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 2047,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L2047"
+						}
+					],
+					"signatures": [
+						{
+							"id": 241,
+							"name": "getDpopNonce",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Returns the current DPoP nonce used for making requests to Auth0.\n\nIt can return "
+									},
+									{
+										"kind": "code",
+										"text": "`undefined`"
+									},
+									{
+										"kind": "text",
+										"text": " because when starting fresh it will not\nbe populated until after the first response from the server.\n\nIt requires enabling the "
+									},
+									{
+										"kind": "inline-tag",
+										"tag": "@link",
+										"text": "Auth0ClientOptions.useDpop",
+										"target": 1262,
+										"tsLinkText": ""
+									},
+									{
+										"kind": "text",
+										"text": " option."
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 2047,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L2047"
+								}
+							],
+							"parameters": [
+								{
+									"id": 242,
+									"name": "id",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {
+										"isOptional": true
+									},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The identifier of a nonce: if absent, it will get the nonce\n             used for requests to Auth0. Otherwise, it will be used to\n             select a specific non-Auth0 nonce."
+											}
+										]
+									},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "union",
+										"types": [
+											{
+												"type": "intrinsic",
+												"name": "undefined"
+											},
+											{
+												"type": "intrinsic",
+												"name": "string"
+											}
+										]
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 99,
+					"name": "getIdTokenClaims",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 644,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L644"
+						}
+					],
+					"signatures": [
+						{
+							"id": 100,
+							"name": "getIdTokenClaims",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "code",
+										"text": "```js\nconst claims = await auth0.getIdTokenClaims();\n```"
+									},
+									{
+										"kind": "text",
+										"text": "\n\nReturns all claims from the id_token if available."
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 644,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L644"
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "union",
+										"types": [
+											{
+												"type": "intrinsic",
+												"name": "undefined"
+											},
+											{
+												"type": "reference",
+												"target": 1432,
+												"name": "IdToken",
+												"package": "@auth0/auth0-spa-js"
+											}
+										]
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 122,
+					"name": "getTokenSilently",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 900,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L900"
+						},
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 909,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L909"
+						},
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 949,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L949"
+						}
+					],
+					"signatures": [
+						{
+							"id": 123,
+							"name": "getTokenSilently",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Fetches a new access token and returns the response from the /oauth/token endpoint, omitting the refresh token."
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 900,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L900"
+								}
+							],
+							"parameters": [
+								{
+									"id": 124,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "\n\nType: [GetTokenSilentlyOptions](/docs/sdk/typescript/interfaces/GetTokenSilentlyOptions)"
+											}
+										]
+									},
+									"type": {
+										"type": "intersection",
+										"types": [
+											{
+												"type": "reference",
+												"target": 1319,
+												"name": "GetTokenSilentlyOptions",
+												"package": "@auth0/auth0-spa-js"
+											},
+											{
+												"type": "reflection",
+												"declaration": {
+													"id": 125,
+													"name": "__type",
+													"variant": "declaration",
+													"kind": 65536,
+													"flags": {},
+													"children": [
+														{
+															"id": 126,
+															"name": "detailedResponse",
+															"variant": "declaration",
+															"kind": 1024,
+															"flags": {},
+															"sources": [
+																{
+																	"fileName": "src/Auth0Client.ts",
+																	"line": 901,
+																	"character": 41,
+																	"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L901"
+																}
+															],
+															"type": {
+																"type": "literal",
+																"value": true
+															}
+														}
+													],
+													"groups": [
+														{
+															"title": "Properties",
+															"children": [
+																126
+															]
+														}
+													],
+													"sources": [
+														{
+															"fileName": "src/Auth0Client.ts",
+															"line": 901,
+															"character": 39,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L901"
+														}
+													]
+												}
+											}
+										]
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 1513,
+										"name": "GetTokenSilentlyVerboseResponse",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						},
+						{
+							"id": 127,
+							"name": "getTokenSilently",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Fetches a new access token and returns it."
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 909,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L909"
+								}
+							],
+							"parameters": [
+								{
+									"id": 128,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {
+										"isOptional": true
+									},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "\n\nType: [GetTokenSilentlyOptions](/docs/sdk/typescript/interfaces/GetTokenSilentlyOptions)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 1319,
+										"name": "GetTokenSilentlyOptions",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "intrinsic",
+										"name": "string"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 149,
+					"name": "getTokenWithPopup",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 1131,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L1131"
+						}
+					],
+					"signatures": [
+						{
+							"id": 150,
+							"name": "getTokenWithPopup",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "code",
+										"text": "```js\nconst token = await auth0.getTokenWithPopup(options);\n```"
+									},
+									{
+										"kind": "text",
+										"text": "\nOpens a popup with the "
+									},
+									{
+										"kind": "code",
+										"text": "`/authorize`"
+									},
+									{
+										"kind": "text",
+										"text": " URL using the parameters\nprovided as arguments. Random and secure "
+									},
+									{
+										"kind": "code",
+										"text": "`state`"
+									},
+									{
+										"kind": "text",
+										"text": " and "
+									},
+									{
+										"kind": "code",
+										"text": "`nonce`"
+									},
+									{
+										"kind": "text",
+										"text": "\nparameters will be auto-generated. If the response is successful,\nresults will be valid according to their expiration times."
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 1131,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L1131"
+								}
+							],
+							"parameters": [
+								{
+									"id": 151,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "\n\nType: [GetTokenWithPopupOptions](/docs/sdk/typescript/interfaces/GetTokenWithPopupOptions)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 1330,
+										"name": "GetTokenWithPopupOptions",
+										"package": "@auth0/auth0-spa-js"
+									},
+									"defaultValue": "{}"
+								},
+								{
+									"id": 152,
+									"name": "config",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "\n\nType: [PopupConfigOptions](/docs/sdk/typescript/interfaces/PopupConfigOptions)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 1315,
+										"name": "PopupConfigOptions",
+										"package": "@auth0/auth0-spa-js"
+									},
+									"defaultValue": "{}"
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "union",
+										"types": [
+											{
+												"type": "intrinsic",
+												"name": "undefined"
+											},
+											{
+												"type": "intrinsic",
+												"name": "string"
+											}
+										]
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 96,
+					"name": "getUser",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 627,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L627"
+						}
+					],
+					"signatures": [
+						{
+							"id": 97,
+							"name": "getUser",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "code",
+										"text": "```js\nconst user = await auth0.getUser();\n```"
+									},
+									{
+										"kind": "text",
+										"text": "\n\nReturns the user information if available (decoded\nfrom the "
+									},
+									{
+										"kind": "code",
+										"text": "`id_token`"
+									},
+									{
+										"kind": "text",
+										"text": ")."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@typeparam",
+										"content": [
+											{
+												"kind": "text",
+												"text": "TUser The type to return, has to extend "
+											},
+											{
+												"kind": "inline-tag",
+												"tag": "@link",
+												"text": "User",
+												"target": 1475,
+												"tsLinkText": ""
+											},
+											{
+												"kind": "text",
+												"text": "."
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 627,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L627"
+								}
+							],
+							"typeParameter": [
+								{
+									"id": 98,
+									"name": "TUser",
+									"variant": "typeParam",
+									"kind": 131072,
+									"flags": {},
+									"type": {
+										"type": "reference",
+										"target": 1475,
+										"typeArguments": [
+											{
+												"type": "reference",
+												"target": 98,
+												"name": "TUser",
+												"package": "@auth0/auth0-spa-js",
+												"refersToTypeParameter": true
+											}
+										],
+										"name": "User",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "union",
+										"types": [
+											{
+												"type": "intrinsic",
+												"name": "undefined"
+											},
+											{
+												"type": "reference",
+												"target": 98,
+												"name": "TUser",
+												"package": "@auth0/auth0-spa-js",
+												"refersToTypeParameter": true
+											}
+										]
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 105,
+					"name": "handleRedirectCallback",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 703,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L703"
+						}
+					],
+					"signatures": [
+						{
+							"id": 106,
+							"name": "handleRedirectCallback",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "After the browser redirects back to the callback page,\ncall "
+									},
+									{
+										"kind": "code",
+										"text": "`handleRedirectCallback`"
+									},
+									{
+										"kind": "text",
+										"text": " to handle success and error\nresponses from Auth0. If the response is successful, results\nwill be valid according to their expiration times."
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 703,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L703"
+								}
+							],
+							"typeParameter": [
+								{
+									"id": 107,
+									"name": "TAppState",
+									"variant": "typeParam",
+									"kind": 131072,
+									"flags": {},
+									"default": {
+										"type": "intrinsic",
+										"name": "any"
+									}
+								}
+							],
+							"parameters": [
+								{
+									"id": 108,
+									"name": "url",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									},
+									"defaultValue": "window.location.href"
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "union",
+										"types": [
+											{
+												"type": "reference",
+												"target": 1309,
+												"typeArguments": [
+													{
+														"type": "reference",
+														"target": 107,
+														"name": "TAppState",
+														"package": "@auth0/auth0-spa-js",
+														"refersToTypeParameter": true
+													}
+												],
+												"name": "RedirectLoginResult",
+												"package": "@auth0/auth0-spa-js"
+											},
+											{
+												"type": "reference",
+												"target": 1368,
+												"typeArguments": [
+													{
+														"type": "reference",
+														"target": 107,
+														"name": "TAppState",
+														"package": "@auth0/auth0-spa-js",
+														"refersToTypeParameter": true
+													}
+												],
+												"name": "ConnectAccountRedirectResult",
+												"package": "@auth0/auth0-spa-js"
+											}
+										]
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 153,
+					"name": "isAuthenticated",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 1177,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L1177"
+						}
+					],
+					"signatures": [
+						{
+							"id": 154,
+							"name": "isAuthenticated",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "code",
+										"text": "```js\nconst isAuthenticated = await auth0.isAuthenticated();\n```"
+									},
+									{
+										"kind": "text",
+										"text": "\n\nReturns "
+									},
+									{
+										"kind": "code",
+										"text": "`true`"
+									},
+									{
+										"kind": "text",
+										"text": " if there's valid information stored,\notherwise returns "
+									},
+									{
+										"kind": "code",
+										"text": "`false`"
+									},
+									{
+										"kind": "text",
+										"text": "."
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 1177,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L1177"
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "intrinsic",
+										"name": "boolean"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 228,
+					"name": "loginWithCustomTokenExchange",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 1935,
+							"character": 8,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L1935"
+						}
+					],
+					"signatures": [
+						{
+							"id": 229,
+							"name": "loginWithCustomTokenExchange",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 1935,
+									"character": 8,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L1935"
+								}
+							],
+							"parameters": [
+								{
+									"id": 230,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Type: [CustomTokenExchangeOptions](/docs/sdk/typescript/types/CustomTokenExchangeOptions)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 1196,
+										"name": "CustomTokenExchangeOptions",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 1389,
+										"name": "TokenEndpointResponse",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 92,
+					"name": "loginWithPopup",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 557,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L557"
+						}
+					],
+					"signatures": [
+						{
+							"id": 93,
+							"name": "loginWithPopup",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "code",
+										"text": "```js\ntry {\n await auth0.loginWithPopup(options);\n} catch(e) {\n if (e instanceof PopupCancelledError) {\n   // Popup was closed before login completed\n }\n}\n```"
+									},
+									{
+										"kind": "text",
+										"text": "\n\nOpens a popup with the "
+									},
+									{
+										"kind": "code",
+										"text": "`/authorize`"
+									},
+									{
+										"kind": "text",
+										"text": " URL using the parameters\nprovided as arguments. Random and secure "
+									},
+									{
+										"kind": "code",
+										"text": "`state`"
+									},
+									{
+										"kind": "text",
+										"text": " and "
+									},
+									{
+										"kind": "code",
+										"text": "`nonce`"
+									},
+									{
+										"kind": "text",
+										"text": "\nparameters will be auto-generated. If the response is successful,\nresults will be valid according to their expiration times.\n\nIMPORTANT: This method has to be called from an event handler\nthat was started by the user like a button click, for example,\notherwise the popup will be blocked in most browsers."
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 557,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L557"
+								}
+							],
+							"parameters": [
+								{
+									"id": 94,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {
+										"isOptional": true
+									},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "\n\nType: [PopupLoginOptions](/docs/sdk/typescript/interfaces/PopupLoginOptions)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 1313,
+										"name": "PopupLoginOptions",
+										"package": "@auth0/auth0-spa-js"
+									}
+								},
+								{
+									"id": 95,
+									"name": "config",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {
+										"isOptional": true
+									},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "\n\nType: [PopupConfigOptions](/docs/sdk/typescript/interfaces/PopupConfigOptions)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 1315,
+										"name": "PopupConfigOptions",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "intrinsic",
+										"name": "void"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 101,
+					"name": "loginWithRedirect",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 665,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L665"
+						}
+					],
+					"signatures": [
+						{
+							"id": 102,
+							"name": "loginWithRedirect",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "code",
+										"text": "```js\nawait auth0.loginWithRedirect(options);\n```"
+									},
+									{
+										"kind": "text",
+										"text": "\n\nPerforms a redirect to "
+									},
+									{
+										"kind": "code",
+										"text": "`/authorize`"
+									},
+									{
+										"kind": "text",
+										"text": " using the parameters\nprovided as arguments. Random and secure "
+									},
+									{
+										"kind": "code",
+										"text": "`state`"
+									},
+									{
+										"kind": "text",
+										"text": " and "
+									},
+									{
+										"kind": "code",
+										"text": "`nonce`"
+									},
+									{
+										"kind": "text",
+										"text": "\nparameters will be auto-generated."
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 665,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L665"
+								}
+							],
+							"typeParameter": [
+								{
+									"id": 103,
+									"name": "TAppState",
+									"variant": "typeParam",
+									"kind": 131072,
+									"flags": {},
+									"default": {
+										"type": "intrinsic",
+										"name": "any"
+									}
+								}
+							],
+							"parameters": [
+								{
+									"id": 104,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "\n\nType: [RedirectLoginOptions](/docs/sdk/typescript/interfaces/RedirectLoginOptions)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 1293,
+										"typeArguments": [
+											{
+												"type": "reference",
+												"target": 103,
+												"name": "TAppState",
+												"package": "@auth0/auth0-spa-js",
+												"refersToTypeParameter": true
+											}
+										],
+										"name": "RedirectLoginOptions",
+										"package": "@auth0/auth0-spa-js"
+									},
+									"defaultValue": "{}"
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "intrinsic",
+										"name": "void"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 161,
+					"name": "logout",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 1310,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L1310"
+						}
+					],
+					"signatures": [
+						{
+							"id": 162,
+							"name": "logout",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "code",
+										"text": "```js\nawait auth0.logout(options);\n```"
+									},
+									{
+										"kind": "text",
+										"text": "\n\nClears the application session and performs a redirect to "
+									},
+									{
+										"kind": "code",
+										"text": "`/v2/logout`"
+									},
+									{
+										"kind": "text",
+										"text": ", using\nthe parameters provided as arguments, to clear the Auth0 session.\n\nIf the "
+									},
+									{
+										"kind": "code",
+										"text": "`federated`"
+									},
+									{
+										"kind": "text",
+										"text": " option is specified it also clears the Identity Provider session.\n[Read more about how Logout works at Auth0](https://auth0.com/docs/logout)."
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 1310,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L1310"
+								}
+							],
+							"parameters": [
+								{
+									"id": 163,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "\n\nType: [LogoutOptions](/docs/sdk/typescript/interfaces/LogoutOptions)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 1341,
+										"name": "LogoutOptions",
+										"package": "@auth0/auth0-spa-js"
+									},
+									"defaultValue": "{}"
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "intrinsic",
+										"name": "void"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 158,
+					"name": "revokeRefreshToken",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 1255,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L1255"
+						}
+					],
+					"signatures": [
+						{
+							"id": 159,
+							"name": "revokeRefreshToken",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "code",
+										"text": "```js\nawait auth0.revokeRefreshToken();\n```"
+									},
+									{
+										"kind": "text",
+										"text": "\n\nRevokes the refresh token using the "
+									},
+									{
+										"kind": "code",
+										"text": "`/oauth/revoke`"
+									},
+									{
+										"kind": "text",
+										"text": " endpoint.\nThis invalidates the refresh token so it can no longer be used to obtain new access tokens.\n\nThe method works with both memory and localStorage cache modes:\n- For memory storage with worker: The refresh token never leaves the worker thread,\n  maintaining security isolation\n- For localStorage: The token is retrieved from cache and revoked\n\nIf "
+									},
+									{
+										"kind": "code",
+										"text": "`useRefreshTokens`"
+									},
+									{
+										"kind": "text",
+										"text": " is disabled, this method does nothing.\n\n**Online mode:** when "
+									},
+									{
+										"kind": "code",
+										"text": "`refreshTokenMode`"
+									},
+									{
+										"kind": "text",
+										"text": " is "
+									},
+									{
+										"kind": "code",
+										"text": "`'online'`"
+									},
+									{
+										"kind": "text",
+										"text": ", revoking the ORT via\n"
+									},
+									{
+										"kind": "code",
+										"text": "`/oauth/revoke`"
+									},
+									{
+										"kind": "text",
+										"text": " **also terminates the Auth0 session** and **clears the entire local\ncache** (access token, ID token, user profile). Because Online Refresh Tokens are\nsession-bound, the authorization server ties the token directly to the session —\nrevoking the ORT invalidates the session server-side. The local cache is cleared\nimmediately so that "
+									},
+									{
+										"kind": "code",
+										"text": "`isAuthenticated()`"
+									},
+									{
+										"kind": "text",
+										"text": " returns "
+									},
+									{
+										"kind": "code",
+										"text": "`false`"
+									},
+									{
+										"kind": "text",
+										"text": " and "
+									},
+									{
+										"kind": "code",
+										"text": "`getUser()`"
+									},
+									{
+										"kind": "text",
+										"text": " returns\n"
+									},
+									{
+										"kind": "code",
+										"text": "`undefined`"
+									},
+									{
+										"kind": "text",
+										"text": " right away, without waiting for the access token to expire.\nUse this when you need to force a sign-out without a redirect (e.g. background\nrevocation). For a redirect-based sign-out, prefer "
+									},
+									{
+										"kind": "code",
+										"text": "`logout()`"
+									},
+									{
+										"kind": "text",
+										"text": ".\n\n**Important:** This method revokes the refresh token for a single audience. If your\napplication requests tokens for multiple audiences, each audience may have its own\nrefresh token. To fully revoke all refresh tokens, call this method once per audience.\nIf you want to terminate the user's session with a redirect, use "
+									},
+									{
+										"kind": "code",
+										"text": "`logout()`"
+									},
+									{
+										"kind": "text",
+										"text": " instead.\n\nWhen using Multi-Resource Refresh Tokens (MRRT), a single refresh token may cover\nmultiple audiences. In that case, revoking it will affect all cache entries that\nshare the same token."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@example",
+										"content": [
+											{
+												"kind": "code",
+												"text": "```ts\n// Revoke the default refresh token\nawait auth0.revokeRefreshToken();\n```"
+											}
+										]
+									},
+									{
+										"tag": "@example",
+										"content": [
+											{
+												"kind": "code",
+												"text": "```ts\n// Revoke refresh tokens for each audience individually\nawait auth0.revokeRefreshToken({ audience: 'https://api.example.com' });\nawait auth0.revokeRefreshToken({ audience: 'https://api2.example.com' });\n```"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 1255,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L1255"
+								}
+							],
+							"parameters": [
+								{
+									"id": 160,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Optional parameters to identify which refresh token to revoke.\n  Defaults to the audience configured in "
+											},
+											{
+												"kind": "code",
+												"text": "`authorizationParams`"
+											},
+											{
+												"kind": "text",
+												"text": "."
+											},
+											{
+												"kind": "text",
+												"text": "\n\nType: [RevokeRefreshTokenOptions](/docs/sdk/typescript/interfaces/RevokeRefreshTokenOptions)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 1514,
+										"name": "RevokeRefreshTokenOptions",
+										"package": "@auth0/auth0-spa-js"
+									},
+									"defaultValue": "{}"
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "intrinsic",
+										"name": "void"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 243,
+					"name": "setDpopNonce",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/Auth0Client.ts",
+							"line": 2063,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L2063"
+						}
+					],
+					"signatures": [
+						{
+							"id": 244,
+							"name": "setDpopNonce",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Sets the current DPoP nonce used for making requests to Auth0.\n\nIt requires enabling the "
+									},
+									{
+										"kind": "inline-tag",
+										"tag": "@link",
+										"text": "Auth0ClientOptions.useDpop",
+										"target": 1262,
+										"tsLinkText": ""
+									},
+									{
+										"kind": "text",
+										"text": " option."
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/Auth0Client.ts",
+									"line": 2063,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L2063"
+								}
+							],
+							"parameters": [
+								{
+									"id": 245,
+									"name": "nonce",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The nonce value."
+											}
+										]
+									},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 246,
+									"name": "id",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {
+										"isOptional": true
+									},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The identifier of a nonce: if absent, it will set the nonce\n             used for requests to Auth0. Otherwise, it will be used to\n             select a specific non-Auth0 nonce."
+											}
+										]
+									},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "intrinsic",
+										"name": "void"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						13
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						37,
+						36,
+						38
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						119,
+						259,
+						255,
+						231,
+						234,
+						247,
+						45,
+						240,
+						99,
+						122,
+						149,
+						96,
+						105,
+						153,
+						228,
+						92,
+						101,
+						161,
+						158,
+						243
+					]
+				}
+			],
+			"categories": [
+				{
+					"title": "Sub-clients",
+					"children": [
+						37,
+						36,
+						38
+					]
+				},
+				{
+					"title": "Authentication",
+					"children": [
+						119,
+						105,
+						153,
+						92,
+						101,
+						161
+					]
+				},
+				{
+					"title": "Tokens",
+					"children": [
+						231,
+						234,
+						122,
+						149,
+						228,
+						158
+					]
+				},
+				{
+					"title": "User Profile",
+					"children": [
+						99,
+						96
+					]
+				},
+				{
+					"title": "Connected Accounts",
+					"children": [
+						259
+					]
+				},
+				{
+					"title": "Advanced",
+					"children": [
+						13,
+						255,
+						247,
+						45,
+						240,
+						243
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/Auth0Client.ts",
+					"line": 145,
+					"character": 13,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/Auth0Client.ts#L145"
+				}
+			]
+		},
+		{
+			"id": 332,
+			"name": "AuthenticationError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Thrown when handling the redirect callback fails, will be one of Auth0's\nAuthentication API's Standard Error Responses: https://auth0.com/docs/api/authentication?javascript#standard-error-responses"
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 339,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 47,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L47"
+						}
+					],
+					"signatures": [
+						{
+							"id": 340,
+							"name": "new AuthenticationError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/errors.ts",
+									"line": 47,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L47"
+								}
+							],
+							"parameters": [
+								{
+									"id": 341,
+									"name": "error",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 342,
+									"name": "error_description",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 343,
+									"name": "state",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 344,
+									"name": "appState",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "any"
+									},
+									"defaultValue": "null"
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 332,
+								"name": "AuthenticationError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 313,
+								"name": "GenericError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 312,
+						"name": "GenericError.constructor"
+					}
+				},
+				{
+					"id": 346,
+					"name": "appState",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 51,
+							"character": 11,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L51"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "any"
+					},
+					"defaultValue": "null"
+				},
+				{
+					"id": 347,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 21,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 316,
+						"name": "GenericError.error"
+					}
+				},
+				{
+					"id": 348,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 43,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 317,
+						"name": "GenericError.error_description"
+					}
+				},
+				{
+					"id": 345,
+					"name": "state",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 50,
+							"character": 11,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L50"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 333,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 20,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L20"
+						}
+					],
+					"signatures": [
+						{
+							"id": 334,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/errors.ts",
+									"line": 20,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L20"
+								}
+							],
+							"parameters": [
+								{
+									"id": 335,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 336,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 337,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/errors.ts",
+															"line": 24,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L24"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 338,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/errors.ts",
+															"line": 25,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L25"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														337,
+														338
+													]
+												}
+											],
+											"sources": [
+												{
+													"fileName": "src/errors.ts",
+													"line": 23,
+													"character": 5,
+													"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L23"
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 305,
+								"name": "GenericError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"inheritedFrom": {
+								"type": "reference",
+								"target": 307,
+								"name": "GenericError.fromPayload"
+							}
+						}
+					],
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 306,
+						"name": "GenericError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						339
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						346,
+						347,
+						348,
+						345
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						333
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/errors.ts",
+					"line": 46,
+					"character": 13,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L46"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 305,
+					"name": "GenericError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 618,
+			"name": "CacheKey",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"children": [
+				{
+					"id": 625,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/cache/shared.ts",
+							"line": 17,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L17"
+						}
+					],
+					"signatures": [
+						{
+							"id": 626,
+							"name": "new CacheKey",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/cache/shared.ts",
+									"line": 17,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L17"
+								}
+							],
+							"parameters": [
+								{
+									"id": 627,
+									"name": "data",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Type: [CacheKeyData](/docs/sdk/typescript/types/CacheKeyData)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 677,
+										"name": "CacheKeyData",
+										"package": "@auth0/auth0-spa-js"
+									}
+								},
+								{
+									"id": 628,
+									"name": "prefix",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									},
+									"defaultValue": "CACHE_KEY_PREFIX"
+								},
+								{
+									"id": 629,
+									"name": "suffix",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {
+										"isOptional": true
+									},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 618,
+								"name": "CacheKey",
+								"package": "@auth0/auth0-spa-js"
+							}
+						}
+					]
+				},
+				{
+					"id": 632,
+					"name": "audience",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true,
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/cache/shared.ts",
+							"line": 15,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 630,
+					"name": "clientId",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/cache/shared.ts",
+							"line": 13,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L13"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 633,
+					"name": "prefix",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/cache/shared.ts",
+							"line": 19,
+							"character": 11,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L19"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"defaultValue": "CACHE_KEY_PREFIX"
+				},
+				{
+					"id": 631,
+					"name": "scope",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true,
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/cache/shared.ts",
+							"line": 14,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L14"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 634,
+					"name": "suffix",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true,
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/cache/shared.ts",
+							"line": 20,
+							"character": 11,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L20"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 622,
+					"name": "fromCacheEntry",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/cache/shared.ts",
+							"line": 53,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L53"
+						}
+					],
+					"signatures": [
+						{
+							"id": 623,
+							"name": "fromCacheEntry",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Utility function to build a "
+									},
+									{
+										"kind": "code",
+										"text": "`CacheKey`"
+									},
+									{
+										"kind": "text",
+										"text": " instance from a cache entry"
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "An instance of "
+											},
+											{
+												"kind": "code",
+												"text": "`CacheKey`"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/cache/shared.ts",
+									"line": 53,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L53"
+								}
+							],
+							"parameters": [
+								{
+									"id": 624,
+									"name": "entry",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The entry"
+											},
+											{
+												"kind": "text",
+												"text": "\n\nType: [CacheEntry](/docs/sdk/typescript/types/CacheEntry)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 656,
+										"name": "CacheEntry",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 618,
+								"name": "CacheKey",
+								"package": "@auth0/auth0-spa-js"
+							}
+						}
+					]
+				},
+				{
+					"id": 619,
+					"name": "fromKey",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/cache/shared.ts",
+							"line": 42,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L42"
+						}
+					],
+					"signatures": [
+						{
+							"id": 620,
+							"name": "fromKey",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Converts a cache key string into a "
+									},
+									{
+										"kind": "code",
+										"text": "`CacheKey`"
+									},
+									{
+										"kind": "text",
+										"text": " instance."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "An instance of "
+											},
+											{
+												"kind": "code",
+												"text": "`CacheKey`"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/cache/shared.ts",
+									"line": 42,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L42"
+								}
+							],
+							"parameters": [
+								{
+									"id": 621,
+									"name": "key",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The key to convert"
+											}
+										]
+									},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 618,
+								"name": "CacheKey",
+								"package": "@auth0/auth0-spa-js"
+							}
+						}
+					]
+				},
+				{
+					"id": 635,
+					"name": "toKey",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/cache/shared.ts",
+							"line": 31,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L31"
+						}
+					],
+					"signatures": [
+						{
+							"id": 636,
+							"name": "toKey",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Converts this "
+									},
+									{
+										"kind": "code",
+										"text": "`CacheKey`"
+									},
+									{
+										"kind": "text",
+										"text": " instance into a string for use in a cache"
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A string representation of the key"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/cache/shared.ts",
+									"line": 31,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L31"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						}
+					]
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						625
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						632,
+						630,
+						633,
+						631,
+						634
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						622,
+						619,
+						635
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/cache/shared.ts",
+					"line": 12,
+					"character": 13,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L12"
+				}
+			]
+		},
+		{
+			"id": 286,
+			"name": "ConnectError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Thrown when handling the redirect callback for the connect flow fails, will be one of Auth0's\nAuthentication API's Standard Error Responses: https://auth0.com/docs/api/authentication?javascript#standard-error-responses"
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 293,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 64,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L64"
+						}
+					],
+					"signatures": [
+						{
+							"id": 294,
+							"name": "new ConnectError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/errors.ts",
+									"line": 64,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L64"
+								}
+							],
+							"parameters": [
+								{
+									"id": 295,
+									"name": "error",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 296,
+									"name": "error_description",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 297,
+									"name": "connection",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 298,
+									"name": "state",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 299,
+									"name": "appState",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "any"
+									},
+									"defaultValue": "null"
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 286,
+								"name": "ConnectError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 313,
+								"name": "GenericError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 312,
+						"name": "GenericError.constructor"
+					}
+				},
+				{
+					"id": 302,
+					"name": "appState",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 69,
+							"character": 11,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L69"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "any"
+					},
+					"defaultValue": "null"
+				},
+				{
+					"id": 300,
+					"name": "connection",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 67,
+							"character": 11,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L67"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 303,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 21,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 316,
+						"name": "GenericError.error"
+					}
+				},
+				{
+					"id": 304,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 43,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 317,
+						"name": "GenericError.error_description"
+					}
+				},
+				{
+					"id": 301,
+					"name": "state",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 68,
+							"character": 11,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L68"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 287,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 20,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L20"
+						}
+					],
+					"signatures": [
+						{
+							"id": 288,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/errors.ts",
+									"line": 20,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L20"
+								}
+							],
+							"parameters": [
+								{
+									"id": 289,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 290,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 291,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/errors.ts",
+															"line": 24,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L24"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 292,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/errors.ts",
+															"line": 25,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L25"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														291,
+														292
+													]
+												}
+											],
+											"sources": [
+												{
+													"fileName": "src/errors.ts",
+													"line": 23,
+													"character": 5,
+													"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L23"
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 305,
+								"name": "GenericError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"inheritedFrom": {
+								"type": "reference",
+								"target": 307,
+								"name": "GenericError.fromPayload"
+							}
+						}
+					],
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 306,
+						"name": "GenericError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						293
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						302,
+						300,
+						303,
+						304,
+						301
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						287
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/errors.ts",
+					"line": 63,
+					"character": 13,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L63"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 305,
+					"name": "GenericError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 689,
+			"name": "Fetcher",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"children": [
+				{
+					"id": 690,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/fetcher.ts",
+							"line": 61,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/fetcher.ts#L61"
+						}
+					],
+					"signatures": [
+						{
+							"id": 691,
+							"name": "new Fetcher",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/fetcher.ts",
+									"line": 61,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/fetcher.ts#L61"
+								}
+							],
+							"typeParameter": [
+								{
+									"id": 692,
+									"name": "TOutput",
+									"variant": "typeParam",
+									"kind": 131072,
+									"flags": {},
+									"type": {
+										"type": "reference",
+										"target": 750,
+										"name": "CustomFetchMinimalOutput",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"parameters": [
+								{
+									"id": 693,
+									"name": "config",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Type: [FetcherConfig](/docs/sdk/typescript/types/FetcherConfig)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 682,
+										"typeArguments": [
+											{
+												"type": "reference",
+												"target": 692,
+												"name": "TOutput",
+												"package": "@auth0/auth0-spa-js",
+												"qualifiedName": "Fetcher.TOutput",
+												"refersToTypeParameter": true
+											}
+										],
+										"name": "FetcherConfig",
+										"package": "@auth0/auth0-spa-js"
+									}
+								},
+								{
+									"id": 694,
+									"name": "hooks",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reference",
+										"target": {
+											"sourceFileName": "src/fetcher.ts",
+											"qualifiedName": "FetcherHooks"
+										},
+										"name": "FetcherHooks",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 689,
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 692,
+										"name": "TOutput",
+										"package": "@auth0/auth0-spa-js",
+										"qualifiedName": "Fetcher.TOutput",
+										"refersToTypeParameter": true
+									}
+								],
+								"name": "Fetcher",
+								"package": "@auth0/auth0-spa-js"
+							}
+						}
+					]
+				},
+				{
+					"id": 744,
+					"name": "fetchWithAuth",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/fetcher.ts",
+							"line": 250,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/fetcher.ts#L250"
+						}
+					],
+					"signatures": [
+						{
+							"id": 745,
+							"name": "fetchWithAuth",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/fetcher.ts",
+									"line": 250,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/fetcher.ts#L250"
+								}
+							],
+							"parameters": [
+								{
+									"id": 746,
+									"name": "info",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "union",
+										"types": [
+											{
+												"type": "reference",
+												"target": {
+													"sourceFileName": "node_modules/typescript/lib/lib.dom.d.ts",
+													"qualifiedName": "URL"
+												},
+												"name": "URL",
+												"package": "typescript"
+											},
+											{
+												"type": "reference",
+												"target": {
+													"sourceFileName": "node_modules/typescript/lib/lib.dom.d.ts",
+													"qualifiedName": "RequestInfo"
+												},
+												"name": "RequestInfo",
+												"package": "typescript"
+											}
+										]
+									}
+								},
+								{
+									"id": 747,
+									"name": "init",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {
+										"isOptional": true
+									},
+									"type": {
+										"type": "reference",
+										"target": {
+											"sourceFileName": "node_modules/typescript/lib/lib.dom.d.ts",
+											"qualifiedName": "RequestInit"
+										},
+										"name": "RequestInit",
+										"package": "typescript"
+									}
+								},
+								{
+									"id": 748,
+									"name": "authParams",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {
+										"isOptional": true
+									},
+									"type": {
+										"type": "reference",
+										"target": {
+											"sourceFileName": "src/fetcher.ts",
+											"qualifiedName": "AuthParams"
+										},
+										"name": "AuthParams",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 692,
+										"name": "TOutput",
+										"package": "@auth0/auth0-spa-js",
+										"qualifiedName": "Fetcher.TOutput",
+										"refersToTypeParameter": true
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						690
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						744
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/fetcher.ts",
+					"line": 55,
+					"character": 13,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/fetcher.ts#L55"
+				}
+			],
+			"typeParameters": [
+				{
+					"id": 749,
+					"name": "TOutput",
+					"variant": "typeParam",
+					"kind": 131072,
+					"flags": {},
+					"type": {
+						"type": "reference",
+						"target": 750,
+						"name": "CustomFetchMinimalOutput",
+						"package": "@auth0/auth0-spa-js"
+					}
+				}
+			]
+		},
+		{
+			"id": 305,
+			"name": "GenericError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Thrown when network requests to the Auth server fail."
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 312,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"signatures": [
+						{
+							"id": 313,
+							"name": "new GenericError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/errors.ts",
+									"line": 15,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+								}
+							],
+							"parameters": [
+								{
+									"id": 314,
+									"name": "error",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 315,
+									"name": "error_description",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 305,
+								"name": "GenericError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": -1,
+								"name": "Error.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": -1,
+						"name": "Error.constructor"
+					}
+				},
+				{
+					"id": 316,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 21,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 317,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 43,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 306,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 20,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L20"
+						}
+					],
+					"signatures": [
+						{
+							"id": 307,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/errors.ts",
+									"line": 20,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L20"
+								}
+							],
+							"parameters": [
+								{
+									"id": 308,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 309,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 310,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/errors.ts",
+															"line": 24,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L24"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 311,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/errors.ts",
+															"line": 25,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L25"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														310,
+														311
+													]
+												}
+											],
+											"sources": [
+												{
+													"fileName": "src/errors.ts",
+													"line": 23,
+													"character": 5,
+													"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L23"
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 305,
+								"name": "GenericError",
+								"package": "@auth0/auth0-spa-js"
+							}
+						}
+					]
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						312
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						316,
+						317
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						306
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/errors.ts",
+					"line": 14,
+					"character": 13,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L14"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+						"qualifiedName": "Error"
+					},
+					"name": "Error",
+					"package": "typescript"
+				}
+			],
+			"extendedBy": [
+				{
+					"type": "reference",
+					"target": 286,
+					"name": "ConnectError"
+				},
+				{
+					"type": "reference",
+					"target": 318,
+					"name": "InvalidConfigurationError"
+				},
+				{
+					"type": "reference",
+					"target": 332,
+					"name": "AuthenticationError"
+				},
+				{
+					"type": "reference",
+					"target": 349,
+					"name": "TimeoutError"
+				},
+				{
+					"type": "reference",
+					"target": 373,
+					"name": "PopupCancelledError"
+				},
+				{
+					"type": "reference",
+					"target": 386,
+					"name": "PopupOpenError"
+				},
+				{
+					"type": "reference",
+					"target": 397,
+					"name": "MfaRequiredError"
+				},
+				{
+					"type": "reference",
+					"target": 414,
+					"name": "MissingRefreshTokenError"
+				},
+				{
+					"type": "reference",
+					"target": 429,
+					"name": "MissingScopesError"
+				},
+				{
+					"type": "reference",
+					"target": 444,
+					"name": "UseDpopNonceError"
+				},
+				{
+					"type": "reference",
+					"target": 464,
+					"name": "MfaError"
+				}
+			]
+		},
+		{
+			"id": 614,
+			"name": "InMemoryCache",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"children": [
+				{
+					"id": 615,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"signatures": [
+						{
+							"id": 616,
+							"name": "new InMemoryCache",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"type": {
+								"type": "reference",
+								"target": 614,
+								"name": "InMemoryCache",
+								"package": "@auth0/auth0-spa-js"
+							}
+						}
+					]
+				},
+				{
+					"id": 617,
+					"name": "enclosedCache",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Type: [ICache](/docs/sdk/typescript/interfaces/ICache)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/cache/cache-memory.ts",
+							"line": 4,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/cache-memory.ts#L4"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 637,
+						"name": "ICache",
+						"package": "@auth0/auth0-spa-js"
+					},
+					"defaultValue": "..."
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						615
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						617
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/cache/cache-memory.ts",
+					"line": 3,
+					"character": 13,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/cache-memory.ts#L3"
+				}
+			]
+		},
+		{
+			"id": 318,
+			"name": "InvalidConfigurationError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Thrown at construction time for an invalid option combination (e.g.\n"
+					},
+					{
+						"kind": "code",
+						"text": "`refreshTokenMode: 'online'`"
+					},
+					{
+						"kind": "text",
+						"text": " without "
+					},
+					{
+						"kind": "code",
+						"text": "`useDpop: true`"
+					},
+					{
+						"kind": "text",
+						"text": "). The "
+					},
+					{
+						"kind": "code",
+						"text": "`suggestion`"
+					},
+					{
+						"kind": "text",
+						"text": " names the fix."
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 325,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 36,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L36"
+						}
+					],
+					"signatures": [
+						{
+							"id": 326,
+							"name": "new InvalidConfigurationError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/errors.ts",
+									"line": 36,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L36"
+								}
+							],
+							"parameters": [
+								{
+									"id": 327,
+									"name": "message",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 328,
+									"name": "suggestion",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 318,
+								"name": "InvalidConfigurationError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 313,
+								"name": "GenericError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 312,
+						"name": "GenericError.constructor"
+					}
+				},
+				{
+					"id": 330,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 21,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 316,
+						"name": "GenericError.error"
+					}
+				},
+				{
+					"id": 331,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 43,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 317,
+						"name": "GenericError.error_description"
+					}
+				},
+				{
+					"id": 329,
+					"name": "suggestion",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 36,
+							"character": 38,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L36"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 319,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 20,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L20"
+						}
+					],
+					"signatures": [
+						{
+							"id": 320,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/errors.ts",
+									"line": 20,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L20"
+								}
+							],
+							"parameters": [
+								{
+									"id": 321,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 322,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 323,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/errors.ts",
+															"line": 24,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L24"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 324,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/errors.ts",
+															"line": 25,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L25"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														323,
+														324
+													]
+												}
+											],
+											"sources": [
+												{
+													"fileName": "src/errors.ts",
+													"line": 23,
+													"character": 5,
+													"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L23"
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 305,
+								"name": "GenericError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"inheritedFrom": {
+								"type": "reference",
+								"target": 307,
+								"name": "GenericError.fromPayload"
+							}
+						}
+					],
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 306,
+						"name": "GenericError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						325
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						330,
+						331,
+						329
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						319
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/errors.ts",
+					"line": 35,
+					"character": 13,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L35"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 305,
+					"name": "GenericError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 597,
+			"name": "LocalStorageCache",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"children": [
+				{
+					"id": 598,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"signatures": [
+						{
+							"id": 599,
+							"name": "new LocalStorageCache",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"type": {
+								"type": "reference",
+								"target": 597,
+								"name": "LocalStorageCache",
+								"package": "@auth0/auth0-spa-js"
+							}
+						}
+					]
+				},
+				{
+					"id": 612,
+					"name": "allKeys",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/cache/cache-localstorage.ts",
+							"line": 26,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/cache-localstorage.ts#L26"
+						}
+					],
+					"signatures": [
+						{
+							"id": 613,
+							"name": "allKeys",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/cache/cache-localstorage.ts",
+									"line": 26,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/cache-localstorage.ts#L26"
+								}
+							],
+							"type": {
+								"type": "array",
+								"elementType": {
+									"type": "intrinsic",
+									"name": "string"
+								}
+							},
+							"implementationOf": {
+								"type": "reference",
+								"target": 651,
+								"name": "ICache.allKeys"
+							}
+						}
+					],
+					"implementationOf": {
+						"type": "reference",
+						"target": 650,
+						"name": "ICache.allKeys"
+					}
+				},
+				{
+					"id": 605,
+					"name": "get",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/cache/cache-localstorage.ts",
+							"line": 8,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/cache-localstorage.ts#L8"
+						}
+					],
+					"signatures": [
+						{
+							"id": 606,
+							"name": "get",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/cache/cache-localstorage.ts",
+									"line": 8,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/cache-localstorage.ts#L8"
+								}
+							],
+							"typeParameter": [
+								{
+									"id": 607,
+									"name": "T",
+									"variant": "typeParam",
+									"kind": 131072,
+									"flags": {},
+									"default": {
+										"type": "reference",
+										"target": 652,
+										"name": "Cacheable",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"parameters": [
+								{
+									"id": 608,
+									"name": "key",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 675,
+								"typeArguments": [
+									{
+										"type": "union",
+										"types": [
+											{
+												"type": "intrinsic",
+												"name": "undefined"
+											},
+											{
+												"type": "reference",
+												"target": 607,
+												"name": "T",
+												"package": "@auth0/auth0-spa-js",
+												"refersToTypeParameter": true
+											}
+										]
+									}
+								],
+								"name": "MaybePromise",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"implementationOf": {
+								"type": "reference",
+								"target": 644,
+								"name": "ICache.get"
+							}
+						}
+					],
+					"implementationOf": {
+						"type": "reference",
+						"target": 643,
+						"name": "ICache.get"
+					}
+				},
+				{
+					"id": 609,
+					"name": "remove",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/cache/cache-localstorage.ts",
+							"line": 22,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/cache-localstorage.ts#L22"
+						}
+					],
+					"signatures": [
+						{
+							"id": 610,
+							"name": "remove",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/cache/cache-localstorage.ts",
+									"line": 22,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/cache-localstorage.ts#L22"
+								}
+							],
+							"parameters": [
+								{
+									"id": 611,
+									"name": "key",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "void"
+							},
+							"implementationOf": {
+								"type": "reference",
+								"target": 648,
+								"name": "ICache.remove"
+							}
+						}
+					],
+					"implementationOf": {
+						"type": "reference",
+						"target": 647,
+						"name": "ICache.remove"
+					}
+				},
+				{
+					"id": 600,
+					"name": "set",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/cache/cache-localstorage.ts",
+							"line": 4,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/cache-localstorage.ts#L4"
+						}
+					],
+					"signatures": [
+						{
+							"id": 601,
+							"name": "set",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/cache/cache-localstorage.ts",
+									"line": 4,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/cache-localstorage.ts#L4"
+								}
+							],
+							"typeParameter": [
+								{
+									"id": 602,
+									"name": "T",
+									"variant": "typeParam",
+									"kind": 131072,
+									"flags": {},
+									"default": {
+										"type": "reference",
+										"target": 652,
+										"name": "Cacheable",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"parameters": [
+								{
+									"id": 603,
+									"name": "key",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 604,
+									"name": "entry",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reference",
+										"target": 602,
+										"name": "T",
+										"package": "@auth0/auth0-spa-js",
+										"refersToTypeParameter": true
+									}
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "void"
+							},
+							"implementationOf": {
+								"type": "reference",
+								"target": 639,
+								"name": "ICache.set"
+							}
+						}
+					],
+					"implementationOf": {
+						"type": "reference",
+						"target": 638,
+						"name": "ICache.set"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						598
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						612,
+						605,
+						609,
+						600
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/cache/cache-localstorage.ts",
+					"line": 3,
+					"character": 13,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/cache-localstorage.ts#L3"
+				}
+			],
+			"implementedTypes": [
+				{
+					"type": "reference",
+					"target": 637,
+					"name": "ICache",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 542,
+			"name": "MfaApiClient",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Client for Auth0 MFA API operations\n\nManages multi-factor authentication including:\n- Listing enrolled authenticators\n- Enrolling new authenticators (OTP, SMS, Voice, Push, Email)\n- Initiating MFA challenges\n- Verifying MFA challenges\n\nThis is a wrapper around auth0-auth-js MfaClient that maintains\nbackward compatibility with the existing spa-js API.\n\nMFA context (scope, audience) is stored internally keyed by mfaToken,\nenabling concurrent MFA flows without state conflicts."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@example",
+						"content": [
+							{
+								"kind": "code",
+								"text": "```typescript\ntry {\n  await auth0.getTokenSilently({ authorizationParams: { audience: 'https://api.example.com' } });\n} catch (e) {\n  if (e instanceof MfaRequiredError) {\n    // SDK automatically stores context for this mfaToken\n    const authenticators = await auth0.mfa.getAuthenticators({ mfaToken: e.mfa_token });\n    // ... complete MFA flow\n  }\n}\n```"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 562,
+					"name": "challenge",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/MfaApiClient.ts",
+							"line": 233,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/MfaApiClient.ts#L233"
+						}
+					],
+					"signatures": [
+						{
+							"id": 563,
+							"name": "challenge",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Initiates an MFA challenge\n\nSends OTP via SMS, initiates push notification, or prepares for OTP entry"
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "Challenge response with oobCode if applicable"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If challenge initiation fails"
+											}
+										]
+									},
+									{
+										"tag": "@example",
+										"name": "OTP challenge",
+										"content": [
+											{
+												"kind": "code",
+												"text": "```typescript\nconst challenge = await mfa.challenge({\n  mfaToken: mfaTokenFromLogin,\n  challengeType: 'otp',\n  authenticatorId: 'otp|dev_xxx'\n});\n// User enters OTP from their authenticator app\n```"
+											}
+										]
+									},
+									{
+										"tag": "@example",
+										"name": "SMS challenge",
+										"content": [
+											{
+												"kind": "code",
+												"text": "```typescript\nconst challenge = await mfa.challenge({\n  mfaToken: mfaTokenFromLogin,\n  challengeType: 'oob',\n  authenticatorId: 'sms|dev_xxx'\n});\nconsole.log(challenge.oobCode); // Use for verification\n```"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/mfa/MfaApiClient.ts",
+									"line": 233,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/MfaApiClient.ts#L233"
+								}
+							],
+							"parameters": [
+								{
+									"id": 564,
+									"name": "params",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Challenge parameters including mfaToken"
+											},
+											{
+												"kind": "text",
+												"text": "\n\nType: [ChallengeAuthenticatorParams](/docs/sdk/typescript/interfaces/ChallengeAuthenticatorParams)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 1541,
+										"name": "ChallengeAuthenticatorParams",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 1545,
+										"name": "ChallengeResponse",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 559,
+					"name": "enroll",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/MfaApiClient.ts",
+							"line": 185,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/MfaApiClient.ts#L185"
+						}
+					],
+					"signatures": [
+						{
+							"id": 560,
+							"name": "enroll",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Enrolls a new MFA authenticator\n\nRequires MFA access token with 'enroll' scope"
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "Enrollment response with authenticator details"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If enrollment fails"
+											}
+										]
+									},
+									{
+										"tag": "@example",
+										"name": "OTP enrollment",
+										"content": [
+											{
+												"kind": "code",
+												"text": "```typescript\nconst enrollment = await mfa.enroll({\n  mfaToken: mfaToken,\n  factorType: 'otp'\n});\nconsole.log(enrollment.secret); // Base32 secret\nconsole.log(enrollment.barcodeUri); // QR code URI\n```"
+											}
+										]
+									},
+									{
+										"tag": "@example",
+										"name": "SMS enrollment",
+										"content": [
+											{
+												"kind": "code",
+												"text": "```typescript\nconst enrollment = await mfa.enroll({\n  mfaToken: mfaToken,\n  factorType: 'sms',\n  phoneNumber: '+12025551234'\n});\n```"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/mfa/MfaApiClient.ts",
+									"line": 185,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/MfaApiClient.ts#L185"
+								}
+							],
+							"parameters": [
+								{
+									"id": 561,
+									"name": "params",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Enrollment parameters including mfaToken and factorType"
+											},
+											{
+												"kind": "text",
+												"text": "\n\nType: [EnrollParams](/docs/sdk/typescript/types/EnrollParams)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 572,
+										"name": "EnrollParams",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 1526,
+										"name": "EnrollmentResponse",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 556,
+					"name": "getAuthenticators",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/MfaApiClient.ts",
+							"line": 117,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/MfaApiClient.ts#L117"
+						}
+					],
+					"signatures": [
+						{
+							"id": 557,
+							"name": "getAuthenticators",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Gets enrolled MFA authenticators filtered by challenge types from context.\n\nChallenge types are automatically resolved from the stored MFA context\n(set when mfa_required error occurred)."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "Array of enrolled authenticators matching the challenge types"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If the request fails or context not found"
+											}
+										]
+									},
+									{
+										"tag": "@example",
+										"name": "Basic usage",
+										"content": [
+											{
+												"kind": "code",
+												"text": "```typescript\ntry {\n  await auth0.getTokenSilently();\n} catch (e) {\n  if (e instanceof MfaRequiredError) {\n    // SDK automatically uses challenge types from error context\n    const authenticators = await auth0.mfa.getAuthenticators(e.mfa_token);\n  }\n}\n```"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/mfa/MfaApiClient.ts",
+									"line": 117,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/MfaApiClient.ts#L117"
+								}
+							],
+							"parameters": [
+								{
+									"id": 558,
+									"name": "mfaToken",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "MFA token from mfa_required error"
+											}
+										]
+									},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "array",
+										"elementType": {
+											"type": "reference",
+											"target": 1516,
+											"name": "Authenticator",
+											"package": "@auth0/auth0-spa-js"
+										}
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 565,
+					"name": "getEnrollmentFactors",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/MfaApiClient.ts",
+							"line": 305,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/MfaApiClient.ts#L305"
+						}
+					],
+					"signatures": [
+						{
+							"id": 566,
+							"name": "getEnrollmentFactors",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Gets available MFA enrollment factors from the stored context.\n\nThis method exposes the enrollment options from the mfa_required error's\nmfaRequirements.enroll array, eliminating the need for manual parsing."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "Array of enrollment factors available for the user (empty array if no enrollment required)"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If MFA context not found"
+											}
+										]
+									},
+									{
+										"tag": "@example",
+										"name": "Basic usage",
+										"content": [
+											{
+												"kind": "code",
+												"text": "```typescript\ntry {\n  await auth0.getTokenSilently();\n} catch (error) {\n  if (error.error === 'mfa_required') {\n    // Get enrollment options from SDK\n    const enrollOptions = await auth0.mfa.getEnrollmentFactors(error.mfa_token);\n    // [{ type: 'otp' }, { type: 'phone' }, { type: 'push-notification' }]\n\n    showEnrollmentOptions(enrollOptions);\n  }\n}\n```"
+											}
+										]
+									},
+									{
+										"tag": "@example",
+										"name": "Check if enrollment is required",
+										"content": [
+											{
+												"kind": "code",
+												"text": "```typescript\ntry {\n  const factors = await auth0.mfa.getEnrollmentFactors(mfaToken);\n  if (factors.length > 0) {\n    // User needs to enroll in MFA\n    renderEnrollmentUI(factors);\n  } else {\n    // No enrollment required, proceed with challenge\n  }\n} catch (error) {\n  if (error instanceof MfaEnrollmentFactorsError) {\n    console.error('Context not found:', error.error_description);\n  }\n}\n```"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/mfa/MfaApiClient.ts",
+									"line": 305,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/MfaApiClient.ts#L305"
+								}
+							],
+							"parameters": [
+								{
+									"id": 567,
+									"name": "mfaToken",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "MFA token from mfa_required error"
+											}
+										]
+									},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "array",
+										"elementType": {
+											"type": "reference",
+											"target": 1550,
+											"name": "EnrollmentFactor",
+											"package": "@auth0/auth0-spa-js"
+										}
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 568,
+					"name": "verify",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/MfaApiClient.ts",
+							"line": 368,
+							"character": 15,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/MfaApiClient.ts#L368"
+						}
+					],
+					"signatures": [
+						{
+							"id": 569,
+							"name": "verify",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Verifies an MFA challenge and completes authentication\n\nThe scope and audience are retrieved from the stored context (set when the\nmfa_required error occurred). The grant_type is automatically inferred from\nwhich verification field is provided (otp, oobCode, or recoveryCode)."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "Token response with access_token, id_token, refresh_token"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If verification fails (invalid code, expired, rate limited)"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If MFA context not found"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If grant_type cannot be inferred\n\nRate limits:\n- 10 verification attempts allowed\n- Refreshes at 1 attempt per 6 minutes"
+											}
+										]
+									},
+									{
+										"tag": "@example",
+										"name": "OTP verification (grant_type inferred from otp field)",
+										"content": [
+											{
+												"kind": "code",
+												"text": "```typescript\nconst tokens = await mfa.verify({\n  mfaToken: mfaTokenFromLogin,\n  otp: '123456'\n});\nconsole.log(tokens.access_token);\n```"
+											}
+										]
+									},
+									{
+										"tag": "@example",
+										"name": "OOB verification (grant_type inferred from oobCode field)",
+										"content": [
+											{
+												"kind": "code",
+												"text": "```typescript\nconst tokens = await mfa.verify({\n  mfaToken: mfaTokenFromLogin,\n  oobCode: challenge.oobCode,\n  bindingCode: '123456' // Code user received via SMS\n});\n```"
+											}
+										]
+									},
+									{
+										"tag": "@example",
+										"name": "Recovery code verification (grant_type inferred from recoveryCode field)",
+										"content": [
+											{
+												"kind": "code",
+												"text": "```typescript\nconst tokens = await mfa.verify({\n  mfaToken: mfaTokenFromLogin,\n  recoveryCode: 'XXXX-XXXX-XXXX'\n});\n```"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/mfa/MfaApiClient.ts",
+									"line": 368,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/MfaApiClient.ts#L368"
+								}
+							],
+							"parameters": [
+								{
+									"id": 570,
+									"name": "params",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Verification parameters with OTP, OOB code, or recovery code"
+											},
+											{
+												"kind": "text",
+												"text": "\n\nType: [VerifyParams](/docs/sdk/typescript/interfaces/VerifyParams)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 591,
+										"name": "VerifyParams",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 1389,
+										"name": "TokenEndpointResponse",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				}
+			],
+			"groups": [
+				{
+					"title": "Methods",
+					"children": [
+						562,
+						559,
+						556,
+						565,
+						568
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/mfa/MfaApiClient.ts",
+					"line": 59,
+					"character": 13,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/MfaApiClient.ts#L59"
+				}
+			]
+		},
+		{
+			"id": 503,
+			"name": "MfaChallengeError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Error thrown when initiating an MFA challenge fails."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@example",
+						"content": [
+							{
+								"kind": "code",
+								"text": "```typescript\ntry {\n  const challenge = await mfa.challenge({\n    mfaToken: mfaToken,\n    challengeType: 'otp',\n    authenticatorId: 'otp|dev_123'\n  });\n} catch (error) {\n  if (error instanceof MfaChallengeError) {\n    console.log(error.error); // 'too_many_attempts'\n    console.log(error.error_description); // 'Rate limit exceeded'\n  }\n}\n```"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 510,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/mfa/errors.ts",
+							"line": 94,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L94"
+						}
+					],
+					"signatures": [
+						{
+							"id": 511,
+							"name": "new MfaChallengeError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/mfa/errors.ts",
+									"line": 94,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L94"
+								}
+							],
+							"parameters": [
+								{
+									"id": 512,
+									"name": "error",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 513,
+									"name": "error_description",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 503,
+								"name": "MfaChallengeError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 472,
+								"name": "MfaError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 471,
+						"name": "MfaError.constructor"
+					}
+				},
+				{
+					"id": 514,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 21,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 475,
+						"name": "MfaError.error"
+					}
+				},
+				{
+					"id": 515,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 43,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 476,
+						"name": "MfaError.error_description"
+					}
+				},
+				{
+					"id": 504,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/errors.ts",
+							"line": 15,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L15"
+						}
+					],
+					"signatures": [
+						{
+							"id": 505,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/mfa/errors.ts",
+									"line": 15,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L15"
+								}
+							],
+							"parameters": [
+								{
+									"id": 506,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 507,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 508,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/mfa/errors.ts",
+															"line": 19,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L19"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 509,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/mfa/errors.ts",
+															"line": 20,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L20"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														508,
+														509
+													]
+												}
+											],
+											"sources": [
+												{
+													"fileName": "src/mfa/errors.ts",
+													"line": 18,
+													"character": 5,
+													"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L18"
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 464,
+								"name": "MfaError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"inheritedFrom": {
+								"type": "reference",
+								"target": 466,
+								"name": "MfaError.fromPayload"
+							}
+						}
+					],
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 465,
+						"name": "MfaError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						510
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						514,
+						515
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						504
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/mfa/errors.ts",
+					"line": 93,
+					"character": 13,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L93"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 464,
+					"name": "MfaError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 490,
+			"name": "MfaEnrollmentError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Error thrown when enrolling an MFA authenticator fails."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@example",
+						"content": [
+							{
+								"kind": "code",
+								"text": "```typescript\ntry {\n  const enrollment = await mfa.enroll({\n    authenticator_types: ['otp']\n  });\n} catch (error) {\n  if (error instanceof MfaEnrollmentError) {\n    console.log(error.error); // 'invalid_phone_number'\n    console.log(error.error_description); // 'Invalid phone number format'\n  }\n}\n```"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 497,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/mfa/errors.ts",
+							"line": 67,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L67"
+						}
+					],
+					"signatures": [
+						{
+							"id": 498,
+							"name": "new MfaEnrollmentError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/mfa/errors.ts",
+									"line": 67,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L67"
+								}
+							],
+							"parameters": [
+								{
+									"id": 499,
+									"name": "error",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 500,
+									"name": "error_description",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 490,
+								"name": "MfaEnrollmentError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 472,
+								"name": "MfaError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 471,
+						"name": "MfaError.constructor"
+					}
+				},
+				{
+					"id": 501,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 21,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 475,
+						"name": "MfaError.error"
+					}
+				},
+				{
+					"id": 502,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 43,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 476,
+						"name": "MfaError.error_description"
+					}
+				},
+				{
+					"id": 491,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/errors.ts",
+							"line": 15,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L15"
+						}
+					],
+					"signatures": [
+						{
+							"id": 492,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/mfa/errors.ts",
+									"line": 15,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L15"
+								}
+							],
+							"parameters": [
+								{
+									"id": 493,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 494,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 495,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/mfa/errors.ts",
+															"line": 19,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L19"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 496,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/mfa/errors.ts",
+															"line": 20,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L20"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														495,
+														496
+													]
+												}
+											],
+											"sources": [
+												{
+													"fileName": "src/mfa/errors.ts",
+													"line": 18,
+													"character": 5,
+													"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L18"
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 464,
+								"name": "MfaError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"inheritedFrom": {
+								"type": "reference",
+								"target": 466,
+								"name": "MfaError.fromPayload"
+							}
+						}
+					],
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 465,
+						"name": "MfaError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						497
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						501,
+						502
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						491
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/mfa/errors.ts",
+					"line": 66,
+					"character": 13,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L66"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 464,
+					"name": "MfaError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 529,
+			"name": "MfaEnrollmentFactorsError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Error thrown when getting enrollment factors fails."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@example",
+						"content": [
+							{
+								"kind": "code",
+								"text": "```typescript\ntry {\n  const factors = await mfa.getEnrollmentFactors(mfaToken);\n} catch (error) {\n  if (error instanceof MfaEnrollmentFactorsError) {\n    console.log(error.error); // 'mfa_context_not_found'\n    console.log(error.error_description); // 'MFA context not found...'\n  }\n}\n```"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 536,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/mfa/errors.ts",
+							"line": 144,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L144"
+						}
+					],
+					"signatures": [
+						{
+							"id": 537,
+							"name": "new MfaEnrollmentFactorsError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/mfa/errors.ts",
+									"line": 144,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L144"
+								}
+							],
+							"parameters": [
+								{
+									"id": 538,
+									"name": "error",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 539,
+									"name": "error_description",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 529,
+								"name": "MfaEnrollmentFactorsError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 472,
+								"name": "MfaError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 471,
+						"name": "MfaError.constructor"
+					}
+				},
+				{
+					"id": 540,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 21,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 475,
+						"name": "MfaError.error"
+					}
+				},
+				{
+					"id": 541,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 43,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 476,
+						"name": "MfaError.error_description"
+					}
+				},
+				{
+					"id": 530,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/errors.ts",
+							"line": 15,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L15"
+						}
+					],
+					"signatures": [
+						{
+							"id": 531,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/mfa/errors.ts",
+									"line": 15,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L15"
+								}
+							],
+							"parameters": [
+								{
+									"id": 532,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 533,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 534,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/mfa/errors.ts",
+															"line": 19,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L19"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 535,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/mfa/errors.ts",
+															"line": 20,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L20"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														534,
+														535
+													]
+												}
+											],
+											"sources": [
+												{
+													"fileName": "src/mfa/errors.ts",
+													"line": 18,
+													"character": 5,
+													"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L18"
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 464,
+								"name": "MfaError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"inheritedFrom": {
+								"type": "reference",
+								"target": 466,
+								"name": "MfaError.fromPayload"
+							}
+						}
+					],
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 465,
+						"name": "MfaError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						536
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						540,
+						541
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						530
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/mfa/errors.ts",
+					"line": 143,
+					"character": 13,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L143"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 464,
+					"name": "MfaError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 464,
+			"name": "MfaError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Base class for MFA-related errors in auth0-spa-js.\nExtends GenericError for unified error hierarchy across the SDK."
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 471,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/mfa/errors.ts",
+							"line": 9,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L9"
+						}
+					],
+					"signatures": [
+						{
+							"id": 472,
+							"name": "new MfaError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/mfa/errors.ts",
+									"line": 9,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L9"
+								}
+							],
+							"parameters": [
+								{
+									"id": 473,
+									"name": "error",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 474,
+									"name": "error_description",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 464,
+								"name": "MfaError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 313,
+								"name": "GenericError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 312,
+						"name": "GenericError.constructor"
+					}
+				},
+				{
+					"id": 475,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 21,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 316,
+						"name": "GenericError.error"
+					}
+				},
+				{
+					"id": 476,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 43,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 317,
+						"name": "GenericError.error_description"
+					}
+				},
+				{
+					"id": 465,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/errors.ts",
+							"line": 15,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L15"
+						}
+					],
+					"signatures": [
+						{
+							"id": 466,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/mfa/errors.ts",
+									"line": 15,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L15"
+								}
+							],
+							"parameters": [
+								{
+									"id": 467,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 468,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 469,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/mfa/errors.ts",
+															"line": 19,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L19"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 470,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/mfa/errors.ts",
+															"line": 20,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L20"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														469,
+														470
+													]
+												}
+											],
+											"sources": [
+												{
+													"fileName": "src/mfa/errors.ts",
+													"line": 18,
+													"character": 5,
+													"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L18"
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 464,
+								"name": "MfaError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 307,
+								"name": "GenericError.fromPayload"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 306,
+						"name": "GenericError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						471
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						475,
+						476
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						465
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/mfa/errors.ts",
+					"line": 8,
+					"character": 13,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L8"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 305,
+					"name": "GenericError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			],
+			"extendedBy": [
+				{
+					"type": "reference",
+					"target": 477,
+					"name": "MfaListAuthenticatorsError"
+				},
+				{
+					"type": "reference",
+					"target": 490,
+					"name": "MfaEnrollmentError"
+				},
+				{
+					"type": "reference",
+					"target": 503,
+					"name": "MfaChallengeError"
+				},
+				{
+					"type": "reference",
+					"target": 516,
+					"name": "MfaVerifyError"
+				},
+				{
+					"type": "reference",
+					"target": 529,
+					"name": "MfaEnrollmentFactorsError"
+				}
+			]
+		},
+		{
+			"id": 477,
+			"name": "MfaListAuthenticatorsError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Error thrown when listing MFA authenticators fails."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@example",
+						"content": [
+							{
+								"kind": "code",
+								"text": "```typescript\ntry {\n  const authenticators = await mfa.getAuthenticators();\n} catch (error) {\n  if (error instanceof MfaListAuthenticatorsError) {\n    console.log(error.error); // 'access_denied'\n    console.log(error.error_description); // 'Unauthorized'\n  }\n}\n```"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 484,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/mfa/errors.ts",
+							"line": 42,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L42"
+						}
+					],
+					"signatures": [
+						{
+							"id": 485,
+							"name": "new MfaListAuthenticatorsError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/mfa/errors.ts",
+									"line": 42,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L42"
+								}
+							],
+							"parameters": [
+								{
+									"id": 486,
+									"name": "error",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 487,
+									"name": "error_description",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 477,
+								"name": "MfaListAuthenticatorsError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 472,
+								"name": "MfaError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 471,
+						"name": "MfaError.constructor"
+					}
+				},
+				{
+					"id": 488,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 21,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 475,
+						"name": "MfaError.error"
+					}
+				},
+				{
+					"id": 489,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 43,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 476,
+						"name": "MfaError.error_description"
+					}
+				},
+				{
+					"id": 478,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/errors.ts",
+							"line": 15,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L15"
+						}
+					],
+					"signatures": [
+						{
+							"id": 479,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/mfa/errors.ts",
+									"line": 15,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L15"
+								}
+							],
+							"parameters": [
+								{
+									"id": 480,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 481,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 482,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/mfa/errors.ts",
+															"line": 19,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L19"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 483,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/mfa/errors.ts",
+															"line": 20,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L20"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														482,
+														483
+													]
+												}
+											],
+											"sources": [
+												{
+													"fileName": "src/mfa/errors.ts",
+													"line": 18,
+													"character": 5,
+													"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L18"
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 464,
+								"name": "MfaError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"inheritedFrom": {
+								"type": "reference",
+								"target": 466,
+								"name": "MfaError.fromPayload"
+							}
+						}
+					],
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 465,
+						"name": "MfaError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						484
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						488,
+						489
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						478
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/mfa/errors.ts",
+					"line": 41,
+					"character": 13,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L41"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 464,
+					"name": "MfaError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 397,
+			"name": "MfaRequiredError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Error thrown when the token exchange results in a "
+					},
+					{
+						"kind": "code",
+						"text": "`mfa_required`"
+					},
+					{
+						"kind": "text",
+						"text": " error"
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 404,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 120,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L120"
+						}
+					],
+					"signatures": [
+						{
+							"id": 405,
+							"name": "new MfaRequiredError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/errors.ts",
+									"line": 120,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L120"
+								}
+							],
+							"parameters": [
+								{
+									"id": 406,
+									"name": "error",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 407,
+									"name": "error_description",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 408,
+									"name": "mfa_token",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 409,
+									"name": "mfa_requirements",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Type: [MfaRequirements](/docs/sdk/typescript/interfaces/MfaRequirements)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 457,
+										"name": "MfaRequirements",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 397,
+								"name": "MfaRequiredError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 313,
+								"name": "GenericError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 312,
+						"name": "GenericError.constructor"
+					}
+				},
+				{
+					"id": 412,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 21,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 316,
+						"name": "GenericError.error"
+					}
+				},
+				{
+					"id": 413,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 43,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 317,
+						"name": "GenericError.error_description"
+					}
+				},
+				{
+					"id": 411,
+					"name": "mfa_requirements",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Type: [MfaRequirements](/docs/sdk/typescript/interfaces/MfaRequirements)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 124,
+							"character": 11,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L124"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 457,
+						"name": "MfaRequirements",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 410,
+					"name": "mfa_token",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 123,
+							"character": 11,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L123"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 398,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 20,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L20"
+						}
+					],
+					"signatures": [
+						{
+							"id": 399,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/errors.ts",
+									"line": 20,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L20"
+								}
+							],
+							"parameters": [
+								{
+									"id": 400,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 401,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 402,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/errors.ts",
+															"line": 24,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L24"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 403,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/errors.ts",
+															"line": 25,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L25"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														402,
+														403
+													]
+												}
+											],
+											"sources": [
+												{
+													"fileName": "src/errors.ts",
+													"line": 23,
+													"character": 5,
+													"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L23"
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 305,
+								"name": "GenericError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"inheritedFrom": {
+								"type": "reference",
+								"target": 307,
+								"name": "GenericError.fromPayload"
+							}
+						}
+					],
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 306,
+						"name": "GenericError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						404
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						412,
+						413,
+						411,
+						410
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						398
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/errors.ts",
+					"line": 119,
+					"character": 13,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L119"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 305,
+					"name": "GenericError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 516,
+			"name": "MfaVerifyError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Error thrown when verifying an MFA challenge fails."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@example",
+						"content": [
+							{
+								"kind": "code",
+								"text": "```typescript\ntry {\n  const tokens = await mfa.verify({\n    mfaToken: mfaToken,\n    grant_type: 'http://auth0.com/oauth/grant-type/mfa-otp',\n    otp: '123456'\n  });\n} catch (error) {\n  if (error instanceof MfaVerifyError) {\n    console.log(error.error); // 'invalid_otp' or 'context_not_found'\n    console.log(error.error_description); // Error details\n  }\n}\n```"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 523,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/mfa/errors.ts",
+							"line": 121,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L121"
+						}
+					],
+					"signatures": [
+						{
+							"id": 524,
+							"name": "new MfaVerifyError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/mfa/errors.ts",
+									"line": 121,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L121"
+								}
+							],
+							"parameters": [
+								{
+									"id": 525,
+									"name": "error",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 526,
+									"name": "error_description",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 516,
+								"name": "MfaVerifyError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 472,
+								"name": "MfaError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 471,
+						"name": "MfaError.constructor"
+					}
+				},
+				{
+					"id": 527,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 21,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 475,
+						"name": "MfaError.error"
+					}
+				},
+				{
+					"id": 528,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 43,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 476,
+						"name": "MfaError.error_description"
+					}
+				},
+				{
+					"id": 517,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/errors.ts",
+							"line": 15,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L15"
+						}
+					],
+					"signatures": [
+						{
+							"id": 518,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/mfa/errors.ts",
+									"line": 15,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L15"
+								}
+							],
+							"parameters": [
+								{
+									"id": 519,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 520,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 521,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/mfa/errors.ts",
+															"line": 19,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L19"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 522,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/mfa/errors.ts",
+															"line": 20,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L20"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														521,
+														522
+													]
+												}
+											],
+											"sources": [
+												{
+													"fileName": "src/mfa/errors.ts",
+													"line": 18,
+													"character": 5,
+													"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L18"
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 464,
+								"name": "MfaError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"inheritedFrom": {
+								"type": "reference",
+								"target": 466,
+								"name": "MfaError.fromPayload"
+							}
+						}
+					],
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 465,
+						"name": "MfaError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						523
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						527,
+						528
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						517
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/mfa/errors.ts",
+					"line": 120,
+					"character": 13,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/errors.ts#L120"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 464,
+					"name": "MfaError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 414,
+			"name": "MissingRefreshTokenError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Error thrown when there is no refresh token to use"
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 421,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 136,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L136"
+						}
+					],
+					"signatures": [
+						{
+							"id": 422,
+							"name": "new MissingRefreshTokenError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/errors.ts",
+									"line": 136,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L136"
+								}
+							],
+							"parameters": [
+								{
+									"id": 423,
+									"name": "audience",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 424,
+									"name": "scope",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 414,
+								"name": "MissingRefreshTokenError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 313,
+								"name": "GenericError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 312,
+						"name": "GenericError.constructor"
+					}
+				},
+				{
+					"id": 425,
+					"name": "audience",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 136,
+							"character": 21,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L136"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 427,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 21,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 316,
+						"name": "GenericError.error"
+					}
+				},
+				{
+					"id": 428,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 43,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 317,
+						"name": "GenericError.error_description"
+					}
+				},
+				{
+					"id": 426,
+					"name": "scope",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 136,
+							"character": 46,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L136"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 415,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 20,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L20"
+						}
+					],
+					"signatures": [
+						{
+							"id": 416,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/errors.ts",
+									"line": 20,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L20"
+								}
+							],
+							"parameters": [
+								{
+									"id": 417,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 418,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 419,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/errors.ts",
+															"line": 24,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L24"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 420,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/errors.ts",
+															"line": 25,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L25"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														419,
+														420
+													]
+												}
+											],
+											"sources": [
+												{
+													"fileName": "src/errors.ts",
+													"line": 23,
+													"character": 5,
+													"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L23"
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 305,
+								"name": "GenericError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"inheritedFrom": {
+								"type": "reference",
+								"target": 307,
+								"name": "GenericError.fromPayload"
+							}
+						}
+					],
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 306,
+						"name": "GenericError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						421
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						425,
+						427,
+						428,
+						426
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						415
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/errors.ts",
+					"line": 135,
+					"character": 13,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L135"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 305,
+					"name": "GenericError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 429,
+			"name": "MissingScopesError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Error thrown when there are missing scopes after refreshing a token"
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 436,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 151,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L151"
+						}
+					],
+					"signatures": [
+						{
+							"id": 437,
+							"name": "new MissingScopesError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/errors.ts",
+									"line": 151,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L151"
+								}
+							],
+							"parameters": [
+								{
+									"id": 438,
+									"name": "audience",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 439,
+									"name": "scope",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 429,
+								"name": "MissingScopesError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 313,
+								"name": "GenericError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 312,
+						"name": "GenericError.constructor"
+					}
+				},
+				{
+					"id": 440,
+					"name": "audience",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 151,
+							"character": 21,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L151"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 442,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 21,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 316,
+						"name": "GenericError.error"
+					}
+				},
+				{
+					"id": 443,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 43,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 317,
+						"name": "GenericError.error_description"
+					}
+				},
+				{
+					"id": 441,
+					"name": "scope",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 151,
+							"character": 46,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L151"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 430,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 20,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L20"
+						}
+					],
+					"signatures": [
+						{
+							"id": 431,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/errors.ts",
+									"line": 20,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L20"
+								}
+							],
+							"parameters": [
+								{
+									"id": 432,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 433,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 434,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/errors.ts",
+															"line": 24,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L24"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 435,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/errors.ts",
+															"line": 25,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L25"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														434,
+														435
+													]
+												}
+											],
+											"sources": [
+												{
+													"fileName": "src/errors.ts",
+													"line": 23,
+													"character": 5,
+													"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L23"
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 305,
+								"name": "GenericError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"inheritedFrom": {
+								"type": "reference",
+								"target": 307,
+								"name": "GenericError.fromPayload"
+							}
+						}
+					],
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 306,
+						"name": "GenericError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						436
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						440,
+						442,
+						443,
+						441
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						430
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/errors.ts",
+					"line": 150,
+					"character": 13,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L150"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 305,
+					"name": "GenericError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 754,
+			"name": "MyAccountApiClient",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Client for Auth0 MyAccount API operations.\n\nProvides methods for managing the current user's account:\n- Connected accounts (link/unlink external identity providers)\n- MFA factors\n- Authentication methods (passkeys, phone, email, TOTP) - list, get, update, delete\n- Authentication method enrollment (challenge and verify)"
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 755,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/MyAccountApiClient.ts",
+							"line": 42,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/MyAccountApiClient.ts#L42"
+						}
+					],
+					"signatures": [
+						{
+							"id": 756,
+							"name": "new MyAccountApiClient",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/myaccount/MyAccountApiClient.ts",
+									"line": 42,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/MyAccountApiClient.ts#L42"
+								}
+							],
+							"parameters": [
+								{
+									"id": 757,
+									"name": "myAccountFetcher",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Type: [Fetcher](/docs/sdk/typescript/classes/Fetcher)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 689,
+										"typeArguments": [
+											{
+												"type": "reference",
+												"target": {
+													"sourceFileName": "node_modules/typescript/lib/lib.dom.d.ts",
+													"qualifiedName": "Response"
+												},
+												"name": "Response",
+												"package": "typescript"
+											}
+										],
+										"name": "Fetcher",
+										"package": "@auth0/auth0-spa-js"
+									}
+								},
+								{
+									"id": 758,
+									"name": "apiBase",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 754,
+								"name": "MyAccountApiClient",
+								"package": "@auth0/auth0-spa-js"
+							}
+						}
+					]
+				},
+				{
+					"id": 764,
+					"name": "completeAccount",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/MyAccountApiClient.ts",
+							"line": 72,
+							"character": 8,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/MyAccountApiClient.ts#L72"
+						}
+					],
+					"signatures": [
+						{
+							"id": 765,
+							"name": "completeAccount",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Verify the redirect from the connect account flow and complete the connecting of the account."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A promise that resolves to the completed connected account details"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/myaccount/MyAccountApiClient.ts",
+									"line": 72,
+									"character": 8,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/MyAccountApiClient.ts#L72"
+								}
+							],
+							"parameters": [
+								{
+									"id": 766,
+									"name": "params",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Completion parameters including auth session, connect code, and redirect URI"
+											},
+											{
+												"kind": "text",
+												"text": "\n\nType: [CompleteRequest](/docs/sdk/typescript/interfaces/CompleteRequest)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 821,
+										"name": "CompleteRequest",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 826,
+										"name": "CompleteResponse",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 761,
+					"name": "connectAccount",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/MyAccountApiClient.ts",
+							"line": 53,
+							"character": 8,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/MyAccountApiClient.ts#L53"
+						}
+					],
+					"signatures": [
+						{
+							"id": 762,
+							"name": "connectAccount",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Get a ticket for the connect account flow."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A promise that resolves to a connect response with the redirect URI and auth session"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/myaccount/MyAccountApiClient.ts",
+									"line": 53,
+									"character": 8,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/MyAccountApiClient.ts#L53"
+								}
+							],
+							"parameters": [
+								{
+									"id": 763,
+									"name": "params",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Connection parameters including connection name and redirect URI"
+											},
+											{
+												"kind": "text",
+												"text": "\n\nType: [ConnectRequest](/docs/sdk/typescript/interfaces/ConnectRequest)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 806,
+										"name": "ConnectRequest",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 814,
+										"name": "ConnectResponse",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 775,
+					"name": "deleteAuthenticationMethod",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/MyAccountApiClient.ts",
+							"line": 138,
+							"character": 8,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/MyAccountApiClient.ts#L138"
+						}
+					],
+					"signatures": [
+						{
+							"id": 776,
+							"name": "deleteAuthenticationMethod",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Delete an authentication method by ID."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A promise that resolves when the authentication method has been deleted"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/myaccount/MyAccountApiClient.ts",
+									"line": 138,
+									"character": 8,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/MyAccountApiClient.ts#L138"
+								}
+							],
+							"parameters": [
+								{
+									"id": 777,
+									"name": "id",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The ID of the authentication method to delete"
+											}
+										]
+									},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "intrinsic",
+										"name": "void"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 782,
+					"name": "enrollmentChallenge",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/MyAccountApiClient.ts",
+							"line": 179,
+							"character": 8,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/MyAccountApiClient.ts#L179"
+						}
+					],
+					"signatures": [
+						{
+							"id": 783,
+							"name": "enrollmentChallenge",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Start the enrollment of an authentication method for the current user.\nThe response shape varies by type."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A promise that resolves to the enrollment challenge response (shape varies by type)"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/myaccount/MyAccountApiClient.ts",
+									"line": 179,
+									"character": 8,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/MyAccountApiClient.ts#L179"
+								}
+							],
+							"parameters": [
+								{
+									"id": 784,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Enrollment challenge options specifying the factor type and any type-specific fields"
+											},
+											{
+												"kind": "text",
+												"text": "\n\nType: [EnrollmentChallengeOptions](/docs/sdk/typescript/types/EnrollmentChallengeOptions)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 937,
+										"name": "EnrollmentChallengeOptions",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 959,
+										"name": "EnrollmentChallengeResponse",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 785,
+					"name": "enrollmentVerify",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/MyAccountApiClient.ts",
+							"line": 204,
+							"character": 8,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/MyAccountApiClient.ts#L204"
+						}
+					],
+					"signatures": [
+						{
+							"id": 786,
+							"name": "enrollmentVerify",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Confirm the enrollment of an authentication method to complete registration."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A promise that resolves to the confirmed authentication method"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/myaccount/MyAccountApiClient.ts",
+									"line": 204,
+									"character": 8,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/MyAccountApiClient.ts#L204"
+								}
+							],
+							"parameters": [
+								{
+									"id": 787,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Enrollment verify options including the auth session and type-specific verification data"
+											},
+											{
+												"kind": "text",
+												"text": "\n\nType: [EnrollmentVerifyOptions](/docs/sdk/typescript/types/EnrollmentVerifyOptions)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 1023,
+										"name": "EnrollmentVerifyOptions",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 848,
+										"name": "AuthenticationMethod",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 772,
+					"name": "getAuthenticationMethod",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/MyAccountApiClient.ts",
+							"line": 123,
+							"character": 8,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/MyAccountApiClient.ts#L123"
+						}
+					],
+					"signatures": [
+						{
+							"id": 773,
+							"name": "getAuthenticationMethod",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Get an authentication method by ID."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A promise that resolves to the authentication method"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/myaccount/MyAccountApiClient.ts",
+									"line": 123,
+									"character": 8,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/MyAccountApiClient.ts#L123"
+								}
+							],
+							"parameters": [
+								{
+									"id": 774,
+									"name": "id",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The ID of the authentication method to retrieve"
+											}
+										]
+									},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 848,
+										"name": "AuthenticationMethod",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 769,
+					"name": "getAuthenticationMethods",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/MyAccountApiClient.ts",
+							"line": 106,
+							"character": 8,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/MyAccountApiClient.ts#L106"
+						}
+					],
+					"signatures": [
+						{
+							"id": 770,
+							"name": "getAuthenticationMethods",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Get a list of all authentication methods for the current user."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A promise that resolves to an array of authentication methods"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/myaccount/MyAccountApiClient.ts",
+									"line": 106,
+									"character": 8,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/MyAccountApiClient.ts#L106"
+								}
+							],
+							"parameters": [
+								{
+									"id": 771,
+									"name": "type",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {
+										"isOptional": true
+									},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Optional filter to return only methods of a specific type"
+											},
+											{
+												"kind": "text",
+												"text": "\n\nType: [AuthenticationMethodType](/docs/sdk/typescript/types/AuthenticationMethodType)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 847,
+										"name": "AuthenticationMethodType",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "array",
+										"elementType": {
+											"type": "reference",
+											"target": 848,
+											"name": "AuthenticationMethod",
+											"package": "@auth0/auth0-spa-js"
+										}
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 767,
+					"name": "getFactors",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/MyAccountApiClient.ts",
+							"line": 90,
+							"character": 8,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/MyAccountApiClient.ts#L90"
+						}
+					],
+					"signatures": [
+						{
+							"id": 768,
+							"name": "getFactors",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Get the status of all factors for the current user."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A promise that resolves to an array of factors with their enabled/disabled status"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/myaccount/MyAccountApiClient.ts",
+									"line": 90,
+									"character": 8,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/MyAccountApiClient.ts#L90"
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "array",
+										"elementType": {
+											"type": "reference",
+											"target": 844,
+											"name": "Factor",
+											"package": "@auth0/auth0-spa-js"
+										}
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 778,
+					"name": "updateAuthenticationMethod",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/MyAccountApiClient.ts",
+							"line": 156,
+							"character": 8,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/MyAccountApiClient.ts#L156"
+						}
+					],
+					"signatures": [
+						{
+							"id": 779,
+							"name": "updateAuthenticationMethod",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Update details of an authentication method by ID."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A promise that resolves to the updated authentication method"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/myaccount/MyAccountApiClient.ts",
+									"line": 156,
+									"character": 8,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/MyAccountApiClient.ts#L156"
+								}
+							],
+							"parameters": [
+								{
+									"id": 780,
+									"name": "id",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The ID of the authentication method to update"
+											}
+										]
+									},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 781,
+									"name": "data",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The fields to update (e.g. name, preferred_authentication_method for phone)"
+											},
+											{
+												"kind": "text",
+												"text": "\n\nType: [UpdateAuthenticationMethodRequest](/docs/sdk/typescript/interfaces/UpdateAuthenticationMethodRequest)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 934,
+										"name": "UpdateAuthenticationMethodRequest",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 848,
+										"name": "AuthenticationMethod",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						755
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						764,
+						761,
+						775,
+						782,
+						785,
+						772,
+						769,
+						767,
+						778
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/MyAccountApiClient.ts",
+					"line": 41,
+					"character": 13,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/MyAccountApiClient.ts#L41"
+				}
+			]
+		},
+		{
+			"id": 792,
+			"name": "MyAccountApiError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Error thrown when the MyAccount API returns a non-2xx response."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@example",
+						"content": [
+							{
+								"kind": "code",
+								"text": "```typescript\ntry {\n  await myAccount.getAuthenticationMethods();\n} catch (err) {\n  if (err instanceof MyAccountApiError) {\n    console.error(err.status, err.title, err.detail);\n  }\n}\n```"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 793,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/MyAccountApiClient.ts",
+							"line": 267,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/MyAccountApiClient.ts#L267"
+						}
+					],
+					"signatures": [
+						{
+							"id": 794,
+							"name": "new MyAccountApiError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/myaccount/MyAccountApiClient.ts",
+									"line": 267,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/MyAccountApiClient.ts#L267"
+								}
+							],
+							"parameters": [
+								{
+									"id": 795,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Type: [ErrorResponse](/docs/sdk/typescript/interfaces/ErrorResponse)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 833,
+										"name": "ErrorResponse",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 792,
+								"name": "MyAccountApiError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": -1,
+								"name": "Error.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": -1,
+						"name": "Error.constructor"
+					}
+				},
+				{
+					"id": 799,
+					"name": "detail",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true,
+						"isReadonly": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Human-readable explanation specific to this occurrence"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/MyAccountApiClient.ts",
+							"line": 263,
+							"character": 18,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/MyAccountApiClient.ts#L263"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 797,
+					"name": "status",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true,
+						"isReadonly": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "HTTP status code"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/MyAccountApiClient.ts",
+							"line": 259,
+							"character": 18,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/MyAccountApiClient.ts#L259"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "number"
+					}
+				},
+				{
+					"id": 798,
+					"name": "title",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true,
+						"isReadonly": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Short human-readable summary of the error"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/MyAccountApiClient.ts",
+							"line": 261,
+							"character": 18,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/MyAccountApiClient.ts#L261"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 796,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true,
+						"isReadonly": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "RFC 7807 error type identifier"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/MyAccountApiClient.ts",
+							"line": 257,
+							"character": 18,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/MyAccountApiClient.ts#L257"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 800,
+					"name": "validation_errors",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true,
+						"isOptional": true,
+						"isReadonly": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Field-level validation errors, if present"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/MyAccountApiClient.ts",
+							"line": 265,
+							"character": 18,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/MyAccountApiClient.ts#L265"
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "reflection",
+							"declaration": {
+								"id": 801,
+								"name": "__type",
+								"variant": "declaration",
+								"kind": 65536,
+								"flags": {},
+								"children": [
+									{
+										"id": 802,
+										"name": "detail",
+										"variant": "declaration",
+										"kind": 1024,
+										"flags": {},
+										"sources": [
+											{
+												"fileName": "src/myaccount/types.ts",
+												"line": 52,
+												"character": 4,
+												"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L52"
+											}
+										],
+										"type": {
+											"type": "intrinsic",
+											"name": "string"
+										}
+									},
+									{
+										"id": 803,
+										"name": "field",
+										"variant": "declaration",
+										"kind": 1024,
+										"flags": {
+											"isOptional": true
+										},
+										"sources": [
+											{
+												"fileName": "src/myaccount/types.ts",
+												"line": 53,
+												"character": 4,
+												"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L53"
+											}
+										],
+										"type": {
+											"type": "intrinsic",
+											"name": "string"
+										}
+									},
+									{
+										"id": 804,
+										"name": "pointer",
+										"variant": "declaration",
+										"kind": 1024,
+										"flags": {
+											"isOptional": true
+										},
+										"sources": [
+											{
+												"fileName": "src/myaccount/types.ts",
+												"line": 54,
+												"character": 4,
+												"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L54"
+											}
+										],
+										"type": {
+											"type": "intrinsic",
+											"name": "string"
+										}
+									},
+									{
+										"id": 805,
+										"name": "source",
+										"variant": "declaration",
+										"kind": 1024,
+										"flags": {
+											"isOptional": true
+										},
+										"sources": [
+											{
+												"fileName": "src/myaccount/types.ts",
+												"line": 55,
+												"character": 4,
+												"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L55"
+											}
+										],
+										"type": {
+											"type": "intrinsic",
+											"name": "string"
+										}
+									}
+								],
+								"groups": [
+									{
+										"title": "Properties",
+										"children": [
+											802,
+											803,
+											804,
+											805
+										]
+									}
+								],
+								"sources": [
+									{
+										"fileName": "src/myaccount/types.ts",
+										"line": 51,
+										"character": 22,
+										"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L51"
+									}
+								]
+							}
+						}
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						793
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						799,
+						797,
+						798,
+						796,
+						800
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/MyAccountApiClient.ts",
+					"line": 255,
+					"character": 13,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/MyAccountApiClient.ts#L255"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+						"qualifiedName": "Error"
+					},
+					"name": "Error",
+					"package": "typescript"
+				}
+			]
+		},
+		{
+			"id": 1057,
+			"name": "PasskeyApiClient",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Client for Auth0 Passkey operations.\n\nProvides 2 public methods:\n- "
+					},
+					{
+						"kind": "code",
+						"text": "`signup`"
+					},
+					{
+						"kind": "text",
+						"text": " — Register a new user with a passkey (full flow: challenge → WebAuthn → token exchange)\n- "
+					},
+					{
+						"kind": "code",
+						"text": "`login`"
+					},
+					{
+						"kind": "text",
+						"text": " — Sign in with a passkey (full flow: challenge → WebAuthn → token exchange)"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@example",
+						"content": [
+							{
+								"kind": "code",
+								"text": "```typescript\n// Signup — single call handles everything\nconst tokens = await auth0.passkey.signup({ email: 'user@example.com' });\n\n// Login — single call handles everything\nconst tokens = await auth0.passkey.login();\n```"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 1073,
+					"name": "getLoginChallenge",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/passkey/PasskeyApiClient.ts",
+							"line": 191,
+							"character": 8,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/PasskeyApiClient.ts#L191"
+						}
+					],
+					"signatures": [
+						{
+							"id": 1074,
+							"name": "getLoginChallenge",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Request a passkey login challenge.\n\nStep 1 of the granular login flow. Returns the auth session and a\ndecoded "
+									},
+									{
+										"kind": "code",
+										"text": "`PublicKeyCredentialRequestOptions`"
+									},
+									{
+										"kind": "text",
+										"text": ". Run the WebAuthn assertion\nceremony with "
+									},
+									{
+										"kind": "code",
+										"text": "`publicKey`"
+									},
+									{
+										"kind": "text",
+										"text": ", then hand the resulting credential and "
+									},
+									{
+										"kind": "code",
+										"text": "`authSession`"
+									},
+									{
+										"kind": "text",
+										"text": " to\n"
+									},
+									{
+										"kind": "code",
+										"text": "`getTokenWithPasskey()`"
+									},
+									{
+										"kind": "text",
+										"text": "."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A promise resolving to "
+											},
+											{
+												"kind": "code",
+												"text": "`{ authSession, publicKey }`"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If WebAuthn is not supported in the browser"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If the challenge request fails"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/passkey/PasskeyApiClient.ts",
+									"line": 191,
+									"character": 8,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/PasskeyApiClient.ts#L191"
+								}
+							],
+							"parameters": [
+								{
+									"id": 1075,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {
+										"isOptional": true
+									},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Optional login challenge options (realm/organization)"
+											},
+											{
+												"kind": "text",
+												"text": "\n\nType: [PasskeyLoginChallengeOptions](/docs/sdk/typescript/interfaces/PasskeyLoginChallengeOptions)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 1128,
+										"name": "PasskeyLoginChallengeOptions",
+										"package": "@auth0/auth0-auth-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 1184,
+										"name": "PasskeyLoginChallenge",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 1070,
+					"name": "getSignupChallenge",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/passkey/PasskeyApiClient.ts",
+							"line": 164,
+							"character": 8,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/PasskeyApiClient.ts#L164"
+						}
+					],
+					"signatures": [
+						{
+							"id": 1071,
+							"name": "getSignupChallenge",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Request a passkey signup challenge.\n\nStep 1 of the granular signup flow. Returns the auth session and a\ndecoded "
+									},
+									{
+										"kind": "code",
+										"text": "`PublicKeyCredentialCreationOptions`"
+									},
+									{
+										"kind": "text",
+										"text": ". Run the WebAuthn credential\ncreation ceremony with "
+									},
+									{
+										"kind": "code",
+										"text": "`publicKey`"
+									},
+									{
+										"kind": "text",
+										"text": ", then hand the resulting credential and "
+									},
+									{
+										"kind": "code",
+										"text": "`authSession`"
+									},
+									{
+										"kind": "text",
+										"text": " to\n"
+									},
+									{
+										"kind": "code",
+										"text": "`getTokenWithPasskey()`"
+									},
+									{
+										"kind": "text",
+										"text": "."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A promise resolving to "
+											},
+											{
+												"kind": "code",
+												"text": "`{ authSession, publicKey }`"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If WebAuthn is not supported in the browser"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If the challenge request fails"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/passkey/PasskeyApiClient.ts",
+									"line": 164,
+									"character": 8,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/PasskeyApiClient.ts#L164"
+								}
+							],
+							"parameters": [
+								{
+									"id": 1072,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Signup challenge options (user identifier, optional realm/organization/metadata)"
+											},
+											{
+												"kind": "text",
+												"text": "\n\nType: [PasskeySignupChallengeOptions](/docs/sdk/typescript/types/PasskeySignupChallengeOptions)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 1112,
+										"name": "PasskeySignupChallengeOptions",
+										"package": "@auth0/auth0-auth-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 1180,
+										"name": "PasskeySignupChallenge",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 1076,
+					"name": "getTokenWithPasskey",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/passkey/PasskeyApiClient.ts",
+							"line": 220,
+							"character": 8,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/PasskeyApiClient.ts#L220"
+						}
+					],
+					"signatures": [
+						{
+							"id": 1077,
+							"name": "getTokenWithPasskey",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Exchange a signed passkey credential for tokens.\n\nStep 2 of the granular flow. Serializes the raw "
+									},
+									{
+										"kind": "code",
+										"text": "`PublicKeyCredential`"
+									},
+									{
+										"kind": "text",
+										"text": "\nproduced by the WebAuthn ceremony — either a creation (signup) or an\nassertion (login) credential — and exchanges it for tokens. The credential\ntype (attestation vs assertion) is detected automatically."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A promise resolving to the token endpoint response"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If WebAuthn is not supported in the browser"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If the credential is not a valid attestation or assertion response"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If the token exchange fails"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/passkey/PasskeyApiClient.ts",
+									"line": 220,
+									"character": 8,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/PasskeyApiClient.ts#L220"
+								}
+							],
+							"parameters": [
+								{
+									"id": 1078,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The auth session, raw credential, and optional realm/organization/scope/audience"
+											},
+											{
+												"kind": "text",
+												"text": "\n\nType: [PasskeyGetTokenOptions](/docs/sdk/typescript/types/PasskeyGetTokenOptions)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 1188,
+										"name": "PasskeyGetTokenOptions",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 1389,
+										"name": "TokenEndpointResponse",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 1067,
+					"name": "login",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/passkey/PasskeyApiClient.ts",
+							"line": 112,
+							"character": 8,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/PasskeyApiClient.ts#L112"
+						}
+					],
+					"signatures": [
+						{
+							"id": 1068,
+							"name": "login",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Sign in with an existing passkey.\n\nHandles the full flow: requests a login challenge, triggers the browser\nWebAuthn assertion ceremony, serializes the result, and exchanges it\nfor tokens."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A promise that resolves to the token endpoint response containing access/ID tokens"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If WebAuthn is not supported in the browser"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If the challenge request fails"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If the token exchange fails"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If the user cancels the WebAuthn prompt"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/passkey/PasskeyApiClient.ts",
+									"line": 112,
+									"character": 8,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/PasskeyApiClient.ts#L112"
+								}
+							],
+							"parameters": [
+								{
+									"id": 1069,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {
+										"isOptional": true
+									},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Optional passkey login options (optional scope/audience/realm/organization)"
+											},
+											{
+												"kind": "text",
+												"text": "\n\nType: [PasskeyLoginOptions](/docs/sdk/typescript/types/PasskeyLoginOptions)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 1176,
+										"name": "PasskeyLoginOptions",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 1389,
+										"name": "TokenEndpointResponse",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				},
+				{
+					"id": 1064,
+					"name": "signup",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/passkey/PasskeyApiClient.ts",
+							"line": 61,
+							"character": 8,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/PasskeyApiClient.ts#L61"
+						}
+					],
+					"signatures": [
+						{
+							"id": 1065,
+							"name": "signup",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Register a new user with a passkey.\n\nHandles the full flow: requests a signup challenge, triggers the browser\nWebAuthn credential creation ceremony, serializes the result, and exchanges\nit for tokens."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@returns",
+										"content": [
+											{
+												"kind": "text",
+												"text": "A promise that resolves to the token endpoint response containing access/ID tokens"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If WebAuthn is not supported in the browser"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If the challenge request fails"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If the token exchange fails"
+											}
+										]
+									},
+									{
+										"tag": "@throws",
+										"content": [
+											{
+												"kind": "text",
+												"text": "If the user cancels the WebAuthn prompt"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/passkey/PasskeyApiClient.ts",
+									"line": 61,
+									"character": 8,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/PasskeyApiClient.ts#L61"
+								}
+							],
+							"parameters": [
+								{
+									"id": 1066,
+									"name": "options",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Passkey signup options (user identifier, optional scope/audience)"
+											},
+											{
+												"kind": "text",
+												"text": "\n\nType: [PasskeySignupOptions](/docs/sdk/typescript/types/PasskeySignupOptions)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 1172,
+										"name": "PasskeySignupOptions",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 1389,
+										"name": "TokenEndpointResponse",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
+							}
+						}
+					]
+				}
+			],
+			"groups": [
+				{
+					"title": "Methods",
+					"children": [
+						1073,
+						1070,
+						1076,
+						1067,
+						1064
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/passkey/PasskeyApiClient.ts",
+					"line": 34,
+					"character": 13,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/PasskeyApiClient.ts#L34"
+				}
+			]
+		},
+		{
+			"id": 1094,
+			"name": "PasskeyChallengeError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Error thrown when requesting a passkey login challenge fails."
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 1095,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 2029,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 1096,
+							"name": "new PasskeyChallengeError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+									"line": 2029,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 1097,
+									"name": "message",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 1098,
+									"name": "cause",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {
+										"isOptional": true
+									},
+									"type": {
+										"type": "reference",
+										"target": {
+											"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+											"qualifiedName": "PasskeyApiErrorResponse"
+										},
+										"name": "PasskeyApiErrorResponse",
+										"package": "@auth0/auth0-auth-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 1094,
+								"name": "PasskeyChallengeError",
+								"package": "@auth0/auth0-auth-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": -1,
+								"name": "PasskeyError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": -1,
+						"name": "PasskeyError.constructor"
+					}
+				},
+				{
+					"id": 1099,
+					"name": "cause",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 2015,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": {
+							"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"qualifiedName": "PasskeyApiErrorResponse"
+						},
+						"name": "PasskeyApiErrorResponse",
+						"package": "@auth0/auth0-auth-js"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "PasskeyError.cause"
+					}
+				},
+				{
+					"id": 1100,
+					"name": "code",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 2016,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "PasskeyError.code"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						1095
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						1099,
+						1100
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+					"line": 2028,
+					"character": 14
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+						"qualifiedName": "PasskeyError"
+					},
+					"name": "PasskeyError",
+					"package": "@auth0/auth0-auth-js"
+				}
+			]
+		},
+		{
+			"id": 1079,
+			"name": "PasskeyError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"children": [
+				{
+					"id": 1080,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/passkey/errors.ts",
+							"line": 17,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/errors.ts#L17"
+						}
+					],
+					"signatures": [
+						{
+							"id": 1081,
+							"name": "new PasskeyError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/passkey/errors.ts",
+									"line": 17,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/errors.ts#L17"
+								}
+							],
+							"parameters": [
+								{
+									"id": 1082,
+									"name": "code",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 1083,
+									"name": "message",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 1084,
+									"name": "cause",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {
+										"isOptional": true
+									},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "Type: [PasskeyErrorResponse](/docs/sdk/typescript/interfaces/PasskeyErrorResponse)"
+											}
+										]
+									},
+									"type": {
+										"type": "reference",
+										"target": 1108,
+										"name": "PasskeyErrorResponse",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 1079,
+								"name": "PasskeyError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": -1,
+								"name": "Error.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": -1,
+						"name": "Error.constructor"
+					}
+				},
+				{
+					"id": 1086,
+					"name": "cause",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true,
+						"isOptional": true,
+						"isReadonly": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Type: [PasskeyErrorResponse](/docs/sdk/typescript/interfaces/PasskeyErrorResponse)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/passkey/errors.ts",
+							"line": 15,
+							"character": 18,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 1108,
+						"name": "PasskeyErrorResponse",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 1085,
+					"name": "code",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true,
+						"isReadonly": true
+					},
+					"sources": [
+						{
+							"fileName": "src/passkey/errors.ts",
+							"line": 14,
+							"character": 18,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/errors.ts#L14"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						1080
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						1086,
+						1085
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/passkey/errors.ts",
+					"line": 13,
+					"character": 13,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/errors.ts#L13"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+						"qualifiedName": "Error"
+					},
+					"name": "Error",
+					"package": "typescript"
+				}
+			]
+		},
+		{
+			"id": 1101,
+			"name": "PasskeyGetTokenError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Error thrown when exchanging a passkey credential for tokens fails.\n\nUnlike the challenge errors, this carries "
+					},
+					{
+						"kind": "code",
+						"text": "`mfa_token`"
+					},
+					{
+						"kind": "text",
+						"text": " / "
+					},
+					{
+						"kind": "code",
+						"text": "`mfa_requirements`"
+					},
+					{
+						"kind": "text",
+						"text": " on\nits "
+					},
+					{
+						"kind": "code",
+						"text": "`cause`"
+					},
+					{
+						"kind": "text",
+						"text": " when the server responds with "
+					},
+					{
+						"kind": "code",
+						"text": "`mfa_required`"
+					},
+					{
+						"kind": "text",
+						"text": "."
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 1102,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 2039,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 1103,
+							"name": "new PasskeyGetTokenError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+									"line": 2039,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 1104,
+									"name": "message",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 1105,
+									"name": "cause",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {
+										"isOptional": true
+									},
+									"type": {
+										"type": "reference",
+										"target": {
+											"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+											"qualifiedName": "PasskeyGetTokenApiErrorResponse"
+										},
+										"name": "PasskeyGetTokenApiErrorResponse",
+										"package": "@auth0/auth0-auth-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 1101,
+								"name": "PasskeyGetTokenError",
+								"package": "@auth0/auth0-auth-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": -1,
+								"name": "PasskeyError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": -1,
+						"name": "PasskeyError.constructor"
+					}
+				},
+				{
+					"id": 1106,
+					"name": "cause",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 2038,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": {
+							"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"qualifiedName": "PasskeyGetTokenApiErrorResponse"
+						},
+						"name": "PasskeyGetTokenApiErrorResponse",
+						"package": "@auth0/auth0-auth-js"
+					},
+					"overwrites": {
+						"type": "reference",
+						"target": -1,
+						"name": "PasskeyError.cause"
+					}
+				},
+				{
+					"id": 1107,
+					"name": "code",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 2016,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "PasskeyError.code"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						1102
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						1106,
+						1107
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+					"line": 2037,
+					"character": 14
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+						"qualifiedName": "PasskeyError"
+					},
+					"name": "PasskeyError",
+					"package": "@auth0/auth0-auth-js"
+				}
+			]
+		},
+		{
+			"id": 1087,
+			"name": "PasskeyRegisterError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Error thrown when requesting a passkey register challenge fails."
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 1088,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 2023,
+							"character": 4
+						}
+					],
+					"signatures": [
+						{
+							"id": 1089,
+							"name": "new PasskeyRegisterError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+									"line": 2023,
+									"character": 4
+								}
+							],
+							"parameters": [
+								{
+									"id": 1090,
+									"name": "message",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 1091,
+									"name": "cause",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {
+										"isOptional": true
+									},
+									"type": {
+										"type": "reference",
+										"target": {
+											"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+											"qualifiedName": "PasskeyApiErrorResponse"
+										},
+										"name": "PasskeyApiErrorResponse",
+										"package": "@auth0/auth0-auth-js"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 1087,
+								"name": "PasskeyRegisterError",
+								"package": "@auth0/auth0-auth-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": -1,
+								"name": "PasskeyError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": -1,
+						"name": "PasskeyError.constructor"
+					}
+				},
+				{
+					"id": 1092,
+					"name": "cause",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 2015,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": {
+							"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"qualifiedName": "PasskeyApiErrorResponse"
+						},
+						"name": "PasskeyApiErrorResponse",
+						"package": "@auth0/auth0-auth-js"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "PasskeyError.cause"
+					}
+				},
+				{
+					"id": 1093,
+					"name": "code",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 2016,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "PasskeyError.code"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						1088
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						1092,
+						1093
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+					"line": 2022,
+					"character": 14
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+						"qualifiedName": "PasskeyError"
+					},
+					"name": "PasskeyError",
+					"package": "@auth0/auth0-auth-js"
+				}
+			]
+		},
+		{
+			"id": 373,
+			"name": "PopupCancelledError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"children": [
+				{
+					"id": 380,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 101,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L101"
+						}
+					],
+					"signatures": [
+						{
+							"id": 381,
+							"name": "new PopupCancelledError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/errors.ts",
+									"line": 101,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L101"
+								}
+							],
+							"parameters": [
+								{
+									"id": 382,
+									"name": "popup",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reference",
+										"target": {
+											"sourceFileName": "node_modules/typescript/lib/lib.dom.d.ts",
+											"qualifiedName": "Window"
+										},
+										"name": "Window",
+										"package": "typescript"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 373,
+								"name": "PopupCancelledError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 313,
+								"name": "GenericError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 312,
+						"name": "GenericError.constructor"
+					}
+				},
+				{
+					"id": 384,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 21,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 316,
+						"name": "GenericError.error"
+					}
+				},
+				{
+					"id": 385,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 43,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 317,
+						"name": "GenericError.error_description"
+					}
+				},
+				{
+					"id": 383,
+					"name": "popup",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 101,
+							"character": 21,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L101"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": {
+							"sourceFileName": "node_modules/typescript/lib/lib.dom.d.ts",
+							"qualifiedName": "Window"
+						},
+						"name": "Window",
+						"package": "typescript"
+					}
+				},
+				{
+					"id": 374,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 20,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L20"
+						}
+					],
+					"signatures": [
+						{
+							"id": 375,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/errors.ts",
+									"line": 20,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L20"
+								}
+							],
+							"parameters": [
+								{
+									"id": 376,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 377,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 378,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/errors.ts",
+															"line": 24,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L24"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 379,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/errors.ts",
+															"line": 25,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L25"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														378,
+														379
+													]
+												}
+											],
+											"sources": [
+												{
+													"fileName": "src/errors.ts",
+													"line": 23,
+													"character": 5,
+													"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L23"
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 305,
+								"name": "GenericError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"inheritedFrom": {
+								"type": "reference",
+								"target": 307,
+								"name": "GenericError.fromPayload"
+							}
+						}
+					],
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 306,
+						"name": "GenericError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						380
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						384,
+						385,
+						383
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						374
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/errors.ts",
+					"line": 100,
+					"character": 13,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L100"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 305,
+					"name": "GenericError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 386,
+			"name": "PopupOpenError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"children": [
+				{
+					"id": 393,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 109,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L109"
+						}
+					],
+					"signatures": [
+						{
+							"id": 394,
+							"name": "new PopupOpenError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/errors.ts",
+									"line": 109,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L109"
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 386,
+								"name": "PopupOpenError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 313,
+								"name": "GenericError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 312,
+						"name": "GenericError.constructor"
+					}
+				},
+				{
+					"id": 395,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 21,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 316,
+						"name": "GenericError.error"
+					}
+				},
+				{
+					"id": 396,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 43,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 317,
+						"name": "GenericError.error_description"
+					}
+				},
+				{
+					"id": 387,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 20,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L20"
+						}
+					],
+					"signatures": [
+						{
+							"id": 388,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/errors.ts",
+									"line": 20,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L20"
+								}
+							],
+							"parameters": [
+								{
+									"id": 389,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 390,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 391,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/errors.ts",
+															"line": 24,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L24"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 392,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/errors.ts",
+															"line": 25,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L25"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														391,
+														392
+													]
+												}
+											],
+											"sources": [
+												{
+													"fileName": "src/errors.ts",
+													"line": 23,
+													"character": 5,
+													"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L23"
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 305,
+								"name": "GenericError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"inheritedFrom": {
+								"type": "reference",
+								"target": 307,
+								"name": "GenericError.fromPayload"
+							}
+						}
+					],
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 306,
+						"name": "GenericError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						393
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						395,
+						396
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						387
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/errors.ts",
+					"line": 108,
+					"character": 13,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L108"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 305,
+					"name": "GenericError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 360,
+			"name": "PopupTimeoutError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Error thrown when the login popup times out (if the user does not complete auth)"
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 367,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 93,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L93"
+						}
+					],
+					"signatures": [
+						{
+							"id": 368,
+							"name": "new PopupTimeoutError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/errors.ts",
+									"line": 93,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L93"
+								}
+							],
+							"parameters": [
+								{
+									"id": 369,
+									"name": "popup",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reference",
+										"target": {
+											"sourceFileName": "node_modules/typescript/lib/lib.dom.d.ts",
+											"qualifiedName": "Window"
+										},
+										"name": "Window",
+										"package": "typescript"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 360,
+								"name": "PopupTimeoutError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 357,
+								"name": "TimeoutError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 356,
+						"name": "TimeoutError.constructor"
+					}
+				},
+				{
+					"id": 371,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 21,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 358,
+						"name": "TimeoutError.error"
+					}
+				},
+				{
+					"id": 372,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 43,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 359,
+						"name": "TimeoutError.error_description"
+					}
+				},
+				{
+					"id": 370,
+					"name": "popup",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 93,
+							"character": 21,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L93"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": {
+							"sourceFileName": "node_modules/typescript/lib/lib.dom.d.ts",
+							"qualifiedName": "Window"
+						},
+						"name": "Window",
+						"package": "typescript"
+					}
+				},
+				{
+					"id": 361,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 20,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L20"
+						}
+					],
+					"signatures": [
+						{
+							"id": 362,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/errors.ts",
+									"line": 20,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L20"
+								}
+							],
+							"parameters": [
+								{
+									"id": 363,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 364,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 365,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/errors.ts",
+															"line": 24,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L24"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 366,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/errors.ts",
+															"line": 25,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L25"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														365,
+														366
+													]
+												}
+											],
+											"sources": [
+												{
+													"fileName": "src/errors.ts",
+													"line": 23,
+													"character": 5,
+													"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L23"
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 305,
+								"name": "GenericError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"inheritedFrom": {
+								"type": "reference",
+								"target": 351,
+								"name": "TimeoutError.fromPayload"
+							}
+						}
+					],
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 350,
+						"name": "TimeoutError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						367
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						371,
+						372,
+						370
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						361
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/errors.ts",
+					"line": 92,
+					"character": 13,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L92"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 349,
+					"name": "TimeoutError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 349,
+			"name": "TimeoutError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Thrown when silent auth times out (usually due to a configuration issue) or\nwhen network requests to the Auth server timeout."
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 356,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 82,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L82"
+						}
+					],
+					"signatures": [
+						{
+							"id": 357,
+							"name": "new TimeoutError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/errors.ts",
+									"line": 82,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L82"
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 349,
+								"name": "TimeoutError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 313,
+								"name": "GenericError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 312,
+						"name": "GenericError.constructor"
+					}
+				},
+				{
+					"id": 358,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 21,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 316,
+						"name": "GenericError.error"
+					}
+				},
+				{
+					"id": 359,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 43,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 317,
+						"name": "GenericError.error_description"
+					}
+				},
+				{
+					"id": 350,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 20,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L20"
+						}
+					],
+					"signatures": [
+						{
+							"id": 351,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/errors.ts",
+									"line": 20,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L20"
+								}
+							],
+							"parameters": [
+								{
+									"id": 352,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 353,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 354,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/errors.ts",
+															"line": 24,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L24"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 355,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/errors.ts",
+															"line": 25,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L25"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														354,
+														355
+													]
+												}
+											],
+											"sources": [
+												{
+													"fileName": "src/errors.ts",
+													"line": 23,
+													"character": 5,
+													"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L23"
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 305,
+								"name": "GenericError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"inheritedFrom": {
+								"type": "reference",
+								"target": 307,
+								"name": "GenericError.fromPayload"
+							}
+						}
+					],
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 306,
+						"name": "GenericError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						356
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						358,
+						359
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						350
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/errors.ts",
+					"line": 81,
+					"character": 13,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L81"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 305,
+					"name": "GenericError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			],
+			"extendedBy": [
+				{
+					"type": "reference",
+					"target": 360,
+					"name": "PopupTimeoutError"
+				}
+			]
+		},
+		{
+			"id": 444,
+			"name": "UseDpopNonceError",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Error thrown when the wrong DPoP nonce is used and a potential subsequent retry wasn't able to fix it."
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 451,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 166,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L166"
+						}
+					],
+					"signatures": [
+						{
+							"id": 452,
+							"name": "new UseDpopNonceError",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/errors.ts",
+									"line": 166,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L166"
+								}
+							],
+							"parameters": [
+								{
+									"id": 453,
+									"name": "newDpopNonce",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "union",
+										"types": [
+											{
+												"type": "intrinsic",
+												"name": "undefined"
+											},
+											{
+												"type": "intrinsic",
+												"name": "string"
+											}
+										]
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 444,
+								"name": "UseDpopNonceError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"overwrites": {
+								"type": "reference",
+								"target": 313,
+								"name": "GenericError.constructor"
+							}
+						}
+					],
+					"overwrites": {
+						"type": "reference",
+						"target": 312,
+						"name": "GenericError.constructor"
+					}
+				},
+				{
+					"id": 455,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 21,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 316,
+						"name": "GenericError.error"
+					}
+				},
+				{
+					"id": 456,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 15,
+							"character": 43,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L15"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 317,
+						"name": "GenericError.error_description"
+					}
+				},
+				{
+					"id": 454,
+					"name": "newDpopNonce",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isPublic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 166,
+							"character": 21,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L166"
+						}
+					],
+					"type": {
+						"type": "union",
+						"types": [
+							{
+								"type": "intrinsic",
+								"name": "undefined"
+							},
+							{
+								"type": "intrinsic",
+								"name": "string"
+							}
+						]
+					}
+				},
+				{
+					"id": 445,
+					"name": "fromPayload",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isStatic": true
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 20,
+							"character": 9,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L20"
+						}
+					],
+					"signatures": [
+						{
+							"id": 446,
+							"name": "fromPayload",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/errors.ts",
+									"line": 20,
+									"character": 9,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L20"
+								}
+							],
+							"parameters": [
+								{
+									"id": 447,
+									"name": "__namedParameters",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 448,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 449,
+													"name": "error",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/errors.ts",
+															"line": 24,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L24"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 450,
+													"name": "error_description",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "src/errors.ts",
+															"line": 25,
+															"character": 4,
+															"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L25"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														449,
+														450
+													]
+												}
+											],
+											"sources": [
+												{
+													"fileName": "src/errors.ts",
+													"line": 23,
+													"character": 5,
+													"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L23"
+												}
+											]
+										}
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 305,
+								"name": "GenericError",
+								"package": "@auth0/auth0-spa-js"
+							},
+							"inheritedFrom": {
+								"type": "reference",
+								"target": 307,
+								"name": "GenericError.fromPayload"
+							}
+						}
+					],
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 306,
+						"name": "GenericError.fromPayload"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						451
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						455,
+						456,
+						454
+					]
+				},
+				{
+					"title": "Methods",
+					"children": [
+						445
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/errors.ts",
+					"line": 165,
+					"character": 13,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L165"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 305,
+					"name": "GenericError",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 1475,
+			"name": "User",
+			"variant": "declaration",
+			"kind": 128,
+			"flags": {},
+			"children": [
+				{
+					"id": 1476,
+					"name": "constructor",
+					"variant": "declaration",
+					"kind": 512,
+					"flags": {},
+					"signatures": [
+						{
+							"id": 1477,
+							"name": "new User",
+							"variant": "signature",
+							"kind": 16384,
+							"flags": {},
+							"type": {
+								"type": "reference",
+								"target": 1475,
+								"name": "User",
+								"package": "@auth0/auth0-spa-js"
+							}
+						}
+					]
+				},
+				{
+					"id": 1498,
+					"name": "act",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Type: [ActClaim](/docs/sdk/typescript/interfaces/ActClaim)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 931,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L931"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 1428,
+						"name": "ActClaim",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 1495,
+					"name": "address",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 928,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L928"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1490,
+					"name": "birthdate",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 923,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L923"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1487,
+					"name": "email",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 920,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L920"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1488,
+					"name": "email_verified",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 921,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L921"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					}
+				},
+				{
+					"id": 1480,
+					"name": "family_name",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 913,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L913"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1489,
+					"name": "gender",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 922,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L922"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1479,
+					"name": "given_name",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 912,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L912"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1492,
+					"name": "locale",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 925,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L925"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1481,
+					"name": "middle_name",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 914,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L914"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1478,
+					"name": "name",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 911,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L911"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1482,
+					"name": "nickname",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 915,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L915"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1493,
+					"name": "phone_number",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 926,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L926"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1494,
+					"name": "phone_number_verified",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 927,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L927"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					}
+				},
+				{
+					"id": 1485,
+					"name": "picture",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 918,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L918"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1483,
+					"name": "preferred_username",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 916,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L916"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1484,
+					"name": "profile",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 917,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L917"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1497,
+					"name": "sub",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 930,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L930"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1496,
+					"name": "updated_at",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 929,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L929"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1486,
+					"name": "website",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 919,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L919"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1491,
+					"name": "zoneinfo",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 924,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L924"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Constructors",
+					"children": [
+						1476
+					]
+				},
+				{
+					"title": "Properties",
+					"children": [
+						1498,
+						1495,
+						1490,
+						1487,
+						1488,
+						1480,
+						1489,
+						1479,
+						1492,
+						1481,
+						1478,
+						1482,
+						1493,
+						1494,
+						1485,
+						1483,
+						1484,
+						1497,
+						1496,
+						1486,
+						1491
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/global.ts",
+					"line": 910,
+					"character": 13,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L910"
+				}
+			],
+			"indexSignature": {
+				"id": 1499,
+				"name": "__index",
+				"variant": "signature",
+				"kind": 8192,
+				"flags": {},
+				"sources": [
+					{
+						"fileName": "src/global.ts",
+						"line": 932,
+						"character": 2,
+						"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L932"
+					}
+				],
+				"parameters": [
+					{
+						"id": 1500,
+						"name": "key",
+						"variant": "param",
+						"kind": 32768,
+						"flags": {},
+						"type": {
+							"type": "intrinsic",
+							"name": "string"
+						}
+					}
+				],
+				"type": {
+					"type": "intrinsic",
+					"name": "any"
+				}
+			}
+		},
+		{
+			"id": 1428,
+			"name": "ActClaim",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Represents the actor claim ("
+					},
+					{
+						"kind": "code",
+						"text": "`act`"
+					},
+					{
+						"kind": "text",
+						"text": ") in an ID token returned via a token exchange response.\n\nThe "
+					},
+					{
+						"kind": "code",
+						"text": "`act`"
+					},
+					{
+						"kind": "text",
+						"text": " claim identifies the acting party — the entity that has been delegated authority\nto act on behalf of the subject. It is set via Auth0 Actions using the "
+					},
+					{
+						"kind": "code",
+						"text": "`setActor`"
+					},
+					{
+						"kind": "text",
+						"text": " command."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@see",
+						"content": [
+							{
+								"kind": "inline-tag",
+								"tag": "@link",
+								"text": "RFC 8693 Section 4.1",
+								"target": "https://www.rfc-editor.org/rfc/rfc8693#section-4.1"
+							}
+						]
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 1429,
+					"name": "sub",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The identifier of the acting party."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 853,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L853"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1429
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/global.ts",
+					"line": 851,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L851"
+				}
+			],
+			"indexSignature": {
+				"id": 1430,
+				"name": "__index",
+				"variant": "signature",
+				"kind": 8192,
+				"flags": {},
+				"sources": [
+					{
+						"fileName": "src/global.ts",
+						"line": 854,
+						"character": 2,
+						"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L854"
+					}
+				],
+				"parameters": [
+					{
+						"id": 1431,
+						"name": "key",
+						"variant": "param",
+						"kind": 32768,
+						"flags": {},
+						"type": {
+							"type": "intrinsic",
+							"name": "string"
+						}
+					}
+				],
+				"type": {
+					"type": "intrinsic",
+					"name": "any"
+				}
+			}
+		},
+		{
+			"id": 1233,
+			"name": "Auth0ClientOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 1265,
+					"name": "authorizationParams",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "URL parameters that will be sent back to the Authorization Server. This can be known parameters\ndefined by Auth0 or custom parameters that you define."
+							},
+							{
+								"kind": "text",
+								"text": "\n\nType: [ClientAuthorizationParams](/docs/sdk/typescript/interfaces/ClientAuthorizationParams)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 363,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L363"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 1231,
+						"name": "ClientAuthorizationParams",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 1242,
+					"name": "authorizeTimeoutInSeconds",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "A maximum number of seconds to wait before declaring background calls to /authorize as failed for timeout\nDefaults to 60s."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 232,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L232"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "number"
+					}
+				},
+				{
+					"id": 1239,
+					"name": "cache",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Specify a custom cache implementation to use for token storage and retrieval. This setting takes precedence over "
+							},
+							{
+								"kind": "code",
+								"text": "`cacheLocation`"
+							},
+							{
+								"kind": "text",
+								"text": " if they are both specified."
+							},
+							{
+								"kind": "text",
+								"text": "\n\nType: [ICache](/docs/sdk/typescript/interfaces/ICache)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 193,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L193"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 637,
+						"name": "ICache",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 1238,
+					"name": "cacheLocation",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The location to use when storing cache data. Valid values are "
+							},
+							{
+								"kind": "code",
+								"text": "`memory`"
+							},
+							{
+								"kind": "text",
+								"text": " or "
+							},
+							{
+								"kind": "code",
+								"text": "`localstorage`"
+							},
+							{
+								"kind": "text",
+								"text": ".\nThe default setting is "
+							},
+							{
+								"kind": "code",
+								"text": "`memory`"
+							},
+							{
+								"kind": "text",
+								"text": ".\n\nRead more about [changing storage options in the Auth0 docs](https://auth0.com/docs/libraries/auth0-single-page-app-sdk#change-storage-options)"
+							},
+							{
+								"kind": "text",
+								"text": "\n\nType: [CacheLocation](/docs/sdk/typescript/types/CacheLocation)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 188,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L188"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 1270,
+						"name": "CacheLocation",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 1236,
+					"name": "clientId",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The Client ID found on your Application settings page"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 174,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L174"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1255,
+					"name": "cookieDomain",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The domain the cookie is accessible from. If not set, the cookie is scoped to\nthe current domain, including the subdomain.\n\nNote: setting this incorrectly may cause silent authentication to stop working\non page load.\n\n\nTo keep a user logged in across multiple subdomains set this to your\ntop-level domain and prefixed with a "
+							},
+							{
+								"kind": "code",
+								"text": "`.`"
+							},
+							{
+								"kind": "text",
+								"text": " (eg: "
+							},
+							{
+								"kind": "code",
+								"text": "`.example.com`"
+							},
+							{
+								"kind": "text",
+								"text": ")."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 289,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L289"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1234,
+					"name": "domain",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Your Auth0 account domain such as "
+							},
+							{
+								"kind": "code",
+								"text": "`'example.auth0.com'`"
+							},
+							{
+								"kind": "text",
+								"text": ",\n"
+							},
+							{
+								"kind": "code",
+								"text": "`'example.eu.auth0.com'`"
+							},
+							{
+								"kind": "text",
+								"text": " or , "
+							},
+							{
+								"kind": "code",
+								"text": "`'example.mycompany.com'`"
+							},
+							{
+								"kind": "text",
+								"text": "\n(when using [custom domains](https://auth0.com/docs/custom-domains))"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 166,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L166"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1243,
+					"name": "httpTimeoutInSeconds",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Specify the timeout for HTTP calls using "
+							},
+							{
+								"kind": "code",
+								"text": "`fetch`"
+							},
+							{
+								"kind": "text",
+								"text": ". The default is 10 seconds."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 237,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L237"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "number"
+					}
+				},
+				{
+					"id": 1264,
+					"name": "interactiveErrorHandler",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Configures automatic handling of interactive authentication errors.\n\nWhen set, the SDK intercepts "
+							},
+							{
+								"kind": "code",
+								"text": "`mfa_required`"
+							},
+							{
+								"kind": "text",
+								"text": " errors from "
+							},
+							{
+								"kind": "code",
+								"text": "`getTokenSilently()`"
+							},
+							{
+								"kind": "text",
+								"text": "\nand handles them automatically instead of throwing to the caller.\n\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`'popup'`"
+							},
+							{
+								"kind": "text",
+								"text": ": Opens Universal Login in a popup to complete MFA.\n  The original "
+							},
+							{
+								"kind": "code",
+								"text": "`authorizationParams`"
+							},
+							{
+								"kind": "text",
+								"text": " (audience, scope) are preserved.\n  On success, the token is returned. On failure, popup errors are thrown.\n\nThis option only affects "
+							},
+							{
+								"kind": "code",
+								"text": "`getTokenSilently()`"
+							},
+							{
+								"kind": "text",
+								"text": ". Other methods are not affected."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@default",
+								"content": [
+									{
+										"kind": "code",
+										"text": "```ts\nundefined (MFA errors are thrown to the caller)\n```"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 357,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L357"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "popup"
+					}
+				},
+				{
+					"id": 1235,
+					"name": "issuer",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The issuer to be used for validation of JWTs, optionally defaults to the domain above"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 170,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L170"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1237,
+					"name": "leeway",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The value in seconds used to account for clock skew in JWT expirations.\nTypically, this value is no more than a minute or two at maximum.\nDefaults to 60s."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 180,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L180"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "number"
+					}
+				},
+				{
+					"id": 1252,
+					"name": "legacySameSiteCookie",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Sets an additional cookie with no SameSite attribute to support legacy browsers\nthat are not compatible with the latest SameSite changes.\nThis will log a warning on modern browsers, you can disable the warning by setting\nthis to false but be aware that some older useragents will not work,\nSee https://www.chromium.org/updates/same-site/incompatible-clients\nDefaults to true"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 257,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L257"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					}
+				},
+				{
+					"id": 1257,
+					"name": "nowProvider",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Modify the value used as the current time during the token validation.\n\n**Note**: Using this improperly can potentially compromise the token validation."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 304,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L304"
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 1258,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/global.ts",
+									"line": 304,
+									"character": 16,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L304"
+								}
+							],
+							"signatures": [
+								{
+									"id": 1259,
+									"name": "__type",
+									"variant": "signature",
+									"kind": 4096,
+									"flags": {},
+									"sources": [
+										{
+											"fileName": "src/global.ts",
+											"line": 304,
+											"character": 16,
+											"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L304"
+										}
+									],
+									"type": {
+										"type": "union",
+										"types": [
+											{
+												"type": "intrinsic",
+												"name": "number"
+											},
+											{
+												"type": "reference",
+												"target": {
+													"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+													"qualifiedName": "Promise"
+												},
+												"typeArguments": [
+													{
+														"type": "intrinsic",
+														"name": "number"
+													}
+												],
+												"name": "Promise",
+												"package": "typescript"
+											}
+										]
+									}
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": 1263,
+					"name": "refreshTokenMode",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Selects the refresh-token variant used when "
+							},
+							{
+								"kind": "code",
+								"text": "`useRefreshTokens: true`"
+							},
+							{
+								"kind": "text",
+								"text": ".\nDefaults to "
+							},
+							{
+								"kind": "inline-tag",
+								"tag": "@link",
+								"text": "RefreshTokenMode.Offline",
+								"target": 1210,
+								"tsLinkText": ""
+							},
+							{
+								"kind": "text",
+								"text": ".\n\n- "
+							},
+							{
+								"kind": "inline-tag",
+								"tag": "@link",
+								"text": "RefreshTokenMode.Offline",
+								"target": 1210,
+								"tsLinkText": ""
+							},
+							{
+								"kind": "text",
+								"text": " (default): rotating offline refresh tokens ("
+							},
+							{
+								"kind": "code",
+								"text": "`offline_access`"
+							},
+							{
+								"kind": "text",
+								"text": ").\n- "
+							},
+							{
+								"kind": "inline-tag",
+								"tag": "@link",
+								"text": "RefreshTokenMode.Online",
+								"target": 1211,
+								"tsLinkText": ""
+							},
+							{
+								"kind": "text",
+								"text": ": non-rotating, session-bound Online Refresh Tokens ("
+							},
+							{
+								"kind": "code",
+								"text": "`online_access`"
+							},
+							{
+								"kind": "text",
+								"text": ").\n\nOnline mode requires "
+							},
+							{
+								"kind": "code",
+								"text": "`useRefreshTokens: true`"
+							},
+							{
+								"kind": "text",
+								"text": " and "
+							},
+							{
+								"kind": "code",
+								"text": "`useDpop: true`"
+							},
+							{
+								"kind": "text",
+								"text": ". The\n"
+							},
+							{
+								"kind": "code",
+								"text": "`online_access`"
+							},
+							{
+								"kind": "text",
+								"text": " and "
+							},
+							{
+								"kind": "code",
+								"text": "`offline_access`"
+							},
+							{
+								"kind": "text",
+								"text": " scopes are mutually exclusive."
+							},
+							{
+								"kind": "text",
+								"text": "\n\nType: [RefreshTokenMode](/docs/sdk/typescript/variables/RefreshTokenMode)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 341,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L341"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 1212,
+						"name": "RefreshTokenMode",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 1254,
+					"name": "sessionCheckExpiryDays",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Number of days until the cookie "
+							},
+							{
+								"kind": "code",
+								"text": "`auth0.is.authenticated`"
+							},
+							{
+								"kind": "text",
+								"text": " will expire\nDefaults to 1."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 276,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L276"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "number"
+					}
+				},
+				{
+					"id": 1266,
+					"name": "sessionTransferTokenQueryParamName",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Query parameter name to extract the session transfer token from for Native to Web SSO.\n\nWhen set, the SDK automatically extracts the token from the specified URL query\nparameter and includes it as "
+							},
+							{
+								"kind": "code",
+								"text": "`session_transfer_token`"
+							},
+							{
+								"kind": "text",
+								"text": " in authorization requests.\nThis enables seamless single sign-on when users transition from a native mobile\napplication to a web application.\n\nAfter extraction, the token is automatically removed from the URL using\n"
+							},
+							{
+								"kind": "code",
+								"text": "`window.history.replaceState()`"
+							},
+							{
+								"kind": "text",
+								"text": " to prevent accidental reuse on subsequent\nauthentication requests.\n\n**Default:** "
+							},
+							{
+								"kind": "code",
+								"text": "`undefined`"
+							},
+							{
+								"kind": "text",
+								"text": " (feature disabled)\n\n**Common values:**\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`'session_transfer_token'`"
+							},
+							{
+								"kind": "text",
+								"text": " - Standard parameter name\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`'stt'`"
+							},
+							{
+								"kind": "text",
+								"text": " - Shortened version\n- Custom parameter name of your choice\n\nSet to "
+							},
+							{
+								"kind": "code",
+								"text": "`undefined`"
+							},
+							{
+								"kind": "text",
+								"text": " to disable automatic extraction if you prefer to handle\nsession transfer tokens manually."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@example",
+								"content": [
+									{
+										"kind": "code",
+										"text": "```js\nconst auth0 = await createAuth0Client({\n  domain: '<AUTH0_DOMAIN>',\n  clientId: '<AUTH0_CLIENT_ID>',\n  sessionTransferTokenQueryParamName: 'session_transfer_token'\n});\n```"
+									}
+								]
+							},
+							{
+								"tag": "@see",
+								"content": [
+									{
+										"kind": "text",
+										"text": "https://auth0.com/docs/authenticate/single-sign-on/native-to-web"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 398,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L398"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1253,
+					"name": "useCookiesForTransactions",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "If "
+							},
+							{
+								"kind": "code",
+								"text": "`true`"
+							},
+							{
+								"kind": "text",
+								"text": ", the SDK will use a cookie when storing information about the auth transaction while\nthe user is going through the authentication flow on the authorization server.\n\nThe default is "
+							},
+							{
+								"kind": "code",
+								"text": "`false`"
+							},
+							{
+								"kind": "text",
+								"text": ", in which case the SDK will use session storage."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@notes",
+								"content": [
+									{
+										"kind": "text",
+										"text": "You might want to enable this if you rely on your users being able to authenticate using flows that\nmay end up spanning across multiple tabs (e.g. magic links) or you cannot otherwise rely on session storage being available."
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 270,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L270"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					}
+				},
+				{
+					"id": 1262,
+					"name": "useDpop",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "If "
+							},
+							{
+								"kind": "code",
+								"text": "`true`"
+							},
+							{
+								"kind": "text",
+								"text": ", DPoP (OAuth 2.0 Demonstrating Proof of Possession, RFC9449)\nwill be used to cryptographically bind tokens to this specific browser\nso they can't be used from a different device in case of a leak.\n\nThe default setting is "
+							},
+							{
+								"kind": "code",
+								"text": "`false`"
+							},
+							{
+								"kind": "text",
+								"text": "."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 329,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L329"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					}
+				},
+				{
+					"id": 1256,
+					"name": "useFormData",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "If true, data to the token endpoint is transmitted as x-www-form-urlencoded data, if false it will be transmitted as JSON. The default setting is "
+							},
+							{
+								"kind": "code",
+								"text": "`true`"
+							},
+							{
+								"kind": "text",
+								"text": ".\n\n**Note:** Setting this to "
+							},
+							{
+								"kind": "code",
+								"text": "`false`"
+							},
+							{
+								"kind": "text",
+								"text": " may affect you if you use Auth0 Rules and are sending custom, non-primitive data. If you disable this,\nplease verify that your Auth0 Rules continue to work as intended."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 297,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L297"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					}
+				},
+				{
+					"id": 1261,
+					"name": "useMrrt",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "If "
+							},
+							{
+								"kind": "code",
+								"text": "`true`"
+							},
+							{
+								"kind": "text",
+								"text": ", the SDK will allow the refreshing of tokens using MRRT"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 320,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L320"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					}
+				},
+				{
+					"id": 1240,
+					"name": "useRefreshTokens",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "If true, refresh tokens are used to fetch new access tokens from the Auth0 server. If false, the standard technique of using a hidden iframe and the "
+							},
+							{
+								"kind": "code",
+								"text": "`authorization_code`"
+							},
+							{
+								"kind": "text",
+								"text": " grant with "
+							},
+							{
+								"kind": "code",
+								"text": "`prompt=none`"
+							},
+							{
+								"kind": "text",
+								"text": " is used.\nThe default setting is "
+							},
+							{
+								"kind": "code",
+								"text": "`false`"
+							},
+							{
+								"kind": "text",
+								"text": ".\n\nStandard technique relies on cookies. Because browsers increasingly block third-party cookies, it requires a Custom Domain to function reliably. Refresh tokens serve as a fallback for environments where third-party cookies are blocked.\nUsing a Custom Domain with this set to "
+							},
+							{
+								"kind": "code",
+								"text": "`false`"
+							},
+							{
+								"kind": "text",
+								"text": " is the most secure and recommended approach.\n\n**Note**: Use of refresh tokens must be enabled by an administrator on your Auth0 client application."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 204,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L204"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					}
+				},
+				{
+					"id": 1241,
+					"name": "useRefreshTokensFallback",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "If true, fallback to the technique of using a hidden iframe and the "
+							},
+							{
+								"kind": "code",
+								"text": "`authorization_code`"
+							},
+							{
+								"kind": "text",
+								"text": " grant with "
+							},
+							{
+								"kind": "code",
+								"text": "`prompt=none`"
+							},
+							{
+								"kind": "text",
+								"text": " when unable to use refresh tokens. If false, the iframe fallback is not used and\nerrors relating to a failed "
+							},
+							{
+								"kind": "code",
+								"text": "`refresh_token`"
+							},
+							{
+								"kind": "text",
+								"text": " grant should be handled appropriately. The default setting is "
+							},
+							{
+								"kind": "code",
+								"text": "`false`"
+							},
+							{
+								"kind": "text",
+								"text": ".\n\n**Note**: There might be situations where doing silent auth with a Web Message response from an iframe is not possible,\nlike when you're serving your application from the file system or a custom protocol (like in a Desktop or Native app).\nIn situations like this you can disable the iframe fallback and handle the failed "
+							},
+							{
+								"kind": "code",
+								"text": "`refresh_token`"
+							},
+							{
+								"kind": "text",
+								"text": " grant and prompt the user to login interactively with "
+							},
+							{
+								"kind": "code",
+								"text": "`loginWithRedirect`"
+							},
+							{
+								"kind": "text",
+								"text": " or "
+							},
+							{
+								"kind": "code",
+								"text": "`loginWithPopup`"
+							},
+							{
+								"kind": "text",
+								"text": ".\"\n\nE.g. Using the "
+							},
+							{
+								"kind": "code",
+								"text": "`file:`"
+							},
+							{
+								"kind": "text",
+								"text": " protocol in an Electron application does not support that legacy technique."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@example",
+								"content": [
+									{
+										"kind": "code",
+										"text": "```ts\nlet token: string;\ntry {\n  token = await auth0.getTokenSilently();\n} catch (e) {\n  if (e.error === 'missing_refresh_token' || e.error === 'invalid_grant') {\n    auth0.loginWithRedirect();\n  }\n}\n```"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 226,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L226"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					}
+				},
+				{
+					"id": 1260,
+					"name": "workerUrl",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "If provided, the SDK will load the token worker from this URL instead of the integrated "
+							},
+							{
+								"kind": "code",
+								"text": "`blob`"
+							},
+							{
+								"kind": "text",
+								"text": ". An example of when this is useful is if you have strict\nContent-Security-Policy (CSP) and wish to avoid needing to set "
+							},
+							{
+								"kind": "code",
+								"text": "`worker-src: blob:`"
+							},
+							{
+								"kind": "text",
+								"text": ". We recommend either serving the worker, which you can find in the module\nat "
+							},
+							{
+								"kind": "code",
+								"text": "`<module_path>/dist/auth0-spa-js.worker.production.js`"
+							},
+							{
+								"kind": "text",
+								"text": ", from the same host as your application or using the Auth0 CDN\n"
+							},
+							{
+								"kind": "code",
+								"text": "`https://cdn.auth0.com/js/auth0-spa-js/<version>/auth0-spa-js.worker.production.js`"
+							},
+							{
+								"kind": "text",
+								"text": ".\n\n**Note**: The worker is only used when "
+							},
+							{
+								"kind": "code",
+								"text": "`useRefreshTokens: true`"
+							},
+							{
+								"kind": "text",
+								"text": ", "
+							},
+							{
+								"kind": "code",
+								"text": "`cacheLocation: 'memory'`"
+							},
+							{
+								"kind": "text",
+								"text": ", and the "
+							},
+							{
+								"kind": "code",
+								"text": "`cache`"
+							},
+							{
+								"kind": "text",
+								"text": " is not custom."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 314,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L314"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1265,
+						1242,
+						1239,
+						1238,
+						1236,
+						1255,
+						1234,
+						1243,
+						1264,
+						1235,
+						1237,
+						1252,
+						1257,
+						1263,
+						1254,
+						1266,
+						1253,
+						1262,
+						1256,
+						1261,
+						1240,
+						1241,
+						1260
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/global.ts",
+					"line": 160,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L160"
+				}
+			]
+		},
+		{
+			"id": 1516,
+			"name": "Authenticator",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Represents an MFA authenticator enrolled by a user"
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 1519,
+					"name": "active",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Whether the authenticator is active"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 12,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L12"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					}
+				},
+				{
+					"id": 1518,
+					"name": "authenticatorType",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Type of authenticator"
+							},
+							{
+								"kind": "text",
+								"text": "\n\nType: [AuthenticatorType](/docs/sdk/typescript/types/AuthenticatorType)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 10,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L10"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 1524,
+						"name": "AuthenticatorType",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 1521,
+					"name": "createdAt",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "ISO 8601 timestamp when created"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 16,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L16"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1517,
+					"name": "id",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Unique identifier for the authenticator"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 8,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L8"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1522,
+					"name": "lastAuth",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "ISO 8601 timestamp of last authentication"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 18,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L18"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1520,
+					"name": "name",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Optional friendly name"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 14,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L14"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1523,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Types of MFA challenges"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 20,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L20"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1519,
+						1518,
+						1521,
+						1517,
+						1522,
+						1520,
+						1523
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/mfa/types.ts",
+					"line": 6,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L6"
+				}
+			]
+		},
+		{
+			"id": 1213,
+			"name": "AuthorizationParams",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 1221,
+					"name": "acr_values",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 81,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L81"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1223,
+					"name": "audience",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The default audience to be used for requesting API access."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 96,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L96"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1224,
+					"name": "connection",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The name of the connection configured for your application.\nIf null, it will redirect to the Auth0 Login Page and show\nthe Login Widget."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 103,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L103"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1214,
+					"name": "display",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "- "
+							},
+							{
+								"kind": "code",
+								"text": "`'page'`"
+							},
+							{
+								"kind": "text",
+								"text": ": displays the UI with a full page view\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`'popup'`"
+							},
+							{
+								"kind": "text",
+								"text": ": displays the UI with a popup window\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`'touch'`"
+							},
+							{
+								"kind": "text",
+								"text": ": displays the UI in a way that leverages a touch interface\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`'wap'`"
+							},
+							{
+								"kind": "text",
+								"text": ": displays the UI with a \"feature phone\" type interface"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 35,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L35"
+						}
+					],
+					"type": {
+						"type": "union",
+						"types": [
+							{
+								"type": "literal",
+								"value": "page"
+							},
+							{
+								"type": "literal",
+								"value": "popup"
+							},
+							{
+								"type": "literal",
+								"value": "touch"
+							},
+							{
+								"type": "literal",
+								"value": "wap"
+							}
+						]
+					}
+				},
+				{
+					"id": 1218,
+					"name": "id_token_hint",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Previously issued ID Token."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 61,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L61"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1226,
+					"name": "invitation",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The Id of an invitation to accept. This is available from the user invitation URL that is given when participating in a user invitation flow."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 121,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L121"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1220,
+					"name": "login_hint",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The user's email address or other identifier. When your app knows\nwhich user is trying to authenticate, you can provide this parameter\nto pre-fill the email box or select the right session for sign-in.\n\nThis currently only affects the classic Lock experience."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 79,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L79"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1216,
+					"name": "max_age",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Maximum allowable elapsed time (in seconds) since authentication.\nIf the last time the user authenticated is greater than this value,\nthe user must be reauthenticated."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 50,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L50"
+						}
+					],
+					"type": {
+						"type": "union",
+						"types": [
+							{
+								"type": "intrinsic",
+								"name": "string"
+							},
+							{
+								"type": "intrinsic",
+								"name": "number"
+							}
+						]
+					}
+				},
+				{
+					"id": 1225,
+					"name": "organization",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The organization to log in to.\n\nThis will specify an "
+							},
+							{
+								"kind": "code",
+								"text": "`organization`"
+							},
+							{
+								"kind": "text",
+								"text": " parameter in your user's login request.\n\n- If you provide an Organization ID (a string with the prefix "
+							},
+							{
+								"kind": "code",
+								"text": "`org_`"
+							},
+							{
+								"kind": "text",
+								"text": "), it will be validated against the "
+							},
+							{
+								"kind": "code",
+								"text": "`org_id`"
+							},
+							{
+								"kind": "text",
+								"text": " claim of your user's ID Token. The validation is case-sensitive.\n- If you provide an Organization Name (a string *without* the prefix "
+							},
+							{
+								"kind": "code",
+								"text": "`org_`"
+							},
+							{
+								"kind": "text",
+								"text": "), it will be validated against the "
+							},
+							{
+								"kind": "code",
+								"text": "`org_name`"
+							},
+							{
+								"kind": "text",
+								"text": " claim of your user's ID Token. The validation is case-insensitive.\n  To use an Organization Name you must have \"Allow Organization Names in Authentication API\" switched on in your Auth0 settings dashboard.\n  More information is available on the [Auth0 documentation portal](https://auth0.com/docs/manage-users/organizations/configure-organizations/use-org-name-authentication-api)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 116,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L116"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1215,
+					"name": "prompt",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "- "
+							},
+							{
+								"kind": "code",
+								"text": "`'none'`"
+							},
+							{
+								"kind": "text",
+								"text": ": do not prompt user for login or consent on reauthentication\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`'login'`"
+							},
+							{
+								"kind": "text",
+								"text": ": prompt user for reauthentication\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`'consent'`"
+							},
+							{
+								"kind": "text",
+								"text": ": prompt user for consent before processing request\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`'select_account'`"
+							},
+							{
+								"kind": "text",
+								"text": ": prompt user to select an account"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 43,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L43"
+						}
+					],
+					"type": {
+						"type": "union",
+						"types": [
+							{
+								"type": "literal",
+								"value": "none"
+							},
+							{
+								"type": "literal",
+								"value": "login"
+							},
+							{
+								"type": "literal",
+								"value": "consent"
+							},
+							{
+								"type": "literal",
+								"value": "select_account"
+							}
+						]
+					}
+				},
+				{
+					"id": 1227,
+					"name": "redirect_uri",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The default URL where Auth0 will redirect your browser to with\nthe authentication result. It must be whitelisted in\nthe \"Allowed Callback URLs\" field in your Auth0 Application's\nsettings. If not provided here, it should be provided in the other\nmethods that provide authentication."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 130,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L130"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1222,
+					"name": "scope",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The default scope to be used on authentication requests.\n\nThis defaults to "
+							},
+							{
+								"kind": "code",
+								"text": "`profile email`"
+							},
+							{
+								"kind": "text",
+								"text": " if not set. If you are setting extra scopes and require\n"
+							},
+							{
+								"kind": "code",
+								"text": "`profile`"
+							},
+							{
+								"kind": "text",
+								"text": " and "
+							},
+							{
+								"kind": "code",
+								"text": "`email`"
+							},
+							{
+								"kind": "text",
+								"text": " to be included then you must include them in the provided scope.\n\nNote: The "
+							},
+							{
+								"kind": "code",
+								"text": "`openid`"
+							},
+							{
+								"kind": "text",
+								"text": " scope is **always applied** regardless of this setting."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 91,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L91"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1219,
+					"name": "screen_hint",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Provides a hint to Auth0 as to what flow should be displayed.\nThe default behavior is to show a login page but you can override\nthis by passing 'signup' to show the signup page instead.\n\nThis only affects the New Universal Login Experience."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 70,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L70"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1228,
+					"name": "session_transfer_token",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Session transfer token from a native application for Native to Web SSO.\nWhen "
+							},
+							{
+								"kind": "code",
+								"text": "`sessionTransferTokenQueryParamName`"
+							},
+							{
+								"kind": "text",
+								"text": " is set, this is automatically\nextracted from the specified URL query parameter if present."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@see",
+								"content": [
+									{
+										"kind": "text",
+										"text": "https://auth0.com/docs/authenticate/single-sign-on/native-to-web"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 139,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L139"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1217,
+					"name": "ui_locales",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The space-separated list of language tags, ordered by preference.\nFor example: "
+							},
+							{
+								"kind": "code",
+								"text": "`'fr-CA fr en'`"
+							},
+							{
+								"kind": "text",
+								"text": "."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 56,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L56"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1221,
+						1223,
+						1224,
+						1214,
+						1218,
+						1226,
+						1220,
+						1216,
+						1225,
+						1215,
+						1227,
+						1222,
+						1219,
+						1228,
+						1217
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/global.ts",
+					"line": 28,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L28"
+				}
+			],
+			"indexSignature": {
+				"id": 1229,
+				"name": "__index",
+				"variant": "signature",
+				"kind": 8192,
+				"flags": {},
+				"comment": {
+					"summary": [
+						{
+							"kind": "text",
+							"text": "If you need to send custom parameters to the Authorization Server,\nmake sure to use the original parameter name."
+						}
+					]
+				},
+				"sources": [
+					{
+						"fileName": "src/global.ts",
+						"line": 145,
+						"character": 2,
+						"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L145"
+					}
+				],
+				"parameters": [
+					{
+						"id": 1230,
+						"name": "key",
+						"variant": "param",
+						"kind": 32768,
+						"flags": {},
+						"type": {
+							"type": "intrinsic",
+							"name": "string"
+						}
+					}
+				],
+				"type": {
+					"type": "intrinsic",
+					"name": "any"
+				}
+			}
+		},
+		{
+			"id": 1541,
+			"name": "ChallengeAuthenticatorParams",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Parameters for initiating an MFA challenge"
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 1544,
+					"name": "authenticatorId",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Specific authenticator to challenge (optional)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 162,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L162"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1543,
+					"name": "challengeType",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Type of challenge to initiate"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 160,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L160"
+						}
+					],
+					"type": {
+						"type": "union",
+						"types": [
+							{
+								"type": "literal",
+								"value": "otp"
+							},
+							{
+								"type": "literal",
+								"value": "oob"
+							}
+						]
+					}
+				},
+				{
+					"id": 1542,
+					"name": "mfaToken",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "MFA token from mfa_required error or MFA-scoped access token"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 158,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L158"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1544,
+						1543,
+						1542
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/mfa/types.ts",
+					"line": 156,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L156"
+				}
+			]
+		},
+		{
+			"id": 1545,
+			"name": "ChallengeResponse",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Response from initiating an MFA challenge"
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 1548,
+					"name": "bindingMethod",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Binding method for OOB (e.g., 'prompt')"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 174,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L174"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1546,
+					"name": "challengeType",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Type of challenge created"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 170,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L170"
+						}
+					],
+					"type": {
+						"type": "union",
+						"types": [
+							{
+								"type": "literal",
+								"value": "otp"
+							},
+							{
+								"type": "literal",
+								"value": "oob"
+							}
+						]
+					}
+				},
+				{
+					"id": 1547,
+					"name": "oobCode",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Out-of-band code (for OOB challenges)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 172,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L172"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1548,
+						1546,
+						1547
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/mfa/types.ts",
+					"line": 168,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L168"
+				}
+			]
+		},
+		{
+			"id": 1231,
+			"name": "ClientAuthorizationParams",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 1232,
+					"name": "scope",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 149,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L149"
+						}
+					],
+					"type": {
+						"type": "union",
+						"types": [
+							{
+								"type": "intrinsic",
+								"name": "string"
+							},
+							{
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Record"
+								},
+								"typeArguments": [
+									{
+										"type": "intrinsic",
+										"name": "string"
+									},
+									{
+										"type": "intrinsic",
+										"name": "string"
+									}
+								],
+								"name": "Record",
+								"package": "typescript"
+							}
+						]
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1232
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/global.ts",
+					"line": 148,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L148"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+						"qualifiedName": "Omit"
+					},
+					"typeArguments": [
+						{
+							"type": "reference",
+							"target": 1213,
+							"name": "AuthorizationParams",
+							"package": "@auth0/auth0-spa-js"
+						},
+						{
+							"type": "literal",
+							"value": "scope"
+						}
+					],
+					"name": "Omit",
+					"package": "typescript"
+				}
+			]
+		},
+		{
+			"id": 1267,
+			"name": "ClientConfiguration",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Configuration details exposed by the Auth0Client after initialization."
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 1269,
+					"name": "clientId",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The Auth0 client ID that was configured"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 415,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L415"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1268,
+					"name": "domain",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The Auth0 domain that was configured"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 410,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L410"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1269,
+						1268
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/global.ts",
+					"line": 406,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L406"
+				}
+			]
+		},
+		{
+			"id": 821,
+			"name": "CompleteRequest",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 822,
+					"name": "auth_session",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 29,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L29"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 825,
+					"name": "code_verifier",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 32,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L32"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 823,
+					"name": "connect_code",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 30,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L30"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 824,
+					"name": "redirect_uri",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 31,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L31"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						822,
+						825,
+						823,
+						824
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 28,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L28"
+				}
+			]
+		},
+		{
+			"id": 826,
+			"name": "CompleteResponse",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 829,
+					"name": "access_type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 38,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L38"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "offline"
+					}
+				},
+				{
+					"id": 828,
+					"name": "connection",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 37,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L37"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 831,
+					"name": "created_at",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 40,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L40"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 832,
+					"name": "expires_at",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 41,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L41"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 827,
+					"name": "id",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 36,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L36"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 830,
+					"name": "scopes",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 39,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L39"
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "intrinsic",
+							"name": "string"
+						}
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						829,
+						828,
+						831,
+						832,
+						827,
+						830
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 35,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L35"
+				}
+			]
+		},
+		{
+			"id": 806,
+			"name": "ConnectRequest",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 813,
+					"name": "authorization_params",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Type: [AuthorizationParams](/docs/sdk/typescript/interfaces/AuthorizationParams)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 16,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L16"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 1213,
+						"name": "AuthorizationParams",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 811,
+					"name": "code_challenge",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 14,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L14"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 812,
+					"name": "code_challenge_method",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 15,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L15"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "S256"
+					}
+				},
+				{
+					"id": 807,
+					"name": "connection",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 10,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L10"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 809,
+					"name": "redirect_uri",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 12,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L12"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 808,
+					"name": "scopes",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 11,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L11"
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "intrinsic",
+							"name": "string"
+						}
+					}
+				},
+				{
+					"id": 810,
+					"name": "state",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 13,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L13"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						813,
+						811,
+						812,
+						807,
+						809,
+						808,
+						810
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 9,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L9"
+				}
+			]
+		},
+		{
+			"id": 814,
+			"name": "ConnectResponse",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 816,
+					"name": "auth_session",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 21,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L21"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 817,
+					"name": "connect_params",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 22,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L22"
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 818,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"children": [
+								{
+									"id": 819,
+									"name": "ticket",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {},
+									"sources": [
+										{
+											"fileName": "src/myaccount/types.ts",
+											"line": 23,
+											"character": 4,
+											"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L23"
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"groups": [
+								{
+									"title": "Properties",
+									"children": [
+										819
+									]
+								}
+							],
+							"sources": [
+								{
+									"fileName": "src/myaccount/types.ts",
+									"line": 22,
+									"character": 18,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L22"
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": 815,
+					"name": "connect_uri",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 20,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L20"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 820,
+					"name": "expires_in",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 25,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L25"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "number"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						816,
+						817,
+						815,
+						820
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 19,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L19"
+				}
+			]
+		},
+		{
+			"id": 653,
+			"name": "DecodedToken",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 654,
+					"name": "claims",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Type: [IdToken](/docs/sdk/typescript/interfaces/IdToken)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/cache/shared.ts",
+							"line": 65,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L65"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 1432,
+						"name": "IdToken",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 655,
+					"name": "user",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Type: [User](/docs/sdk/typescript/classes/User)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/cache/shared.ts",
+							"line": 66,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L66"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 1475,
+						"name": "User",
+						"package": "@auth0/auth0-spa-js"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						654,
+						655
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/cache/shared.ts",
+					"line": 64,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L64"
+				}
+			]
+		},
+		{
+			"id": 895,
+			"name": "EmailAuthenticationMethod",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 898,
+					"name": "confirmed",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 86,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L86"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthenticationMethodWithMetadata.confirmed"
+					}
+				},
+				{
+					"id": 902,
+					"name": "created_at",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 81,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L81"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthenticationMethodWithMetadata.created_at"
+					}
+				},
+				{
+					"id": 897,
+					"name": "email",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 132,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L132"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 901,
+					"name": "id",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 80,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L80"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthenticationMethodWithMetadata.id"
+					}
+				},
+				{
+					"id": 900,
+					"name": "last_auth_at",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 88,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L88"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthenticationMethodWithMetadata.last_auth_at"
+					}
+				},
+				{
+					"id": 899,
+					"name": "name",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 87,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L87"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthenticationMethodWithMetadata.name"
+					}
+				},
+				{
+					"id": 896,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 131,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L131"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "email"
+					}
+				},
+				{
+					"id": 903,
+					"name": "usage",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 82,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L82"
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "union",
+							"types": [
+								{
+									"type": "literal",
+									"value": "primary"
+								},
+								{
+									"type": "literal",
+									"value": "secondary"
+								}
+							]
+						}
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthenticationMethodWithMetadata.usage"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						898,
+						902,
+						897,
+						901,
+						900,
+						899,
+						896,
+						903
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 129,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L129"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "src/myaccount/types.ts",
+						"qualifiedName": "AuthenticationMethodWithMetadata"
+					},
+					"name": "AuthenticationMethodWithMetadata",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 946,
+			"name": "EmailEnrollmentChallengeOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 948,
+					"name": "email",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 189,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L189"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 947,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 188,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L188"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "email"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						948,
+						947
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 187,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L187"
+				}
+			]
+		},
+		{
+			"id": 971,
+			"name": "EmailEnrollmentChallengeResponse",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 975,
+					"name": "auth_session",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 224,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L224"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentChallengeBaseResponse.auth_session"
+					}
+				},
+				{
+					"id": 973,
+					"name": "id",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 222,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L222"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentChallengeBaseResponse.id"
+					}
+				},
+				{
+					"id": 974,
+					"name": "location",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 223,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L223"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentChallengeBaseResponse.location"
+					}
+				},
+				{
+					"id": 972,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 240,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L240"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "email"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						975,
+						973,
+						974,
+						972
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 238,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L238"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "src/myaccount/types.ts",
+						"qualifiedName": "EnrollmentChallengeBaseResponse"
+					},
+					"name": "EnrollmentChallengeBaseResponse",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 1034,
+			"name": "EmailEnrollmentVerifyOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 1038,
+					"name": "auth_session",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 305,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L305"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentVerifyBaseOptions.auth_session"
+					}
+				},
+				{
+					"id": 1037,
+					"name": "location",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 304,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L304"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentVerifyBaseOptions.location"
+					}
+				},
+				{
+					"id": 1036,
+					"name": "otp_code",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 323,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L323"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1035,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 322,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L322"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "email"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1038,
+						1037,
+						1036,
+						1035
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 320,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L320"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "src/myaccount/types.ts",
+						"qualifiedName": "EnrollmentVerifyBaseOptions"
+					},
+					"name": "EnrollmentVerifyBaseOptions",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 584,
+			"name": "EnrollEmailParams",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Email enrollment parameters"
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 586,
+					"name": "email",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Email address (optional, uses user's email if not provided)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 88,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L88"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 585,
+					"name": "factorType",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The factor type for enrollment"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 86,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L86"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "email"
+					}
+				},
+				{
+					"id": 587,
+					"name": "mfaToken",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "MFA token from mfa_required error"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 50,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L50"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollBaseParams.mfaToken"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						586,
+						585,
+						587
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/mfa/types.ts",
+					"line": 84,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L84"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "src/mfa/types.ts",
+						"qualifiedName": "EnrollBaseParams"
+					},
+					"name": "EnrollBaseParams",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 573,
+			"name": "EnrollOtpParams",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "OTP (Time-based One-Time Password) enrollment parameters"
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 574,
+					"name": "factorType",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The factor type for enrollment"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 58,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L58"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "otp"
+					}
+				},
+				{
+					"id": 575,
+					"name": "mfaToken",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "MFA token from mfa_required error"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 50,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L50"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollBaseParams.mfaToken"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						574,
+						575
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/mfa/types.ts",
+					"line": 56,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L56"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "src/mfa/types.ts",
+						"qualifiedName": "EnrollBaseParams"
+					},
+					"name": "EnrollBaseParams",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 588,
+			"name": "EnrollPushParams",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Push notification enrollment parameters"
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 589,
+					"name": "factorType",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The factor type for enrollment"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 96,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L96"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "push"
+					}
+				},
+				{
+					"id": 590,
+					"name": "mfaToken",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "MFA token from mfa_required error"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 50,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L50"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollBaseParams.mfaToken"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						589,
+						590
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/mfa/types.ts",
+					"line": 94,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L94"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "src/mfa/types.ts",
+						"qualifiedName": "EnrollBaseParams"
+					},
+					"name": "EnrollBaseParams",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 576,
+			"name": "EnrollSmsParams",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "SMS enrollment parameters"
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 577,
+					"name": "factorType",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The factor type for enrollment"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 66,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L66"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "sms"
+					}
+				},
+				{
+					"id": 579,
+					"name": "mfaToken",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "MFA token from mfa_required error"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 50,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L50"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollBaseParams.mfaToken"
+					}
+				},
+				{
+					"id": 578,
+					"name": "phoneNumber",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Phone number in E.164 format (required for SMS)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 68,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L68"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						577,
+						579,
+						578
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/mfa/types.ts",
+					"line": 64,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L64"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "src/mfa/types.ts",
+						"qualifiedName": "EnrollBaseParams"
+					},
+					"name": "EnrollBaseParams",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 580,
+			"name": "EnrollVoiceParams",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Voice enrollment parameters"
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 581,
+					"name": "factorType",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The factor type for enrollment"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 76,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L76"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "voice"
+					}
+				},
+				{
+					"id": 583,
+					"name": "mfaToken",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "MFA token from mfa_required error"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 50,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L50"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollBaseParams.mfaToken"
+					}
+				},
+				{
+					"id": 582,
+					"name": "phoneNumber",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Phone number in E.164 format (required for voice)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 78,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L78"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						581,
+						583,
+						582
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/mfa/types.ts",
+					"line": 74,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L74"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "src/mfa/types.ts",
+						"qualifiedName": "EnrollBaseParams"
+					},
+					"name": "EnrollBaseParams",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 1550,
+			"name": "EnrollmentFactor",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Enrollment factor returned by getEnrollmentFactors"
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 1551,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Type of enrollment factor available"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 208,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L208"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1551
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/mfa/types.ts",
+					"line": 206,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L206"
+				}
+			]
+		},
+		{
+			"id": 833,
+			"name": "ErrorResponse",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 837,
+					"name": "detail",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 50,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L50"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 835,
+					"name": "status",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 48,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L48"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "number"
+					}
+				},
+				{
+					"id": 836,
+					"name": "title",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 49,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L49"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 834,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 47,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L47"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 838,
+					"name": "validation_errors",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 51,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L51"
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "reflection",
+							"declaration": {
+								"id": 839,
+								"name": "__type",
+								"variant": "declaration",
+								"kind": 65536,
+								"flags": {},
+								"children": [
+									{
+										"id": 840,
+										"name": "detail",
+										"variant": "declaration",
+										"kind": 1024,
+										"flags": {},
+										"sources": [
+											{
+												"fileName": "src/myaccount/types.ts",
+												"line": 52,
+												"character": 4,
+												"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L52"
+											}
+										],
+										"type": {
+											"type": "intrinsic",
+											"name": "string"
+										}
+									},
+									{
+										"id": 841,
+										"name": "field",
+										"variant": "declaration",
+										"kind": 1024,
+										"flags": {
+											"isOptional": true
+										},
+										"sources": [
+											{
+												"fileName": "src/myaccount/types.ts",
+												"line": 53,
+												"character": 4,
+												"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L53"
+											}
+										],
+										"type": {
+											"type": "intrinsic",
+											"name": "string"
+										}
+									},
+									{
+										"id": 842,
+										"name": "pointer",
+										"variant": "declaration",
+										"kind": 1024,
+										"flags": {
+											"isOptional": true
+										},
+										"sources": [
+											{
+												"fileName": "src/myaccount/types.ts",
+												"line": 54,
+												"character": 4,
+												"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L54"
+											}
+										],
+										"type": {
+											"type": "intrinsic",
+											"name": "string"
+										}
+									},
+									{
+										"id": 843,
+										"name": "source",
+										"variant": "declaration",
+										"kind": 1024,
+										"flags": {
+											"isOptional": true
+										},
+										"sources": [
+											{
+												"fileName": "src/myaccount/types.ts",
+												"line": 55,
+												"character": 4,
+												"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L55"
+											}
+										],
+										"type": {
+											"type": "intrinsic",
+											"name": "string"
+										}
+									}
+								],
+								"groups": [
+									{
+										"title": "Properties",
+										"children": [
+											840,
+											841,
+											842,
+											843
+										]
+									}
+								],
+								"sources": [
+									{
+										"fileName": "src/myaccount/types.ts",
+										"line": 51,
+										"character": 22,
+										"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L51"
+									}
+								]
+							}
+						}
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						837,
+						835,
+						836,
+						834,
+						838
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 46,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L46"
+				}
+			]
+		},
+		{
+			"id": 844,
+			"name": "Factor",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 845,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Type: [AuthenticationMethodType](/docs/sdk/typescript/types/AuthenticationMethodType)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 73,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L73"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 847,
+						"name": "AuthenticationMethodType",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 846,
+					"name": "usage",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 74,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L74"
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "union",
+							"types": [
+								{
+									"type": "literal",
+									"value": "primary"
+								},
+								{
+									"type": "literal",
+									"value": "secondary"
+								}
+							]
+						}
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						845,
+						846
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 72,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L72"
+				}
+			]
+		},
+		{
+			"id": 1319,
+			"name": "GetTokenSilentlyOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 1321,
+					"name": "authorizationParams",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Parameters that will be sent back to Auth0 as part of a request."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 557,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L557"
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 1322,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"children": [
+								{
+									"id": 1325,
+									"name": "audience",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {
+										"isOptional": true
+									},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The audience that was used in the authentication request"
+											}
+										]
+									},
+									"sources": [
+										{
+											"fileName": "src/global.ts",
+											"line": 576,
+											"character": 4,
+											"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L576"
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 1323,
+									"name": "redirect_uri",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {
+										"isOptional": true
+									},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "There's no actual redirect when getting a token silently,\nbut, according to the spec, a "
+											},
+											{
+												"kind": "code",
+												"text": "`redirect_uri`"
+											},
+											{
+												"kind": "text",
+												"text": " param is required.\nAuth0 uses this parameter to validate that the current "
+											},
+											{
+												"kind": "code",
+												"text": "`origin`"
+											},
+											{
+												"kind": "text",
+												"text": "\nmatches the "
+											},
+											{
+												"kind": "code",
+												"text": "`redirect_uri`"
+											},
+											{
+												"kind": "text",
+												"text": " "
+											},
+											{
+												"kind": "code",
+												"text": "`origin`"
+											},
+											{
+												"kind": "text",
+												"text": " when sending the response.\nIt must be whitelisted in the \"Allowed Web Origins\" in your\nAuth0 Application's settings."
+											}
+										]
+									},
+									"sources": [
+										{
+											"fileName": "src/global.ts",
+											"line": 566,
+											"character": 4,
+											"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L566"
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 1324,
+									"name": "scope",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {
+										"isOptional": true
+									},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The scope that was used in the authentication request"
+											}
+										]
+									},
+									"sources": [
+										{
+											"fileName": "src/global.ts",
+											"line": 571,
+											"character": 4,
+											"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L571"
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"groups": [
+								{
+									"title": "Properties",
+									"children": [
+										1325,
+										1323,
+										1324
+									]
+								}
+							],
+							"sources": [
+								{
+									"fileName": "src/global.ts",
+									"line": 557,
+									"character": 24,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L557"
+								}
+							],
+							"indexSignature": {
+								"id": 1326,
+								"name": "__index",
+								"variant": "signature",
+								"kind": 8192,
+								"flags": {},
+								"comment": {
+									"summary": [
+										{
+											"kind": "text",
+											"text": "If you need to send custom parameters to the Authorization Server,\nmake sure to use the original parameter name."
+										}
+									]
+								},
+								"sources": [
+									{
+										"fileName": "src/global.ts",
+										"line": 582,
+										"character": 4,
+										"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L582"
+									}
+								],
+								"parameters": [
+									{
+										"id": 1327,
+										"name": "key",
+										"variant": "param",
+										"kind": 32768,
+										"flags": {},
+										"type": {
+											"type": "intrinsic",
+											"name": "string"
+										}
+									}
+								],
+								"type": {
+									"type": "intrinsic",
+									"name": "any"
+								}
+							}
+						}
+					}
+				},
+				{
+					"id": 1320,
+					"name": "cacheMode",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "When "
+							},
+							{
+								"kind": "code",
+								"text": "`off`"
+							},
+							{
+								"kind": "text",
+								"text": ", ignores the cache and always sends a\nrequest to Auth0.\nWhen "
+							},
+							{
+								"kind": "code",
+								"text": "`cache-only`"
+							},
+							{
+								"kind": "text",
+								"text": ", only reads from the cache and never sends a request to Auth0.\nDefaults to "
+							},
+							{
+								"kind": "code",
+								"text": "`on`"
+							},
+							{
+								"kind": "text",
+								"text": ", where it both reads from the cache and sends a request to Auth0 as needed."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 552,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L552"
+						}
+					],
+					"type": {
+						"type": "union",
+						"types": [
+							{
+								"type": "literal",
+								"value": "cache-only"
+							},
+							{
+								"type": "literal",
+								"value": "on"
+							},
+							{
+								"type": "literal",
+								"value": "off"
+							}
+						]
+					}
+				},
+				{
+					"id": 1329,
+					"name": "detailedResponse",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "If true, the full response from the /oauth/token endpoint (or the cache, if the cache was used) is returned\n(minus "
+							},
+							{
+								"kind": "code",
+								"text": "`refresh_token`"
+							},
+							{
+								"kind": "text",
+								"text": " if one was issued). Otherwise, just the access token is returned.\n\nThe default is "
+							},
+							{
+								"kind": "code",
+								"text": "`false`"
+							},
+							{
+								"kind": "text",
+								"text": "."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 596,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L596"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					}
+				},
+				{
+					"id": 1328,
+					"name": "timeoutInSeconds",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "A maximum number of seconds to wait before declaring the background /authorize call as failed for timeout\nDefaults to 60s."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 588,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L588"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "number"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1321,
+						1320,
+						1329,
+						1328
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/global.ts",
+					"line": 545,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L545"
+				}
+			]
+		},
+		{
+			"id": 1330,
+			"name": "GetTokenWithPopupOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 1332,
+					"name": "authorizationParams",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "URL parameters that will be sent back to the Authorization Server. This can be known parameters\ndefined by Auth0 or custom parameters that you define."
+							},
+							{
+								"kind": "text",
+								"text": "\n\nType: [AuthorizationParams](/docs/sdk/typescript/interfaces/AuthorizationParams)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 157,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L157"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 1213,
+						"name": "AuthorizationParams",
+						"package": "@auth0/auth0-spa-js"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 1314,
+						"name": "PopupLoginOptions.authorizationParams"
+					}
+				},
+				{
+					"id": 1331,
+					"name": "cacheMode",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "When "
+							},
+							{
+								"kind": "code",
+								"text": "`off`"
+							},
+							{
+								"kind": "text",
+								"text": ", ignores the cache and always sends a request to Auth0.\nWhen "
+							},
+							{
+								"kind": "code",
+								"text": "`cache-only`"
+							},
+							{
+								"kind": "text",
+								"text": ", only reads from the cache and never sends a request to Auth0.\nDefaults to "
+							},
+							{
+								"kind": "code",
+								"text": "`on`"
+							},
+							{
+								"kind": "text",
+								"text": ", where it both reads from the cache and sends a request to Auth0 as needed."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 605,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L605"
+						}
+					],
+					"type": {
+						"type": "union",
+						"types": [
+							{
+								"type": "literal",
+								"value": "cache-only"
+							},
+							{
+								"type": "literal",
+								"value": "on"
+							},
+							{
+								"type": "literal",
+								"value": "off"
+							}
+						]
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1332,
+						1331
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/global.ts",
+					"line": 599,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L599"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 1313,
+					"name": "PopupLoginOptions",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 637,
+			"name": "ICache",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 650,
+					"name": "allKeys",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/cache/shared.ts",
+							"line": 104,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L104"
+						}
+					],
+					"signatures": [
+						{
+							"id": 651,
+							"name": "allKeys",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/cache/shared.ts",
+									"line": 104,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L104"
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 675,
+								"typeArguments": [
+									{
+										"type": "array",
+										"elementType": {
+											"type": "intrinsic",
+											"name": "string"
+										}
+									}
+								],
+								"name": "MaybePromise",
+								"package": "@auth0/auth0-spa-js"
+							}
+						}
+					]
+				},
+				{
+					"id": 643,
+					"name": "get",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/cache/shared.ts",
+							"line": 102,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L102"
+						}
+					],
+					"signatures": [
+						{
+							"id": 644,
+							"name": "get",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/cache/shared.ts",
+									"line": 102,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L102"
+								}
+							],
+							"typeParameter": [
+								{
+									"id": 645,
+									"name": "T",
+									"variant": "typeParam",
+									"kind": 131072,
+									"flags": {},
+									"default": {
+										"type": "reference",
+										"target": 652,
+										"name": "Cacheable",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"parameters": [
+								{
+									"id": 646,
+									"name": "key",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 675,
+								"typeArguments": [
+									{
+										"type": "union",
+										"types": [
+											{
+												"type": "intrinsic",
+												"name": "undefined"
+											},
+											{
+												"type": "reference",
+												"target": 645,
+												"name": "T",
+												"package": "@auth0/auth0-spa-js",
+												"refersToTypeParameter": true
+											}
+										]
+									}
+								],
+								"name": "MaybePromise",
+								"package": "@auth0/auth0-spa-js"
+							}
+						}
+					]
+				},
+				{
+					"id": 647,
+					"name": "remove",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/cache/shared.ts",
+							"line": 103,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L103"
+						}
+					],
+					"signatures": [
+						{
+							"id": 648,
+							"name": "remove",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/cache/shared.ts",
+									"line": 103,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L103"
+								}
+							],
+							"parameters": [
+								{
+									"id": 649,
+									"name": "key",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 675,
+								"typeArguments": [
+									{
+										"type": "intrinsic",
+										"name": "void"
+									}
+								],
+								"name": "MaybePromise",
+								"package": "@auth0/auth0-spa-js"
+							}
+						}
+					]
+				},
+				{
+					"id": 638,
+					"name": "set",
+					"variant": "declaration",
+					"kind": 2048,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/cache/shared.ts",
+							"line": 101,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L101"
+						}
+					],
+					"signatures": [
+						{
+							"id": 639,
+							"name": "set",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/cache/shared.ts",
+									"line": 101,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L101"
+								}
+							],
+							"typeParameter": [
+								{
+									"id": 640,
+									"name": "T",
+									"variant": "typeParam",
+									"kind": 131072,
+									"flags": {},
+									"default": {
+										"type": "reference",
+										"target": 652,
+										"name": "Cacheable",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"parameters": [
+								{
+									"id": 641,
+									"name": "key",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 642,
+									"name": "entry",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reference",
+										"target": 640,
+										"name": "T",
+										"package": "@auth0/auth0-spa-js",
+										"refersToTypeParameter": true
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 675,
+								"typeArguments": [
+									{
+										"type": "intrinsic",
+										"name": "void"
+									}
+								],
+								"name": "MaybePromise",
+								"package": "@auth0/auth0-spa-js"
+							}
+						}
+					]
+				}
+			],
+			"groups": [
+				{
+					"title": "Methods",
+					"children": [
+						650,
+						643,
+						647,
+						638
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/cache/shared.ts",
+					"line": 100,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L100"
+				}
+			],
+			"implementedBy": [
+				{
+					"type": "reference",
+					"target": 597,
+					"name": "LocalStorageCache"
+				}
+			]
+		},
+		{
+			"id": 1432,
+			"name": "IdToken",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 1433,
+					"name": "__raw",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 858,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L858"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1464,
+					"name": "acr",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 889,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L889"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1472,
+					"name": "act",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The actor claim, present in ID tokens returned via token exchange responses.\nIdentifies the acting party that has been delegated authority to act on behalf\nof the subject. Set via Auth0 Actions using the "
+							},
+							{
+								"kind": "code",
+								"text": "`setActor`"
+							},
+							{
+								"kind": "text",
+								"text": " command."
+							},
+							{
+								"kind": "text",
+								"text": "\n\nType: [ActClaim](/docs/sdk/typescript/interfaces/ActClaim)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 906,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L906"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 1428,
+						"name": "ActClaim",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 1451,
+					"name": "address",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 876,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L876"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1465,
+					"name": "amr",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 890,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L890"
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "intrinsic",
+							"name": "string"
+						}
+					}
+				},
+				{
+					"id": 1462,
+					"name": "at_hash",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 887,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L887"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1454,
+					"name": "aud",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 879,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L879"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1461,
+					"name": "auth_time",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 886,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L886"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1459,
+					"name": "azp",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 884,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L884"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1446,
+					"name": "birthdate",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 871,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L871"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1463,
+					"name": "c_hash",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 888,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L888"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1467,
+					"name": "cnf",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 892,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L892"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1443,
+					"name": "email",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 868,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L868"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1444,
+					"name": "email_verified",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 869,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L869"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					}
+				},
+				{
+					"id": 1455,
+					"name": "exp",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 880,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L880"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "number"
+					}
+				},
+				{
+					"id": 1436,
+					"name": "family_name",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 861,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L861"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1445,
+					"name": "gender",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 870,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L870"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1435,
+					"name": "given_name",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 860,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L860"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1457,
+					"name": "iat",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 882,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L882"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "number"
+					}
+				},
+				{
+					"id": 1453,
+					"name": "iss",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 878,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L878"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1458,
+					"name": "jti",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 883,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L883"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1448,
+					"name": "locale",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 873,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L873"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1437,
+					"name": "middle_name",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 862,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L862"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1434,
+					"name": "name",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 859,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L859"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1456,
+					"name": "nbf",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 881,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L881"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "number"
+					}
+				},
+				{
+					"id": 1438,
+					"name": "nickname",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 863,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L863"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1460,
+					"name": "nonce",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 885,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L885"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1469,
+					"name": "org_id",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 894,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L894"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1470,
+					"name": "org_name",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 895,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L895"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1449,
+					"name": "phone_number",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 874,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L874"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1450,
+					"name": "phone_number_verified",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 875,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L875"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					}
+				},
+				{
+					"id": 1441,
+					"name": "picture",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 866,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L866"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1439,
+					"name": "preferred_username",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 864,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L864"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1440,
+					"name": "profile",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 865,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L865"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1471,
+					"name": "session_expiry",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "IPSIE session expiry ceiling (Unix timestamp in seconds).\nWhen present, the SDK will not return tokens after this point in time."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 900,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L900"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "number"
+					}
+				},
+				{
+					"id": 1468,
+					"name": "sid",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 893,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L893"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1466,
+					"name": "sub_jwk",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 891,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L891"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1452,
+					"name": "updated_at",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 877,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L877"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1442,
+					"name": "website",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 867,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L867"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1447,
+					"name": "zoneinfo",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 872,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L872"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1433,
+						1464,
+						1472,
+						1451,
+						1465,
+						1462,
+						1454,
+						1461,
+						1459,
+						1446,
+						1463,
+						1467,
+						1443,
+						1444,
+						1455,
+						1436,
+						1445,
+						1435,
+						1457,
+						1453,
+						1458,
+						1448,
+						1437,
+						1434,
+						1456,
+						1438,
+						1460,
+						1469,
+						1470,
+						1449,
+						1450,
+						1441,
+						1439,
+						1440,
+						1471,
+						1468,
+						1466,
+						1452,
+						1442,
+						1447
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/global.ts",
+					"line": 857,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L857"
+				}
+			],
+			"indexSignature": {
+				"id": 1473,
+				"name": "__index",
+				"variant": "signature",
+				"kind": 8192,
+				"flags": {},
+				"sources": [
+					{
+						"fileName": "src/global.ts",
+						"line": 907,
+						"character": 2,
+						"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L907"
+					}
+				],
+				"parameters": [
+					{
+						"id": 1474,
+						"name": "key",
+						"variant": "param",
+						"kind": 32768,
+						"flags": {},
+						"type": {
+							"type": "intrinsic",
+							"name": "string"
+						}
+					}
+				],
+				"type": {
+					"type": "intrinsic",
+					"name": "any"
+				}
+			}
+		},
+		{
+			"id": 1341,
+			"name": "LogoutOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 1350,
+					"name": "clientId",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The "
+							},
+							{
+								"kind": "code",
+								"text": "`clientId`"
+							},
+							{
+								"kind": "text",
+								"text": " of your application.\n\nIf this property is not set, then the "
+							},
+							{
+								"kind": "code",
+								"text": "`clientId`"
+							},
+							{
+								"kind": "text",
+								"text": " that was used during initialization of the SDK is sent to the logout endpoint.\n\nIf this property is set to "
+							},
+							{
+								"kind": "code",
+								"text": "`null`"
+							},
+							{
+								"kind": "text",
+								"text": ", then no client ID value is sent to the logout endpoint.\n\n[Read more about how redirecting after logout works](https://auth0.com/docs/logout/guides/redirect-users-after-logout)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 618,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L618"
+						}
+					],
+					"type": {
+						"type": "union",
+						"types": [
+							{
+								"type": "literal",
+								"value": null
+							},
+							{
+								"type": "intrinsic",
+								"name": "string"
+							}
+						]
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 1334,
+						"name": "LogoutUrlOptions.clientId"
+					}
+				},
+				{
+					"id": 1351,
+					"name": "logoutParams",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Parameters to pass to the logout endpoint. This can be known parameters defined by Auth0 or custom parameters\nyou wish to provide."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 624,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L624"
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 1352,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"children": [
+								{
+									"id": 1353,
+									"name": "federated",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {
+										"isOptional": true
+									},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "When supported by the upstream identity provider,\nforces the user to logout of their identity provider\nand from Auth0.\n[Read more about how federated logout works at Auth0](https://auth0.com/docs/logout/guides/logout-idps)"
+											}
+										]
+									},
+									"sources": [
+										{
+											"fileName": "src/global.ts",
+											"line": 631,
+											"character": 4,
+											"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L631"
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "boolean"
+									}
+								},
+								{
+									"id": 1354,
+									"name": "returnTo",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {
+										"isOptional": true
+									},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The URL where Auth0 will redirect your browser to after the logout.\n\n**Note**: If the "
+											},
+											{
+												"kind": "code",
+												"text": "`client_id`"
+											},
+											{
+												"kind": "text",
+												"text": " parameter is included, the\n"
+											},
+											{
+												"kind": "code",
+												"text": "`returnTo`"
+											},
+											{
+												"kind": "text",
+												"text": " URL that is provided must be listed in the\nApplication's \"Allowed Logout URLs\" in the Auth0 dashboard.\nHowever, if the "
+											},
+											{
+												"kind": "code",
+												"text": "`client_id`"
+											},
+											{
+												"kind": "text",
+												"text": " parameter is not included, the\n"
+											},
+											{
+												"kind": "code",
+												"text": "`returnTo`"
+											},
+											{
+												"kind": "text",
+												"text": " URL must be listed in the \"Allowed Logout URLs\" at\nthe account level in the Auth0 dashboard.\n\n[Read more about how redirecting after logout works](https://auth0.com/docs/logout/guides/redirect-users-after-logout)"
+											}
+										]
+									},
+									"sources": [
+										{
+											"fileName": "src/global.ts",
+											"line": 644,
+											"character": 4,
+											"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L644"
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"groups": [
+								{
+									"title": "Properties",
+									"children": [
+										1353,
+										1354
+									]
+								}
+							],
+							"sources": [
+								{
+									"fileName": "src/global.ts",
+									"line": 624,
+									"character": 17,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L624"
+								}
+							],
+							"indexSignature": {
+								"id": 1355,
+								"name": "__index",
+								"variant": "signature",
+								"kind": 8192,
+								"flags": {},
+								"comment": {
+									"summary": [
+										{
+											"kind": "text",
+											"text": "If you need to send custom parameters to the logout endpoint, make sure to use the original parameter name."
+										}
+									]
+								},
+								"sources": [
+									{
+										"fileName": "src/global.ts",
+										"line": 649,
+										"character": 4,
+										"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L649"
+									}
+								],
+								"parameters": [
+									{
+										"id": 1356,
+										"name": "key",
+										"variant": "param",
+										"kind": 32768,
+										"flags": {},
+										"type": {
+											"type": "intrinsic",
+											"name": "string"
+										}
+									}
+								],
+								"type": {
+									"type": "intrinsic",
+									"name": "any"
+								}
+							}
+						}
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": 1335,
+						"name": "LogoutUrlOptions.logoutParams"
+					}
+				},
+				{
+					"id": 1342,
+					"name": "onRedirect",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Used to control the redirect and not rely on the SDK to do the actual redirect."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@example",
+								"content": [
+									{
+										"kind": "code",
+										"text": "```ts\nawait auth0.logout({\n  async onRedirect(url) {\n    window.location.replace(url);\n  }\n});\n```"
+									}
+								]
+							},
+							{
+								"tag": "@deprecated",
+								"content": [
+									{
+										"kind": "text",
+										"text": "since v2.0.1, use "
+									},
+									{
+										"kind": "code",
+										"text": "`openUrl`"
+									},
+									{
+										"kind": "text",
+										"text": " instead."
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 665,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L665"
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 1343,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/global.ts",
+									"line": 665,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L665"
+								}
+							],
+							"signatures": [
+								{
+									"id": 1344,
+									"name": "__type",
+									"variant": "signature",
+									"kind": 4096,
+									"flags": {},
+									"sources": [
+										{
+											"fileName": "src/global.ts",
+											"line": 665,
+											"character": 15,
+											"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L665"
+										}
+									],
+									"parameters": [
+										{
+											"id": 1345,
+											"name": "url",
+											"variant": "param",
+											"kind": 32768,
+											"flags": {},
+											"type": {
+												"type": "intrinsic",
+												"name": "string"
+											}
+										}
+									],
+									"type": {
+										"type": "reference",
+										"target": {
+											"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+											"qualifiedName": "Promise"
+										},
+										"typeArguments": [
+											{
+												"type": "intrinsic",
+												"name": "void"
+											}
+										],
+										"name": "Promise",
+										"package": "typescript"
+									}
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": 1346,
+					"name": "openUrl",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Used to control the redirect and not rely on the SDK to do the actual redirect.\n\nSet to "
+							},
+							{
+								"kind": "code",
+								"text": "`false`"
+							},
+							{
+								"kind": "text",
+								"text": " to disable the redirect, or provide a function to handle the actual redirect yourself."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@example",
+								"content": [
+									{
+										"kind": "code",
+										"text": "```ts\nawait auth0.logout({\n  openUrl(url) {\n    window.location.replace(url);\n  }\n});\n```"
+									}
+								]
+							},
+							{
+								"tag": "@example",
+								"content": [
+									{
+										"kind": "code",
+										"text": "```ts\nimport { Browser } from '@capacitor/browser';\n\nawait auth0.logout({\n  async openUrl(url) {\n    await Browser.open({ url });\n  }\n});\n```"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 688,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L688"
+						}
+					],
+					"type": {
+						"type": "union",
+						"types": [
+							{
+								"type": "literal",
+								"value": false
+							},
+							{
+								"type": "reflection",
+								"declaration": {
+									"id": 1347,
+									"name": "__type",
+									"variant": "declaration",
+									"kind": 65536,
+									"flags": {},
+									"sources": [
+										{
+											"fileName": "src/global.ts",
+											"line": 688,
+											"character": 21,
+											"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L688"
+										}
+									],
+									"signatures": [
+										{
+											"id": 1348,
+											"name": "__type",
+											"variant": "signature",
+											"kind": 4096,
+											"flags": {},
+											"sources": [
+												{
+													"fileName": "src/global.ts",
+													"line": 688,
+													"character": 21,
+													"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L688"
+												}
+											],
+											"parameters": [
+												{
+													"id": 1349,
+													"name": "url",
+													"variant": "param",
+													"kind": 32768,
+													"flags": {},
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"type": {
+												"type": "union",
+												"types": [
+													{
+														"type": "intrinsic",
+														"name": "void"
+													},
+													{
+														"type": "reference",
+														"target": {
+															"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+															"qualifiedName": "Promise"
+														},
+														"typeArguments": [
+															{
+																"type": "intrinsic",
+																"name": "void"
+															}
+														],
+														"name": "Promise",
+														"package": "typescript"
+													}
+												]
+											}
+										}
+									]
+								}
+							}
+						]
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1350,
+						1351,
+						1342,
+						1346
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/global.ts",
+					"line": 653,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L653"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": 1333,
+					"name": "LogoutUrlOptions",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 1333,
+			"name": "LogoutUrlOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 1334,
+					"name": "clientId",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The "
+							},
+							{
+								"kind": "code",
+								"text": "`clientId`"
+							},
+							{
+								"kind": "text",
+								"text": " of your application.\n\nIf this property is not set, then the "
+							},
+							{
+								"kind": "code",
+								"text": "`clientId`"
+							},
+							{
+								"kind": "text",
+								"text": " that was used during initialization of the SDK is sent to the logout endpoint.\n\nIf this property is set to "
+							},
+							{
+								"kind": "code",
+								"text": "`null`"
+							},
+							{
+								"kind": "text",
+								"text": ", then no client ID value is sent to the logout endpoint.\n\n[Read more about how redirecting after logout works](https://auth0.com/docs/logout/guides/redirect-users-after-logout)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 618,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L618"
+						}
+					],
+					"type": {
+						"type": "union",
+						"types": [
+							{
+								"type": "literal",
+								"value": null
+							},
+							{
+								"type": "intrinsic",
+								"name": "string"
+							}
+						]
+					}
+				},
+				{
+					"id": 1335,
+					"name": "logoutParams",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Parameters to pass to the logout endpoint. This can be known parameters defined by Auth0 or custom parameters\nyou wish to provide."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 624,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L624"
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 1336,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"children": [
+								{
+									"id": 1337,
+									"name": "federated",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {
+										"isOptional": true
+									},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "When supported by the upstream identity provider,\nforces the user to logout of their identity provider\nand from Auth0.\n[Read more about how federated logout works at Auth0](https://auth0.com/docs/logout/guides/logout-idps)"
+											}
+										]
+									},
+									"sources": [
+										{
+											"fileName": "src/global.ts",
+											"line": 631,
+											"character": 4,
+											"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L631"
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "boolean"
+									}
+								},
+								{
+									"id": 1338,
+									"name": "returnTo",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {
+										"isOptional": true
+									},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The URL where Auth0 will redirect your browser to after the logout.\n\n**Note**: If the "
+											},
+											{
+												"kind": "code",
+												"text": "`client_id`"
+											},
+											{
+												"kind": "text",
+												"text": " parameter is included, the\n"
+											},
+											{
+												"kind": "code",
+												"text": "`returnTo`"
+											},
+											{
+												"kind": "text",
+												"text": " URL that is provided must be listed in the\nApplication's \"Allowed Logout URLs\" in the Auth0 dashboard.\nHowever, if the "
+											},
+											{
+												"kind": "code",
+												"text": "`client_id`"
+											},
+											{
+												"kind": "text",
+												"text": " parameter is not included, the\n"
+											},
+											{
+												"kind": "code",
+												"text": "`returnTo`"
+											},
+											{
+												"kind": "text",
+												"text": " URL must be listed in the \"Allowed Logout URLs\" at\nthe account level in the Auth0 dashboard.\n\n[Read more about how redirecting after logout works](https://auth0.com/docs/logout/guides/redirect-users-after-logout)"
+											}
+										]
+									},
+									"sources": [
+										{
+											"fileName": "src/global.ts",
+											"line": 644,
+											"character": 4,
+											"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L644"
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"groups": [
+								{
+									"title": "Properties",
+									"children": [
+										1337,
+										1338
+									]
+								}
+							],
+							"sources": [
+								{
+									"fileName": "src/global.ts",
+									"line": 624,
+									"character": 17,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L624"
+								}
+							],
+							"indexSignature": {
+								"id": 1339,
+								"name": "__index",
+								"variant": "signature",
+								"kind": 8192,
+								"flags": {},
+								"comment": {
+									"summary": [
+										{
+											"kind": "text",
+											"text": "If you need to send custom parameters to the logout endpoint, make sure to use the original parameter name."
+										}
+									]
+								},
+								"sources": [
+									{
+										"fileName": "src/global.ts",
+										"line": 649,
+										"character": 4,
+										"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L649"
+									}
+								],
+								"parameters": [
+									{
+										"id": 1340,
+										"name": "key",
+										"variant": "param",
+										"kind": 32768,
+										"flags": {},
+										"type": {
+											"type": "intrinsic",
+											"name": "string"
+										}
+									}
+								],
+								"type": {
+									"type": "intrinsic",
+									"name": "any"
+								}
+							}
+						}
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1334,
+						1335
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/global.ts",
+					"line": 608,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L608"
+				}
+			],
+			"extendedBy": [
+				{
+					"type": "reference",
+					"target": 1341,
+					"name": "LogoutOptions"
+				}
+			]
+		},
+		{
+			"id": 457,
+			"name": "MfaRequirements",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "MFA requirements from an mfa_required error response"
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 461,
+					"name": "challenge",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Required challenge types"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 8,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L8"
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "reflection",
+							"declaration": {
+								"id": 462,
+								"name": "__type",
+								"variant": "declaration",
+								"kind": 65536,
+								"flags": {},
+								"children": [
+									{
+										"id": 463,
+										"name": "type",
+										"variant": "declaration",
+										"kind": 1024,
+										"flags": {},
+										"sources": [
+											{
+												"fileName": "src/errors.ts",
+												"line": 8,
+												"character": 22,
+												"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L8"
+											}
+										],
+										"type": {
+											"type": "intrinsic",
+											"name": "string"
+										}
+									}
+								],
+								"groups": [
+									{
+										"title": "Properties",
+										"children": [
+											463
+										]
+									}
+								],
+								"sources": [
+									{
+										"fileName": "src/errors.ts",
+										"line": 8,
+										"character": 20,
+										"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L8"
+									}
+								]
+							}
+						}
+					}
+				},
+				{
+					"id": 458,
+					"name": "enroll",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Required enrollment types"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/errors.ts",
+							"line": 6,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L6"
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "reflection",
+							"declaration": {
+								"id": 459,
+								"name": "__type",
+								"variant": "declaration",
+								"kind": 65536,
+								"flags": {},
+								"children": [
+									{
+										"id": 460,
+										"name": "type",
+										"variant": "declaration",
+										"kind": 1024,
+										"flags": {},
+										"sources": [
+											{
+												"fileName": "src/errors.ts",
+												"line": 6,
+												"character": 19,
+												"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L6"
+											}
+										],
+										"type": {
+											"type": "intrinsic",
+											"name": "string"
+										}
+									}
+								],
+								"groups": [
+									{
+										"title": "Properties",
+										"children": [
+											460
+										]
+									}
+								],
+								"sources": [
+									{
+										"fileName": "src/errors.ts",
+										"line": 6,
+										"character": 17,
+										"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L6"
+									}
+								]
+							}
+						}
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						461,
+						458
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/errors.ts",
+					"line": 4,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/errors.ts#L4"
+				}
+			]
+		},
+		{
+			"id": 1533,
+			"name": "OobEnrollmentResponse",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Response when enrolling an OOB authenticator"
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 1534,
+					"name": "authenticatorType",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Authenticator type"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 130,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L130"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "oob"
+					}
+				},
+				{
+					"id": 1540,
+					"name": "barcodeUri",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "URI for QR code (for Push/Guardian enrollment)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 142,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L142"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1537,
+					"name": "bindingMethod",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Binding method (e.g., 'prompt' for user code entry)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 136,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L136"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1539,
+					"name": "id",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Authenticator ID"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 140,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L140"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1535,
+					"name": "oobChannel",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Delivery channel used"
+							},
+							{
+								"kind": "text",
+								"text": "\n\nType: [OobChannel](/docs/sdk/typescript/types/OobChannel)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 132,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L132"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 1525,
+						"name": "OobChannel",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 1536,
+					"name": "oobCode",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Out-of-band code for verification"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 134,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L134"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1538,
+					"name": "recoveryCodes",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Recovery codes (generated when enrolling first MFA factor)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 138,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L138"
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "intrinsic",
+							"name": "string"
+						}
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1534,
+						1540,
+						1537,
+						1539,
+						1535,
+						1536,
+						1538
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/mfa/types.ts",
+					"line": 128,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L128"
+				}
+			]
+		},
+		{
+			"id": 1527,
+			"name": "OtpEnrollmentResponse",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Response when enrolling an OTP authenticator"
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 1528,
+					"name": "authenticatorType",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Authenticator type"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 114,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L114"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "otp"
+					}
+				},
+				{
+					"id": 1530,
+					"name": "barcodeUri",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "URI for generating QR code (otpauth://...)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 118,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L118"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1532,
+					"name": "id",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Authenticator ID"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 122,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L122"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1531,
+					"name": "recoveryCodes",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Recovery codes for account recovery"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 120,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L120"
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "intrinsic",
+							"name": "string"
+						}
+					}
+				},
+				{
+					"id": 1529,
+					"name": "secret",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Base32-encoded secret for TOTP generation"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 116,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L116"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1528,
+						1530,
+						1532,
+						1531,
+						1529
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/mfa/types.ts",
+					"line": 112,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L112"
+				}
+			]
+		},
+		{
+			"id": 849,
+			"name": "PasskeyAuthenticationMethod",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 859,
+					"name": "aaguid",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 107,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L107"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 863,
+					"name": "created_at",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 81,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L81"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthenticationMethodBase.created_at"
+					}
+				},
+				{
+					"id": 854,
+					"name": "credential_backed_up",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 102,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L102"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					}
+				},
+				{
+					"id": 853,
+					"name": "credential_device_type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 101,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L101"
+						}
+					],
+					"type": {
+						"type": "union",
+						"types": [
+							{
+								"type": "literal",
+								"value": "single_device"
+							},
+							{
+								"type": "literal",
+								"value": "multi_device"
+							}
+						]
+					}
+				},
+				{
+					"id": 862,
+					"name": "id",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 80,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L80"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthenticationMethodBase.id"
+					}
+				},
+				{
+					"id": 855,
+					"name": "identity_user_id",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 103,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L103"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 851,
+					"name": "key_id",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 99,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L99"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 861,
+					"name": "last_auth_at",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 109,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L109"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 852,
+					"name": "public_key",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 100,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L100"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 860,
+					"name": "relying_party_id",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 108,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L108"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 857,
+					"name": "transports",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 105,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L105"
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "intrinsic",
+							"name": "string"
+						}
+					}
+				},
+				{
+					"id": 850,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 98,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L98"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "passkey"
+					}
+				},
+				{
+					"id": 864,
+					"name": "usage",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 82,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L82"
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "union",
+							"types": [
+								{
+									"type": "literal",
+									"value": "primary"
+								},
+								{
+									"type": "literal",
+									"value": "secondary"
+								}
+							]
+						}
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthenticationMethodBase.usage"
+					}
+				},
+				{
+					"id": 858,
+					"name": "user_agent",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 106,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L106"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 856,
+					"name": "user_handle",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 104,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L104"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						859,
+						863,
+						854,
+						853,
+						862,
+						855,
+						851,
+						861,
+						852,
+						860,
+						857,
+						850,
+						864,
+						858,
+						856
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 97,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L97"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "src/myaccount/types.ts",
+						"qualifiedName": "AuthenticationMethodBase"
+					},
+					"name": "AuthenticationMethodBase",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 1147,
+			"name": "PasskeyCreationOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Public key credential creation options returned by signup challenges."
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 1162,
+					"name": "authenticatorSelection",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 1076,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 1163,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"children": [
+								{
+									"id": 1164,
+									"name": "residentKey",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {
+										"isOptional": true
+									},
+									"sources": [
+										{
+											"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+											"line": 1077,
+											"character": 8
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 1165,
+									"name": "userVerification",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {
+										"isOptional": true
+									},
+									"sources": [
+										{
+											"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+											"line": 1078,
+											"character": 8
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"groups": [
+								{
+									"title": "Properties",
+									"children": [
+										1164,
+										1165
+									]
+								}
+							],
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+									"line": 1076,
+									"character": 29
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": 1148,
+					"name": "challenge",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 1062,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1158,
+					"name": "pubKeyCredParams",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 1072,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "reflection",
+							"declaration": {
+								"id": 1159,
+								"name": "__type",
+								"variant": "declaration",
+								"kind": 65536,
+								"flags": {},
+								"children": [
+									{
+										"id": 1161,
+										"name": "alg",
+										"variant": "declaration",
+										"kind": 1024,
+										"flags": {},
+										"sources": [
+											{
+												"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+												"line": 1074,
+												"character": 8
+											}
+										],
+										"type": {
+											"type": "intrinsic",
+											"name": "number"
+										}
+									},
+									{
+										"id": 1160,
+										"name": "type",
+										"variant": "declaration",
+										"kind": 1024,
+										"flags": {},
+										"sources": [
+											{
+												"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+												"line": 1073,
+												"character": 8
+											}
+										],
+										"type": {
+											"type": "intrinsic",
+											"name": "string"
+										}
+									}
+								],
+								"groups": [
+									{
+										"title": "Properties",
+										"children": [
+											1161,
+											1160
+										]
+									}
+								],
+								"sources": [
+									{
+										"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+										"line": 1072,
+										"character": 28
+									}
+								]
+							}
+						}
+					}
+				},
+				{
+					"id": 1149,
+					"name": "rp",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 1063,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 1150,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"children": [
+								{
+									"id": 1151,
+									"name": "id",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {},
+									"sources": [
+										{
+											"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+											"line": 1064,
+											"character": 8
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 1152,
+									"name": "name",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {},
+									"sources": [
+										{
+											"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+											"line": 1065,
+											"character": 8
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"groups": [
+								{
+									"title": "Properties",
+									"children": [
+										1151,
+										1152
+									]
+								}
+							],
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+									"line": 1063,
+									"character": 8
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": 1166,
+					"name": "timeout",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 1080,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "number"
+					}
+				},
+				{
+					"id": 1153,
+					"name": "user",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 1067,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 1154,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"children": [
+								{
+									"id": 1157,
+									"name": "displayName",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {},
+									"sources": [
+										{
+											"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+											"line": 1070,
+											"character": 8
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 1155,
+									"name": "id",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {},
+									"sources": [
+										{
+											"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+											"line": 1068,
+											"character": 8
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 1156,
+									"name": "name",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {},
+									"sources": [
+										{
+											"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+											"line": 1069,
+											"character": 8
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"groups": [
+								{
+									"title": "Properties",
+									"children": [
+										1157,
+										1155,
+										1156
+									]
+								}
+							],
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+									"line": 1067,
+									"character": 10
+								}
+							]
+						}
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1162,
+						1148,
+						1158,
+						1149,
+						1166,
+						1153
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+					"line": 1061,
+					"character": 10
+				}
+			]
+		},
+		{
+			"id": 1134,
+			"name": "PasskeyCredentialResponse",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Serialized credential response from the platform WebAuthn API.\nAll binary fields (rawId, clientDataJSON, etc.) must be base64url-encoded strings."
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 1138,
+					"name": "authenticatorAttachment",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 1099,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1146,
+					"name": "clientExtensionResults",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 1107,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": {
+							"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+							"qualifiedName": "Record"
+						},
+						"typeArguments": [
+							{
+								"type": "intrinsic",
+								"name": "string"
+							},
+							{
+								"type": "intrinsic",
+								"name": "unknown"
+							}
+						],
+						"name": "Record",
+						"package": "typescript"
+					}
+				},
+				{
+					"id": 1135,
+					"name": "id",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 1096,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1136,
+					"name": "rawId",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 1097,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1139,
+					"name": "response",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 1100,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 1140,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"children": [
+								{
+									"id": 1142,
+									"name": "attestationObject",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {
+										"isOptional": true
+									},
+									"sources": [
+										{
+											"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+											"line": 1102,
+											"character": 8
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 1143,
+									"name": "authenticatorData",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {
+										"isOptional": true
+									},
+									"sources": [
+										{
+											"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+											"line": 1103,
+											"character": 8
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 1141,
+									"name": "clientDataJSON",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {},
+									"sources": [
+										{
+											"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+											"line": 1101,
+											"character": 8
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 1144,
+									"name": "signature",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {
+										"isOptional": true
+									},
+									"sources": [
+										{
+											"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+											"line": 1104,
+											"character": 8
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 1145,
+									"name": "userHandle",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {
+										"isOptional": true
+									},
+									"sources": [
+										{
+											"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+											"line": 1105,
+											"character": 8
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"groups": [
+								{
+									"title": "Properties",
+									"children": [
+										1142,
+										1143,
+										1141,
+										1144,
+										1145
+									]
+								}
+							],
+							"sources": [
+								{
+									"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+									"line": 1100,
+									"character": 14
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": 1137,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 1098,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1138,
+						1146,
+						1135,
+						1136,
+						1139,
+						1137
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+					"line": 1095,
+					"character": 10
+				}
+			]
+		},
+		{
+			"id": 938,
+			"name": "PasskeyEnrollmentChallengeOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 940,
+					"name": "connection",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 177,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L177"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 941,
+					"name": "identity_user_id",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 178,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L178"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 939,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 176,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L176"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "passkey"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						940,
+						941,
+						939
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 175,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L175"
+				}
+			]
+		},
+		{
+			"id": 960,
+			"name": "PasskeyEnrollmentChallengeResponse",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 965,
+					"name": "auth_session",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 224,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L224"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentChallengeBaseResponse.auth_session"
+					}
+				},
+				{
+					"id": 962,
+					"name": "authn_params_public_key",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Type: [PasskeyCreationOptions](/docs/sdk/typescript/interfaces/PasskeyCreationOptions)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 230,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L230"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 1147,
+						"name": "PasskeyCreationOptions",
+						"package": "@auth0/auth0-auth-js"
+					}
+				},
+				{
+					"id": 963,
+					"name": "id",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 222,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L222"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentChallengeBaseResponse.id"
+					}
+				},
+				{
+					"id": 964,
+					"name": "location",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 223,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L223"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentChallengeBaseResponse.location"
+					}
+				},
+				{
+					"id": 961,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 229,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L229"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "passkey"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						965,
+						962,
+						963,
+						964,
+						961
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 227,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L227"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "src/myaccount/types.ts",
+						"qualifiedName": "EnrollmentChallengeBaseResponse"
+					},
+					"name": "EnrollmentChallengeBaseResponse",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 1024,
+			"name": "PasskeyEnrollmentVerifyOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 1028,
+					"name": "auth_session",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 305,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L305"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentVerifyBaseOptions.auth_session"
+					}
+				},
+				{
+					"id": 1026,
+					"name": "authn_response",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Type: [PasskeyCredentialResponse](/docs/sdk/typescript/interfaces/PasskeyCredentialResponse)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 311,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L311"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 1134,
+						"name": "PasskeyCredentialResponse",
+						"package": "@auth0/auth0-auth-js"
+					}
+				},
+				{
+					"id": 1027,
+					"name": "location",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 304,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L304"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentVerifyBaseOptions.location"
+					}
+				},
+				{
+					"id": 1025,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 310,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L310"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "passkey"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1028,
+						1026,
+						1027,
+						1025
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 308,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L308"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "src/myaccount/types.ts",
+						"qualifiedName": "EnrollmentVerifyBaseOptions"
+					},
+					"name": "EnrollmentVerifyBaseOptions",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 1108,
+			"name": "PasskeyErrorResponse",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 1109,
+					"name": "error",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/passkey/errors.ts",
+							"line": 8,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/errors.ts#L8"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1110,
+					"name": "error_description",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/passkey/errors.ts",
+							"line": 9,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/errors.ts#L9"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1111,
+					"name": "message",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/passkey/errors.ts",
+							"line": 10,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/errors.ts#L10"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1109,
+						1110,
+						1111
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/passkey/errors.ts",
+					"line": 7,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/errors.ts#L7"
+				}
+			]
+		},
+		{
+			"id": 1128,
+			"name": "PasskeyLoginChallengeOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Options for requesting a passkey login challenge."
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 1130,
+					"name": "organization",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Organization ID or name (scopes tokens to the organization context)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 1163,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1129,
+					"name": "realm",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Database connection name (sent as "
+							},
+							{
+								"kind": "code",
+								"text": "`realm`"
+							},
+							{
+								"kind": "text",
+								"text": " to the API)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 1161,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1130,
+						1129
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+					"line": 1159,
+					"character": 10
+				}
+			]
+		},
+		{
+			"id": 1131,
+			"name": "PasskeyLoginChallengeResponse",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Response from a passkey login challenge request."
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 1132,
+					"name": "authSession",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 1169,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1133,
+					"name": "authnParamsPublicKey",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Type: [PasskeyRequestOptions](/docs/sdk/typescript/interfaces/PasskeyRequestOptions)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 1170,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 1167,
+						"name": "PasskeyRequestOptions",
+						"package": "@auth0/auth0-auth-js"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1132,
+						1133
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+					"line": 1168,
+					"character": 10
+				}
+			]
+		},
+		{
+			"id": 1167,
+			"name": "PasskeyRequestOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Public key credential request options returned by login challenges."
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 1168,
+					"name": "challenge",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 1086,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1169,
+					"name": "rpId",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 1087,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1170,
+					"name": "timeout",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 1088,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "number"
+					}
+				},
+				{
+					"id": 1171,
+					"name": "userVerification",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 1089,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1168,
+						1169,
+						1170,
+						1171
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+					"line": 1085,
+					"character": 10
+				}
+			]
+		},
+		{
+			"id": 1125,
+			"name": "PasskeySignupChallengeResponse",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Response from a passkey signup challenge request."
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 1126,
+					"name": "authSession",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 1153,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1127,
+					"name": "authnParamsPublicKey",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Type: [PasskeyCreationOptions](/docs/sdk/typescript/interfaces/PasskeyCreationOptions)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"line": 1154,
+							"character": 4
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 1147,
+						"name": "PasskeyCreationOptions",
+						"package": "@auth0/auth0-auth-js"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1126,
+						1127
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+					"line": 1152,
+					"character": 10
+				}
+			]
+		},
+		{
+			"id": 904,
+			"name": "PasswordAuthenticationMethod",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 909,
+					"name": "created_at",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 81,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L81"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthenticationMethodBase.created_at"
+					}
+				},
+				{
+					"id": 908,
+					"name": "id",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 80,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L80"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthenticationMethodBase.id"
+					}
+				},
+				{
+					"id": 906,
+					"name": "identity_user_id",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 137,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L137"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 907,
+					"name": "last_password_reset",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 138,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L138"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 905,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 136,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L136"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "password"
+					}
+				},
+				{
+					"id": 910,
+					"name": "usage",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 82,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L82"
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "union",
+							"types": [
+								{
+									"type": "literal",
+									"value": "primary"
+								},
+								{
+									"type": "literal",
+									"value": "secondary"
+								}
+							]
+						}
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthenticationMethodBase.usage"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						909,
+						908,
+						906,
+						907,
+						905,
+						910
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 135,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L135"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "src/myaccount/types.ts",
+						"qualifiedName": "AuthenticationMethodBase"
+					},
+					"name": "AuthenticationMethodBase",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 955,
+			"name": "PasswordEnrollmentChallengeOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 957,
+					"name": "connection",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 206,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L206"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 958,
+					"name": "identity_user_id",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 207,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L207"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 956,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 205,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L205"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "password"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						957,
+						958,
+						956
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 204,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L204"
+				}
+			]
+		},
+		{
+			"id": 996,
+			"name": "PasswordEnrollmentChallengeResponse",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 1001,
+					"name": "auth_session",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 224,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L224"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentChallengeBaseResponse.auth_session"
+					}
+				},
+				{
+					"id": 999,
+					"name": "id",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 222,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L222"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentChallengeBaseResponse.id"
+					}
+				},
+				{
+					"id": 1000,
+					"name": "location",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 223,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L223"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentChallengeBaseResponse.location"
+					}
+				},
+				{
+					"id": 998,
+					"name": "policy",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Type: [PasswordPolicy](/docs/sdk/typescript/interfaces/PasswordPolicy)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 289,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L289"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 1002,
+						"name": "PasswordPolicy",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 997,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 288,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L288"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "password"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1001,
+						999,
+						1000,
+						998,
+						997
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 286,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L286"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "src/myaccount/types.ts",
+						"qualifiedName": "EnrollmentChallengeBaseResponse"
+					},
+					"name": "EnrollmentChallengeBaseResponse",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 1052,
+			"name": "PasswordEnrollmentVerifyOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 1056,
+					"name": "auth_session",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 305,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L305"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentVerifyBaseOptions.auth_session"
+					}
+				},
+				{
+					"id": 1055,
+					"name": "location",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 304,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L304"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentVerifyBaseOptions.location"
+					}
+				},
+				{
+					"id": 1054,
+					"name": "new_password",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 345,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L345"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1053,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 344,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L344"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "password"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1056,
+						1055,
+						1054,
+						1053
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 342,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L342"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "src/myaccount/types.ts",
+						"qualifiedName": "EnrollmentVerifyBaseOptions"
+					},
+					"name": "EnrollmentVerifyBaseOptions",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 1002,
+			"name": "PasswordPolicy",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 1003,
+					"name": "complexity",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 264,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L264"
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 1004,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"children": [
+								{
+									"id": 1007,
+									"name": "character_type_rule",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {},
+									"sources": [
+										{
+											"fileName": "src/myaccount/types.ts",
+											"line": 267,
+											"character": 4,
+											"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L267"
+										}
+									],
+									"type": {
+										"type": "union",
+										"types": [
+											{
+												"type": "literal",
+												"value": "all"
+											},
+											{
+												"type": "literal",
+												"value": "three_of_four"
+											}
+										]
+									}
+								},
+								{
+									"id": 1006,
+									"name": "character_types",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {},
+									"sources": [
+										{
+											"fileName": "src/myaccount/types.ts",
+											"line": 266,
+											"character": 4,
+											"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L266"
+										}
+									],
+									"type": {
+										"type": "array",
+										"elementType": {
+											"type": "union",
+											"types": [
+												{
+													"type": "literal",
+													"value": "number"
+												},
+												{
+													"type": "literal",
+													"value": "uppercase"
+												},
+												{
+													"type": "literal",
+													"value": "lowercase"
+												},
+												{
+													"type": "literal",
+													"value": "special"
+												}
+											]
+										}
+									}
+								},
+								{
+									"id": 1008,
+									"name": "identical_characters",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {},
+									"sources": [
+										{
+											"fileName": "src/myaccount/types.ts",
+											"line": 268,
+											"character": 4,
+											"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L268"
+										}
+									],
+									"type": {
+										"type": "union",
+										"types": [
+											{
+												"type": "literal",
+												"value": "allow"
+											},
+											{
+												"type": "literal",
+												"value": "block"
+											}
+										]
+									}
+								},
+								{
+									"id": 1010,
+									"name": "max_length_exceeded",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {},
+									"sources": [
+										{
+											"fileName": "src/myaccount/types.ts",
+											"line": 270,
+											"character": 4,
+											"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L270"
+										}
+									],
+									"type": {
+										"type": "union",
+										"types": [
+											{
+												"type": "literal",
+												"value": "error"
+											},
+											{
+												"type": "literal",
+												"value": "truncate"
+											}
+										]
+									}
+								},
+								{
+									"id": 1005,
+									"name": "min_length",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {},
+									"sources": [
+										{
+											"fileName": "src/myaccount/types.ts",
+											"line": 265,
+											"character": 4,
+											"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L265"
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "number"
+									}
+								},
+								{
+									"id": 1009,
+									"name": "sequential_characters",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {},
+									"sources": [
+										{
+											"fileName": "src/myaccount/types.ts",
+											"line": 269,
+											"character": 4,
+											"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L269"
+										}
+									],
+									"type": {
+										"type": "union",
+										"types": [
+											{
+												"type": "literal",
+												"value": "allow"
+											},
+											{
+												"type": "literal",
+												"value": "block"
+											}
+										]
+									}
+								}
+							],
+							"groups": [
+								{
+									"title": "Properties",
+									"children": [
+										1007,
+										1006,
+										1008,
+										1010,
+										1005,
+										1009
+									]
+								}
+							],
+							"sources": [
+								{
+									"fileName": "src/myaccount/types.ts",
+									"line": 264,
+									"character": 14,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L264"
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": 1019,
+					"name": "dictionary",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 280,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L280"
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 1020,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"children": [
+								{
+									"id": 1021,
+									"name": "active",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {},
+									"sources": [
+										{
+											"fileName": "src/myaccount/types.ts",
+											"line": 281,
+											"character": 4,
+											"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L281"
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "boolean"
+									}
+								},
+								{
+									"id": 1022,
+									"name": "default",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {},
+									"sources": [
+										{
+											"fileName": "src/myaccount/types.ts",
+											"line": 282,
+											"character": 4,
+											"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L282"
+										}
+									],
+									"type": {
+										"type": "union",
+										"types": [
+											{
+												"type": "literal",
+												"value": "en_10k"
+											},
+											{
+												"type": "literal",
+												"value": "en_100k"
+											}
+										]
+									}
+								}
+							],
+							"groups": [
+								{
+									"title": "Properties",
+									"children": [
+										1021,
+										1022
+									]
+								}
+							],
+							"sources": [
+								{
+									"fileName": "src/myaccount/types.ts",
+									"line": 280,
+									"character": 14,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L280"
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": 1015,
+					"name": "history",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 276,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L276"
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 1016,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"children": [
+								{
+									"id": 1017,
+									"name": "active",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {},
+									"sources": [
+										{
+											"fileName": "src/myaccount/types.ts",
+											"line": 277,
+											"character": 4,
+											"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L277"
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "boolean"
+									}
+								},
+								{
+									"id": 1018,
+									"name": "size",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {},
+									"sources": [
+										{
+											"fileName": "src/myaccount/types.ts",
+											"line": 278,
+											"character": 4,
+											"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L278"
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "number"
+									}
+								}
+							],
+							"groups": [
+								{
+									"title": "Properties",
+									"children": [
+										1017,
+										1018
+									]
+								}
+							],
+							"sources": [
+								{
+									"fileName": "src/myaccount/types.ts",
+									"line": 276,
+									"character": 11,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L276"
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": 1011,
+					"name": "profile_data",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 272,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L272"
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 1012,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"children": [
+								{
+									"id": 1013,
+									"name": "active",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {},
+									"sources": [
+										{
+											"fileName": "src/myaccount/types.ts",
+											"line": 273,
+											"character": 4,
+											"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L273"
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "boolean"
+									}
+								},
+								{
+									"id": 1014,
+									"name": "blocked_fields",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {},
+									"sources": [
+										{
+											"fileName": "src/myaccount/types.ts",
+											"line": 274,
+											"character": 4,
+											"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L274"
+										}
+									],
+									"type": {
+										"type": "array",
+										"elementType": {
+											"type": "intrinsic",
+											"name": "string"
+										}
+									}
+								}
+							],
+							"groups": [
+								{
+									"title": "Properties",
+									"children": [
+										1013,
+										1014
+									]
+								}
+							],
+							"sources": [
+								{
+									"fileName": "src/myaccount/types.ts",
+									"line": 272,
+									"character": 16,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L272"
+								}
+							]
+						}
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1003,
+						1019,
+						1015,
+						1011
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 263,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L263"
+				}
+			]
+		},
+		{
+			"id": 885,
+			"name": "PhoneAuthenticationMethod",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 889,
+					"name": "confirmed",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 86,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L86"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthenticationMethodWithMetadata.confirmed"
+					}
+				},
+				{
+					"id": 893,
+					"name": "created_at",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 81,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L81"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthenticationMethodWithMetadata.created_at"
+					}
+				},
+				{
+					"id": 892,
+					"name": "id",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 80,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L80"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthenticationMethodWithMetadata.id"
+					}
+				},
+				{
+					"id": 891,
+					"name": "last_auth_at",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 88,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L88"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthenticationMethodWithMetadata.last_auth_at"
+					}
+				},
+				{
+					"id": 890,
+					"name": "name",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 87,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L87"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthenticationMethodWithMetadata.name"
+					}
+				},
+				{
+					"id": 887,
+					"name": "phone_number",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 125,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L125"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 888,
+					"name": "preferred_authentication_method",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 126,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L126"
+						}
+					],
+					"type": {
+						"type": "union",
+						"types": [
+							{
+								"type": "literal",
+								"value": "sms"
+							},
+							{
+								"type": "literal",
+								"value": "voice"
+							}
+						]
+					}
+				},
+				{
+					"id": 886,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 124,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L124"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "phone"
+					}
+				},
+				{
+					"id": 894,
+					"name": "usage",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 82,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L82"
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "union",
+							"types": [
+								{
+									"type": "literal",
+									"value": "primary"
+								},
+								{
+									"type": "literal",
+									"value": "secondary"
+								}
+							]
+						}
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthenticationMethodWithMetadata.usage"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						889,
+						893,
+						892,
+						891,
+						890,
+						887,
+						888,
+						886,
+						894
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 122,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L122"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "src/myaccount/types.ts",
+						"qualifiedName": "AuthenticationMethodWithMetadata"
+					},
+					"name": "AuthenticationMethodWithMetadata",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 942,
+			"name": "PhoneEnrollmentChallengeOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 944,
+					"name": "phone_number",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 183,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L183"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 945,
+					"name": "preferred_authentication_method",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 184,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L184"
+						}
+					],
+					"type": {
+						"type": "union",
+						"types": [
+							{
+								"type": "literal",
+								"value": "sms"
+							},
+							{
+								"type": "literal",
+								"value": "voice"
+							}
+						]
+					}
+				},
+				{
+					"id": 943,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 182,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L182"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "phone"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						944,
+						945,
+						943
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 181,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L181"
+				}
+			]
+		},
+		{
+			"id": 966,
+			"name": "PhoneEnrollmentChallengeResponse",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 970,
+					"name": "auth_session",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 224,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L224"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentChallengeBaseResponse.auth_session"
+					}
+				},
+				{
+					"id": 968,
+					"name": "id",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 222,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L222"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentChallengeBaseResponse.id"
+					}
+				},
+				{
+					"id": 969,
+					"name": "location",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 223,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L223"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentChallengeBaseResponse.location"
+					}
+				},
+				{
+					"id": 967,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 235,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L235"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "phone"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						970,
+						968,
+						969,
+						967
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 233,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L233"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "src/myaccount/types.ts",
+						"qualifiedName": "EnrollmentChallengeBaseResponse"
+					},
+					"name": "EnrollmentChallengeBaseResponse",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 1029,
+			"name": "PhoneEnrollmentVerifyOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 1033,
+					"name": "auth_session",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 305,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L305"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentVerifyBaseOptions.auth_session"
+					}
+				},
+				{
+					"id": 1032,
+					"name": "location",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 304,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L304"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentVerifyBaseOptions.location"
+					}
+				},
+				{
+					"id": 1031,
+					"name": "otp_code",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 317,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L317"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1030,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 316,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L316"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "phone"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1033,
+						1032,
+						1031,
+						1030
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 314,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L314"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "src/myaccount/types.ts",
+						"qualifiedName": "EnrollmentVerifyBaseOptions"
+					},
+					"name": "EnrollmentVerifyBaseOptions",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 1315,
+			"name": "PopupConfigOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 1318,
+					"name": "closePopup",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Controls whether the SDK automatically closes the popup window.\n\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`true`"
+							},
+							{
+								"kind": "text",
+								"text": " (default): SDK closes the popup automatically after receiving the authorization response\n- "
+							},
+							{
+								"kind": "code",
+								"text": "`false`"
+							},
+							{
+								"kind": "text",
+								"text": ": SDK does not close the popup. The caller is responsible for closing it, including on errors.\n\nSetting this to "
+							},
+							{
+								"kind": "code",
+								"text": "`false`"
+							},
+							{
+								"kind": "text",
+								"text": " is useful when you need full control over the popup lifecycle,\nsuch as in Chrome extensions where closing the popup too early can terminate the\nextension's service worker before authentication completes.\n\nWhen "
+							},
+							{
+								"kind": "code",
+								"text": "`closePopup: false`"
+							},
+							{
+								"kind": "text",
+								"text": ", you should close the popup in a try/finally block:\n"
+							},
+							{
+								"kind": "code",
+								"text": "```\nconst popup = window.open('', '_blank');\ntry {\n  await auth0.loginWithPopup({}, { popup, closePopup: false });\n} finally {\n  popup.close();\n}\n```"
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@default",
+								"content": [
+									{
+										"kind": "code",
+										"text": "```ts\ntrue\n```"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 542,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L542"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					}
+				},
+				{
+					"id": 1317,
+					"name": "popup",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Accepts an already-created popup window to use. If not specified, the SDK\nwill create its own. This may be useful for platforms like iOS that have\nsecurity restrictions around when popups can be invoked (e.g. from a user click event)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 518,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L518"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "any"
+					}
+				},
+				{
+					"id": 1316,
+					"name": "timeoutInSeconds",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The number of seconds to wait for a popup response before\nthrowing a timeout error. Defaults to 60s"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 511,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L511"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "number"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1318,
+						1317,
+						1316
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/global.ts",
+					"line": 506,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L506"
+				}
+			]
+		},
+		{
+			"id": 1313,
+			"name": "PopupLoginOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 1314,
+					"name": "authorizationParams",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "URL parameters that will be sent back to the Authorization Server. This can be known parameters\ndefined by Auth0 or custom parameters that you define."
+							},
+							{
+								"kind": "text",
+								"text": "\n\nType: [AuthorizationParams](/docs/sdk/typescript/interfaces/AuthorizationParams)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 157,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L157"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 1213,
+						"name": "AuthorizationParams",
+						"package": "@auth0/auth0-spa-js"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "BaseLoginOptions.authorizationParams"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1314
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/global.ts",
+					"line": 504,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L504"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "src/global.ts",
+						"qualifiedName": "BaseLoginOptions"
+					},
+					"name": "BaseLoginOptions",
+					"package": "@auth0/auth0-spa-js"
+				}
+			],
+			"extendedBy": [
+				{
+					"type": "reference",
+					"target": 1330,
+					"name": "GetTokenWithPopupOptions"
+				}
+			]
+		},
+		{
+			"id": 919,
+			"name": "PushNotificationAuthenticationMethod",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 921,
+					"name": "confirmed",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 86,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L86"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthenticationMethodWithMetadata.confirmed"
+					}
+				},
+				{
+					"id": 925,
+					"name": "created_at",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 81,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L81"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthenticationMethodWithMetadata.created_at"
+					}
+				},
+				{
+					"id": 924,
+					"name": "id",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 80,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L80"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthenticationMethodWithMetadata.id"
+					}
+				},
+				{
+					"id": 923,
+					"name": "last_auth_at",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 88,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L88"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthenticationMethodWithMetadata.last_auth_at"
+					}
+				},
+				{
+					"id": 922,
+					"name": "name",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 87,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L87"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthenticationMethodWithMetadata.name"
+					}
+				},
+				{
+					"id": 920,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 148,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L148"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "push-notification"
+					}
+				},
+				{
+					"id": 926,
+					"name": "usage",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 82,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L82"
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "union",
+							"types": [
+								{
+									"type": "literal",
+									"value": "primary"
+								},
+								{
+									"type": "literal",
+									"value": "secondary"
+								}
+							]
+						}
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthenticationMethodWithMetadata.usage"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						921,
+						925,
+						924,
+						923,
+						922,
+						920,
+						926
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 146,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L146"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "src/myaccount/types.ts",
+						"qualifiedName": "AuthenticationMethodWithMetadata"
+					},
+					"name": "AuthenticationMethodWithMetadata",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 951,
+			"name": "PushNotificationEnrollmentChallengeOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 952,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 197,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L197"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "push-notification"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						952
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 196,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L196"
+				}
+			]
+		},
+		{
+			"id": 983,
+			"name": "PushNotificationEnrollmentChallengeResponse",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 989,
+					"name": "auth_session",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 224,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L224"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentChallengeBaseResponse.auth_session"
+					}
+				},
+				{
+					"id": 985,
+					"name": "barcode_uri",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 253,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L253"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 987,
+					"name": "id",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 222,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L222"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentChallengeBaseResponse.id"
+					}
+				},
+				{
+					"id": 988,
+					"name": "location",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 223,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L223"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentChallengeBaseResponse.location"
+					}
+				},
+				{
+					"id": 986,
+					"name": "manual_input_code",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 254,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L254"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 984,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 252,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L252"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "push-notification"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						989,
+						985,
+						987,
+						988,
+						986,
+						984
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 250,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L250"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "src/myaccount/types.ts",
+						"qualifiedName": "EnrollmentChallengeBaseResponse"
+					},
+					"name": "EnrollmentChallengeBaseResponse",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 1044,
+			"name": "PushNotificationEnrollmentVerifyOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 1047,
+					"name": "auth_session",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 305,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L305"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentVerifyBaseOptions.auth_session"
+					}
+				},
+				{
+					"id": 1046,
+					"name": "location",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 304,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L304"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentVerifyBaseOptions.location"
+					}
+				},
+				{
+					"id": 1045,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 334,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L334"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "push-notification"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1047,
+						1046,
+						1045
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 332,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L332"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "src/myaccount/types.ts",
+						"qualifiedName": "EnrollmentVerifyBaseOptions"
+					},
+					"name": "EnrollmentVerifyBaseOptions",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 927,
+			"name": "RecoveryCodeAuthenticationMethod",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 929,
+					"name": "confirmed",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 86,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L86"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "Omit.confirmed"
+					}
+				},
+				{
+					"id": 932,
+					"name": "created_at",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 81,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L81"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "Omit.created_at"
+					}
+				},
+				{
+					"id": 931,
+					"name": "id",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 80,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L80"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "Omit.id"
+					}
+				},
+				{
+					"id": 930,
+					"name": "last_auth_at",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 88,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L88"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "Omit.last_auth_at"
+					}
+				},
+				{
+					"id": 928,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 153,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L153"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "recovery-code"
+					}
+				},
+				{
+					"id": 933,
+					"name": "usage",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 82,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L82"
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "union",
+							"types": [
+								{
+									"type": "literal",
+									"value": "primary"
+								},
+								{
+									"type": "literal",
+									"value": "secondary"
+								}
+							]
+						}
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "Omit.usage"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						929,
+						932,
+						931,
+						930,
+						928,
+						933
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 151,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L151"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+						"qualifiedName": "Omit"
+					},
+					"typeArguments": [
+						{
+							"type": "reference",
+							"target": {
+								"sourceFileName": "src/myaccount/types.ts",
+								"qualifiedName": "AuthenticationMethodWithMetadata"
+							},
+							"name": "AuthenticationMethodWithMetadata",
+							"package": "@auth0/auth0-spa-js"
+						},
+						{
+							"type": "literal",
+							"value": "name"
+						}
+					],
+					"name": "Omit",
+					"package": "typescript"
+				}
+			]
+		},
+		{
+			"id": 953,
+			"name": "RecoveryCodeEnrollmentChallengeOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 954,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 201,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L201"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "recovery-code"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						954
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 200,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L200"
+				}
+			]
+		},
+		{
+			"id": 990,
+			"name": "RecoveryCodeEnrollmentChallengeResponse",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 995,
+					"name": "auth_session",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 224,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L224"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentChallengeBaseResponse.auth_session"
+					}
+				},
+				{
+					"id": 993,
+					"name": "id",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 222,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L222"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentChallengeBaseResponse.id"
+					}
+				},
+				{
+					"id": 994,
+					"name": "location",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 223,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L223"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentChallengeBaseResponse.location"
+					}
+				},
+				{
+					"id": 992,
+					"name": "recovery_code",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 260,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L260"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 991,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 259,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L259"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "recovery-code"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						995,
+						993,
+						994,
+						992,
+						991
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 257,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L257"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "src/myaccount/types.ts",
+						"qualifiedName": "EnrollmentChallengeBaseResponse"
+					},
+					"name": "EnrollmentChallengeBaseResponse",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 1048,
+			"name": "RecoveryCodeEnrollmentVerifyOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 1051,
+					"name": "auth_session",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 305,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L305"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentVerifyBaseOptions.auth_session"
+					}
+				},
+				{
+					"id": 1050,
+					"name": "location",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 304,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L304"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentVerifyBaseOptions.location"
+					}
+				},
+				{
+					"id": 1049,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 339,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L339"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "recovery-code"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1051,
+						1050,
+						1049
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 337,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L337"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "src/myaccount/types.ts",
+						"qualifiedName": "EnrollmentVerifyBaseOptions"
+					},
+					"name": "EnrollmentVerifyBaseOptions",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 1357,
+			"name": "RedirectConnectAccountOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 1362,
+					"name": "appState",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Optional application state to persist through the transaction."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@example",
+								"content": [
+									{
+										"kind": "code",
+										"text": "```ts\nawait auth0.connectAccountWithRedirect({\n  connection: 'google-oauth2',\n  appState: { returnTo: '/settings' }\n});\n```"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 735,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L735"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 1367,
+						"name": "TAppState",
+						"package": "@auth0/auth0-spa-js",
+						"qualifiedName": "RedirectConnectAccountOptions.TAppState",
+						"refersToTypeParameter": true
+					}
+				},
+				{
+					"id": 1360,
+					"name": "authorization_params",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Additional authorization parameters for the request."
+							},
+							{
+								"kind": "text",
+								"text": "\n\nType: [AuthorizationParams](/docs/sdk/typescript/interfaces/AuthorizationParams)"
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@example",
+								"content": [
+									{
+										"kind": "code",
+										"text": "```ts\nawait auth0.connectAccountWithRedirect({\n  connection: 'github',\n  authorization_params: {\n    audience: 'https://api.github.com'\n  }\n});\n```"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 719,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L719"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 1213,
+						"name": "AuthorizationParams",
+						"package": "@auth0/auth0-spa-js"
+					}
+				},
+				{
+					"id": 1358,
+					"name": "connection",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The name of the connection to link (e.g. 'google-oauth2')."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 695,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L695"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1363,
+					"name": "openUrl",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Optional function to handle the redirect URL."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@example",
+								"content": [
+									{
+										"kind": "code",
+										"text": "```ts\nawait auth0.connectAccountWithRedirect({\n  connection: 'google-oauth2',\n  openUrl: async (url) => { myBrowserApi.open(url); }\n});\n```"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 746,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L746"
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 1364,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/global.ts",
+									"line": 746,
+									"character": 12,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L746"
+								}
+							],
+							"signatures": [
+								{
+									"id": 1365,
+									"name": "__type",
+									"variant": "signature",
+									"kind": 4096,
+									"flags": {},
+									"sources": [
+										{
+											"fileName": "src/global.ts",
+											"line": 746,
+											"character": 12,
+											"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L746"
+										}
+									],
+									"parameters": [
+										{
+											"id": 1366,
+											"name": "url",
+											"variant": "param",
+											"kind": 32768,
+											"flags": {},
+											"type": {
+												"type": "intrinsic",
+												"name": "string"
+											}
+										}
+									],
+									"type": {
+										"type": "reference",
+										"target": {
+											"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+											"qualifiedName": "Promise"
+										},
+										"typeArguments": [
+											{
+												"type": "intrinsic",
+												"name": "void"
+											}
+										],
+										"name": "Promise",
+										"package": "typescript"
+									}
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": 1361,
+					"name": "redirectUri",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The URI to redirect back to after connecting the account."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 724,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L724"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1359,
+					"name": "scopes",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Array of scopes to request from the Identity Provider during the connect account flow."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@example",
+								"content": [
+									{
+										"kind": "code",
+										"text": "```ts\nawait auth0.connectAccountWithRedirect({\n  connection: 'google-oauth2',\n  scopes: ['https://www.googleapis.com/auth/calendar']\n});\n```"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 706,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L706"
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "intrinsic",
+							"name": "string"
+						}
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1362,
+						1360,
+						1358,
+						1363,
+						1361,
+						1359
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/global.ts",
+					"line": 691,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L691"
+				}
+			],
+			"typeParameters": [
+				{
+					"id": 1367,
+					"name": "TAppState",
+					"variant": "typeParam",
+					"kind": 131072,
+					"flags": {},
+					"default": {
+						"type": "intrinsic",
+						"name": "any"
+					}
+				}
+			]
+		},
+		{
+			"id": 1293,
+			"name": "RedirectLoginOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 1294,
+					"name": "appState",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Used to store state before doing the redirect"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 442,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L442"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 1305,
+						"name": "TAppState",
+						"package": "@auth0/auth0-spa-js",
+						"qualifiedName": "RedirectLoginOptions.TAppState",
+						"refersToTypeParameter": true
+					}
+				},
+				{
+					"id": 1304,
+					"name": "authorizationParams",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "URL parameters that will be sent back to the Authorization Server. This can be known parameters\ndefined by Auth0 or custom parameters that you define."
+							},
+							{
+								"kind": "text",
+								"text": "\n\nType: [AuthorizationParams](/docs/sdk/typescript/interfaces/AuthorizationParams)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 157,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L157"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 1213,
+						"name": "AuthorizationParams",
+						"package": "@auth0/auth0-spa-js"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "BaseLoginOptions.authorizationParams"
+					}
+				},
+				{
+					"id": 1295,
+					"name": "fragment",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Used to add to the URL fragment before redirecting"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 446,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L446"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1296,
+					"name": "onRedirect",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Used to control the redirect and not rely on the SDK to do the actual redirect."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@example",
+								"content": [
+									{
+										"kind": "code",
+										"text": "```ts\nconst client = new Auth0Client({\n  async onRedirect(url) {\n    window.location.replace(url);\n  }\n});\n```"
+									}
+								]
+							},
+							{
+								"tag": "@deprecated",
+								"content": [
+									{
+										"kind": "text",
+										"text": "since v2.0.1, use "
+									},
+									{
+										"kind": "code",
+										"text": "`openUrl`"
+									},
+									{
+										"kind": "text",
+										"text": " instead."
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 458,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L458"
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 1297,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/global.ts",
+									"line": 458,
+									"character": 15,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L458"
+								}
+							],
+							"signatures": [
+								{
+									"id": 1298,
+									"name": "__type",
+									"variant": "signature",
+									"kind": 4096,
+									"flags": {},
+									"sources": [
+										{
+											"fileName": "src/global.ts",
+											"line": 458,
+											"character": 15,
+											"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L458"
+										}
+									],
+									"parameters": [
+										{
+											"id": 1299,
+											"name": "url",
+											"variant": "param",
+											"kind": 32768,
+											"flags": {},
+											"type": {
+												"type": "intrinsic",
+												"name": "string"
+											}
+										}
+									],
+									"type": {
+										"type": "reference",
+										"target": {
+											"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+											"qualifiedName": "Promise"
+										},
+										"typeArguments": [
+											{
+												"type": "intrinsic",
+												"name": "void"
+											}
+										],
+										"name": "Promise",
+										"package": "typescript"
+									}
+								}
+							]
+						}
+					}
+				},
+				{
+					"id": 1300,
+					"name": "openUrl",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Used to control the redirect and not rely on the SDK to do the actual redirect."
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@example",
+								"content": [
+									{
+										"kind": "code",
+										"text": "```ts\nconst client = new Auth0Client({\n  openUrl(url) {\n    window.location.replace(url);\n  }\n});\n```"
+									}
+								]
+							},
+							{
+								"tag": "@example",
+								"content": [
+									{
+										"kind": "code",
+										"text": "```ts\nimport { Browser } from '@capacitor/browser';\n\nconst client = new Auth0Client({\n  async openUrl(url) {\n    await Browser.open({ url });\n  }\n});\n```"
+									}
+								]
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 479,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L479"
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 1301,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/global.ts",
+									"line": 479,
+									"character": 12,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L479"
+								}
+							],
+							"signatures": [
+								{
+									"id": 1302,
+									"name": "__type",
+									"variant": "signature",
+									"kind": 4096,
+									"flags": {},
+									"sources": [
+										{
+											"fileName": "src/global.ts",
+											"line": 479,
+											"character": 12,
+											"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L479"
+										}
+									],
+									"parameters": [
+										{
+											"id": 1303,
+											"name": "url",
+											"variant": "param",
+											"kind": 32768,
+											"flags": {},
+											"type": {
+												"type": "intrinsic",
+												"name": "string"
+											}
+										}
+									],
+									"type": {
+										"type": "union",
+										"types": [
+											{
+												"type": "intrinsic",
+												"name": "void"
+											},
+											{
+												"type": "reference",
+												"target": {
+													"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+													"qualifiedName": "Promise"
+												},
+												"typeArguments": [
+													{
+														"type": "intrinsic",
+														"name": "void"
+													}
+												],
+												"name": "Promise",
+												"package": "typescript"
+											}
+										]
+									}
+								}
+							]
+						}
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1294,
+						1304,
+						1295,
+						1296,
+						1300
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/global.ts",
+					"line": 437,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L437"
+				}
+			],
+			"typeParameters": [
+				{
+					"id": 1305,
+					"name": "TAppState",
+					"variant": "typeParam",
+					"kind": 131072,
+					"flags": {},
+					"default": {
+						"type": "intrinsic",
+						"name": "any"
+					}
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "src/global.ts",
+						"qualifiedName": "BaseLoginOptions"
+					},
+					"name": "BaseLoginOptions",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 1309,
+			"name": "RedirectLoginResult",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 1310,
+					"name": "appState",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "State stored when the redirect request was made"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 496,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L496"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 1312,
+						"name": "TAppState",
+						"package": "@auth0/auth0-spa-js",
+						"qualifiedName": "RedirectLoginResult.TAppState",
+						"refersToTypeParameter": true
+					}
+				},
+				{
+					"id": 1311,
+					"name": "response_type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The type of response, for login it will be "
+							},
+							{
+								"kind": "code",
+								"text": "`code`"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 501,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L501"
+						}
+					],
+					"type": {
+						"type": "reference",
+						"target": 1307,
+						"name": "Code",
+						"package": "@auth0/auth0-spa-js",
+						"qualifiedName": "ResponseType.Code"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1310,
+						1311
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/global.ts",
+					"line": 492,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L492"
+				}
+			],
+			"typeParameters": [
+				{
+					"id": 1312,
+					"name": "TAppState",
+					"variant": "typeParam",
+					"kind": 131072,
+					"flags": {},
+					"default": {
+						"type": "intrinsic",
+						"name": "any"
+					}
+				}
+			]
+		},
+		{
+			"id": 1514,
+			"name": "RevokeRefreshTokenOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Options for revoking a refresh token"
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 1515,
+					"name": "audience",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Audience to identify which refresh token to revoke. Omit for default audience."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 965,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L965"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1515
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/global.ts",
+					"line": 963,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L963"
+				}
+			]
+		},
+		{
+			"id": 911,
+			"name": "TotpAuthenticationMethod",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 913,
+					"name": "confirmed",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 86,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L86"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthenticationMethodWithMetadata.confirmed"
+					}
+				},
+				{
+					"id": 917,
+					"name": "created_at",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 81,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L81"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthenticationMethodWithMetadata.created_at"
+					}
+				},
+				{
+					"id": 916,
+					"name": "id",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 80,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L80"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthenticationMethodWithMetadata.id"
+					}
+				},
+				{
+					"id": 915,
+					"name": "last_auth_at",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 88,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L88"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthenticationMethodWithMetadata.last_auth_at"
+					}
+				},
+				{
+					"id": 914,
+					"name": "name",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 87,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L87"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthenticationMethodWithMetadata.name"
+					}
+				},
+				{
+					"id": 912,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 143,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L143"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "totp"
+					}
+				},
+				{
+					"id": 918,
+					"name": "usage",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 82,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L82"
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "union",
+							"types": [
+								{
+									"type": "literal",
+									"value": "primary"
+								},
+								{
+									"type": "literal",
+									"value": "secondary"
+								}
+							]
+						}
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "AuthenticationMethodWithMetadata.usage"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						913,
+						917,
+						916,
+						915,
+						914,
+						912,
+						918
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 141,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L141"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "src/myaccount/types.ts",
+						"qualifiedName": "AuthenticationMethodWithMetadata"
+					},
+					"name": "AuthenticationMethodWithMetadata",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 949,
+			"name": "TotpEnrollmentChallengeOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 950,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 193,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L193"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "totp"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						950
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 192,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L192"
+				}
+			]
+		},
+		{
+			"id": 976,
+			"name": "TotpEnrollmentChallengeResponse",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 982,
+					"name": "auth_session",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 224,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L224"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentChallengeBaseResponse.auth_session"
+					}
+				},
+				{
+					"id": 978,
+					"name": "barcode_uri",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 246,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L246"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 980,
+					"name": "id",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 222,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L222"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentChallengeBaseResponse.id"
+					}
+				},
+				{
+					"id": 981,
+					"name": "location",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 223,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L223"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentChallengeBaseResponse.location"
+					}
+				},
+				{
+					"id": 979,
+					"name": "manual_input_code",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 247,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L247"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 977,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 245,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L245"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "totp"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						982,
+						978,
+						980,
+						981,
+						979,
+						977
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 243,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L243"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "src/myaccount/types.ts",
+						"qualifiedName": "EnrollmentChallengeBaseResponse"
+					},
+					"name": "EnrollmentChallengeBaseResponse",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 1039,
+			"name": "TotpEnrollmentVerifyOptions",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 1043,
+					"name": "auth_session",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 305,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L305"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentVerifyBaseOptions.auth_session"
+					}
+				},
+				{
+					"id": 1042,
+					"name": "location",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 304,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L304"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "EnrollmentVerifyBaseOptions.location"
+					}
+				},
+				{
+					"id": 1041,
+					"name": "otp_code",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 329,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L329"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 1040,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 328,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L328"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "totp"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						1043,
+						1042,
+						1041,
+						1040
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 326,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L326"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "src/myaccount/types.ts",
+						"qualifiedName": "EnrollmentVerifyBaseOptions"
+					},
+					"name": "EnrollmentVerifyBaseOptions",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 934,
+			"name": "UpdateAuthenticationMethodRequest",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 935,
+					"name": "name",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 168,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L168"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 936,
+					"name": "preferred_authentication_method",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Only valid when updating a phone authentication method."
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 170,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L170"
+						}
+					],
+					"type": {
+						"type": "union",
+						"types": [
+							{
+								"type": "literal",
+								"value": "sms"
+							},
+							{
+								"type": "literal",
+								"value": "voice"
+							}
+						]
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						935,
+						936
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 167,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L167"
+				}
+			]
+		},
+		{
+			"id": 591,
+			"name": "VerifyParams",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Parameters for verifying an MFA challenge.\n\nThe grant_type is automatically inferred from which verification field is provided:\n- "
+					},
+					{
+						"kind": "code",
+						"text": "`otp`"
+					},
+					{
+						"kind": "text",
+						"text": " field → MFA-OTP grant type\n- "
+					},
+					{
+						"kind": "code",
+						"text": "`oobCode`"
+					},
+					{
+						"kind": "text",
+						"text": " field → MFA-OOB grant type\n- "
+					},
+					{
+						"kind": "code",
+						"text": "`recoveryCode`"
+					},
+					{
+						"kind": "text",
+						"text": " field → MFA-RECOVERY-CODE grant type"
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 595,
+					"name": "bindingCode",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Binding code (for OOB challenges with binding)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 198,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L198"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 592,
+					"name": "mfaToken",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "MFA token from challenge flow"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 192,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L192"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 594,
+					"name": "oobCode",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Out-of-band code (for OOB challenges)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 196,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L196"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 593,
+					"name": "otp",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "One-time password (for OTP challenges)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 194,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L194"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				},
+				{
+					"id": 596,
+					"name": "recoveryCode",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "Recovery code (for recovery code verification)"
+							}
+						]
+					},
+					"sources": [
+						{
+							"fileName": "src/mfa/types.ts",
+							"line": 200,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L200"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						595,
+						592,
+						594,
+						593,
+						596
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/mfa/types.ts",
+					"line": 190,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L190"
+				}
+			]
+		},
+		{
+			"id": 865,
+			"name": "WebAuthnPlatformAuthenticationMethod",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 869,
+					"name": "confirmed",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 86,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L86"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "WebAuthnAuthenticationMethodBase.confirmed"
+					}
+				},
+				{
+					"id": 873,
+					"name": "created_at",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 81,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L81"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "WebAuthnAuthenticationMethodBase.created_at"
+					}
+				},
+				{
+					"id": 872,
+					"name": "id",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 80,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L80"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "WebAuthnAuthenticationMethodBase.id"
+					}
+				},
+				{
+					"id": 867,
+					"name": "key_id",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 93,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L93"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "WebAuthnAuthenticationMethodBase.key_id"
+					}
+				},
+				{
+					"id": 871,
+					"name": "last_auth_at",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 88,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L88"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "WebAuthnAuthenticationMethodBase.last_auth_at"
+					}
+				},
+				{
+					"id": 870,
+					"name": "name",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 87,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L87"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "WebAuthnAuthenticationMethodBase.name"
+					}
+				},
+				{
+					"id": 868,
+					"name": "public_key",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 94,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L94"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "WebAuthnAuthenticationMethodBase.public_key"
+					}
+				},
+				{
+					"id": 866,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 114,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L114"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "webauthn-platform"
+					}
+				},
+				{
+					"id": 874,
+					"name": "usage",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 82,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L82"
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "union",
+							"types": [
+								{
+									"type": "literal",
+									"value": "primary"
+								},
+								{
+									"type": "literal",
+									"value": "secondary"
+								}
+							]
+						}
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "WebAuthnAuthenticationMethodBase.usage"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						869,
+						873,
+						872,
+						867,
+						871,
+						870,
+						868,
+						866,
+						874
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 112,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L112"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "src/myaccount/types.ts",
+						"qualifiedName": "WebAuthnAuthenticationMethodBase"
+					},
+					"name": "WebAuthnAuthenticationMethodBase",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 875,
+			"name": "WebAuthnRoamingAuthenticationMethod",
+			"variant": "declaration",
+			"kind": 256,
+			"flags": {},
+			"children": [
+				{
+					"id": 879,
+					"name": "confirmed",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 86,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L86"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "boolean"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "WebAuthnAuthenticationMethodBase.confirmed"
+					}
+				},
+				{
+					"id": 883,
+					"name": "created_at",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 81,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L81"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "WebAuthnAuthenticationMethodBase.created_at"
+					}
+				},
+				{
+					"id": 882,
+					"name": "id",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 80,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L80"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "WebAuthnAuthenticationMethodBase.id"
+					}
+				},
+				{
+					"id": 877,
+					"name": "key_id",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 93,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L93"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "WebAuthnAuthenticationMethodBase.key_id"
+					}
+				},
+				{
+					"id": 881,
+					"name": "last_auth_at",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 88,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L88"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "WebAuthnAuthenticationMethodBase.last_auth_at"
+					}
+				},
+				{
+					"id": 880,
+					"name": "name",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 87,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L87"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "WebAuthnAuthenticationMethodBase.name"
+					}
+				},
+				{
+					"id": 878,
+					"name": "public_key",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isOptional": true
+					},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 94,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L94"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "WebAuthnAuthenticationMethodBase.public_key"
+					}
+				},
+				{
+					"id": 876,
+					"name": "type",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 119,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L119"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "webauthn-roaming"
+					}
+				},
+				{
+					"id": 884,
+					"name": "usage",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/myaccount/types.ts",
+							"line": 82,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L82"
+						}
+					],
+					"type": {
+						"type": "array",
+						"elementType": {
+							"type": "union",
+							"types": [
+								{
+									"type": "literal",
+									"value": "primary"
+								},
+								{
+									"type": "literal",
+									"value": "secondary"
+								}
+							]
+						}
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "WebAuthnAuthenticationMethodBase.usage"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						879,
+						883,
+						882,
+						877,
+						881,
+						880,
+						878,
+						876,
+						884
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 117,
+					"character": 17,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L117"
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": {
+						"sourceFileName": "src/myaccount/types.ts",
+						"qualifiedName": "WebAuthnAuthenticationMethodBase"
+					},
+					"name": "WebAuthnAuthenticationMethodBase",
+					"package": "@auth0/auth0-spa-js"
+				}
+			]
+		},
+		{
+			"id": 848,
+			"name": "AuthenticationMethod",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "\n\nType: [EmailAuthenticationMethod](/docs/sdk/typescript/interfaces/EmailAuthenticationMethod), [PasskeyAuthenticationMethod](/docs/sdk/typescript/interfaces/PasskeyAuthenticationMethod), [PasswordAuthenticationMethod](/docs/sdk/typescript/interfaces/PasswordAuthenticationMethod), [PhoneAuthenticationMethod](/docs/sdk/typescript/interfaces/PhoneAuthenticationMethod), [PushNotificationAuthenticationMethod](/docs/sdk/typescript/interfaces/PushNotificationAuthenticationMethod), [RecoveryCodeAuthenticationMethod](/docs/sdk/typescript/interfaces/RecoveryCodeAuthenticationMethod), [TotpAuthenticationMethod](/docs/sdk/typescript/interfaces/TotpAuthenticationMethod), [WebAuthnPlatformAuthenticationMethod](/docs/sdk/typescript/interfaces/WebAuthnPlatformAuthenticationMethod), [WebAuthnRoamingAuthenticationMethod](/docs/sdk/typescript/interfaces/WebAuthnRoamingAuthenticationMethod)"
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 156,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L156"
+				}
+			],
+			"type": {
+				"type": "union",
+				"types": [
+					{
+						"type": "reference",
+						"target": 849,
+						"name": "PasskeyAuthenticationMethod",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 865,
+						"name": "WebAuthnPlatformAuthenticationMethod",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 875,
+						"name": "WebAuthnRoamingAuthenticationMethod",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 885,
+						"name": "PhoneAuthenticationMethod",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 895,
+						"name": "EmailAuthenticationMethod",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 904,
+						"name": "PasswordAuthenticationMethod",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 911,
+						"name": "TotpAuthenticationMethod",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 919,
+						"name": "PushNotificationAuthenticationMethod",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 927,
+						"name": "RecoveryCodeAuthenticationMethod",
+						"package": "@auth0/auth0-spa-js"
+					}
+				]
+			}
+		},
+		{
+			"id": 847,
+			"name": "AuthenticationMethodType",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 61,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L61"
+				}
+			],
+			"type": {
+				"type": "union",
+				"types": [
+					{
+						"type": "literal",
+						"value": "passkey"
+					},
+					{
+						"type": "literal",
+						"value": "password"
+					},
+					{
+						"type": "literal",
+						"value": "phone"
+					},
+					{
+						"type": "literal",
+						"value": "totp"
+					},
+					{
+						"type": "literal",
+						"value": "email"
+					},
+					{
+						"type": "literal",
+						"value": "push-notification"
+					},
+					{
+						"type": "literal",
+						"value": "recovery-code"
+					},
+					{
+						"type": "literal",
+						"value": "webauthn-platform"
+					},
+					{
+						"type": "literal",
+						"value": "webauthn-roaming"
+					}
+				]
+			}
+		},
+		{
+			"id": 1524,
+			"name": "AuthenticatorType",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Supported authenticator types.\nNote: Email authenticators use 'oob' type with oobChannel: 'email'"
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "src/mfa/types.ts",
+					"line": 27,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L27"
+				}
+			],
+			"type": {
+				"type": "union",
+				"types": [
+					{
+						"type": "literal",
+						"value": "otp"
+					},
+					{
+						"type": "literal",
+						"value": "oob"
+					},
+					{
+						"type": "literal",
+						"value": "recovery-code"
+					}
+				]
+			}
+		},
+		{
+			"id": 656,
+			"name": "CacheEntry",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"sources": [
+				{
+					"fileName": "src/cache/shared.ts",
+					"line": 74,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L74"
+				}
+			],
+			"type": {
+				"type": "reflection",
+				"declaration": {
+					"id": 657,
+					"name": "__type",
+					"variant": "declaration",
+					"kind": 65536,
+					"flags": {},
+					"children": [
+						{
+							"id": 660,
+							"name": "access_token",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/cache/shared.ts",
+									"line": 77,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L77"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						},
+						{
+							"id": 663,
+							"name": "audience",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/cache/shared.ts",
+									"line": 80,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L80"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						},
+						{
+							"id": 665,
+							"name": "client_id",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/cache/shared.ts",
+									"line": 82,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L82"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						},
+						{
+							"id": 662,
+							"name": "decodedToken",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {
+								"isOptional": true
+							},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Type: [DecodedToken](/docs/sdk/typescript/interfaces/DecodedToken)"
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/cache/shared.ts",
+									"line": 79,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L79"
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": 653,
+								"name": "DecodedToken",
+								"package": "@auth0/auth0-spa-js"
+							}
+						},
+						{
+							"id": 661,
+							"name": "expires_in",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/cache/shared.ts",
+									"line": 78,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L78"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "number"
+							}
+						},
+						{
+							"id": 658,
+							"name": "id_token",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {
+								"isOptional": true
+							},
+							"sources": [
+								{
+									"fileName": "src/cache/shared.ts",
+									"line": 75,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L75"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						},
+						{
+							"id": 667,
+							"name": "oauthTokenScope",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {
+								"isOptional": true
+							},
+							"sources": [
+								{
+									"fileName": "src/cache/shared.ts",
+									"line": 84,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L84"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						},
+						{
+							"id": 666,
+							"name": "refresh_token",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {
+								"isOptional": true
+							},
+							"sources": [
+								{
+									"fileName": "src/cache/shared.ts",
+									"line": 83,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L83"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						},
+						{
+							"id": 664,
+							"name": "scope",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/cache/shared.ts",
+									"line": 81,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L81"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						},
+						{
+							"id": 659,
+							"name": "token_type",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {
+								"isOptional": true
+							},
+							"sources": [
+								{
+									"fileName": "src/cache/shared.ts",
+									"line": 76,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L76"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						}
+					],
+					"groups": [
+						{
+							"title": "Properties",
+							"children": [
+								660,
+								663,
+								665,
+								662,
+								661,
+								658,
+								667,
+								666,
+								664,
+								659
+							]
+						}
+					],
+					"sources": [
+						{
+							"fileName": "src/cache/shared.ts",
+							"line": 74,
+							"character": 25,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L74"
+						}
+					]
+				}
+			}
+		},
+		{
+			"id": 677,
+			"name": "CacheKeyData",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"sources": [
+				{
+					"fileName": "src/cache/shared.ts",
+					"line": 6,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L6"
+				}
+			],
+			"type": {
+				"type": "reflection",
+				"declaration": {
+					"id": 678,
+					"name": "__type",
+					"variant": "declaration",
+					"kind": 65536,
+					"flags": {},
+					"children": [
+						{
+							"id": 679,
+							"name": "audience",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {
+								"isOptional": true
+							},
+							"sources": [
+								{
+									"fileName": "src/cache/shared.ts",
+									"line": 7,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L7"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						},
+						{
+							"id": 681,
+							"name": "clientId",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/cache/shared.ts",
+									"line": 9,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L9"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						},
+						{
+							"id": 680,
+							"name": "scope",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {
+								"isOptional": true
+							},
+							"sources": [
+								{
+									"fileName": "src/cache/shared.ts",
+									"line": 8,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L8"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						}
+					],
+					"groups": [
+						{
+							"title": "Properties",
+							"children": [
+								679,
+								681,
+								680
+							]
+						}
+					],
+					"sources": [
+						{
+							"fileName": "src/cache/shared.ts",
+							"line": 6,
+							"character": 27,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L6"
+						}
+					]
+				}
+			}
+		},
+		{
+			"id": 1270,
+			"name": "CacheLocation",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "The possible locations where tokens can be stored"
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "src/global.ts",
+					"line": 421,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L421"
+				}
+			],
+			"type": {
+				"type": "union",
+				"types": [
+					{
+						"type": "literal",
+						"value": "memory"
+					},
+					{
+						"type": "literal",
+						"value": "localstorage"
+					}
+				]
+			}
+		},
+		{
+			"id": 652,
+			"name": "Cacheable",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "\n\nType: [KeyManifestEntry](/docs/sdk/typescript/types/KeyManifestEntry), [WrappedCacheEntry](/docs/sdk/typescript/types/WrappedCacheEntry)"
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "src/cache/shared.ts",
+					"line": 96,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L96"
+				}
+			],
+			"type": {
+				"type": "union",
+				"types": [
+					{
+						"type": "reference",
+						"target": 668,
+						"name": "WrappedCacheEntry",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 672,
+						"name": "KeyManifestEntry",
+						"package": "@auth0/auth0-spa-js"
+					}
+				]
+			}
+		},
+		{
+			"id": 1368,
+			"name": "ConnectAccountRedirectResult",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "The result returned after a successful account connection redirect.\n\nCombines the redirect login result (including any persisted app state)\nwith the complete response from the My Account API."
+					},
+					{
+						"kind": "text",
+						"text": "\n\nType: [CompleteResponse](/docs/sdk/typescript/interfaces/CompleteResponse)"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@example",
+						"content": [
+							{
+								"kind": "code",
+								"text": "```ts\nconst result = await auth0.connectAccountWithRedirect(options);\nconsole.log(result.appState); // Access persisted app state\nconsole.log(result.connection);   // The connection of the account you connected to.\nconsole.log(result.response_type === 'connect_code');   // The response type will be 'connect_code'\n```"
+							}
+						]
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "src/global.ts",
+					"line": 762,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L762"
+				}
+			],
+			"typeParameters": [
+				{
+					"id": 1372,
+					"name": "TAppState",
+					"variant": "typeParam",
+					"kind": 131072,
+					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The type of application state persisted through the transaction."
+							}
+						]
+					},
+					"default": {
+						"type": "intrinsic",
+						"name": "any"
+					}
+				}
+			],
+			"type": {
+				"type": "intersection",
+				"types": [
+					{
+						"type": "reference",
+						"target": 826,
+						"name": "CompleteResponse",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reflection",
+						"declaration": {
+							"id": 1369,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"children": [
+								{
+									"id": 1370,
+									"name": "appState",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {
+										"isOptional": true
+									},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "State stored when the redirect request was made"
+											}
+										]
+									},
+									"sources": [
+										{
+											"fileName": "src/global.ts",
+											"line": 766,
+											"character": 2,
+											"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L766"
+										}
+									],
+									"type": {
+										"type": "reference",
+										"target": 1372,
+										"name": "TAppState",
+										"package": "@auth0/auth0-spa-js",
+										"refersToTypeParameter": true
+									}
+								},
+								{
+									"id": 1371,
+									"name": "response_type",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {},
+									"comment": {
+										"summary": [
+											{
+												"kind": "text",
+												"text": "The type of response, for connect account it will be "
+											},
+											{
+												"kind": "code",
+												"text": "`connect_code`"
+											}
+										]
+									},
+									"sources": [
+										{
+											"fileName": "src/global.ts",
+											"line": 771,
+											"character": 2,
+											"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L771"
+										}
+									],
+									"type": {
+										"type": "reference",
+										"target": 1308,
+										"name": "ResponseType.ConnectCode",
+										"package": "@auth0/auth0-spa-js"
+									}
+								}
+							],
+							"groups": [
+								{
+									"title": "Properties",
+									"children": [
+										1370,
+										1371
+									]
+								}
+							],
+							"sources": [
+								{
+									"fileName": "src/global.ts",
+									"line": 762,
+									"character": 79,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L762"
+								}
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": 750,
+			"name": "CustomFetchMinimalOutput",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"sources": [
+				{
+					"fileName": "src/fetcher.ts",
+					"line": 10,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/fetcher.ts#L10"
+				}
+			],
+			"type": {
+				"type": "reflection",
+				"declaration": {
+					"id": 751,
+					"name": "__type",
+					"variant": "declaration",
+					"kind": 65536,
+					"flags": {},
+					"children": [
+						{
+							"id": 753,
+							"name": "headers",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/fetcher.ts",
+									"line": 12,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/fetcher.ts#L12"
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "src/fetcher.ts",
+									"qualifiedName": "ResponseHeaders"
+								},
+								"name": "ResponseHeaders",
+								"package": "@auth0/auth0-spa-js"
+							}
+						},
+						{
+							"id": 752,
+							"name": "status",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/fetcher.ts",
+									"line": 11,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/fetcher.ts#L11"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "number"
+							}
+						}
+					],
+					"groups": [
+						{
+							"title": "Properties",
+							"children": [
+								753,
+								752
+							]
+						}
+					],
+					"sources": [
+						{
+							"fileName": "src/fetcher.ts",
+							"line": 10,
+							"character": 39,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/fetcher.ts#L10"
+						}
+					]
+				}
+			}
+		},
+		{
+			"id": 1196,
+			"name": "CustomTokenExchangeOptions",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Represents the configuration options required for initiating a Custom Token Exchange request\nfollowing RFC 8693 specifications."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@see",
+						"content": [
+							{
+								"kind": "inline-tag",
+								"tag": "@link",
+								"text": "RFC 8693: OAuth 2.0 Token Exchange",
+								"target": "https://www.rfc-editor.org/rfc/rfc8693"
+							}
+						]
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "src/TokenExchange.ts",
+					"line": 7,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/TokenExchange.ts#L7"
+				}
+			],
+			"type": {
+				"type": "reflection",
+				"declaration": {
+					"id": 1197,
+					"name": "__type",
+					"variant": "declaration",
+					"kind": 65536,
+					"flags": {},
+					"children": [
+						{
+							"id": 1203,
+							"name": "actor_token",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {
+								"isOptional": true
+							},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "A token representing the acting party for delegation or impersonation scenarios."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@remarks",
+										"content": [
+											{
+												"kind": "text",
+												"text": "Used when one principal needs to act on behalf of another.\nFor example, an AI agent acting on behalf of a user."
+											}
+										]
+									},
+									{
+										"tag": "@example",
+										"content": [
+											{
+												"kind": "code",
+												"text": "```ts\n\"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...\"\n```"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/TokenExchange.ts",
+									"line": 77,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/TokenExchange.ts#L77"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						},
+						{
+							"id": 1204,
+							"name": "actor_token_type",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {
+								"isOptional": true
+							},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "The type identifier for the actor token."
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@remarks",
+										"content": [
+											{
+												"kind": "text",
+												"text": "Must be a URI under your organization's control, following the same\nrules as subject_token_type."
+											}
+										]
+									},
+									{
+										"tag": "@example",
+										"content": [
+											{
+												"kind": "code",
+												"text": "```ts\n\"https://idp.example.com/token-type/agent\"\n```"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/TokenExchange.ts",
+									"line": 89,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/TokenExchange.ts#L89"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						},
+						{
+							"id": 1200,
+							"name": "audience",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {
+								"isOptional": true
+							},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "The target audience for the requested Auth0 token"
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@remarks",
+										"content": [
+											{
+												"kind": "text",
+												"text": "Must match exactly with an API identifier configured in your Auth0 tenant.\nIf not provided, falls back to the client's default audience."
+											}
+										]
+									},
+									{
+										"tag": "@example",
+										"content": [
+											{
+												"kind": "code",
+												"text": "```ts\n\"https://api.your-service.com/v1\"\n```"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/TokenExchange.ts",
+									"line": 47,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/TokenExchange.ts#L47"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						},
+						{
+							"id": 1202,
+							"name": "organization",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {
+								"isOptional": true
+							},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "ID or name of the organization to use when authenticating a user.\nWhen provided, the user will be authenticated using the organization context.\nThe organization ID will be present in the access token payload."
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/TokenExchange.ts",
+									"line": 65,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/TokenExchange.ts#L65"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						},
+						{
+							"id": 1201,
+							"name": "scope",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {
+								"isOptional": true
+							},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Space-separated list of OAuth 2.0 scopes being requested"
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@remarks",
+										"content": [
+											{
+												"kind": "text",
+												"text": "Subject to API authorization policies configured in Auth0"
+											}
+										]
+									},
+									{
+										"tag": "@example",
+										"content": [
+											{
+												"kind": "code",
+												"text": "```ts\n\"openid profile email read:data write:data\"\n```"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/TokenExchange.ts",
+									"line": 58,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/TokenExchange.ts#L58"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						},
+						{
+							"id": 1199,
+							"name": "subject_token",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "The opaque token value being exchanged for Auth0 tokens"
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@security",
+										"content": [
+											{
+												"kind": "text",
+												"text": "- Must be validated in Auth0 Actions using strong cryptographic verification\n- Implement replay attack protection\n- Recommended validation libraries: "
+											},
+											{
+												"kind": "code",
+												"text": "`jose`"
+											},
+											{
+												"kind": "text",
+												"text": ", "
+											},
+											{
+												"kind": "code",
+												"text": "`jsonwebtoken`"
+											}
+										]
+									},
+									{
+										"tag": "@example",
+										"content": [
+											{
+												"kind": "code",
+												"text": "```ts\n\"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\"\n```"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/TokenExchange.ts",
+									"line": 35,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/TokenExchange.ts#L35"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						},
+						{
+							"id": 1198,
+							"name": "subject_token_type",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "The type identifier for the subject token being exchanged"
+									}
+								],
+								"blockTags": [
+									{
+										"tag": "@pattern",
+										"content": [
+											{
+												"kind": "text",
+												"text": "- Must be a namespaced URI under your organization's control\n- Forbidden patterns:\n  - "
+											},
+											{
+												"kind": "code",
+												"text": "`^urn:ietf:params:oauth:*`"
+											},
+											{
+												"kind": "text",
+												"text": " (IETF reserved)\n  - "
+											},
+											{
+												"kind": "code",
+												"text": "`^https://auth0\\.com/*`"
+											},
+											{
+												"kind": "text",
+												"text": " (Auth0 reserved)\n  - "
+											},
+											{
+												"kind": "code",
+												"text": "`^urn:auth0:*`"
+											},
+											{
+												"kind": "text",
+												"text": " (Auth0 reserved)"
+											}
+										]
+									},
+									{
+										"tag": "@example",
+										"content": [
+											{
+												"kind": "code",
+												"text": "```ts\n\"urn:acme:legacy-system-token\"\n\"https://api.yourcompany.com/token-type/v1\"\n```"
+											}
+										]
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/TokenExchange.ts",
+									"line": 22,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/TokenExchange.ts#L22"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						}
+					],
+					"groups": [
+						{
+							"title": "Properties",
+							"children": [
+								1203,
+								1204,
+								1200,
+								1202,
+								1201,
+								1199,
+								1198
+							]
+						}
+					],
+					"sources": [
+						{
+							"fileName": "src/TokenExchange.ts",
+							"line": 7,
+							"character": 41,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/TokenExchange.ts#L7"
+						}
+					],
+					"indexSignature": {
+						"id": 1205,
+						"name": "__index",
+						"variant": "signature",
+						"kind": 8192,
+						"flags": {},
+						"comment": {
+							"summary": [
+								{
+									"kind": "text",
+									"text": "Additional custom parameters for Auth0 Action processing"
+								}
+							],
+							"blockTags": [
+								{
+									"tag": "@remarks",
+									"content": [
+										{
+											"kind": "text",
+											"text": "Accessible in Action code via "
+										},
+										{
+											"kind": "code",
+											"text": "`event.request.body`"
+										}
+									]
+								},
+								{
+									"tag": "@example",
+									"content": [
+										{
+											"kind": "code",
+											"text": "```typescript\n{\n  custom_parameter: \"session_context\",\n  device_fingerprint: \"a3d8f7...\",\n}\n```"
+										}
+									]
+								}
+							]
+						},
+						"sources": [
+							{
+								"fileName": "src/TokenExchange.ts",
+								"line": 105,
+								"character": 2,
+								"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/TokenExchange.ts#L105"
+							}
+						],
+						"parameters": [
+							{
+								"id": 1206,
+								"name": "key",
+								"variant": "param",
+								"kind": 32768,
+								"flags": {},
+								"type": {
+									"type": "intrinsic",
+									"name": "string"
+								}
+							}
+						],
+						"type": {
+							"type": "intrinsic",
+							"name": "unknown"
+						}
+					}
+				}
+			}
+		},
+		{
+			"id": 572,
+			"name": "EnrollParams",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Union type for all enrollment parameter types"
+					},
+					{
+						"kind": "text",
+						"text": "\n\nType: [EnrollEmailParams](/docs/sdk/typescript/interfaces/EnrollEmailParams), [EnrollOtpParams](/docs/sdk/typescript/interfaces/EnrollOtpParams), [EnrollPushParams](/docs/sdk/typescript/interfaces/EnrollPushParams), [EnrollSmsParams](/docs/sdk/typescript/interfaces/EnrollSmsParams), [EnrollVoiceParams](/docs/sdk/typescript/interfaces/EnrollVoiceParams)"
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "src/mfa/types.ts",
+					"line": 102,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L102"
+				}
+			],
+			"type": {
+				"type": "union",
+				"types": [
+					{
+						"type": "reference",
+						"target": 573,
+						"name": "EnrollOtpParams",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 576,
+						"name": "EnrollSmsParams",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 580,
+						"name": "EnrollVoiceParams",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 584,
+						"name": "EnrollEmailParams",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 588,
+						"name": "EnrollPushParams",
+						"package": "@auth0/auth0-spa-js"
+					}
+				]
+			}
+		},
+		{
+			"id": 937,
+			"name": "EnrollmentChallengeOptions",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "\n\nType: [EmailEnrollmentChallengeOptions](/docs/sdk/typescript/interfaces/EmailEnrollmentChallengeOptions), [PasskeyEnrollmentChallengeOptions](/docs/sdk/typescript/interfaces/PasskeyEnrollmentChallengeOptions), [PasswordEnrollmentChallengeOptions](/docs/sdk/typescript/interfaces/PasswordEnrollmentChallengeOptions), [PhoneEnrollmentChallengeOptions](/docs/sdk/typescript/interfaces/PhoneEnrollmentChallengeOptions), [PushNotificationEnrollmentChallengeOptions](/docs/sdk/typescript/interfaces/PushNotificationEnrollmentChallengeOptions), [RecoveryCodeEnrollmentChallengeOptions](/docs/sdk/typescript/interfaces/RecoveryCodeEnrollmentChallengeOptions), [TotpEnrollmentChallengeOptions](/docs/sdk/typescript/interfaces/TotpEnrollmentChallengeOptions)"
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 210,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L210"
+				}
+			],
+			"type": {
+				"type": "union",
+				"types": [
+					{
+						"type": "reference",
+						"target": 938,
+						"name": "PasskeyEnrollmentChallengeOptions",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 942,
+						"name": "PhoneEnrollmentChallengeOptions",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 946,
+						"name": "EmailEnrollmentChallengeOptions",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 949,
+						"name": "TotpEnrollmentChallengeOptions",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 951,
+						"name": "PushNotificationEnrollmentChallengeOptions",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 953,
+						"name": "RecoveryCodeEnrollmentChallengeOptions",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 955,
+						"name": "PasswordEnrollmentChallengeOptions",
+						"package": "@auth0/auth0-spa-js"
+					}
+				]
+			}
+		},
+		{
+			"id": 959,
+			"name": "EnrollmentChallengeResponse",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "\n\nType: [EmailEnrollmentChallengeResponse](/docs/sdk/typescript/interfaces/EmailEnrollmentChallengeResponse), [PasskeyEnrollmentChallengeResponse](/docs/sdk/typescript/interfaces/PasskeyEnrollmentChallengeResponse), [PasswordEnrollmentChallengeResponse](/docs/sdk/typescript/interfaces/PasswordEnrollmentChallengeResponse), [PhoneEnrollmentChallengeResponse](/docs/sdk/typescript/interfaces/PhoneEnrollmentChallengeResponse), [PushNotificationEnrollmentChallengeResponse](/docs/sdk/typescript/interfaces/PushNotificationEnrollmentChallengeResponse), [RecoveryCodeEnrollmentChallengeResponse](/docs/sdk/typescript/interfaces/RecoveryCodeEnrollmentChallengeResponse), [TotpEnrollmentChallengeResponse](/docs/sdk/typescript/interfaces/TotpEnrollmentChallengeResponse)"
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 292,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L292"
+				}
+			],
+			"type": {
+				"type": "union",
+				"types": [
+					{
+						"type": "reference",
+						"target": 960,
+						"name": "PasskeyEnrollmentChallengeResponse",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 966,
+						"name": "PhoneEnrollmentChallengeResponse",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 971,
+						"name": "EmailEnrollmentChallengeResponse",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 976,
+						"name": "TotpEnrollmentChallengeResponse",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 983,
+						"name": "PushNotificationEnrollmentChallengeResponse",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 990,
+						"name": "RecoveryCodeEnrollmentChallengeResponse",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 996,
+						"name": "PasswordEnrollmentChallengeResponse",
+						"package": "@auth0/auth0-spa-js"
+					}
+				]
+			}
+		},
+		{
+			"id": 1526,
+			"name": "EnrollmentResponse",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Union type for all enrollment response types"
+					},
+					{
+						"kind": "text",
+						"text": "\n\nType: [OobEnrollmentResponse](/docs/sdk/typescript/interfaces/OobEnrollmentResponse), [OtpEnrollmentResponse](/docs/sdk/typescript/interfaces/OtpEnrollmentResponse)"
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "src/mfa/types.ts",
+					"line": 149,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L149"
+				}
+			],
+			"type": {
+				"type": "union",
+				"types": [
+					{
+						"type": "reference",
+						"target": 1527,
+						"name": "OtpEnrollmentResponse",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 1533,
+						"name": "OobEnrollmentResponse",
+						"package": "@auth0/auth0-spa-js"
+					}
+				]
+			}
+		},
+		{
+			"id": 1023,
+			"name": "EnrollmentVerifyOptions",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "\n\nType: [EmailEnrollmentVerifyOptions](/docs/sdk/typescript/interfaces/EmailEnrollmentVerifyOptions), [PasskeyEnrollmentVerifyOptions](/docs/sdk/typescript/interfaces/PasskeyEnrollmentVerifyOptions), [PasswordEnrollmentVerifyOptions](/docs/sdk/typescript/interfaces/PasswordEnrollmentVerifyOptions), [PhoneEnrollmentVerifyOptions](/docs/sdk/typescript/interfaces/PhoneEnrollmentVerifyOptions), [PushNotificationEnrollmentVerifyOptions](/docs/sdk/typescript/interfaces/PushNotificationEnrollmentVerifyOptions), [RecoveryCodeEnrollmentVerifyOptions](/docs/sdk/typescript/interfaces/RecoveryCodeEnrollmentVerifyOptions), [TotpEnrollmentVerifyOptions](/docs/sdk/typescript/interfaces/TotpEnrollmentVerifyOptions)"
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "src/myaccount/types.ts",
+					"line": 348,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/myaccount/types.ts#L348"
+				}
+			],
+			"type": {
+				"type": "union",
+				"types": [
+					{
+						"type": "reference",
+						"target": 1024,
+						"name": "PasskeyEnrollmentVerifyOptions",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 1029,
+						"name": "PhoneEnrollmentVerifyOptions",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 1034,
+						"name": "EmailEnrollmentVerifyOptions",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 1039,
+						"name": "TotpEnrollmentVerifyOptions",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 1044,
+						"name": "PushNotificationEnrollmentVerifyOptions",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 1048,
+						"name": "RecoveryCodeEnrollmentVerifyOptions",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "reference",
+						"target": 1052,
+						"name": "PasswordEnrollmentVerifyOptions",
+						"package": "@auth0/auth0-spa-js"
+					}
+				]
+			}
+		},
+		{
+			"id": 682,
+			"name": "FetcherConfig",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"sources": [
+				{
+					"fileName": "src/fetcher.ts",
+					"line": 31,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/fetcher.ts#L31"
+				}
+			],
+			"typeParameters": [
+				{
+					"id": 688,
+					"name": "TOutput",
+					"variant": "typeParam",
+					"kind": 131072,
+					"flags": {},
+					"type": {
+						"type": "reference",
+						"target": 750,
+						"name": "CustomFetchMinimalOutput",
+						"package": "@auth0/auth0-spa-js"
+					}
+				}
+			],
+			"type": {
+				"type": "reflection",
+				"declaration": {
+					"id": 683,
+					"name": "__type",
+					"variant": "declaration",
+					"kind": 65536,
+					"flags": {},
+					"children": [
+						{
+							"id": 685,
+							"name": "baseUrl",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {
+								"isOptional": true
+							},
+							"sources": [
+								{
+									"fileName": "src/fetcher.ts",
+									"line": 33,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/fetcher.ts#L33"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						},
+						{
+							"id": 687,
+							"name": "dpopNonceId",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {
+								"isOptional": true
+							},
+							"sources": [
+								{
+									"fileName": "src/fetcher.ts",
+									"line": 35,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/fetcher.ts#L35"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						},
+						{
+							"id": 686,
+							"name": "fetch",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {
+								"isOptional": true
+							},
+							"sources": [
+								{
+									"fileName": "src/fetcher.ts",
+									"line": 34,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/fetcher.ts#L34"
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "src/fetcher.ts",
+									"qualifiedName": "CustomFetchImpl"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 688,
+										"name": "TOutput",
+										"package": "@auth0/auth0-spa-js",
+										"refersToTypeParameter": true
+									}
+								],
+								"name": "CustomFetchImpl",
+								"package": "@auth0/auth0-spa-js"
+							}
+						},
+						{
+							"id": 684,
+							"name": "getAccessToken",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {
+								"isOptional": true
+							},
+							"sources": [
+								{
+									"fileName": "src/fetcher.ts",
+									"line": 32,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/fetcher.ts#L32"
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "src/fetcher.ts",
+									"qualifiedName": "AccessTokenFactory"
+								},
+								"name": "AccessTokenFactory",
+								"package": "@auth0/auth0-spa-js"
+							}
+						}
+					],
+					"groups": [
+						{
+							"title": "Properties",
+							"children": [
+								685,
+								687,
+								686,
+								684
+							]
+						}
+					],
+					"sources": [
+						{
+							"fileName": "src/fetcher.ts",
+							"line": 31,
+							"character": 70,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/fetcher.ts#L31"
+						}
+					]
+				}
+			}
+		},
+		{
+			"id": 1513,
+			"name": "GetTokenSilentlyVerboseResponse",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "\n\nType: [TokenEndpointResponse](/docs/sdk/typescript/types/TokenEndpointResponse)"
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "src/global.ts",
+					"line": 955,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L955"
+				}
+			],
+			"type": {
+				"type": "reference",
+				"target": {
+					"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+					"qualifiedName": "Omit"
+				},
+				"typeArguments": [
+					{
+						"type": "reference",
+						"target": 1389,
+						"name": "TokenEndpointResponse",
+						"package": "@auth0/auth0-spa-js"
+					},
+					{
+						"type": "literal",
+						"value": "refresh_token"
+					}
+				],
+				"name": "Omit",
+				"package": "typescript"
+			}
+		},
+		{
+			"id": 1207,
+			"name": "InteractiveErrorHandler",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Configuration option for automatic interactive error handling.\n\n- "
+					},
+					{
+						"kind": "code",
+						"text": "`'popup'`"
+					},
+					{
+						"kind": "text",
+						"text": ": SDK automatically opens Universal Login popup on MFA error"
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "src/global.ts",
+					"line": 10,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L10"
+				}
+			],
+			"type": {
+				"type": "literal",
+				"value": "popup"
+			}
+		},
+		{
+			"id": 672,
+			"name": "KeyManifestEntry",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"sources": [
+				{
+					"fileName": "src/cache/shared.ts",
+					"line": 92,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L92"
+				}
+			],
+			"type": {
+				"type": "reflection",
+				"declaration": {
+					"id": 673,
+					"name": "__type",
+					"variant": "declaration",
+					"kind": 65536,
+					"flags": {},
+					"children": [
+						{
+							"id": 674,
+							"name": "keys",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/cache/shared.ts",
+									"line": 93,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L93"
+								}
+							],
+							"type": {
+								"type": "array",
+								"elementType": {
+									"type": "intrinsic",
+									"name": "string"
+								}
+							}
+						}
+					],
+					"groups": [
+						{
+							"title": "Properties",
+							"children": [
+								674
+							]
+						}
+					],
+					"sources": [
+						{
+							"fileName": "src/cache/shared.ts",
+							"line": 92,
+							"character": 31,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L92"
+						}
+					]
+				}
+			}
+		},
+		{
+			"id": 675,
+			"name": "MaybePromise",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"sources": [
+				{
+					"fileName": "src/cache/shared.ts",
+					"line": 98,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L98"
+				}
+			],
+			"typeParameters": [
+				{
+					"id": 676,
+					"name": "T",
+					"variant": "typeParam",
+					"kind": 131072,
+					"flags": {}
+				}
+			],
+			"type": {
+				"type": "union",
+				"types": [
+					{
+						"type": "reference",
+						"target": {
+							"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+							"qualifiedName": "Promise"
+						},
+						"typeArguments": [
+							{
+								"type": "reference",
+								"target": 676,
+								"name": "T",
+								"package": "@auth0/auth0-spa-js",
+								"refersToTypeParameter": true
+							}
+						],
+						"name": "Promise",
+						"package": "typescript"
+					},
+					{
+						"type": "reference",
+						"target": 676,
+						"name": "T",
+						"package": "@auth0/auth0-spa-js",
+						"refersToTypeParameter": true
+					}
+				]
+			}
+		},
+		{
+			"id": 571,
+			"name": "MfaFactorType",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Supported MFA factors for enrollment"
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "src/mfa/types.ts",
+					"line": 43,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L43"
+				}
+			],
+			"type": {
+				"type": "union",
+				"types": [
+					{
+						"type": "literal",
+						"value": "otp"
+					},
+					{
+						"type": "literal",
+						"value": "sms"
+					},
+					{
+						"type": "literal",
+						"value": "email"
+					},
+					{
+						"type": "literal",
+						"value": "push"
+					},
+					{
+						"type": "literal",
+						"value": "voice"
+					}
+				]
+			}
+		},
+		{
+			"id": 1549,
+			"name": "MfaGrantType",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Grant types for MFA verification (derived from MfaGrantTypes constants)"
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "src/mfa/types.ts",
+					"line": 180,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L180"
+				}
+			],
+			"type": {
+				"type": "indexedAccess",
+				"indexType": {
+					"type": "typeOperator",
+					"operator": "keyof",
+					"target": {
+						"type": "query",
+						"queryType": {
+							"type": "reference",
+							"target": {
+								"sourceFileName": "src/mfa/constants.ts",
+								"qualifiedName": "MfaGrantTypes"
+							},
+							"name": "MfaGrantTypes",
+							"package": "@auth0/auth0-spa-js",
+							"preferValues": true
+						}
+					}
+				},
+				"objectType": {
+					"type": "query",
+					"queryType": {
+						"type": "reference",
+						"target": {
+							"sourceFileName": "src/mfa/constants.ts",
+							"qualifiedName": "MfaGrantTypes"
+						},
+						"name": "MfaGrantTypes",
+						"package": "@auth0/auth0-spa-js",
+						"preferValues": true
+					}
+				}
+			}
+		},
+		{
+			"id": 1525,
+			"name": "OobChannel",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Out-of-band delivery channels.\nIncludes 'email' which is also delivered out-of-band."
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "src/mfa/types.ts",
+					"line": 38,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/mfa/types.ts#L38"
+				}
+			],
+			"type": {
+				"type": "union",
+				"types": [
+					{
+						"type": "literal",
+						"value": "sms"
+					},
+					{
+						"type": "literal",
+						"value": "voice"
+					},
+					{
+						"type": "literal",
+						"value": "auth0"
+					},
+					{
+						"type": "literal",
+						"value": "email"
+					}
+				]
+			}
+		},
+		{
+			"id": 1188,
+			"name": "PasskeyGetTokenOptions",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Options for exchanging a signed passkey credential for tokens.\n\n"
+					},
+					{
+						"kind": "code",
+						"text": "`credential`"
+					},
+					{
+						"kind": "text",
+						"text": " is the raw "
+					},
+					{
+						"kind": "code",
+						"text": "`PublicKeyCredential`"
+					},
+					{
+						"kind": "text",
+						"text": " produced by the WebAuthn\nceremony — a creation credential (signup) or an assertion credential\n(login). The credential type (attestation vs assertion) is detected\nautomatically during serialization."
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "src/passkey/types.ts",
+					"line": 67,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/types.ts#L67"
+				}
+			],
+			"type": {
+				"type": "reflection",
+				"declaration": {
+					"id": 1189,
+					"name": "__type",
+					"variant": "declaration",
+					"kind": 65536,
+					"flags": {},
+					"children": [
+						{
+							"id": 1195,
+							"name": "audience",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {
+								"isOptional": true
+							},
+							"sources": [
+								{
+									"fileName": "src/passkey/types.ts",
+									"line": 73,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/types.ts#L73"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						},
+						{
+							"id": 1190,
+							"name": "authSession",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/passkey/types.ts",
+									"line": 68,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/types.ts#L68"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						},
+						{
+							"id": 1191,
+							"name": "credential",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/passkey/types.ts",
+									"line": 69,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/types.ts#L69"
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.dom.d.ts",
+									"qualifiedName": "PublicKeyCredential"
+								},
+								"name": "PublicKeyCredential",
+								"package": "typescript"
+							}
+						},
+						{
+							"id": 1193,
+							"name": "organization",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {
+								"isOptional": true
+							},
+							"sources": [
+								{
+									"fileName": "src/passkey/types.ts",
+									"line": 71,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/types.ts#L71"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						},
+						{
+							"id": 1192,
+							"name": "realm",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {
+								"isOptional": true
+							},
+							"sources": [
+								{
+									"fileName": "src/passkey/types.ts",
+									"line": 70,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/types.ts#L70"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						},
+						{
+							"id": 1194,
+							"name": "scope",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {
+								"isOptional": true
+							},
+							"sources": [
+								{
+									"fileName": "src/passkey/types.ts",
+									"line": 72,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/types.ts#L72"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						}
+					],
+					"groups": [
+						{
+							"title": "Properties",
+							"children": [
+								1195,
+								1190,
+								1191,
+								1193,
+								1192,
+								1194
+							]
+						}
+					],
+					"sources": [
+						{
+							"fileName": "src/passkey/types.ts",
+							"line": 67,
+							"character": 37,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/types.ts#L67"
+						}
+					]
+				}
+			}
+		},
+		{
+			"id": 1184,
+			"name": "PasskeyLoginChallenge",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "A passkey login challenge ready for the WebAuthn ceremony.\n\n"
+					},
+					{
+						"kind": "code",
+						"text": "`publicKey`"
+					},
+					{
+						"kind": "text",
+						"text": " is decoded (base64url → ArrayBuffer) and can be fed directly into\na WebAuthn assertion ceremony . "
+					},
+					{
+						"kind": "code",
+						"text": "`authSession`"
+					},
+					{
+						"kind": "text",
+						"text": " must be retained and passed to "
+					},
+					{
+						"kind": "code",
+						"text": "`getTokenWithPasskey()`"
+					},
+					{
+						"kind": "text",
+						"text": "."
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "src/passkey/types.ts",
+					"line": 54,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/types.ts#L54"
+				}
+			],
+			"type": {
+				"type": "reflection",
+				"declaration": {
+					"id": 1185,
+					"name": "__type",
+					"variant": "declaration",
+					"kind": 65536,
+					"flags": {},
+					"children": [
+						{
+							"id": 1186,
+							"name": "authSession",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/passkey/types.ts",
+									"line": 55,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/types.ts#L55"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						},
+						{
+							"id": 1187,
+							"name": "publicKey",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/passkey/types.ts",
+									"line": 56,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/types.ts#L56"
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.dom.d.ts",
+									"qualifiedName": "PublicKeyCredentialRequestOptions"
+								},
+								"name": "PublicKeyCredentialRequestOptions",
+								"package": "typescript"
+							}
+						}
+					],
+					"groups": [
+						{
+							"title": "Properties",
+							"children": [
+								1186,
+								1187
+							]
+						}
+					],
+					"sources": [
+						{
+							"fileName": "src/passkey/types.ts",
+							"line": 54,
+							"character": 36,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/types.ts#L54"
+						}
+					]
+				}
+			}
+		},
+		{
+			"id": 1176,
+			"name": "PasskeyLoginOptions",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Options for passkey login (authenticating with an existing passkey)."
+					},
+					{
+						"kind": "text",
+						"text": "\n\nType: [PasskeyLoginChallengeOptions](/docs/sdk/typescript/interfaces/PasskeyLoginChallengeOptions)"
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "src/passkey/types.ts",
+					"line": 32,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/types.ts#L32"
+				}
+			],
+			"type": {
+				"type": "intersection",
+				"types": [
+					{
+						"type": "reference",
+						"target": 1128,
+						"name": "PasskeyLoginChallengeOptions",
+						"package": "@auth0/auth0-auth-js"
+					},
+					{
+						"type": "reflection",
+						"declaration": {
+							"id": 1177,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"children": [
+								{
+									"id": 1179,
+									"name": "audience",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {
+										"isOptional": true
+									},
+									"sources": [
+										{
+											"fileName": "src/passkey/types.ts",
+											"line": 34,
+											"character": 2,
+											"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/types.ts#L34"
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 1178,
+									"name": "scope",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {
+										"isOptional": true
+									},
+									"sources": [
+										{
+											"fileName": "src/passkey/types.ts",
+											"line": 33,
+											"character": 2,
+											"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/types.ts#L33"
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"groups": [
+								{
+									"title": "Properties",
+									"children": [
+										1179,
+										1178
+									]
+								}
+							],
+							"sources": [
+								{
+									"fileName": "src/passkey/types.ts",
+									"line": 32,
+									"character": 65,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/types.ts#L32"
+								}
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": 1180,
+			"name": "PasskeySignupChallenge",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "A passkey signup challenge ready for the WebAuthn ceremony.\n\n"
+					},
+					{
+						"kind": "code",
+						"text": "`publicKey`"
+					},
+					{
+						"kind": "text",
+						"text": " is decoded (base64url → ArrayBuffer) and can be fed directly into\na WebAuthn credential creation ceremony. "
+					},
+					{
+						"kind": "code",
+						"text": "`authSession`"
+					},
+					{
+						"kind": "text",
+						"text": " must be retained and passed to "
+					},
+					{
+						"kind": "code",
+						"text": "`getTokenWithPasskey()`"
+					},
+					{
+						"kind": "text",
+						"text": "."
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "src/passkey/types.ts",
+					"line": 43,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/types.ts#L43"
+				}
+			],
+			"type": {
+				"type": "reflection",
+				"declaration": {
+					"id": 1181,
+					"name": "__type",
+					"variant": "declaration",
+					"kind": 65536,
+					"flags": {},
+					"children": [
+						{
+							"id": 1182,
+							"name": "authSession",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/passkey/types.ts",
+									"line": 44,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/types.ts#L44"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						},
+						{
+							"id": 1183,
+							"name": "publicKey",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/passkey/types.ts",
+									"line": 45,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/types.ts#L45"
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.dom.d.ts",
+									"qualifiedName": "PublicKeyCredentialCreationOptions"
+								},
+								"name": "PublicKeyCredentialCreationOptions",
+								"package": "typescript"
+							}
+						}
+					],
+					"groups": [
+						{
+							"title": "Properties",
+							"children": [
+								1182,
+								1183
+							]
+						}
+					],
+					"sources": [
+						{
+							"fileName": "src/passkey/types.ts",
+							"line": 43,
+							"character": 37,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/types.ts#L43"
+						}
+					]
+				}
+			}
+		},
+		{
+			"id": 1112,
+			"name": "PasskeySignupChallengeOptions",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Options for requesting a passkey signup challenge.\n\nAt least one user identifier ("
+					},
+					{
+						"kind": "code",
+						"text": "`email`"
+					},
+					{
+						"kind": "text",
+						"text": ", "
+					},
+					{
+						"kind": "code",
+						"text": "`username`"
+					},
+					{
+						"kind": "text",
+						"text": ", or "
+					},
+					{
+						"kind": "code",
+						"text": "`phoneNumber`"
+					},
+					{
+						"kind": "text",
+						"text": ") must be provided.\nWhich identifiers are accepted depends on what is configured on your database connection."
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+					"line": 1136,
+					"character": 5
+				}
+			],
+			"type": {
+				"type": "intersection",
+				"types": [
+					{
+						"type": "reference",
+						"target": {
+							"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+							"qualifiedName": "PasskeySignupChallengeBaseOptions"
+						},
+						"name": "PasskeySignupChallengeBaseOptions",
+						"package": "@auth0/auth0-auth-js"
+					},
+					{
+						"type": "union",
+						"types": [
+							{
+								"type": "reflection",
+								"declaration": {
+									"id": 1113,
+									"name": "__type",
+									"variant": "declaration",
+									"kind": 65536,
+									"flags": {},
+									"children": [
+										{
+											"id": 1114,
+											"name": "email",
+											"variant": "declaration",
+											"kind": 1024,
+											"flags": {},
+											"sources": [
+												{
+													"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+													"line": 1137,
+													"character": 4
+												}
+											],
+											"type": {
+												"type": "intrinsic",
+												"name": "string"
+											}
+										},
+										{
+											"id": 1115,
+											"name": "phoneNumber",
+											"variant": "declaration",
+											"kind": 1024,
+											"flags": {
+												"isOptional": true
+											},
+											"sources": [
+												{
+													"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+													"line": 1138,
+													"character": 4
+												}
+											],
+											"type": {
+												"type": "intrinsic",
+												"name": "string"
+											}
+										},
+										{
+											"id": 1116,
+											"name": "username",
+											"variant": "declaration",
+											"kind": 1024,
+											"flags": {
+												"isOptional": true
+											},
+											"sources": [
+												{
+													"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+													"line": 1139,
+													"character": 4
+												}
+											],
+											"type": {
+												"type": "intrinsic",
+												"name": "string"
+											}
+										}
+									],
+									"groups": [
+										{
+											"title": "Properties",
+											"children": [
+												1114,
+												1115,
+												1116
+											]
+										}
+									],
+									"sources": [
+										{
+											"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+											"line": 1136,
+											"character": 74
+										}
+									]
+								}
+							},
+							{
+								"type": "reflection",
+								"declaration": {
+									"id": 1117,
+									"name": "__type",
+									"variant": "declaration",
+									"kind": 65536,
+									"flags": {},
+									"children": [
+										{
+											"id": 1119,
+											"name": "email",
+											"variant": "declaration",
+											"kind": 1024,
+											"flags": {
+												"isOptional": true
+											},
+											"sources": [
+												{
+													"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+													"line": 1142,
+													"character": 4
+												}
+											],
+											"type": {
+												"type": "intrinsic",
+												"name": "string"
+											}
+										},
+										{
+											"id": 1118,
+											"name": "phoneNumber",
+											"variant": "declaration",
+											"kind": 1024,
+											"flags": {},
+											"sources": [
+												{
+													"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+													"line": 1141,
+													"character": 4
+												}
+											],
+											"type": {
+												"type": "intrinsic",
+												"name": "string"
+											}
+										},
+										{
+											"id": 1120,
+											"name": "username",
+											"variant": "declaration",
+											"kind": 1024,
+											"flags": {
+												"isOptional": true
+											},
+											"sources": [
+												{
+													"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+													"line": 1143,
+													"character": 4
+												}
+											],
+											"type": {
+												"type": "intrinsic",
+												"name": "string"
+											}
+										}
+									],
+									"groups": [
+										{
+											"title": "Properties",
+											"children": [
+												1119,
+												1118,
+												1120
+											]
+										}
+									],
+									"sources": [
+										{
+											"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+											"line": 1140,
+											"character": 4
+										}
+									]
+								}
+							},
+							{
+								"type": "reflection",
+								"declaration": {
+									"id": 1121,
+									"name": "__type",
+									"variant": "declaration",
+									"kind": 65536,
+									"flags": {},
+									"children": [
+										{
+											"id": 1123,
+											"name": "email",
+											"variant": "declaration",
+											"kind": 1024,
+											"flags": {
+												"isOptional": true
+											},
+											"sources": [
+												{
+													"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+													"line": 1146,
+													"character": 4
+												}
+											],
+											"type": {
+												"type": "intrinsic",
+												"name": "string"
+											}
+										},
+										{
+											"id": 1124,
+											"name": "phoneNumber",
+											"variant": "declaration",
+											"kind": 1024,
+											"flags": {
+												"isOptional": true
+											},
+											"sources": [
+												{
+													"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+													"line": 1147,
+													"character": 4
+												}
+											],
+											"type": {
+												"type": "intrinsic",
+												"name": "string"
+											}
+										},
+										{
+											"id": 1122,
+											"name": "username",
+											"variant": "declaration",
+											"kind": 1024,
+											"flags": {},
+											"sources": [
+												{
+													"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+													"line": 1145,
+													"character": 4
+												}
+											],
+											"type": {
+												"type": "intrinsic",
+												"name": "string"
+											}
+										}
+									],
+									"groups": [
+										{
+											"title": "Properties",
+											"children": [
+												1123,
+												1124,
+												1122
+											]
+										}
+									],
+									"sources": [
+										{
+											"fileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+											"line": 1144,
+											"character": 4
+										}
+									]
+								}
+							}
+						]
+					}
+				]
+			}
+		},
+		{
+			"id": 1172,
+			"name": "PasskeySignupOptions",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Options for passkey signup (registering a new user with a passkey)."
+					},
+					{
+						"kind": "text",
+						"text": "\n\nType: [PasskeySignupChallengeOptions](/docs/sdk/typescript/types/PasskeySignupChallengeOptions)"
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "src/passkey/types.ts",
+					"line": 24,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/types.ts#L24"
+				}
+			],
+			"type": {
+				"type": "intersection",
+				"types": [
+					{
+						"type": "reference",
+						"target": 1112,
+						"name": "PasskeySignupChallengeOptions",
+						"package": "@auth0/auth0-auth-js"
+					},
+					{
+						"type": "reflection",
+						"declaration": {
+							"id": 1173,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"children": [
+								{
+									"id": 1175,
+									"name": "audience",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {
+										"isOptional": true
+									},
+									"sources": [
+										{
+											"fileName": "src/passkey/types.ts",
+											"line": 26,
+											"character": 2,
+											"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/types.ts#L26"
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 1174,
+									"name": "scope",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {
+										"isOptional": true
+									},
+									"sources": [
+										{
+											"fileName": "src/passkey/types.ts",
+											"line": 25,
+											"character": 2,
+											"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/types.ts#L25"
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								}
+							],
+							"groups": [
+								{
+									"title": "Properties",
+									"children": [
+										1175,
+										1174
+									]
+								}
+							],
+							"sources": [
+								{
+									"fileName": "src/passkey/types.ts",
+									"line": 24,
+									"character": 67,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/passkey/types.ts#L24"
+								}
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": 1212,
+			"name": "RefreshTokenMode",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"sources": [
+				{
+					"fileName": "src/global.ts",
+					"line": 20,
+					"character": 13,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L20"
+				},
+				{
+					"fileName": "src/global.ts",
+					"line": 25,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L25"
+				}
+			],
+			"type": {
+				"type": "indexedAccess",
+				"indexType": {
+					"type": "typeOperator",
+					"operator": "keyof",
+					"target": {
+						"type": "query",
+						"queryType": {
+							"type": "reference",
+							"target": 1208,
+							"name": "RefreshTokenMode",
+							"package": "@auth0/auth0-spa-js"
+						}
+					}
+				},
+				"objectType": {
+					"type": "query",
+					"queryType": {
+						"type": "reference",
+						"target": 1208,
+						"name": "RefreshTokenMode",
+						"package": "@auth0/auth0-spa-js"
+					}
+				}
+			}
+		},
+		{
+			"id": 1389,
+			"name": "TokenEndpointResponse",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"sources": [
+				{
+					"fileName": "src/global.ts",
+					"line": 802,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L802"
+				}
+			],
+			"type": {
+				"type": "reflection",
+				"declaration": {
+					"id": 1390,
+					"name": "__type",
+					"variant": "declaration",
+					"kind": 65536,
+					"flags": {},
+					"children": [
+						{
+							"id": 1393,
+							"name": "access_token",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/global.ts",
+									"line": 805,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L805"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						},
+						{
+							"id": 1395,
+							"name": "expires_in",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/global.ts",
+									"line": 807,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L807"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "number"
+							}
+						},
+						{
+							"id": 1391,
+							"name": "id_token",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/global.ts",
+									"line": 803,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L803"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						},
+						{
+							"id": 1394,
+							"name": "refresh_token",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {
+								"isOptional": true
+							},
+							"sources": [
+								{
+									"fileName": "src/global.ts",
+									"line": 806,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L806"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						},
+						{
+							"id": 1396,
+							"name": "scope",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {
+								"isOptional": true
+							},
+							"sources": [
+								{
+									"fileName": "src/global.ts",
+									"line": 808,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L808"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						},
+						{
+							"id": 1392,
+							"name": "token_type",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/global.ts",
+									"line": 804,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L804"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						}
+					],
+					"groups": [
+						{
+							"title": "Properties",
+							"children": [
+								1393,
+								1395,
+								1391,
+								1394,
+								1396,
+								1392
+							]
+						}
+					],
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 802,
+							"character": 36,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L802"
+						}
+					]
+				}
+			}
+		},
+		{
+			"id": 668,
+			"name": "WrappedCacheEntry",
+			"variant": "declaration",
+			"kind": 2097152,
+			"flags": {},
+			"sources": [
+				{
+					"fileName": "src/cache/shared.ts",
+					"line": 87,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L87"
+				}
+			],
+			"type": {
+				"type": "reflection",
+				"declaration": {
+					"id": 669,
+					"name": "__type",
+					"variant": "declaration",
+					"kind": 65536,
+					"flags": {},
+					"children": [
+						{
+							"id": 670,
+							"name": "body",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {},
+							"comment": {
+								"summary": [
+									{
+										"kind": "text",
+										"text": "Type: [CacheEntry](/docs/sdk/typescript/types/CacheEntry)"
+									}
+								]
+							},
+							"sources": [
+								{
+									"fileName": "src/cache/shared.ts",
+									"line": 88,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L88"
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Partial"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": 656,
+										"name": "CacheEntry",
+										"package": "@auth0/auth0-spa-js"
+									}
+								],
+								"name": "Partial",
+								"package": "typescript"
+							}
+						},
+						{
+							"id": 671,
+							"name": "expiresAt",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {},
+							"sources": [
+								{
+									"fileName": "src/cache/shared.ts",
+									"line": 89,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L89"
+								}
+							],
+							"type": {
+								"type": "intrinsic",
+								"name": "number"
+							}
+						}
+					],
+					"groups": [
+						{
+							"title": "Properties",
+							"children": [
+								670,
+								671
+							]
+						}
+					],
+					"sources": [
+						{
+							"fileName": "src/cache/shared.ts",
+							"line": 87,
+							"character": 32,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/cache/shared.ts#L87"
+						}
+					]
+				}
+			}
+		},
+		{
+			"id": 1306,
+			"name": "ResponseType",
+			"variant": "declaration",
+			"kind": 8,
+			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "The types of responses expected from the authorization server.\n- "
+					},
+					{
+						"kind": "code",
+						"text": "`code`"
+					},
+					{
+						"kind": "text",
+						"text": ": used for the standard login flow.\n- "
+					},
+					{
+						"kind": "code",
+						"text": "`connect_code`"
+					},
+					{
+						"kind": "text",
+						"text": ": used for the connect account flow."
+					}
+				]
+			},
+			"children": [
+				{
+					"id": 1307,
+					"name": "Code",
+					"variant": "declaration",
+					"kind": 16,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 488,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L488"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "code"
+					}
+				},
+				{
+					"id": 1308,
+					"name": "ConnectCode",
+					"variant": "declaration",
+					"kind": 16,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 489,
+							"character": 2,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L489"
+						}
+					],
+					"type": {
+						"type": "literal",
+						"value": "connect_code"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Enumeration Members",
+					"children": [
+						1307,
+						1308
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "src/global.ts",
+					"line": 487,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L487"
+				}
+			]
+		},
+		{
+			"id": 1208,
+			"name": "RefreshTokenMode",
+			"variant": "declaration",
+			"kind": 32,
+			"flags": {
+				"isConst": true
+			},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "The refresh-token variant used when "
+					},
+					{
+						"kind": "code",
+						"text": "`useRefreshTokens: true`"
+					},
+					{
+						"kind": "text",
+						"text": ".\n\n- "
+					},
+					{
+						"kind": "inline-tag",
+						"tag": "@link",
+						"text": "RefreshTokenMode.Offline",
+						"target": 1210,
+						"tsLinkText": ""
+					},
+					{
+						"kind": "text",
+						"text": " (default): rotating offline refresh tokens.\n- "
+					},
+					{
+						"kind": "inline-tag",
+						"tag": "@link",
+						"text": "RefreshTokenMode.Online",
+						"target": 1211,
+						"tsLinkText": ""
+					},
+					{
+						"kind": "text",
+						"text": ": non-rotating Online Refresh Tokens (ORTs)."
+					}
+				]
+			},
+			"sources": [
+				{
+					"fileName": "src/global.ts",
+					"line": 20,
+					"character": 13,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L20"
+				},
+				{
+					"fileName": "src/global.ts",
+					"line": 25,
+					"character": 12,
+					"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L25"
+				}
+			],
+			"type": {
+				"type": "reflection",
+				"declaration": {
+					"id": 1209,
+					"name": "__type",
+					"variant": "declaration",
+					"kind": 65536,
+					"flags": {},
+					"children": [
+						{
+							"id": 1210,
+							"name": "Offline",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {
+								"isReadonly": true
+							},
+							"sources": [
+								{
+									"fileName": "src/global.ts",
+									"line": 21,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L21"
+								}
+							],
+							"type": {
+								"type": "literal",
+								"value": "offline"
+							},
+							"defaultValue": "'offline'"
+						},
+						{
+							"id": 1211,
+							"name": "Online",
+							"variant": "declaration",
+							"kind": 1024,
+							"flags": {
+								"isReadonly": true
+							},
+							"sources": [
+								{
+									"fileName": "src/global.ts",
+									"line": 22,
+									"character": 2,
+									"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L22"
+								}
+							],
+							"type": {
+								"type": "literal",
+								"value": "online"
+							},
+							"defaultValue": "'online'"
+						}
+					],
+					"groups": [
+						{
+							"title": "Properties",
+							"children": [
+								1210,
+								1211
+							]
+						}
+					],
+					"sources": [
+						{
+							"fileName": "src/global.ts",
+							"line": 20,
+							"character": 32,
+							"url": "https://github.com/auth0/auth0-spa-js/blob/9f363b10e624609ffbff96021231d9ec95e87088/src/global.ts#L20"
+						}
+					]
+				}
+			},
+			"defaultValue": "..."
+		}
+	],
+	"groups": [
+		{
+			"title": "Enumerations",
+			"children": [
+				1306
+			]
+		},
+		{
+			"title": "Classes",
+			"children": [
+				12,
+				332,
+				618,
+				286,
+				689,
+				305,
+				614,
+				318,
+				597,
+				542,
+				503,
+				490,
+				529,
+				464,
+				477,
+				397,
+				516,
+				414,
+				429,
+				754,
+				792,
+				1057,
+				1094,
+				1079,
+				1101,
+				1087,
+				373,
+				386,
+				360,
+				349,
+				444,
+				1475
+			]
+		},
+		{
+			"title": "Interfaces",
+			"children": [
+				1428,
+				1233,
+				1516,
+				1213,
+				1541,
+				1545,
+				1231,
+				1267,
+				821,
+				826,
+				806,
+				814,
+				653,
+				895,
+				946,
+				971,
+				1034,
+				584,
+				573,
+				588,
+				576,
+				580,
+				1550,
+				833,
+				844,
+				1319,
+				1330,
+				637,
+				1432,
+				1341,
+				1333,
+				457,
+				1533,
+				1527,
+				849,
+				1147,
+				1134,
+				938,
+				960,
+				1024,
+				1108,
+				1128,
+				1131,
+				1167,
+				1125,
+				904,
+				955,
+				996,
+				1052,
+				1002,
+				885,
+				942,
+				966,
+				1029,
+				1315,
+				1313,
+				919,
+				951,
+				983,
+				1044,
+				927,
+				953,
+				990,
+				1048,
+				1357,
+				1293,
+				1309,
+				1514,
+				911,
+				949,
+				976,
+				1039,
+				934,
+				591,
+				865,
+				875
+			]
+		},
+		{
+			"title": "Type Aliases",
+			"children": [
+				848,
+				847,
+				1524,
+				656,
+				677,
+				1270,
+				652,
+				1368,
+				750,
+				1196,
+				572,
+				937,
+				959,
+				1526,
+				1023,
+				682,
+				1513,
+				1207,
+				672,
+				675,
+				571,
+				1549,
+				1525,
+				1188,
+				1184,
+				1176,
+				1180,
+				1112,
+				1172,
+				1212,
+				1389,
+				668
+			]
+		},
+		{
+			"title": "Variables",
+			"children": [
+				1208
+			]
+		},
+		{
+			"title": "Functions",
+			"children": [
+				1
+			]
+		}
+	],
+	"categories": [
+		{
+			"title": "Getting Started",
+			"children": [
+				1
+			]
+		},
+		{
+			"title": "Clients",
+			"children": [
+				12,
+				689,
+				542,
+				754,
+				1057
+			]
+		},
+		{
+			"title": "Configuration",
+			"children": [
+				1233,
+				1213,
+				1231,
+				1267,
+				1270,
+				1207,
+				1212,
+				1208
+			]
+		},
+		{
+			"title": "Login & Logout",
+			"children": [
+				1341,
+				1333,
+				1315,
+				1313,
+				1357,
+				1293,
+				1309,
+				1368
+			]
+		},
+		{
+			"title": "Tokens & Users",
+			"children": [
+				1475,
+				1428,
+				1319,
+				1330,
+				1432,
+				1514,
+				750,
+				1196,
+				682,
+				1513,
+				1389
+			]
+		},
+		{
+			"title": "Multi-Factor Authentication",
+			"children": [
+				1516,
+				1541,
+				1545,
+				584,
+				573,
+				588,
+				576,
+				580,
+				1550,
+				1533,
+				1527,
+				591,
+				1524,
+				572,
+				1526,
+				571,
+				1549,
+				1525
+			]
+		},
+		{
+			"title": "Passkeys",
+			"children": [
+				1147,
+				1134,
+				1108,
+				1128,
+				1131,
+				1167,
+				1125,
+				1188,
+				1184,
+				1176,
+				1180,
+				1112,
+				1172
+			]
+		},
+		{
+			"title": "My Account",
+			"children": [
+				821,
+				826,
+				806,
+				814,
+				895,
+				946,
+				971,
+				1034,
+				833,
+				844,
+				849,
+				938,
+				960,
+				1024,
+				904,
+				955,
+				996,
+				1052,
+				1002,
+				885,
+				942,
+				966,
+				1029,
+				919,
+				951,
+				983,
+				1044,
+				927,
+				953,
+				990,
+				1048,
+				911,
+				949,
+				976,
+				1039,
+				934,
+				865,
+				875,
+				848,
+				847,
+				937,
+				959,
+				1023
+			]
+		},
+		{
+			"title": "Errors",
+			"children": [
+				332,
+				286,
+				305,
+				318,
+				503,
+				490,
+				529,
+				464,
+				477,
+				397,
+				516,
+				414,
+				429,
+				792,
+				1094,
+				1079,
+				1101,
+				1087,
+				373,
+				386,
+				360,
+				349,
+				444,
+				457
+			]
+		},
+		{
+			"title": "Caching",
+			"children": [
+				618,
+				614,
+				597,
+				653,
+				637,
+				656,
+				677,
+				652,
+				672,
+				675,
+				668
+			]
+		},
+		{
+			"title": "Other Types",
+			"children": [
+				1306
+			]
+		}
+	],
+	"packageName": "@auth0/auth0-spa-js",
+	"readme": [
+		{
+			"kind": "text",
+			"text": "![Auth0 SDK for Single Page Applications using Authorization Code Grant Flow with PKCE.](https://cdn.auth0.com/website/sdks/banners/spa-js-banner.png)\n\n[![npm version](https://img.shields.io/npm/v/@auth0/auth0-spa-js?style=flat-square&logo=npm&logoColor=CB3837)](https://www.npmjs.com/package/@auth0/auth0-spa-js)\n[![Codecov](https://img.shields.io/codecov/c/github/auth0/auth0-spa-js)](https://codecov.io/gh/auth0/auth0-spa-js)\n[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/auth0/auth0-spa-js)\n![Downloads](https://img.shields.io/npm/dw/@auth0/auth0-spa-js)\n[![License](https://img.shields.io/:license-mit-blue.svg?style=flat)](https://opensource.org/licenses/MIT)\n![CircleCI](https://img.shields.io/circleci/build/github/auth0/auth0-spa-js)\n\n📚 [Documentation](#documentation) - 🚀 [Getting Started](#getting-started) - 💻 [API Reference](#api-reference) - 💬 [Feedback](#feedback)\n\n## Documentation\n\n- [Quickstart](https://auth0.com/docs/quickstart/spa/vanillajs/interactive) - our interactive guide for quickly adding login, logout and user information to your app using Auth0.\n- [Sample app](https://github.com/auth0-samples/auth0-javascript-samples/tree/master/01-Login) - a full-fledged sample app integrated with Auth0.\n- [FAQs](https://github.com/auth0/auth0-spa-js/blob/main/FAQ.md) - frequently asked questions about auth0-spa-js SDK.\n- [Examples](https://github.com/auth0/auth0-spa-js/blob/main/EXAMPLES.md) - code samples for common scenarios.\n- [Docs Site](https://auth0.com/docs) - explore our Docs site and learn more about Auth0.\n\n## Getting Started\n\n### Installation\n\nUsing [npm](https://npmjs.org) in your project directory run the following command:\n\n"
+		},
+		{
+			"kind": "code",
+			"text": "```sh\nnpm install @auth0/auth0-spa-js\n```"
+		},
+		{
+			"kind": "text",
+			"text": "\n\nFrom the CDN:\n\n"
+		},
+		{
+			"kind": "code",
+			"text": "```html\n<script src=\"https://cdn.auth0.com/js/auth0-spa-js/2.24/auth0-spa-js.production.js\"></script>\n```"
+		},
+		{
+			"kind": "text",
+			"text": "\n\n### Configure Auth0\n\nCreate a **Single Page Application** in the [Auth0 Dashboard](https://manage.auth0.com/#/applications).\n\n> **If you're using an existing application**, verify that you have configured the following settings in your Single Page Application:\n>\n> - Click on the \"Settings\" tab of your application's page.\n> - Scroll down and click on the \"Show Advanced Settings\" link.\n> - Under \"Advanced Settings\", click on the \"OAuth\" tab.\n> - Ensure that \"JsonWebToken Signature Algorithm\" is set to "
+		},
+		{
+			"kind": "code",
+			"text": "`RS256`"
+		},
+		{
+			"kind": "text",
+			"text": " and that \"OIDC Conformant\" is enabled.\n\nNext, configure the following URLs for your application under the \"Application URIs\" section of the \"Settings\" page:\n\n- **Allowed Callback URLs**: "
+		},
+		{
+			"kind": "code",
+			"text": "`http://localhost:3000`"
+		},
+		{
+			"kind": "text",
+			"text": "\n- **Allowed Logout URLs**: "
+		},
+		{
+			"kind": "code",
+			"text": "`http://localhost:3000`"
+		},
+		{
+			"kind": "text",
+			"text": "\n- **Allowed Web Origins**: "
+		},
+		{
+			"kind": "code",
+			"text": "`http://localhost:3000`"
+		},
+		{
+			"kind": "text",
+			"text": "\n\n> These URLs should reflect the origins that your application is running on. **Allowed Callback URLs** may also include a path, depending on where you're handling the callback (see below).\n\nTake note of the **Client ID** and **Domain** values under the \"Basic Information\" section. You'll need these values in the next step.\n\n### Configure the SDK\n\nCreate an "
+		},
+		{
+			"kind": "code",
+			"text": "`Auth0Client`"
+		},
+		{
+			"kind": "text",
+			"text": " instance before rendering or initializing your application. You should only have one instance of the client.\n\n"
+		},
+		{
+			"kind": "code",
+			"text": "```js\nimport { createAuth0Client } from '@auth0/auth0-spa-js';\n\n//with async/await\nconst auth0 = await createAuth0Client({\n  domain: '<AUTH0_DOMAIN>',\n  clientId: '<AUTH0_CLIENT_ID>',\n  authorizationParams: {\n    redirect_uri: '<MY_CALLBACK_URL>'\n  }\n});\n\n//or, you can just instantiate the client on its own\nimport { Auth0Client } from '@auth0/auth0-spa-js';\n\nconst auth0 = new Auth0Client({\n  domain: '<AUTH0_DOMAIN>',\n  clientId: '<AUTH0_CLIENT_ID>',\n  authorizationParams: {\n    redirect_uri: '<MY_CALLBACK_URL>'\n  }\n});\n\n//if you do this, you'll need to check the session yourself\ntry {\n  await auth0.getTokenSilently();\n} catch (error) {\n  if (error.error !== 'login_required') {\n    throw error;\n  }\n}\n```"
+		},
+		{
+			"kind": "text",
+			"text": "\n\n### Logging In\n\nYou can then use login using the "
+		},
+		{
+			"kind": "code",
+			"text": "`Auth0Client`"
+		},
+		{
+			"kind": "text",
+			"text": " instance you created:\n\n"
+		},
+		{
+			"kind": "code",
+			"text": "```html\n<button id=\"login\">Click to Login</button>\n```"
+		},
+		{
+			"kind": "text",
+			"text": "\n\n"
+		},
+		{
+			"kind": "code",
+			"text": "```js\n//redirect to the Universal Login Page\ndocument.getElementById('login').addEventListener('click', async () => {\n  await auth0.loginWithRedirect();\n});\n\n//in your callback route (<MY_CALLBACK_URL>)\nwindow.addEventListener('load', async () => {\n  const redirectResult = await auth0.handleRedirectCallback();\n  //logged in. you can get the user profile like this:\n  const user = await auth0.getUser();\n  console.log(user);\n});\n```"
+		},
+		{
+			"kind": "text",
+			"text": "\n\n### Online Access\n\n> [!NOTE]\n> Online Access (Online Refresh Tokens) support via SDKs is currently in Early Access. To request access to this feature, contact your Auth0 representative.\n\n> [!WARNING]\n> Online Refresh Tokens do not currently support resource servers with **Ephemeral Sessions** enabled. Enabling both "
+		},
+		{
+			"kind": "code",
+			"text": "`allow_online_access`"
+		},
+		{
+			"kind": "text",
+			"text": " and \"Allow for Ephemeral Sessions\" on the same resource server results in the authorization server issuing an Online Refresh Token that is then rejected ("
+		},
+		{
+			"kind": "code",
+			"text": "`invalid_grant`"
+		},
+		{
+			"kind": "text",
+			"text": ") on the very next refresh. Until Ephemeral Sessions support is added for Online Refresh Tokens, disable \"Allow for Ephemeral Sessions\" on any resource server used with "
+		},
+		{
+			"kind": "code",
+			"text": "`refreshTokenMode: RefreshTokenMode.Online`"
+		},
+		{
+			"kind": "text",
+			"text": ".\n\nSet "
+		},
+		{
+			"kind": "code",
+			"text": "`refreshTokenMode`"
+		},
+		{
+			"kind": "text",
+			"text": " to "
+		},
+		{
+			"kind": "code",
+			"text": "`RefreshTokenMode.Online`"
+		},
+		{
+			"kind": "text",
+			"text": " (together with the required "
+		},
+		{
+			"kind": "code",
+			"text": "`useRefreshTokens: true`"
+		},
+		{
+			"kind": "text",
+			"text": " and "
+		},
+		{
+			"kind": "code",
+			"text": "`useDpop: true`"
+		},
+		{
+			"kind": "text",
+			"text": ") to use **Online Refresh Tokens** — non-rotating refresh tokens bound to the Auth0 session lifetime. The SDK injects the "
+		},
+		{
+			"kind": "code",
+			"text": "`online_access`"
+		},
+		{
+			"kind": "text",
+			"text": " scope and routes renewal through the refresh-token grant.\n\n"
+		},
+		{
+			"kind": "code",
+			"text": "```js\nimport { createAuth0Client, RefreshTokenMode } from '@auth0/auth0-spa-js';\n\nconst auth0 = await createAuth0Client({\n  domain: '<AUTH0_DOMAIN>',\n  clientId: '<AUTH0_CLIENT_ID>',\n  useRefreshTokens: true,\n  refreshTokenMode: RefreshTokenMode.Online,\n  useDpop: true,\n  authorizationParams: {\n    redirect_uri: '<MY_CALLBACK_URL>'\n  }\n});\n```"
+		},
+		{
+			"kind": "text",
+			"text": "\n\n"
+		},
+		{
+			"kind": "code",
+			"text": "`refreshTokenMode`"
+		},
+		{
+			"kind": "text",
+			"text": " is a sub-option of "
+		},
+		{
+			"kind": "code",
+			"text": "`useRefreshTokens`"
+		},
+		{
+			"kind": "text",
+			"text": ": it defaults to "
+		},
+		{
+			"kind": "code",
+			"text": "`RefreshTokenMode.Offline`"
+		},
+		{
+			"kind": "text",
+			"text": " (the rotating refresh tokens described above) and must be set to "
+		},
+		{
+			"kind": "code",
+			"text": "`RefreshTokenMode.Online`"
+		},
+		{
+			"kind": "text",
+			"text": " for Online Refresh Tokens. Online mode requires both "
+		},
+		{
+			"kind": "code",
+			"text": "`useRefreshTokens: true`"
+		},
+		{
+			"kind": "text",
+			"text": " and "
+		},
+		{
+			"kind": "code",
+			"text": "`useDpop: true`"
+		},
+		{
+			"kind": "text",
+			"text": ". See [Online Access](https://github.com/auth0/auth0-spa-js/blob/main/EXAMPLES.md#online-access-online-refresh-tokens) in EXAMPLES.md for the full guide.\n\n### More Examples\n\nFor comprehensive examples covering various scenarios including logging out, calling APIs, refresh tokens, online access, organizations, passkeys, MFA, DPoP, and more, see the [EXAMPLES.md](https://github.com/auth0/auth0-spa-js/blob/main/EXAMPLES.md) document.\n\n## API Reference\n\nExplore API Methods available in auth0-spa-js. The full reference is at [auth0.github.io/auth0-spa-js](https://auth0.github.io/auth0-spa-js/).\n\n**Getting started**\n\n- [createAuth0Client](https://auth0.github.io/auth0-spa-js/functions/createAuth0Client.html) - create and initialize a client\n- [Auth0ClientOptions](https://auth0.github.io/auth0-spa-js/interfaces/Auth0ClientOptions.html) - configuration options\n\n**Clients**\n\n- [Auth0Client](https://auth0.github.io/auth0-spa-js/classes/Auth0Client.html) - login, logout, tokens and user profile\n- [MfaApiClient](https://auth0.github.io/auth0-spa-js/classes/MfaApiClient.html) - "
+		},
+		{
+			"kind": "code",
+			"text": "`auth0.mfa`"
+		},
+		{
+			"kind": "text",
+			"text": ": enroll, challenge and verify authenticators\n- [PasskeyApiClient](https://auth0.github.io/auth0-spa-js/classes/PasskeyApiClient.html) - "
+		},
+		{
+			"kind": "code",
+			"text": "`auth0.passkey`"
+		},
+		{
+			"kind": "text",
+			"text": ": passkey signup and login\n- [MyAccountApiClient](https://auth0.github.io/auth0-spa-js/classes/MyAccountApiClient.html) - "
+		},
+		{
+			"kind": "code",
+			"text": "`auth0.myAccount`"
+		},
+		{
+			"kind": "text",
+			"text": ": manage the user's own authentication methods\n- [Fetcher](https://auth0.github.io/auth0-spa-js/classes/Fetcher.html) - call your APIs with tokens attached automatically\n\n## Feedback\n\n### Contributing\n\nWe appreciate feedback and contribution to this repo! Before you get started, please see the following:\n\n- [Auth0's general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)\n- [Auth0's code of conduct guidelines](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)\n- [This repo's contribution guide](https://github.com/auth0/auth0-spa-js/blob/main/CONTRIBUTING.md)\n\n### Raise an issue\n\nTo provide feedback or report a bug, please [raise an issue on our issue tracker](https://github.com/auth0/auth0-spa-js/issues).\n\n### Vulnerability Reporting\n\nPlease do not report security vulnerabilities on the public GitHub issue tracker. The [Responsible Disclosure Program](https://auth0.com/whitehat) details the procedure for disclosing security issues.\n\n## What is Auth0?\n\n<p align=\"center\">\n  <picture>\n    <source media=\"(prefers-color-scheme: dark)\" srcset=\"https://cdn.auth0.com/website/sdks/logos/auth0_dark_mode.png\" width=\"150\">\n    <source media=\"(prefers-color-scheme: light)\" srcset=\"https://cdn.auth0.com/website/sdks/logos/auth0_light_mode.png\" width=\"150\">\n    <img alt=\"Auth0 Logo\" src=\"https://cdn.auth0.com/website/sdks/logos/auth0_light_mode.png\" width=\"150\">\n  </picture>\n</p>\n<p align=\"center\">\n  Auth0 is an easy to implement, adaptable authentication and authorization platform. To learn more checkout <a href=\"https://auth0.com/why-auth0\">Why Auth0?</a>\n</p>\n<p align=\"center\">\n  This project is licensed under the MIT license. See the <a href=\"https://github.com/auth0/auth0-spa-js/blob/main/LICENSE\"> LICENSE</a> file for more info.\n</p>"
+		}
+	],
+	"symbolIdMap": {
+		"0": {
+			"sourceFileName": "src/index.ts",
+			"qualifiedName": ""
+		},
+		"1": {
+			"sourceFileName": "src/index.ts",
+			"qualifiedName": "createAuth0Client"
+		},
+		"2": {
+			"sourceFileName": "src/index.ts",
+			"qualifiedName": "createAuth0Client"
+		},
+		"3": {
+			"sourceFileName": "src/index.ts",
+			"qualifiedName": "options"
+		},
+		"4": {
+			"sourceFileName": "src/index.ts",
+			"qualifiedName": "__type"
+		},
+		"5": {
+			"sourceFileName": "src/index.ts",
+			"qualifiedName": "__type.refreshTokenMode"
+		},
+		"6": {
+			"sourceFileName": "src/index.ts",
+			"qualifiedName": "__type.useRefreshTokens"
+		},
+		"7": {
+			"sourceFileName": "src/index.ts",
+			"qualifiedName": "__type.useDpop"
+		},
+		"8": {
+			"sourceFileName": "src/index.ts",
+			"qualifiedName": "createAuth0Client"
+		},
+		"9": {
+			"sourceFileName": "src/index.ts",
+			"qualifiedName": "options"
+		},
+		"10": {
+			"sourceFileName": "src/index.ts",
+			"qualifiedName": "__type"
+		},
+		"11": {
+			"sourceFileName": "src/index.ts",
+			"qualifiedName": "__type.refreshTokenMode"
+		},
+		"12": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client"
+		},
+		"13": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.__constructor"
+		},
+		"14": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client"
+		},
+		"15": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "options"
+		},
+		"36": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.myAccount"
+		},
+		"37": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.mfa"
+		},
+		"38": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.passkey"
+		},
+		"45": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.getConfiguration"
+		},
+		"46": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.getConfiguration"
+		},
+		"92": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.loginWithPopup"
+		},
+		"93": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.loginWithPopup"
+		},
+		"94": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "options"
+		},
+		"95": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "config"
+		},
+		"96": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.getUser"
+		},
+		"97": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.getUser"
+		},
+		"98": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "TUser"
+		},
+		"99": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.getIdTokenClaims"
+		},
+		"100": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.getIdTokenClaims"
+		},
+		"101": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.loginWithRedirect"
+		},
+		"102": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.loginWithRedirect"
+		},
+		"103": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "TAppState"
+		},
+		"104": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "options"
+		},
+		"105": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.handleRedirectCallback"
+		},
+		"106": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.handleRedirectCallback"
+		},
+		"107": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "TAppState"
+		},
+		"108": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "url"
+		},
+		"119": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.checkSession"
+		},
+		"120": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.checkSession"
+		},
+		"121": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "options"
+		},
+		"122": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.getTokenSilently"
+		},
+		"123": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.getTokenSilently"
+		},
+		"124": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "options"
+		},
+		"125": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "__type"
+		},
+		"126": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "__type.detailedResponse"
+		},
+		"127": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.getTokenSilently"
+		},
+		"128": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "options"
+		},
+		"149": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.getTokenWithPopup"
+		},
+		"150": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.getTokenWithPopup"
+		},
+		"151": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "options"
+		},
+		"152": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "config"
+		},
+		"153": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.isAuthenticated"
+		},
+		"154": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.isAuthenticated"
+		},
+		"158": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.revokeRefreshToken"
+		},
+		"159": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.revokeRefreshToken"
+		},
+		"160": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "options"
+		},
+		"161": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.logout"
+		},
+		"162": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.logout"
+		},
+		"163": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "options"
+		},
+		"228": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.loginWithCustomTokenExchange"
+		},
+		"229": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.loginWithCustomTokenExchange"
+		},
+		"230": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "options"
+		},
+		"231": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.customTokenExchange"
+		},
+		"232": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.customTokenExchange"
+		},
+		"233": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "options"
+		},
+		"234": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.exchangeToken"
+		},
+		"235": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.exchangeToken"
+		},
+		"236": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "options"
+		},
+		"240": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.getDpopNonce"
+		},
+		"241": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.getDpopNonce"
+		},
+		"242": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "id"
+		},
+		"243": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.setDpopNonce"
+		},
+		"244": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.setDpopNonce"
+		},
+		"245": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "nonce"
+		},
+		"246": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "id"
+		},
+		"247": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.generateDpopProof"
+		},
+		"248": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.generateDpopProof"
+		},
+		"249": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "params"
+		},
+		"250": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "__type"
+		},
+		"251": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "__type.url"
+		},
+		"252": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "__type.method"
+		},
+		"253": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "__type.nonce"
+		},
+		"254": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "__type.accessToken"
+		},
+		"255": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.createFetcher"
+		},
+		"256": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.createFetcher"
+		},
+		"257": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "TOutput"
+		},
+		"258": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "config"
+		},
+		"259": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.connectAccountWithRedirect"
+		},
+		"260": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "Auth0Client.connectAccountWithRedirect"
+		},
+		"261": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "TAppState"
+		},
+		"262": {
+			"sourceFileName": "src/Auth0Client.ts",
+			"qualifiedName": "options"
+		},
+		"286": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "ConnectError"
+		},
+		"287": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"288": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"289": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__0"
+		},
+		"290": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type"
+		},
+		"291": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type.error"
+		},
+		"292": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"293": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "ConnectError.__constructor"
+		},
+		"294": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "ConnectError"
+		},
+		"295": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "error"
+		},
+		"296": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "error_description"
+		},
+		"297": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "connection"
+		},
+		"298": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "state"
+		},
+		"299": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "appState"
+		},
+		"300": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "ConnectError.connection"
+		},
+		"301": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "ConnectError.state"
+		},
+		"302": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "ConnectError.appState"
+		},
+		"303": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"304": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"305": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError"
+		},
+		"306": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"307": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"308": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__0"
+		},
+		"309": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type"
+		},
+		"310": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type.error"
+		},
+		"311": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"312": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.__constructor"
+		},
+		"313": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError"
+		},
+		"314": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "error"
+		},
+		"315": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "error_description"
+		},
+		"316": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"317": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"318": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "InvalidConfigurationError"
+		},
+		"319": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"320": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"321": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__0"
+		},
+		"322": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type"
+		},
+		"323": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type.error"
+		},
+		"324": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"325": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "InvalidConfigurationError.__constructor"
+		},
+		"326": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "InvalidConfigurationError"
+		},
+		"327": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "message"
+		},
+		"328": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "suggestion"
+		},
+		"329": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "InvalidConfigurationError.suggestion"
+		},
+		"330": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"331": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"332": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "AuthenticationError"
+		},
+		"333": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"334": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"335": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__0"
+		},
+		"336": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type"
+		},
+		"337": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type.error"
+		},
+		"338": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"339": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "AuthenticationError.__constructor"
+		},
+		"340": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "AuthenticationError"
+		},
+		"341": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "error"
+		},
+		"342": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "error_description"
+		},
+		"343": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "state"
+		},
+		"344": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "appState"
+		},
+		"345": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "AuthenticationError.state"
+		},
+		"346": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "AuthenticationError.appState"
+		},
+		"347": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"348": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"349": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "TimeoutError"
+		},
+		"350": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"351": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"352": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__0"
+		},
+		"353": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type"
+		},
+		"354": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type.error"
+		},
+		"355": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"356": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "TimeoutError.__constructor"
+		},
+		"357": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "TimeoutError"
+		},
+		"358": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"359": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"360": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "PopupTimeoutError"
+		},
+		"361": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"362": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"363": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__0"
+		},
+		"364": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type"
+		},
+		"365": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type.error"
+		},
+		"366": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"367": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "PopupTimeoutError.__constructor"
+		},
+		"368": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "PopupTimeoutError"
+		},
+		"369": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "popup"
+		},
+		"370": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "PopupTimeoutError.popup"
+		},
+		"371": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"372": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"373": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "PopupCancelledError"
+		},
+		"374": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"375": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"376": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__0"
+		},
+		"377": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type"
+		},
+		"378": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type.error"
+		},
+		"379": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"380": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "PopupCancelledError.__constructor"
+		},
+		"381": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "PopupCancelledError"
+		},
+		"382": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "popup"
+		},
+		"383": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "PopupCancelledError.popup"
+		},
+		"384": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"385": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"386": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "PopupOpenError"
+		},
+		"387": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"388": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"389": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__0"
+		},
+		"390": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type"
+		},
+		"391": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type.error"
+		},
+		"392": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"393": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "PopupOpenError.__constructor"
+		},
+		"394": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "PopupOpenError"
+		},
+		"395": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"396": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"397": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "MfaRequiredError"
+		},
+		"398": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"399": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"400": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__0"
+		},
+		"401": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type"
+		},
+		"402": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type.error"
+		},
+		"403": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"404": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "MfaRequiredError.__constructor"
+		},
+		"405": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "MfaRequiredError"
+		},
+		"406": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "error"
+		},
+		"407": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "error_description"
+		},
+		"408": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "mfa_token"
+		},
+		"409": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "mfa_requirements"
+		},
+		"410": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "MfaRequiredError.mfa_token"
+		},
+		"411": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "MfaRequiredError.mfa_requirements"
+		},
+		"412": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"413": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"414": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "MissingRefreshTokenError"
+		},
+		"415": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"416": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"417": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__0"
+		},
+		"418": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type"
+		},
+		"419": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type.error"
+		},
+		"420": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"421": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "MissingRefreshTokenError.__constructor"
+		},
+		"422": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "MissingRefreshTokenError"
+		},
+		"423": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "audience"
+		},
+		"424": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "scope"
+		},
+		"425": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "MissingRefreshTokenError.audience"
+		},
+		"426": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "MissingRefreshTokenError.scope"
+		},
+		"427": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"428": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"429": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "MissingScopesError"
+		},
+		"430": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"431": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"432": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__0"
+		},
+		"433": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type"
+		},
+		"434": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type.error"
+		},
+		"435": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"436": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "MissingScopesError.__constructor"
+		},
+		"437": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "MissingScopesError"
+		},
+		"438": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "audience"
+		},
+		"439": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "scope"
+		},
+		"440": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "MissingScopesError.audience"
+		},
+		"441": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "MissingScopesError.scope"
+		},
+		"442": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"443": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"444": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "UseDpopNonceError"
+		},
+		"445": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"446": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.fromPayload"
+		},
+		"447": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__0"
+		},
+		"448": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type"
+		},
+		"449": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type.error"
+		},
+		"450": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"451": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "UseDpopNonceError.__constructor"
+		},
+		"452": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "UseDpopNonceError"
+		},
+		"453": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "newDpopNonce"
+		},
+		"454": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "UseDpopNonceError.newDpopNonce"
+		},
+		"455": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"456": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"457": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "MfaRequirements"
+		},
+		"458": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "MfaRequirements.enroll"
+		},
+		"459": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type"
+		},
+		"460": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type.type"
+		},
+		"461": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "MfaRequirements.challenge"
+		},
+		"462": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type"
+		},
+		"463": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "__type.type"
+		},
+		"464": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "MfaError"
+		},
+		"465": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "MfaError.fromPayload"
+		},
+		"466": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "MfaError.fromPayload"
+		},
+		"467": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "__0"
+		},
+		"468": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "__type"
+		},
+		"469": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "__type.error"
+		},
+		"470": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"471": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "MfaError.__constructor"
+		},
+		"472": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "MfaError"
+		},
+		"473": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "error"
+		},
+		"474": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "error_description"
+		},
+		"475": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"476": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"477": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "MfaListAuthenticatorsError"
+		},
+		"478": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "MfaError.fromPayload"
+		},
+		"479": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "MfaError.fromPayload"
+		},
+		"480": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "__0"
+		},
+		"481": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "__type"
+		},
+		"482": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "__type.error"
+		},
+		"483": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"484": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "MfaListAuthenticatorsError.__constructor"
+		},
+		"485": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "MfaListAuthenticatorsError"
+		},
+		"486": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "error"
+		},
+		"487": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "error_description"
+		},
+		"488": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"489": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"490": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "MfaEnrollmentError"
+		},
+		"491": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "MfaError.fromPayload"
+		},
+		"492": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "MfaError.fromPayload"
+		},
+		"493": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "__0"
+		},
+		"494": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "__type"
+		},
+		"495": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "__type.error"
+		},
+		"496": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"497": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "MfaEnrollmentError.__constructor"
+		},
+		"498": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "MfaEnrollmentError"
+		},
+		"499": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "error"
+		},
+		"500": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "error_description"
+		},
+		"501": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"502": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"503": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "MfaChallengeError"
+		},
+		"504": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "MfaError.fromPayload"
+		},
+		"505": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "MfaError.fromPayload"
+		},
+		"506": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "__0"
+		},
+		"507": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "__type"
+		},
+		"508": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "__type.error"
+		},
+		"509": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"510": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "MfaChallengeError.__constructor"
+		},
+		"511": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "MfaChallengeError"
+		},
+		"512": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "error"
+		},
+		"513": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "error_description"
+		},
+		"514": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"515": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"516": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "MfaVerifyError"
+		},
+		"517": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "MfaError.fromPayload"
+		},
+		"518": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "MfaError.fromPayload"
+		},
+		"519": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "__0"
+		},
+		"520": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "__type"
+		},
+		"521": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "__type.error"
+		},
+		"522": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"523": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "MfaVerifyError.__constructor"
+		},
+		"524": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "MfaVerifyError"
+		},
+		"525": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "error"
+		},
+		"526": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "error_description"
+		},
+		"527": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"528": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"529": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "MfaEnrollmentFactorsError"
+		},
+		"530": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "MfaError.fromPayload"
+		},
+		"531": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "MfaError.fromPayload"
+		},
+		"532": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "__0"
+		},
+		"533": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "__type"
+		},
+		"534": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "__type.error"
+		},
+		"535": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "__type.error_description"
+		},
+		"536": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "MfaEnrollmentFactorsError.__constructor"
+		},
+		"537": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "MfaEnrollmentFactorsError"
+		},
+		"538": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "error"
+		},
+		"539": {
+			"sourceFileName": "src/mfa/errors.ts",
+			"qualifiedName": "error_description"
+		},
+		"540": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error"
+		},
+		"541": {
+			"sourceFileName": "src/errors.ts",
+			"qualifiedName": "GenericError.error_description"
+		},
+		"542": {
+			"sourceFileName": "src/mfa/MfaApiClient.ts",
+			"qualifiedName": "MfaApiClient"
+		},
+		"556": {
+			"sourceFileName": "src/mfa/MfaApiClient.ts",
+			"qualifiedName": "MfaApiClient.getAuthenticators"
+		},
+		"557": {
+			"sourceFileName": "src/mfa/MfaApiClient.ts",
+			"qualifiedName": "MfaApiClient.getAuthenticators"
+		},
+		"558": {
+			"sourceFileName": "src/mfa/MfaApiClient.ts",
+			"qualifiedName": "mfaToken"
+		},
+		"559": {
+			"sourceFileName": "src/mfa/MfaApiClient.ts",
+			"qualifiedName": "MfaApiClient.enroll"
+		},
+		"560": {
+			"sourceFileName": "src/mfa/MfaApiClient.ts",
+			"qualifiedName": "MfaApiClient.enroll"
+		},
+		"561": {
+			"sourceFileName": "src/mfa/MfaApiClient.ts",
+			"qualifiedName": "params"
+		},
+		"562": {
+			"sourceFileName": "src/mfa/MfaApiClient.ts",
+			"qualifiedName": "MfaApiClient.challenge"
+		},
+		"563": {
+			"sourceFileName": "src/mfa/MfaApiClient.ts",
+			"qualifiedName": "MfaApiClient.challenge"
+		},
+		"564": {
+			"sourceFileName": "src/mfa/MfaApiClient.ts",
+			"qualifiedName": "params"
+		},
+		"565": {
+			"sourceFileName": "src/mfa/MfaApiClient.ts",
+			"qualifiedName": "MfaApiClient.getEnrollmentFactors"
+		},
+		"566": {
+			"sourceFileName": "src/mfa/MfaApiClient.ts",
+			"qualifiedName": "MfaApiClient.getEnrollmentFactors"
+		},
+		"567": {
+			"sourceFileName": "src/mfa/MfaApiClient.ts",
+			"qualifiedName": "mfaToken"
+		},
+		"568": {
+			"sourceFileName": "src/mfa/MfaApiClient.ts",
+			"qualifiedName": "MfaApiClient.verify"
+		},
+		"569": {
+			"sourceFileName": "src/mfa/MfaApiClient.ts",
+			"qualifiedName": "MfaApiClient.verify"
+		},
+		"570": {
+			"sourceFileName": "src/mfa/MfaApiClient.ts",
+			"qualifiedName": "params"
+		},
+		"571": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "MfaFactorType"
+		},
+		"572": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "EnrollParams"
+		},
+		"573": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "EnrollOtpParams"
+		},
+		"574": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "EnrollOtpParams.factorType"
+		},
+		"575": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "EnrollBaseParams.mfaToken"
+		},
+		"576": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "EnrollSmsParams"
+		},
+		"577": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "EnrollSmsParams.factorType"
+		},
+		"578": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "EnrollSmsParams.phoneNumber"
+		},
+		"579": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "EnrollBaseParams.mfaToken"
+		},
+		"580": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "EnrollVoiceParams"
+		},
+		"581": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "EnrollVoiceParams.factorType"
+		},
+		"582": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "EnrollVoiceParams.phoneNumber"
+		},
+		"583": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "EnrollBaseParams.mfaToken"
+		},
+		"584": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "EnrollEmailParams"
+		},
+		"585": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "EnrollEmailParams.factorType"
+		},
+		"586": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "EnrollEmailParams.email"
+		},
+		"587": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "EnrollBaseParams.mfaToken"
+		},
+		"588": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "EnrollPushParams"
+		},
+		"589": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "EnrollPushParams.factorType"
+		},
+		"590": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "EnrollBaseParams.mfaToken"
+		},
+		"591": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "VerifyParams"
+		},
+		"592": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "VerifyParams.mfaToken"
+		},
+		"593": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "VerifyParams.otp"
+		},
+		"594": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "VerifyParams.oobCode"
+		},
+		"595": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "VerifyParams.bindingCode"
+		},
+		"596": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "VerifyParams.recoveryCode"
+		},
+		"597": {
+			"sourceFileName": "src/cache/cache-localstorage.ts",
+			"qualifiedName": "LocalStorageCache"
+		},
+		"600": {
+			"sourceFileName": "src/cache/cache-localstorage.ts",
+			"qualifiedName": "LocalStorageCache.set"
+		},
+		"601": {
+			"sourceFileName": "src/cache/cache-localstorage.ts",
+			"qualifiedName": "LocalStorageCache.set"
+		},
+		"602": {
+			"sourceFileName": "src/cache/cache-localstorage.ts",
+			"qualifiedName": "T"
+		},
+		"603": {
+			"sourceFileName": "src/cache/cache-localstorage.ts",
+			"qualifiedName": "key"
+		},
+		"604": {
+			"sourceFileName": "src/cache/cache-localstorage.ts",
+			"qualifiedName": "entry"
+		},
+		"605": {
+			"sourceFileName": "src/cache/cache-localstorage.ts",
+			"qualifiedName": "LocalStorageCache.get"
+		},
+		"606": {
+			"sourceFileName": "src/cache/cache-localstorage.ts",
+			"qualifiedName": "LocalStorageCache.get"
+		},
+		"607": {
+			"sourceFileName": "src/cache/cache-localstorage.ts",
+			"qualifiedName": "T"
+		},
+		"608": {
+			"sourceFileName": "src/cache/cache-localstorage.ts",
+			"qualifiedName": "key"
+		},
+		"609": {
+			"sourceFileName": "src/cache/cache-localstorage.ts",
+			"qualifiedName": "LocalStorageCache.remove"
+		},
+		"610": {
+			"sourceFileName": "src/cache/cache-localstorage.ts",
+			"qualifiedName": "LocalStorageCache.remove"
+		},
+		"611": {
+			"sourceFileName": "src/cache/cache-localstorage.ts",
+			"qualifiedName": "key"
+		},
+		"612": {
+			"sourceFileName": "src/cache/cache-localstorage.ts",
+			"qualifiedName": "LocalStorageCache.allKeys"
+		},
+		"613": {
+			"sourceFileName": "src/cache/cache-localstorage.ts",
+			"qualifiedName": "LocalStorageCache.allKeys"
+		},
+		"614": {
+			"sourceFileName": "src/cache/cache-memory.ts",
+			"qualifiedName": "InMemoryCache"
+		},
+		"617": {
+			"sourceFileName": "src/cache/cache-memory.ts",
+			"qualifiedName": "InMemoryCache.enclosedCache"
+		},
+		"618": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "CacheKey"
+		},
+		"619": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "CacheKey.fromKey"
+		},
+		"620": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "CacheKey.fromKey"
+		},
+		"621": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "key"
+		},
+		"622": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "CacheKey.fromCacheEntry"
+		},
+		"623": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "CacheKey.fromCacheEntry"
+		},
+		"624": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "entry"
+		},
+		"625": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "CacheKey.__constructor"
+		},
+		"626": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "CacheKey"
+		},
+		"627": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "data"
+		},
+		"628": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "prefix"
+		},
+		"629": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "suffix"
+		},
+		"630": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "CacheKey.clientId"
+		},
+		"631": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "CacheKey.scope"
+		},
+		"632": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "CacheKey.audience"
+		},
+		"633": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "CacheKey.prefix"
+		},
+		"634": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "CacheKey.suffix"
+		},
+		"635": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "CacheKey.toKey"
+		},
+		"636": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "CacheKey.toKey"
+		},
+		"637": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "ICache"
+		},
+		"638": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "ICache.set"
+		},
+		"639": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "ICache.set"
+		},
+		"640": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "T"
+		},
+		"641": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "key"
+		},
+		"642": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "entry"
+		},
+		"643": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "ICache.get"
+		},
+		"644": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "ICache.get"
+		},
+		"645": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "T"
+		},
+		"646": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "key"
+		},
+		"647": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "ICache.remove"
+		},
+		"648": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "ICache.remove"
+		},
+		"649": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "key"
+		},
+		"650": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "ICache.allKeys"
+		},
+		"651": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "ICache.allKeys"
+		},
+		"652": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "Cacheable"
+		},
+		"653": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "DecodedToken"
+		},
+		"654": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "DecodedToken.claims"
+		},
+		"655": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "DecodedToken.user"
+		},
+		"656": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "CacheEntry"
+		},
+		"657": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "__type"
+		},
+		"658": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "__type.id_token"
+		},
+		"659": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "__type.token_type"
+		},
+		"660": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "__type.access_token"
+		},
+		"661": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "__type.expires_in"
+		},
+		"662": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "__type.decodedToken"
+		},
+		"663": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "__type.audience"
+		},
+		"664": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "__type.scope"
+		},
+		"665": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "__type.client_id"
+		},
+		"666": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "__type.refresh_token"
+		},
+		"667": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "__type.oauthTokenScope"
+		},
+		"668": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "WrappedCacheEntry"
+		},
+		"669": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "__type"
+		},
+		"670": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "__type.body"
+		},
+		"671": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "__type.expiresAt"
+		},
+		"672": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "KeyManifestEntry"
+		},
+		"673": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "__type"
+		},
+		"674": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "__type.keys"
+		},
+		"675": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "MaybePromise"
+		},
+		"676": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "T"
+		},
+		"677": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "CacheKeyData"
+		},
+		"678": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "__type"
+		},
+		"679": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "__type.audience"
+		},
+		"680": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "__type.scope"
+		},
+		"681": {
+			"sourceFileName": "src/cache/shared.ts",
+			"qualifiedName": "__type.clientId"
+		},
+		"682": {
+			"sourceFileName": "src/fetcher.ts",
+			"qualifiedName": "FetcherConfig"
+		},
+		"683": {
+			"sourceFileName": "src/fetcher.ts",
+			"qualifiedName": "__type"
+		},
+		"684": {
+			"sourceFileName": "src/fetcher.ts",
+			"qualifiedName": "__type.getAccessToken"
+		},
+		"685": {
+			"sourceFileName": "src/fetcher.ts",
+			"qualifiedName": "__type.baseUrl"
+		},
+		"686": {
+			"sourceFileName": "src/fetcher.ts",
+			"qualifiedName": "__type.fetch"
+		},
+		"687": {
+			"sourceFileName": "src/fetcher.ts",
+			"qualifiedName": "__type.dpopNonceId"
+		},
+		"688": {
+			"sourceFileName": "src/fetcher.ts",
+			"qualifiedName": "TOutput"
+		},
+		"689": {
+			"sourceFileName": "src/fetcher.ts",
+			"qualifiedName": "Fetcher"
+		},
+		"690": {
+			"sourceFileName": "src/fetcher.ts",
+			"qualifiedName": "Fetcher.__constructor"
+		},
+		"691": {
+			"sourceFileName": "src/fetcher.ts",
+			"qualifiedName": "Fetcher"
+		},
+		"692": {
+			"sourceFileName": "src/fetcher.ts",
+			"qualifiedName": "Fetcher.TOutput"
+		},
+		"693": {
+			"sourceFileName": "src/fetcher.ts",
+			"qualifiedName": "config"
+		},
+		"694": {
+			"sourceFileName": "src/fetcher.ts",
+			"qualifiedName": "hooks"
+		},
+		"744": {
+			"sourceFileName": "src/fetcher.ts",
+			"qualifiedName": "Fetcher.fetchWithAuth"
+		},
+		"745": {
+			"sourceFileName": "src/fetcher.ts",
+			"qualifiedName": "Fetcher.fetchWithAuth"
+		},
+		"746": {
+			"sourceFileName": "src/fetcher.ts",
+			"qualifiedName": "info"
+		},
+		"747": {
+			"sourceFileName": "src/fetcher.ts",
+			"qualifiedName": "init"
+		},
+		"748": {
+			"sourceFileName": "src/fetcher.ts",
+			"qualifiedName": "authParams"
+		},
+		"749": {
+			"sourceFileName": "src/fetcher.ts",
+			"qualifiedName": "Fetcher.TOutput"
+		},
+		"750": {
+			"sourceFileName": "src/fetcher.ts",
+			"qualifiedName": "CustomFetchMinimalOutput"
+		},
+		"751": {
+			"sourceFileName": "src/fetcher.ts",
+			"qualifiedName": "__type"
+		},
+		"752": {
+			"sourceFileName": "src/fetcher.ts",
+			"qualifiedName": "__type.status"
+		},
+		"753": {
+			"sourceFileName": "src/fetcher.ts",
+			"qualifiedName": "__type.headers"
+		},
+		"754": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "MyAccountApiClient"
+		},
+		"755": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "MyAccountApiClient.__constructor"
+		},
+		"756": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "MyAccountApiClient"
+		},
+		"757": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "myAccountFetcher"
+		},
+		"758": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "apiBase"
+		},
+		"761": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "MyAccountApiClient.connectAccount"
+		},
+		"762": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "MyAccountApiClient.connectAccount"
+		},
+		"763": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "params"
+		},
+		"764": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "MyAccountApiClient.completeAccount"
+		},
+		"765": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "MyAccountApiClient.completeAccount"
+		},
+		"766": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "params"
+		},
+		"767": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "MyAccountApiClient.getFactors"
+		},
+		"768": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "MyAccountApiClient.getFactors"
+		},
+		"769": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "MyAccountApiClient.getAuthenticationMethods"
+		},
+		"770": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "MyAccountApiClient.getAuthenticationMethods"
+		},
+		"771": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "type"
+		},
+		"772": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "MyAccountApiClient.getAuthenticationMethod"
+		},
+		"773": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "MyAccountApiClient.getAuthenticationMethod"
+		},
+		"774": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "id"
+		},
+		"775": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "MyAccountApiClient.deleteAuthenticationMethod"
+		},
+		"776": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "MyAccountApiClient.deleteAuthenticationMethod"
+		},
+		"777": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "id"
+		},
+		"778": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "MyAccountApiClient.updateAuthenticationMethod"
+		},
+		"779": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "MyAccountApiClient.updateAuthenticationMethod"
+		},
+		"780": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "id"
+		},
+		"781": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "data"
+		},
+		"782": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "MyAccountApiClient.enrollmentChallenge"
+		},
+		"783": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "MyAccountApiClient.enrollmentChallenge"
+		},
+		"784": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "options"
+		},
+		"785": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "MyAccountApiClient.enrollmentVerify"
+		},
+		"786": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "MyAccountApiClient.enrollmentVerify"
+		},
+		"787": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "options"
+		},
+		"792": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "MyAccountApiError"
+		},
+		"793": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "MyAccountApiError.__constructor"
+		},
+		"794": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "MyAccountApiError"
+		},
+		"795": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "__0"
+		},
+		"796": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "MyAccountApiError.type"
+		},
+		"797": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "MyAccountApiError.status"
+		},
+		"798": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "MyAccountApiError.title"
+		},
+		"799": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "MyAccountApiError.detail"
+		},
+		"800": {
+			"sourceFileName": "src/myaccount/MyAccountApiClient.ts",
+			"qualifiedName": "MyAccountApiError.validation_errors"
+		},
+		"801": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "__type"
+		},
+		"802": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "__type.detail"
+		},
+		"803": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "__type.field"
+		},
+		"804": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "__type.pointer"
+		},
+		"805": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "__type.source"
+		},
+		"806": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "ConnectRequest"
+		},
+		"807": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "ConnectRequest.connection"
+		},
+		"808": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "ConnectRequest.scopes"
+		},
+		"809": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "ConnectRequest.redirect_uri"
+		},
+		"810": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "ConnectRequest.state"
+		},
+		"811": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "ConnectRequest.code_challenge"
+		},
+		"812": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "ConnectRequest.code_challenge_method"
+		},
+		"813": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "ConnectRequest.authorization_params"
+		},
+		"814": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "ConnectResponse"
+		},
+		"815": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "ConnectResponse.connect_uri"
+		},
+		"816": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "ConnectResponse.auth_session"
+		},
+		"817": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "ConnectResponse.connect_params"
+		},
+		"818": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "__type"
+		},
+		"819": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "__type.ticket"
+		},
+		"820": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "ConnectResponse.expires_in"
+		},
+		"821": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "CompleteRequest"
+		},
+		"822": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "CompleteRequest.auth_session"
+		},
+		"823": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "CompleteRequest.connect_code"
+		},
+		"824": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "CompleteRequest.redirect_uri"
+		},
+		"825": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "CompleteRequest.code_verifier"
+		},
+		"826": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "CompleteResponse"
+		},
+		"827": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "CompleteResponse.id"
+		},
+		"828": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "CompleteResponse.connection"
+		},
+		"829": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "CompleteResponse.access_type"
+		},
+		"830": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "CompleteResponse.scopes"
+		},
+		"831": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "CompleteResponse.created_at"
+		},
+		"832": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "CompleteResponse.expires_at"
+		},
+		"833": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "ErrorResponse"
+		},
+		"834": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "ErrorResponse.type"
+		},
+		"835": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "ErrorResponse.status"
+		},
+		"836": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "ErrorResponse.title"
+		},
+		"837": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "ErrorResponse.detail"
+		},
+		"838": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "ErrorResponse.validation_errors"
+		},
+		"839": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "__type"
+		},
+		"840": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "__type.detail"
+		},
+		"841": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "__type.field"
+		},
+		"842": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "__type.pointer"
+		},
+		"843": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "__type.source"
+		},
+		"844": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "Factor"
+		},
+		"845": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "Factor.type"
+		},
+		"846": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "Factor.usage"
+		},
+		"847": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodType"
+		},
+		"848": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethod"
+		},
+		"849": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasskeyAuthenticationMethod"
+		},
+		"850": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasskeyAuthenticationMethod.type"
+		},
+		"851": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasskeyAuthenticationMethod.key_id"
+		},
+		"852": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasskeyAuthenticationMethod.public_key"
+		},
+		"853": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasskeyAuthenticationMethod.credential_device_type"
+		},
+		"854": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasskeyAuthenticationMethod.credential_backed_up"
+		},
+		"855": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasskeyAuthenticationMethod.identity_user_id"
+		},
+		"856": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasskeyAuthenticationMethod.user_handle"
+		},
+		"857": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasskeyAuthenticationMethod.transports"
+		},
+		"858": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasskeyAuthenticationMethod.user_agent"
+		},
+		"859": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasskeyAuthenticationMethod.aaguid"
+		},
+		"860": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasskeyAuthenticationMethod.relying_party_id"
+		},
+		"861": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasskeyAuthenticationMethod.last_auth_at"
+		},
+		"862": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodBase.id"
+		},
+		"863": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodBase.created_at"
+		},
+		"864": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodBase.usage"
+		},
+		"865": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "WebAuthnPlatformAuthenticationMethod"
+		},
+		"866": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "WebAuthnPlatformAuthenticationMethod.type"
+		},
+		"867": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "WebAuthnAuthenticationMethodBase.key_id"
+		},
+		"868": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "WebAuthnAuthenticationMethodBase.public_key"
+		},
+		"869": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodWithMetadata.confirmed"
+		},
+		"870": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodWithMetadata.name"
+		},
+		"871": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodWithMetadata.last_auth_at"
+		},
+		"872": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodBase.id"
+		},
+		"873": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodBase.created_at"
+		},
+		"874": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodBase.usage"
+		},
+		"875": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "WebAuthnRoamingAuthenticationMethod"
+		},
+		"876": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "WebAuthnRoamingAuthenticationMethod.type"
+		},
+		"877": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "WebAuthnAuthenticationMethodBase.key_id"
+		},
+		"878": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "WebAuthnAuthenticationMethodBase.public_key"
+		},
+		"879": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodWithMetadata.confirmed"
+		},
+		"880": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodWithMetadata.name"
+		},
+		"881": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodWithMetadata.last_auth_at"
+		},
+		"882": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodBase.id"
+		},
+		"883": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodBase.created_at"
+		},
+		"884": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodBase.usage"
+		},
+		"885": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PhoneAuthenticationMethod"
+		},
+		"886": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PhoneAuthenticationMethod.type"
+		},
+		"887": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PhoneAuthenticationMethod.phone_number"
+		},
+		"888": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PhoneAuthenticationMethod.preferred_authentication_method"
+		},
+		"889": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodWithMetadata.confirmed"
+		},
+		"890": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodWithMetadata.name"
+		},
+		"891": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodWithMetadata.last_auth_at"
+		},
+		"892": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodBase.id"
+		},
+		"893": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodBase.created_at"
+		},
+		"894": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodBase.usage"
+		},
+		"895": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EmailAuthenticationMethod"
+		},
+		"896": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EmailAuthenticationMethod.type"
+		},
+		"897": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EmailAuthenticationMethod.email"
+		},
+		"898": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodWithMetadata.confirmed"
+		},
+		"899": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodWithMetadata.name"
+		},
+		"900": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodWithMetadata.last_auth_at"
+		},
+		"901": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodBase.id"
+		},
+		"902": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodBase.created_at"
+		},
+		"903": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodBase.usage"
+		},
+		"904": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasswordAuthenticationMethod"
+		},
+		"905": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasswordAuthenticationMethod.type"
+		},
+		"906": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasswordAuthenticationMethod.identity_user_id"
+		},
+		"907": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasswordAuthenticationMethod.last_password_reset"
+		},
+		"908": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodBase.id"
+		},
+		"909": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodBase.created_at"
+		},
+		"910": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodBase.usage"
+		},
+		"911": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "TotpAuthenticationMethod"
+		},
+		"912": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "TotpAuthenticationMethod.type"
+		},
+		"913": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodWithMetadata.confirmed"
+		},
+		"914": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodWithMetadata.name"
+		},
+		"915": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodWithMetadata.last_auth_at"
+		},
+		"916": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodBase.id"
+		},
+		"917": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodBase.created_at"
+		},
+		"918": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodBase.usage"
+		},
+		"919": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PushNotificationAuthenticationMethod"
+		},
+		"920": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PushNotificationAuthenticationMethod.type"
+		},
+		"921": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodWithMetadata.confirmed"
+		},
+		"922": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodWithMetadata.name"
+		},
+		"923": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodWithMetadata.last_auth_at"
+		},
+		"924": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodBase.id"
+		},
+		"925": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodBase.created_at"
+		},
+		"926": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "AuthenticationMethodBase.usage"
+		},
+		"927": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "RecoveryCodeAuthenticationMethod"
+		},
+		"928": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "RecoveryCodeAuthenticationMethod.type"
+		},
+		"929": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "confirmed"
+		},
+		"930": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "last_auth_at"
+		},
+		"931": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "id"
+		},
+		"932": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "created_at"
+		},
+		"933": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "usage"
+		},
+		"934": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "UpdateAuthenticationMethodRequest"
+		},
+		"935": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "UpdateAuthenticationMethodRequest.name"
+		},
+		"936": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "UpdateAuthenticationMethodRequest.preferred_authentication_method"
+		},
+		"937": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentChallengeOptions"
+		},
+		"938": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasskeyEnrollmentChallengeOptions"
+		},
+		"939": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasskeyEnrollmentChallengeOptions.type"
+		},
+		"940": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasskeyEnrollmentChallengeOptions.connection"
+		},
+		"941": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasskeyEnrollmentChallengeOptions.identity_user_id"
+		},
+		"942": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PhoneEnrollmentChallengeOptions"
+		},
+		"943": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PhoneEnrollmentChallengeOptions.type"
+		},
+		"944": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PhoneEnrollmentChallengeOptions.phone_number"
+		},
+		"945": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PhoneEnrollmentChallengeOptions.preferred_authentication_method"
+		},
+		"946": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EmailEnrollmentChallengeOptions"
+		},
+		"947": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EmailEnrollmentChallengeOptions.type"
+		},
+		"948": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EmailEnrollmentChallengeOptions.email"
+		},
+		"949": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "TotpEnrollmentChallengeOptions"
+		},
+		"950": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "TotpEnrollmentChallengeOptions.type"
+		},
+		"951": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PushNotificationEnrollmentChallengeOptions"
+		},
+		"952": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PushNotificationEnrollmentChallengeOptions.type"
+		},
+		"953": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "RecoveryCodeEnrollmentChallengeOptions"
+		},
+		"954": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "RecoveryCodeEnrollmentChallengeOptions.type"
+		},
+		"955": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasswordEnrollmentChallengeOptions"
+		},
+		"956": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasswordEnrollmentChallengeOptions.type"
+		},
+		"957": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasswordEnrollmentChallengeOptions.connection"
+		},
+		"958": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasswordEnrollmentChallengeOptions.identity_user_id"
+		},
+		"959": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentChallengeResponse"
+		},
+		"960": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasskeyEnrollmentChallengeResponse"
+		},
+		"961": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasskeyEnrollmentChallengeResponse.type"
+		},
+		"962": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasskeyEnrollmentChallengeResponse.authn_params_public_key"
+		},
+		"963": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentChallengeBaseResponse.id"
+		},
+		"964": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentChallengeBaseResponse.location"
+		},
+		"965": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentChallengeBaseResponse.auth_session"
+		},
+		"966": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PhoneEnrollmentChallengeResponse"
+		},
+		"967": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PhoneEnrollmentChallengeResponse.type"
+		},
+		"968": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentChallengeBaseResponse.id"
+		},
+		"969": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentChallengeBaseResponse.location"
+		},
+		"970": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentChallengeBaseResponse.auth_session"
+		},
+		"971": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EmailEnrollmentChallengeResponse"
+		},
+		"972": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EmailEnrollmentChallengeResponse.type"
+		},
+		"973": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentChallengeBaseResponse.id"
+		},
+		"974": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentChallengeBaseResponse.location"
+		},
+		"975": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentChallengeBaseResponse.auth_session"
+		},
+		"976": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "TotpEnrollmentChallengeResponse"
+		},
+		"977": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "TotpEnrollmentChallengeResponse.type"
+		},
+		"978": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "TotpEnrollmentChallengeResponse.barcode_uri"
+		},
+		"979": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "TotpEnrollmentChallengeResponse.manual_input_code"
+		},
+		"980": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentChallengeBaseResponse.id"
+		},
+		"981": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentChallengeBaseResponse.location"
+		},
+		"982": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentChallengeBaseResponse.auth_session"
+		},
+		"983": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PushNotificationEnrollmentChallengeResponse"
+		},
+		"984": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PushNotificationEnrollmentChallengeResponse.type"
+		},
+		"985": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PushNotificationEnrollmentChallengeResponse.barcode_uri"
+		},
+		"986": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PushNotificationEnrollmentChallengeResponse.manual_input_code"
+		},
+		"987": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentChallengeBaseResponse.id"
+		},
+		"988": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentChallengeBaseResponse.location"
+		},
+		"989": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentChallengeBaseResponse.auth_session"
+		},
+		"990": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "RecoveryCodeEnrollmentChallengeResponse"
+		},
+		"991": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "RecoveryCodeEnrollmentChallengeResponse.type"
+		},
+		"992": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "RecoveryCodeEnrollmentChallengeResponse.recovery_code"
+		},
+		"993": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentChallengeBaseResponse.id"
+		},
+		"994": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentChallengeBaseResponse.location"
+		},
+		"995": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentChallengeBaseResponse.auth_session"
+		},
+		"996": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasswordEnrollmentChallengeResponse"
+		},
+		"997": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasswordEnrollmentChallengeResponse.type"
+		},
+		"998": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasswordEnrollmentChallengeResponse.policy"
+		},
+		"999": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentChallengeBaseResponse.id"
+		},
+		"1000": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentChallengeBaseResponse.location"
+		},
+		"1001": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentChallengeBaseResponse.auth_session"
+		},
+		"1002": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasswordPolicy"
+		},
+		"1003": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasswordPolicy.complexity"
+		},
+		"1004": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "__type"
+		},
+		"1005": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "__type.min_length"
+		},
+		"1006": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "__type.character_types"
+		},
+		"1007": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "__type.character_type_rule"
+		},
+		"1008": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "__type.identical_characters"
+		},
+		"1009": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "__type.sequential_characters"
+		},
+		"1010": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "__type.max_length_exceeded"
+		},
+		"1011": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasswordPolicy.profile_data"
+		},
+		"1012": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "__type"
+		},
+		"1013": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "__type.active"
+		},
+		"1014": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "__type.blocked_fields"
+		},
+		"1015": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasswordPolicy.history"
+		},
+		"1016": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "__type"
+		},
+		"1017": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "__type.active"
+		},
+		"1018": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "__type.size"
+		},
+		"1019": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasswordPolicy.dictionary"
+		},
+		"1020": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "__type"
+		},
+		"1021": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "__type.active"
+		},
+		"1022": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "__type.default"
+		},
+		"1023": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentVerifyOptions"
+		},
+		"1024": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasskeyEnrollmentVerifyOptions"
+		},
+		"1025": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasskeyEnrollmentVerifyOptions.type"
+		},
+		"1026": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasskeyEnrollmentVerifyOptions.authn_response"
+		},
+		"1027": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentVerifyBaseOptions.location"
+		},
+		"1028": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentVerifyBaseOptions.auth_session"
+		},
+		"1029": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PhoneEnrollmentVerifyOptions"
+		},
+		"1030": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PhoneEnrollmentVerifyOptions.type"
+		},
+		"1031": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PhoneEnrollmentVerifyOptions.otp_code"
+		},
+		"1032": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentVerifyBaseOptions.location"
+		},
+		"1033": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentVerifyBaseOptions.auth_session"
+		},
+		"1034": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EmailEnrollmentVerifyOptions"
+		},
+		"1035": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EmailEnrollmentVerifyOptions.type"
+		},
+		"1036": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EmailEnrollmentVerifyOptions.otp_code"
+		},
+		"1037": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentVerifyBaseOptions.location"
+		},
+		"1038": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentVerifyBaseOptions.auth_session"
+		},
+		"1039": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "TotpEnrollmentVerifyOptions"
+		},
+		"1040": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "TotpEnrollmentVerifyOptions.type"
+		},
+		"1041": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "TotpEnrollmentVerifyOptions.otp_code"
+		},
+		"1042": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentVerifyBaseOptions.location"
+		},
+		"1043": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentVerifyBaseOptions.auth_session"
+		},
+		"1044": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PushNotificationEnrollmentVerifyOptions"
+		},
+		"1045": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PushNotificationEnrollmentVerifyOptions.type"
+		},
+		"1046": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentVerifyBaseOptions.location"
+		},
+		"1047": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentVerifyBaseOptions.auth_session"
+		},
+		"1048": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "RecoveryCodeEnrollmentVerifyOptions"
+		},
+		"1049": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "RecoveryCodeEnrollmentVerifyOptions.type"
+		},
+		"1050": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentVerifyBaseOptions.location"
+		},
+		"1051": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentVerifyBaseOptions.auth_session"
+		},
+		"1052": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasswordEnrollmentVerifyOptions"
+		},
+		"1053": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasswordEnrollmentVerifyOptions.type"
+		},
+		"1054": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "PasswordEnrollmentVerifyOptions.new_password"
+		},
+		"1055": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentVerifyBaseOptions.location"
+		},
+		"1056": {
+			"sourceFileName": "src/myaccount/types.ts",
+			"qualifiedName": "EnrollmentVerifyBaseOptions.auth_session"
+		},
+		"1057": {
+			"sourceFileName": "src/passkey/PasskeyApiClient.ts",
+			"qualifiedName": "PasskeyApiClient"
+		},
+		"1064": {
+			"sourceFileName": "src/passkey/PasskeyApiClient.ts",
+			"qualifiedName": "PasskeyApiClient.signup"
+		},
+		"1065": {
+			"sourceFileName": "src/passkey/PasskeyApiClient.ts",
+			"qualifiedName": "PasskeyApiClient.signup"
+		},
+		"1066": {
+			"sourceFileName": "src/passkey/PasskeyApiClient.ts",
+			"qualifiedName": "options"
+		},
+		"1067": {
+			"sourceFileName": "src/passkey/PasskeyApiClient.ts",
+			"qualifiedName": "PasskeyApiClient.login"
+		},
+		"1068": {
+			"sourceFileName": "src/passkey/PasskeyApiClient.ts",
+			"qualifiedName": "PasskeyApiClient.login"
+		},
+		"1069": {
+			"sourceFileName": "src/passkey/PasskeyApiClient.ts",
+			"qualifiedName": "options"
+		},
+		"1070": {
+			"sourceFileName": "src/passkey/PasskeyApiClient.ts",
+			"qualifiedName": "PasskeyApiClient.getSignupChallenge"
+		},
+		"1071": {
+			"sourceFileName": "src/passkey/PasskeyApiClient.ts",
+			"qualifiedName": "PasskeyApiClient.getSignupChallenge"
+		},
+		"1072": {
+			"sourceFileName": "src/passkey/PasskeyApiClient.ts",
+			"qualifiedName": "options"
+		},
+		"1073": {
+			"sourceFileName": "src/passkey/PasskeyApiClient.ts",
+			"qualifiedName": "PasskeyApiClient.getLoginChallenge"
+		},
+		"1074": {
+			"sourceFileName": "src/passkey/PasskeyApiClient.ts",
+			"qualifiedName": "PasskeyApiClient.getLoginChallenge"
+		},
+		"1075": {
+			"sourceFileName": "src/passkey/PasskeyApiClient.ts",
+			"qualifiedName": "options"
+		},
+		"1076": {
+			"sourceFileName": "src/passkey/PasskeyApiClient.ts",
+			"qualifiedName": "PasskeyApiClient.getTokenWithPasskey"
+		},
+		"1077": {
+			"sourceFileName": "src/passkey/PasskeyApiClient.ts",
+			"qualifiedName": "PasskeyApiClient.getTokenWithPasskey"
+		},
+		"1078": {
+			"sourceFileName": "src/passkey/PasskeyApiClient.ts",
+			"qualifiedName": "options"
+		},
+		"1079": {
+			"sourceFileName": "src/passkey/errors.ts",
+			"qualifiedName": "PasskeyError"
+		},
+		"1080": {
+			"sourceFileName": "src/passkey/errors.ts",
+			"qualifiedName": "PasskeyError.__constructor"
+		},
+		"1081": {
+			"sourceFileName": "src/passkey/errors.ts",
+			"qualifiedName": "PasskeyError"
+		},
+		"1082": {
+			"sourceFileName": "src/passkey/errors.ts",
+			"qualifiedName": "code"
+		},
+		"1083": {
+			"sourceFileName": "src/passkey/errors.ts",
+			"qualifiedName": "message"
+		},
+		"1084": {
+			"sourceFileName": "src/passkey/errors.ts",
+			"qualifiedName": "cause"
+		},
+		"1085": {
+			"sourceFileName": "src/passkey/errors.ts",
+			"qualifiedName": "PasskeyError.code"
+		},
+		"1086": {
+			"sourceFileName": "src/passkey/errors.ts",
+			"qualifiedName": "PasskeyError.cause"
+		},
+		"1087": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyRegisterError"
+		},
+		"1088": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyRegisterError.__constructor"
+		},
+		"1089": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyRegisterError"
+		},
+		"1090": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "message"
+		},
+		"1091": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "cause"
+		},
+		"1092": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyError.cause"
+		},
+		"1093": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyError.code"
+		},
+		"1094": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyChallengeError"
+		},
+		"1095": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyChallengeError.__constructor"
+		},
+		"1096": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyChallengeError"
+		},
+		"1097": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "message"
+		},
+		"1098": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "cause"
+		},
+		"1099": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyError.cause"
+		},
+		"1100": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyError.code"
+		},
+		"1101": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyGetTokenError"
+		},
+		"1102": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyGetTokenError.__constructor"
+		},
+		"1103": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyGetTokenError"
+		},
+		"1104": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "message"
+		},
+		"1105": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "cause"
+		},
+		"1106": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyGetTokenError.cause"
+		},
+		"1107": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyError.code"
+		},
+		"1108": {
+			"sourceFileName": "src/passkey/errors.ts",
+			"qualifiedName": "PasskeyErrorResponse"
+		},
+		"1109": {
+			"sourceFileName": "src/passkey/errors.ts",
+			"qualifiedName": "PasskeyErrorResponse.error"
+		},
+		"1110": {
+			"sourceFileName": "src/passkey/errors.ts",
+			"qualifiedName": "PasskeyErrorResponse.error_description"
+		},
+		"1111": {
+			"sourceFileName": "src/passkey/errors.ts",
+			"qualifiedName": "PasskeyErrorResponse.message"
+		},
+		"1112": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeySignupChallengeOptions"
+		},
+		"1113": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "__type"
+		},
+		"1114": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "__type.email"
+		},
+		"1115": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "__type.phoneNumber"
+		},
+		"1116": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "__type.username"
+		},
+		"1117": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "__type"
+		},
+		"1118": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "__type.phoneNumber"
+		},
+		"1119": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "__type.email"
+		},
+		"1120": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "__type.username"
+		},
+		"1121": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "__type"
+		},
+		"1122": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "__type.username"
+		},
+		"1123": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "__type.email"
+		},
+		"1124": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "__type.phoneNumber"
+		},
+		"1125": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeySignupChallengeResponse"
+		},
+		"1126": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeySignupChallengeResponse.authSession"
+		},
+		"1127": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeySignupChallengeResponse.authnParamsPublicKey"
+		},
+		"1128": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyLoginChallengeOptions"
+		},
+		"1129": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyLoginChallengeOptions.realm"
+		},
+		"1130": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyLoginChallengeOptions.organization"
+		},
+		"1131": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyLoginChallengeResponse"
+		},
+		"1132": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyLoginChallengeResponse.authSession"
+		},
+		"1133": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyLoginChallengeResponse.authnParamsPublicKey"
+		},
+		"1134": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyCredentialResponse"
+		},
+		"1135": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyCredentialResponse.id"
+		},
+		"1136": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyCredentialResponse.rawId"
+		},
+		"1137": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyCredentialResponse.type"
+		},
+		"1138": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyCredentialResponse.authenticatorAttachment"
+		},
+		"1139": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyCredentialResponse.response"
+		},
+		"1140": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "__type"
+		},
+		"1141": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "__type.clientDataJSON"
+		},
+		"1142": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "__type.attestationObject"
+		},
+		"1143": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "__type.authenticatorData"
+		},
+		"1144": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "__type.signature"
+		},
+		"1145": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "__type.userHandle"
+		},
+		"1146": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyCredentialResponse.clientExtensionResults"
+		},
+		"1147": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyCreationOptions"
+		},
+		"1148": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyCreationOptions.challenge"
+		},
+		"1149": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyCreationOptions.rp"
+		},
+		"1150": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "__type"
+		},
+		"1151": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "__type.id"
+		},
+		"1152": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "__type.name"
+		},
+		"1153": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyCreationOptions.user"
+		},
+		"1154": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "__type"
+		},
+		"1155": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "__type.id"
+		},
+		"1156": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "__type.name"
+		},
+		"1157": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "__type.displayName"
+		},
+		"1158": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyCreationOptions.pubKeyCredParams"
+		},
+		"1159": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "__type"
+		},
+		"1160": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "__type.type"
+		},
+		"1161": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "__type.alg"
+		},
+		"1162": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyCreationOptions.authenticatorSelection"
+		},
+		"1163": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "__type"
+		},
+		"1164": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "__type.residentKey"
+		},
+		"1165": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "__type.userVerification"
+		},
+		"1166": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyCreationOptions.timeout"
+		},
+		"1167": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyRequestOptions"
+		},
+		"1168": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyRequestOptions.challenge"
+		},
+		"1169": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyRequestOptions.rpId"
+		},
+		"1170": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyRequestOptions.timeout"
+		},
+		"1171": {
+			"sourceFileName": "node_modules/@auth0/auth0-auth-js/dist/index.d.ts",
+			"qualifiedName": "PasskeyRequestOptions.userVerification"
+		},
+		"1172": {
+			"sourceFileName": "src/passkey/types.ts",
+			"qualifiedName": "PasskeySignupOptions"
+		},
+		"1173": {
+			"sourceFileName": "src/passkey/types.ts",
+			"qualifiedName": "__type"
+		},
+		"1174": {
+			"sourceFileName": "src/passkey/types.ts",
+			"qualifiedName": "__type.scope"
+		},
+		"1175": {
+			"sourceFileName": "src/passkey/types.ts",
+			"qualifiedName": "__type.audience"
+		},
+		"1176": {
+			"sourceFileName": "src/passkey/types.ts",
+			"qualifiedName": "PasskeyLoginOptions"
+		},
+		"1177": {
+			"sourceFileName": "src/passkey/types.ts",
+			"qualifiedName": "__type"
+		},
+		"1178": {
+			"sourceFileName": "src/passkey/types.ts",
+			"qualifiedName": "__type.scope"
+		},
+		"1179": {
+			"sourceFileName": "src/passkey/types.ts",
+			"qualifiedName": "__type.audience"
+		},
+		"1180": {
+			"sourceFileName": "src/passkey/types.ts",
+			"qualifiedName": "PasskeySignupChallenge"
+		},
+		"1181": {
+			"sourceFileName": "src/passkey/types.ts",
+			"qualifiedName": "__type"
+		},
+		"1182": {
+			"sourceFileName": "src/passkey/types.ts",
+			"qualifiedName": "__type.authSession"
+		},
+		"1183": {
+			"sourceFileName": "src/passkey/types.ts",
+			"qualifiedName": "__type.publicKey"
+		},
+		"1184": {
+			"sourceFileName": "src/passkey/types.ts",
+			"qualifiedName": "PasskeyLoginChallenge"
+		},
+		"1185": {
+			"sourceFileName": "src/passkey/types.ts",
+			"qualifiedName": "__type"
+		},
+		"1186": {
+			"sourceFileName": "src/passkey/types.ts",
+			"qualifiedName": "__type.authSession"
+		},
+		"1187": {
+			"sourceFileName": "src/passkey/types.ts",
+			"qualifiedName": "__type.publicKey"
+		},
+		"1188": {
+			"sourceFileName": "src/passkey/types.ts",
+			"qualifiedName": "PasskeyGetTokenOptions"
+		},
+		"1189": {
+			"sourceFileName": "src/passkey/types.ts",
+			"qualifiedName": "__type"
+		},
+		"1190": {
+			"sourceFileName": "src/passkey/types.ts",
+			"qualifiedName": "__type.authSession"
+		},
+		"1191": {
+			"sourceFileName": "src/passkey/types.ts",
+			"qualifiedName": "__type.credential"
+		},
+		"1192": {
+			"sourceFileName": "src/passkey/types.ts",
+			"qualifiedName": "__type.realm"
+		},
+		"1193": {
+			"sourceFileName": "src/passkey/types.ts",
+			"qualifiedName": "__type.organization"
+		},
+		"1194": {
+			"sourceFileName": "src/passkey/types.ts",
+			"qualifiedName": "__type.scope"
+		},
+		"1195": {
+			"sourceFileName": "src/passkey/types.ts",
+			"qualifiedName": "__type.audience"
+		},
+		"1196": {
+			"sourceFileName": "src/TokenExchange.ts",
+			"qualifiedName": "CustomTokenExchangeOptions"
+		},
+		"1197": {
+			"sourceFileName": "src/TokenExchange.ts",
+			"qualifiedName": "__type"
+		},
+		"1198": {
+			"sourceFileName": "src/TokenExchange.ts",
+			"qualifiedName": "__type.subject_token_type"
+		},
+		"1199": {
+			"sourceFileName": "src/TokenExchange.ts",
+			"qualifiedName": "__type.subject_token"
+		},
+		"1200": {
+			"sourceFileName": "src/TokenExchange.ts",
+			"qualifiedName": "__type.audience"
+		},
+		"1201": {
+			"sourceFileName": "src/TokenExchange.ts",
+			"qualifiedName": "__type.scope"
+		},
+		"1202": {
+			"sourceFileName": "src/TokenExchange.ts",
+			"qualifiedName": "__type.organization"
+		},
+		"1203": {
+			"sourceFileName": "src/TokenExchange.ts",
+			"qualifiedName": "__type.actor_token"
+		},
+		"1204": {
+			"sourceFileName": "src/TokenExchange.ts",
+			"qualifiedName": "__type.actor_token_type"
+		},
+		"1205": {
+			"sourceFileName": "src/TokenExchange.ts",
+			"qualifiedName": "__type.__index"
+		},
+		"1207": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "InteractiveErrorHandler"
+		},
+		"1208": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "RefreshTokenMode"
+		},
+		"1209": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__object"
+		},
+		"1210": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__object.Offline"
+		},
+		"1211": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__object.Online"
+		},
+		"1212": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "RefreshTokenMode"
+		},
+		"1213": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "AuthorizationParams"
+		},
+		"1214": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "AuthorizationParams.display"
+		},
+		"1215": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "AuthorizationParams.prompt"
+		},
+		"1216": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "AuthorizationParams.max_age"
+		},
+		"1217": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "AuthorizationParams.ui_locales"
+		},
+		"1218": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "AuthorizationParams.id_token_hint"
+		},
+		"1219": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "AuthorizationParams.screen_hint"
+		},
+		"1220": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "AuthorizationParams.login_hint"
+		},
+		"1221": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "AuthorizationParams.acr_values"
+		},
+		"1222": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "AuthorizationParams.scope"
+		},
+		"1223": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "AuthorizationParams.audience"
+		},
+		"1224": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "AuthorizationParams.connection"
+		},
+		"1225": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "AuthorizationParams.organization"
+		},
+		"1226": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "AuthorizationParams.invitation"
+		},
+		"1227": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "AuthorizationParams.redirect_uri"
+		},
+		"1228": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "AuthorizationParams.session_transfer_token"
+		},
+		"1229": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "AuthorizationParams.__index"
+		},
+		"1231": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "ClientAuthorizationParams"
+		},
+		"1232": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "ClientAuthorizationParams.scope"
+		},
+		"1233": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "Auth0ClientOptions"
+		},
+		"1234": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "Auth0ClientOptions.domain"
+		},
+		"1235": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "Auth0ClientOptions.issuer"
+		},
+		"1236": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "Auth0ClientOptions.clientId"
+		},
+		"1237": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "Auth0ClientOptions.leeway"
+		},
+		"1238": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "Auth0ClientOptions.cacheLocation"
+		},
+		"1239": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "Auth0ClientOptions.cache"
+		},
+		"1240": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "Auth0ClientOptions.useRefreshTokens"
+		},
+		"1241": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "Auth0ClientOptions.useRefreshTokensFallback"
+		},
+		"1242": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "Auth0ClientOptions.authorizeTimeoutInSeconds"
+		},
+		"1243": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "Auth0ClientOptions.httpTimeoutInSeconds"
+		},
+		"1252": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "Auth0ClientOptions.legacySameSiteCookie"
+		},
+		"1253": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "Auth0ClientOptions.useCookiesForTransactions"
+		},
+		"1254": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "Auth0ClientOptions.sessionCheckExpiryDays"
+		},
+		"1255": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "Auth0ClientOptions.cookieDomain"
+		},
+		"1256": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "Auth0ClientOptions.useFormData"
+		},
+		"1257": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "Auth0ClientOptions.nowProvider"
+		},
+		"1258": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type"
+		},
+		"1259": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type"
+		},
+		"1260": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "Auth0ClientOptions.workerUrl"
+		},
+		"1261": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "Auth0ClientOptions.useMrrt"
+		},
+		"1262": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "Auth0ClientOptions.useDpop"
+		},
+		"1263": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "Auth0ClientOptions.refreshTokenMode"
+		},
+		"1264": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "Auth0ClientOptions.interactiveErrorHandler"
+		},
+		"1265": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "Auth0ClientOptions.authorizationParams"
+		},
+		"1266": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "Auth0ClientOptions.sessionTransferTokenQueryParamName"
+		},
+		"1267": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "ClientConfiguration"
+		},
+		"1268": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "ClientConfiguration.domain"
+		},
+		"1269": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "ClientConfiguration.clientId"
+		},
+		"1270": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "CacheLocation"
+		},
+		"1293": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "RedirectLoginOptions"
+		},
+		"1294": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "RedirectLoginOptions.appState"
+		},
+		"1295": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "RedirectLoginOptions.fragment"
+		},
+		"1296": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "RedirectLoginOptions.onRedirect"
+		},
+		"1297": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type"
+		},
+		"1298": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type"
+		},
+		"1299": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "url"
+		},
+		"1300": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "RedirectLoginOptions.openUrl"
+		},
+		"1301": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type"
+		},
+		"1302": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type"
+		},
+		"1303": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "url"
+		},
+		"1304": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "BaseLoginOptions.authorizationParams"
+		},
+		"1305": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "RedirectLoginOptions.TAppState"
+		},
+		"1306": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "ResponseType"
+		},
+		"1307": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "ResponseType.Code"
+		},
+		"1308": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "ResponseType.ConnectCode"
+		},
+		"1309": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "RedirectLoginResult"
+		},
+		"1310": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "RedirectLoginResult.appState"
+		},
+		"1311": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "RedirectLoginResult.response_type"
+		},
+		"1312": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "RedirectLoginResult.TAppState"
+		},
+		"1313": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "PopupLoginOptions"
+		},
+		"1314": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "BaseLoginOptions.authorizationParams"
+		},
+		"1315": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "PopupConfigOptions"
+		},
+		"1316": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "PopupConfigOptions.timeoutInSeconds"
+		},
+		"1317": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "PopupConfigOptions.popup"
+		},
+		"1318": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "PopupConfigOptions.closePopup"
+		},
+		"1319": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "GetTokenSilentlyOptions"
+		},
+		"1320": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "GetTokenSilentlyOptions.cacheMode"
+		},
+		"1321": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "GetTokenSilentlyOptions.authorizationParams"
+		},
+		"1322": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type"
+		},
+		"1323": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type.redirect_uri"
+		},
+		"1324": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type.scope"
+		},
+		"1325": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type.audience"
+		},
+		"1326": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type.__index"
+		},
+		"1328": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "GetTokenSilentlyOptions.timeoutInSeconds"
+		},
+		"1329": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "GetTokenSilentlyOptions.detailedResponse"
+		},
+		"1330": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "GetTokenWithPopupOptions"
+		},
+		"1331": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "GetTokenWithPopupOptions.cacheMode"
+		},
+		"1332": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "BaseLoginOptions.authorizationParams"
+		},
+		"1333": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "LogoutUrlOptions"
+		},
+		"1334": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "LogoutUrlOptions.clientId"
+		},
+		"1335": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "LogoutUrlOptions.logoutParams"
+		},
+		"1336": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type"
+		},
+		"1337": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type.federated"
+		},
+		"1338": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type.returnTo"
+		},
+		"1339": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type.__index"
+		},
+		"1341": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "LogoutOptions"
+		},
+		"1342": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "LogoutOptions.onRedirect"
+		},
+		"1343": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type"
+		},
+		"1344": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type"
+		},
+		"1345": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "url"
+		},
+		"1346": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "LogoutOptions.openUrl"
+		},
+		"1347": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type"
+		},
+		"1348": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type"
+		},
+		"1349": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "url"
+		},
+		"1350": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "LogoutUrlOptions.clientId"
+		},
+		"1351": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "LogoutUrlOptions.logoutParams"
+		},
+		"1352": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type"
+		},
+		"1353": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type.federated"
+		},
+		"1354": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type.returnTo"
+		},
+		"1355": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type.__index"
+		},
+		"1357": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "RedirectConnectAccountOptions"
+		},
+		"1358": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "RedirectConnectAccountOptions.connection"
+		},
+		"1359": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "RedirectConnectAccountOptions.scopes"
+		},
+		"1360": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "RedirectConnectAccountOptions.authorization_params"
+		},
+		"1361": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "RedirectConnectAccountOptions.redirectUri"
+		},
+		"1362": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "RedirectConnectAccountOptions.appState"
+		},
+		"1363": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "RedirectConnectAccountOptions.openUrl"
+		},
+		"1364": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type"
+		},
+		"1365": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type"
+		},
+		"1366": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "url"
+		},
+		"1367": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "RedirectConnectAccountOptions.TAppState"
+		},
+		"1368": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "ConnectAccountRedirectResult"
+		},
+		"1369": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type"
+		},
+		"1370": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type.appState"
+		},
+		"1371": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type.response_type"
+		},
+		"1372": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "TAppState"
+		},
+		"1389": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "TokenEndpointResponse"
+		},
+		"1390": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type"
+		},
+		"1391": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type.id_token"
+		},
+		"1392": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type.token_type"
+		},
+		"1393": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type.access_token"
+		},
+		"1394": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type.refresh_token"
+		},
+		"1395": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type.expires_in"
+		},
+		"1396": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "__type.scope"
+		},
+		"1428": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "ActClaim"
+		},
+		"1429": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "ActClaim.sub"
+		},
+		"1430": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "ActClaim.__index"
+		},
+		"1432": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken"
+		},
+		"1433": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.__raw"
+		},
+		"1434": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.name"
+		},
+		"1435": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.given_name"
+		},
+		"1436": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.family_name"
+		},
+		"1437": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.middle_name"
+		},
+		"1438": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.nickname"
+		},
+		"1439": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.preferred_username"
+		},
+		"1440": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.profile"
+		},
+		"1441": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.picture"
+		},
+		"1442": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.website"
+		},
+		"1443": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.email"
+		},
+		"1444": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.email_verified"
+		},
+		"1445": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.gender"
+		},
+		"1446": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.birthdate"
+		},
+		"1447": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.zoneinfo"
+		},
+		"1448": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.locale"
+		},
+		"1449": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.phone_number"
+		},
+		"1450": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.phone_number_verified"
+		},
+		"1451": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.address"
+		},
+		"1452": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.updated_at"
+		},
+		"1453": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.iss"
+		},
+		"1454": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.aud"
+		},
+		"1455": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.exp"
+		},
+		"1456": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.nbf"
+		},
+		"1457": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.iat"
+		},
+		"1458": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.jti"
+		},
+		"1459": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.azp"
+		},
+		"1460": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.nonce"
+		},
+		"1461": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.auth_time"
+		},
+		"1462": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.at_hash"
+		},
+		"1463": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.c_hash"
+		},
+		"1464": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.acr"
+		},
+		"1465": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.amr"
+		},
+		"1466": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.sub_jwk"
+		},
+		"1467": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.cnf"
+		},
+		"1468": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.sid"
+		},
+		"1469": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.org_id"
+		},
+		"1470": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.org_name"
+		},
+		"1471": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.session_expiry"
+		},
+		"1472": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.act"
+		},
+		"1473": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "IdToken.__index"
+		},
+		"1475": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "User"
+		},
+		"1478": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "User.name"
+		},
+		"1479": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "User.given_name"
+		},
+		"1480": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "User.family_name"
+		},
+		"1481": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "User.middle_name"
+		},
+		"1482": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "User.nickname"
+		},
+		"1483": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "User.preferred_username"
+		},
+		"1484": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "User.profile"
+		},
+		"1485": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "User.picture"
+		},
+		"1486": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "User.website"
+		},
+		"1487": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "User.email"
+		},
+		"1488": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "User.email_verified"
+		},
+		"1489": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "User.gender"
+		},
+		"1490": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "User.birthdate"
+		},
+		"1491": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "User.zoneinfo"
+		},
+		"1492": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "User.locale"
+		},
+		"1493": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "User.phone_number"
+		},
+		"1494": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "User.phone_number_verified"
+		},
+		"1495": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "User.address"
+		},
+		"1496": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "User.updated_at"
+		},
+		"1497": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "User.sub"
+		},
+		"1498": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "User.act"
+		},
+		"1499": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "User.__index"
+		},
+		"1513": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "GetTokenSilentlyVerboseResponse"
+		},
+		"1514": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "RevokeRefreshTokenOptions"
+		},
+		"1515": {
+			"sourceFileName": "src/global.ts",
+			"qualifiedName": "RevokeRefreshTokenOptions.audience"
+		},
+		"1516": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "Authenticator"
+		},
+		"1517": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "Authenticator.id"
+		},
+		"1518": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "Authenticator.authenticatorType"
+		},
+		"1519": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "Authenticator.active"
+		},
+		"1520": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "Authenticator.name"
+		},
+		"1521": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "Authenticator.createdAt"
+		},
+		"1522": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "Authenticator.lastAuth"
+		},
+		"1523": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "Authenticator.type"
+		},
+		"1524": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "AuthenticatorType"
+		},
+		"1525": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "OobChannel"
+		},
+		"1526": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "EnrollmentResponse"
+		},
+		"1527": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "OtpEnrollmentResponse"
+		},
+		"1528": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "OtpEnrollmentResponse.authenticatorType"
+		},
+		"1529": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "OtpEnrollmentResponse.secret"
+		},
+		"1530": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "OtpEnrollmentResponse.barcodeUri"
+		},
+		"1531": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "OtpEnrollmentResponse.recoveryCodes"
+		},
+		"1532": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "OtpEnrollmentResponse.id"
+		},
+		"1533": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "OobEnrollmentResponse"
+		},
+		"1534": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "OobEnrollmentResponse.authenticatorType"
+		},
+		"1535": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "OobEnrollmentResponse.oobChannel"
+		},
+		"1536": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "OobEnrollmentResponse.oobCode"
+		},
+		"1537": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "OobEnrollmentResponse.bindingMethod"
+		},
+		"1538": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "OobEnrollmentResponse.recoveryCodes"
+		},
+		"1539": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "OobEnrollmentResponse.id"
+		},
+		"1540": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "OobEnrollmentResponse.barcodeUri"
+		},
+		"1541": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "ChallengeAuthenticatorParams"
+		},
+		"1542": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "ChallengeAuthenticatorParams.mfaToken"
+		},
+		"1543": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "ChallengeAuthenticatorParams.challengeType"
+		},
+		"1544": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "ChallengeAuthenticatorParams.authenticatorId"
+		},
+		"1545": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "ChallengeResponse"
+		},
+		"1546": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "ChallengeResponse.challengeType"
+		},
+		"1547": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "ChallengeResponse.oobCode"
+		},
+		"1548": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "ChallengeResponse.bindingMethod"
+		},
+		"1549": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "MfaGrantType"
+		},
+		"1550": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "EnrollmentFactor"
+		},
+		"1551": {
+			"sourceFileName": "src/mfa/types.ts",
+			"qualifiedName": "EnrollmentFactor.type"
+		}
+	}
+}

--- a/main/snippets/SectionsWithCards.jsx
+++ b/main/snippets/SectionsWithCards.jsx
@@ -388,6 +388,7 @@ export const SectionCard = ({ item }) => {
   const sample = getLink(item, "sample app");
   const quickstart = getLink(item, "quickstart");
   const docs = getLink(item, "Get started");
+  const reference = getLink(item, "reference");
 
   const title = item?.name ?? "";
   const subtext = item?.subtext ?? "";
@@ -493,20 +494,33 @@ export const SectionCard = ({ item }) => {
             )}
           </div>
 
-          {tertiary && (
-            <a
-              href={tertiary.url}
-              className="no_external_icon inline-flex flex-1 items-center gap-1.5 text-sm font-medium !text-black dark:!text-white !no-underline !border-0 transition-colors duration-200 hover:!text-neutral-700 dark:hover:!text-neutral-200 h-6"
-              style={{ borderBottom: "none !important" }}
-            >
-              {tertiaryLabel === "Quickstart" ? (
-                <Icon icon="play" className="w-3 h-3 shrink-0" />
-              ) : (
-                <Icon icon="file-lines" className="w-3 h-3 shrink-0" />
-              )}
-              <span className="w-full">{tertiaryLabel}</span>
-            </a>
-          )}
+          <div className="libraries_cards flex items-center w-full gap-5">
+            {tertiary && (
+              <a
+                href={tertiary.url}
+                className="no_external_icon inline-flex flex-1 items-center gap-1.5 text-sm font-medium !text-black dark:!text-white !no-underline !border-0 transition-colors duration-200 hover:!text-neutral-700 dark:hover:!text-neutral-200 h-6"
+                style={{ borderBottom: "none !important" }}
+              >
+                {tertiaryLabel === "Quickstart" ? (
+                  <Icon icon="play" className="w-3 h-3 shrink-0" />
+                ) : (
+                  <Icon icon="file-lines" className="w-3 h-3 shrink-0" />
+                )}
+                <span className="w-full">{tertiaryLabel}</span>
+              </a>
+            )}
+
+            {reference && (
+              <a
+                href={reference.url}
+                className="no_external_icon inline-flex flex-1 items-center gap-1.5 text-sm font-medium !text-black dark:!text-white !no-underline !border-0 transition-colors duration-200 hover:!text-neutral-700 dark:hover:!text-neutral-200 h-6"
+                style={{ borderBottom: "none !important" }}
+              >
+                <Icon icon="book" className="w-3 h-3 shrink-0" />
+                <span className="w-full">Reference</span>
+              </a>
+            )}
+          </div>
         </div>
       </div>
     </article>

--- a/main/snippets/sdks/versions.mdx
+++ b/main/snippets/sdks/versions.mdx
@@ -18,6 +18,10 @@ export const sdkCardInfo =
       {
         "label": "Quickstart",
         "url": "/docs/quickstart/spa/react/interactive"
+      },
+      {
+        "label": "Reference",
+        "url": "/docs/sdk/react/functions/Auth0Provider"
       }
     ]
   },

--- a/main/snippets/sdks/versions.mdx
+++ b/main/snippets/sdks/versions.mdx
@@ -85,6 +85,10 @@ export const sdkCardInfo =
       {
         "label": "Quickstart",
         "url": "/docs/quickstart/spa/vanillajs/interactive"
+      },
+      {
+        "label": "Reference",
+        "url": "/docs/sdk/typescript/functions/createAuth0Client"
       }
     ]
   },

--- a/main/ui/css/styles.css
+++ b/main/ui/css/styles.css
@@ -162,6 +162,12 @@ img.icon.inline {
   a[href="/docs"] {
     display: none;
   }
+
+  /* Hide SDK reference tabs. They exist only to carry the generated reference
+     sidebar; `hidden: true` still surfaces them once the reader is inside one */
+  a[href^="/docs/sdk/"] {
+    display: none;
+  }
 }
 
 .nav-tabs-item {


### PR DESCRIPTION
## Summary

Adds native Mintlify SDK reference docs for **auth0-react** and **auth0-spa-js** in a single PR, superseding **#1688**.

Both SDKs now have TypeDoc-generated reference pages, curated navigation, and a **Reference** link on [/docs/libraries](/docs/libraries) alongside Quickstart.

## Changes made

- Added TypeDoc artifacts for React and JavaScript SDKs.
- Added curated sidebar navigation for both SDKs.
- Added hidden Mintlify SDK tabs to generate pages without showing them in the tab bar.
- Added `/docs/sdk/` CSS rule to keep reference tabs hidden.
- Made the **Reference** link data-driven via `versions.mdx`.
- Verified nav entries, exports, cross-links, and directory prefixes.

## SDK artifact generation references

The TypeDoc artifacts used in this PR are generated from the corresponding SDK repositories:

- **auth0-react:** https://github.com/auth0/auth0-react/pull/1210
- **auth0-spa-js:** https://github.com/auth0/auth0-spa-js/pull/1715

## Testing

- Used `mint dev` to verify the changes locally.
- Verified both SDK reference pages render correctly.
- Verified the **Reference** links on `/docs/libraries`.
- Verified SDK reference tabs remain hidden from the tab bar.

