### PR TITLE
docs: CTE GA - remove EA notices, document profile UI, cross-trigger …

### DIFF
--- a/main/docs/api/authentication/custom-token-exchange/get-token.mdx
+++ b/main/docs/api/authentication/custom-token-exchange/get-token.mdx
@@ -13,7 +13,7 @@ import { ResponseSchema } from '/snippets/ResponseSchema.jsx';
 Custom Token Exchange (CTE) provides a mechanism for applications to exchange pre-existing identity tokens for Auth0 tokens by invoking the `/oauth/token` endpoint, adhering to the specifications of [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693). This functionality is instrumental in addressing advanced integration requirements, such as exchanging existing Auth0 tokens to access another audience on behalf of the same user, facilitating the integration of external identity providers, or enabling seamless user migration into the Auth0 platform. The exchange process is fully governable, as developers can control its details using their custom logic running in a dedicated Auth0 Action for the associated use case.
 
 <Note>
-Custom Token Exchange is currently available in Early Access. By using this feature, you agree to the applicable Free Trial terms in [Okta’s Master Subscription Agreement](https://www.okta.com/legal/). It is your responsibility to securely validate the user's `subject_token`. See the [User Guide](https://auth0.com/docs/authenticate/custom-token-exchange) for more details.
+It is your responsibility to securely validate the user's `subject_token`. See the [User Guide](https://auth0.com/docs/authenticate/custom-token-exchange) for more details.
 </Note>
 
 ### Remarks

--- a/main/docs/authenticate/custom-token-exchange.mdx
+++ b/main/docs/authenticate/custom-token-exchange.mdx
@@ -3,14 +3,11 @@ title: Custom Token Exchange
 description: Exchange existing security tokens for Auth0 access, ID, and refresh tokens using a custom Action and token exchange profile.
 ---
 
-import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
+<Card title="Availability varies by Auth0 plan">
 
-<ReleaseStageNotice
-    feature="Custom Token Exchange (CTE)"
-    stage="ea"
-    plans="B2C Professional, B2B Professional, and Enterprise"
-    terms="true"
-/>
+This feature is available for B2C Professional, B2B Professional, and Enterprise plans.
+
+</Card>
 
 Custom Token Exchange enables applications to exchange their existing tokens for Auth0 tokens when calling the `/oauth/token` endpoint, as defined in [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693). Common use cases for the Custom Token Exchange include:
 

--- a/main/docs/authenticate/custom-token-exchange.mdx
+++ b/main/docs/authenticate/custom-token-exchange.mdx
@@ -52,7 +52,7 @@ Use the tenant logs to help you troubleshoot any issues you encounter with your 
 
 Custom Token Exchange does not support the following:
 
-* MFA API methods `api.authentication.challengeWith()` and `api.authentication.EnrollWith()`
+* `api.authentication.challengeWith()`, `api.authentication.enrollWith()`, `api.redirect.*`, and `api.prompt.*` in Post-Login Actions
 * Custom DB Connections with import mode `ON` are not supported for `setUserByConnection()` operations
 * Third-party and non-OIDC conformant clients
 * The target API must have **Allow Skipping User Consent** enabled since consent cannot be collected in a non-interactive flow.

--- a/main/docs/authenticate/custom-token-exchange.mdx
+++ b/main/docs/authenticate/custom-token-exchange.mdx
@@ -5,7 +5,7 @@ description: Exchange existing security tokens for Auth0 access, ID, and refresh
 
 <Card title="Availability varies by Auth0 plan">
 
-This feature is available for B2C Professional, B2B Professional, and Enterprise plans.
+This feature is available for B2C Professional, B2B Professional, and Enterprise plans. To learn more, read [Pricing](https://auth0.com/pricing).
 
 </Card>
 

--- a/main/docs/authenticate/custom-token-exchange/configure-custom-token-exchange.mdx
+++ b/main/docs/authenticate/custom-token-exchange/configure-custom-token-exchange.mdx
@@ -12,16 +12,12 @@ To configure the Custom Token Exchange for your application, you need to:
 ## Prerequisites
 
 Before configuring the Custom Token Exchange, make sure your application meets the following prerequisites:
-* Is a first-party client
-* Is OIDC-conformant
-
-To configure your application, navigate to **[Applications > Advanced Settings > OAuth](https://auth0.com/docs/get-started/applications/application-settings#oauth)** in the Auth0 Dashboard.
+* Is a [first-party client](/docs/get-started/applications/first-party-and-third-party-applications)
+* Is [OIDC-conformant](/docs/get-started/applications/application-settings#oauth)
 
 ## Enable Custom Token Exchange for your application
 
-To enable the Custom Token Exchange, [create a new application](/docs/get-started/auth0-overview/create-applications) or update an existing one with the Auth0 Dashboard or the Management API. You can create multiple applications to use Custom Token Exchange.
-
-By default, Custom Token Exchange is disabled for an application. To enable it:
+Custom Token Exchange can be enabled across multiple applications. By default Custom Token Exchange is disabled for an application, to enable it:
 
 <Tabs><Tab title="Auth0 Dashboard">
 
@@ -32,7 +28,7 @@ By default, Custom Token Exchange is disabled for an application. To enable it:
 
 </Tab><Tab title="Management API">
 
-Use the Management API to make a `POST` call to [Create a Client](https://auth0.com/docs/api/management/v2/clients/post-clients) or a `PATCH` call to [Update a Client](https://auth0.com/docs/api/management/v2/clients/patch-clients-by-id). Set the `allow_any_profile_of_type` attribute under `token_exchange` to `["custom_authentication"]`:
+Use the Management API to make a `POST` call to [Create a Client](https://auth0.com/docs/api/management/v2/clients/post-clients) or a `PATCH` call to [Update a Client](https://auth0.com/docs/api/management/v2/clients/patch-clients-by-id), setting the `allow_any_profile_of_type` attribute under `token_exchange` to `["custom_authentication"]`:
 
 ```json lines
 {
@@ -44,17 +40,14 @@ Use the Management API to make a `POST` call to [Create a Client](https://auth0.
 
 </Tab></Tabs>
 
-Once Custom Token Exchange is enabled for the application, also make sure to:
-
-1. Enable the connection you want to use with Custom Token Exchange for the application.
-2. Confirm your application is flagged as [First-Party](/docs/get-started/applications/first-party-and-third-party-applications) and it is configured as OIDC Conformant in **[Dashboard > Applications > Advanced Settings > OAuth](/docs/get-started/applications/application-settings#oauth)**.
+Once Custom Token Exchange is enabled for the application, also enable the connection you want to use with Custom Token Exchange for the application.
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 Custom DBs with import mode `ON` are only supported for `setUserById()` operations. 
 </Callout>
 
 
-Once you create the application, note the `client_id` and `client_secret` for later use when calling the `/oauth/token` endpoint.
+Note the application's `client_id` and `client_secret` for later use when calling the `/oauth/token` endpoint.
 
 ## Configure Custom Token Exchange Profile
 

--- a/main/docs/authenticate/custom-token-exchange/configure-custom-token-exchange.mdx
+++ b/main/docs/authenticate/custom-token-exchange/configure-custom-token-exchange.mdx
@@ -82,12 +82,13 @@ To learn from example Custom Token Exchange Actions, read [Example Use Cases and
    * Enter a **Name** for the profile.
    * Enter a unique **Subject Token Type**.
    * Choose how to provide the Action associated with this profile:
-     * **Create a new Action**: enter a **Name** for the new Action. Auth0 creates an empty Action, bound to the Custom Token Exchange trigger, once you create the profile.
-     * **Use an existing Action**: select an existing Action already bound to the Custom Token Exchange trigger.
-     * **Create from a Template**: select an [Action Template](/docs/customize/actions/actions-templates). Auth0 creates a new Action prefilled with the template's code.
+     * **Start from scratch**: enter a **Name** for the new Action. Auth0 creates an empty Action, bound to the Custom Token Exchange trigger, once you create the profile.
+     * **Create from Template**: select an [Action Template](/docs/customize/actions/actions-templates). Auth0 creates a new Action prefilled with the template's code.
+     * **Use existing**: select an existing Action already bound to the Custom Token Exchange trigger.
 3. Select **Create**. Auth0 creates the profile — and the Action, if you chose to create a new one or one from a template — and takes you to the profile's **Details** page.
 4. On the **Details** page:
    * Edit the profile's **Name** or **Subject Token Type** as needed.
+   * Edit the associated Action's **Name** as needed.
    * Use the inline code editor to edit the associated Action's code. Select **Save** to save a draft, or **Deploy** to deploy a new version of the Action.
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
@@ -220,8 +221,12 @@ If you've successfully created a Custom Token Exchange Profile, you should recei
 <Tabs><Tab title="Auth0 Dashboard">
 
 1. Navigate to **Authentication > Custom Token Exchange** to see the list of your Custom Token Exchange Profiles, showing each profile's **Name**, **Subject Token Type**, and **Action ID**.
-2. Select a profile to open its **Details** page, where you can edit its **Name**, **Subject Token Type**, and the associated Action's code (see [Configure Custom Token Exchange Profile](#configure-custom-token-exchange-profile) above).
+2. Select a profile to open its **Details** page, where you can edit its **Name**, **Subject Token Type**, and the associated Action's **Name** and code (see [Configure Custom Token Exchange Profile](#configure-custom-token-exchange-profile) above).
 3. To delete a profile, select the options menu (the three-dot icon) next to it in the list, then select **Delete**.
+
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+An Action bound to a Custom Token Exchange Profile cannot be deleted on its own. Delete the profile first, then delete the Action if you no longer need it.
+</Callout>
 
 </Tab><Tab title="Management API">
 
@@ -292,5 +297,9 @@ curl --location --request DELETE 'https://{yourDomain}/api/v2/token-exchange-pro
 ```
 
 </Tab></Tabs>
+
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+An Action bound to a Custom Token Exchange Profile cannot be deleted on its own. Delete the profile first, then delete the Action if you no longer need it.
+</Callout>
 
 </Tab></Tabs>

--- a/main/docs/authenticate/custom-token-exchange/configure-custom-token-exchange.mdx
+++ b/main/docs/authenticate/custom-token-exchange/configure-custom-token-exchange.mdx
@@ -2,14 +2,6 @@
 description: Learn how to configure the Custom Token Exchange by associating an Action with a Custom Token Profile.
 title: Configure Custom Token Exchange
 ---
-import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
-
-<ReleaseStageNotice
-    feature="Custom Token Exchange (CTE)"
-    stage="ea"
-    plans="B2C Professional, B2B Professional, and Enterprise"
-    terms="true"
-/>
 
 To configure the Custom Token Exchange for your application, you need to:
 
@@ -27,11 +19,20 @@ To configure your application, navigate to **[Applications > Advanced Settings >
 
 ## Enable Custom Token Exchange for your application
 
-To enable the Custom Token Exchange, [create a new application](/docs/get-started/auth0-overview/create-applications) or update an existing one with the Auth0 Dashboard or the Management API. You can create multiple applications to use Custom Token Exchange. 
+To enable the Custom Token Exchange, [create a new application](/docs/get-started/auth0-overview/create-applications) or update an existing one with the Auth0 Dashboard or the Management API. You can create multiple applications to use Custom Token Exchange.
 
-When you create a new application:
+By default, Custom Token Exchange is disabled for an application. To enable it:
 
-1. By default, Custom Token Exchange is disabled. To enable Custom Token Exchange, use the Management API to make a `POST` call to [Create a Client](https://auth0.com/docs/api/management/v2/clients/post-clients) or a `PATCH` call to [Update a Client](https://auth0.com/docs/api/management/v2/clients/patch-clients-by-id). Set the `allow_any_profile_of_type` attribute under `token_exchange` to `["custom_authentication"]`: 
+<Tabs><Tab title="Auth0 Dashboard">
+
+1. Navigate to **Applications > Applications** and select your application.
+2. Select the **Settings** tab.
+3. Find **Custom Token Exchange** and toggle it on.
+4. Select **Save**.
+
+</Tab><Tab title="Management API">
+
+Use the Management API to make a `POST` call to [Create a Client](https://auth0.com/docs/api/management/v2/clients/post-clients) or a `PATCH` call to [Update a Client](https://auth0.com/docs/api/management/v2/clients/patch-clients-by-id). Set the `allow_any_profile_of_type` attribute under `token_exchange` to `["custom_authentication"]`:
 
 ```json lines
 {
@@ -41,8 +42,12 @@ When you create a new application:
 }
 ```
 
-2. Enable the connection you want to use with Custom Token Exchange for the application.
-3. Make sure your application is flagged as [First-Party](/docs/get-started/applications/first-party-and-third-party-applications) and it is configured as OIDC Conformant in **[Dashboard > Applications > Advanced Settings > OAuth](/docs/get-started/applications/application-settings#oauth)**.
+</Tab></Tabs>
+
+Once Custom Token Exchange is enabled for the application, also make sure to:
+
+1. Enable the connection you want to use with Custom Token Exchange for the application.
+2. Confirm your application is flagged as [First-Party](/docs/get-started/applications/first-party-and-third-party-applications) and it is configured as OIDC Conformant in **[Dashboard > Applications > Advanced Settings > OAuth](/docs/get-started/applications/application-settings#oauth)**.
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 Custom DBs with import mode `ON` are only supported for `setUserById()` operations. 
@@ -57,66 +62,106 @@ Each Custom Token Exchange Profile establishes a one-to-one mapping between a `s
 
 Custom Token Exchange requests sent to the `/oauth/token` endpoint with a specific `subject_token_type` value will map to the corresponding Custom Token Profile and route to the associated Action for processing.
 
-To create a Custom Token Exchange Profile, you need to:
-1. [Create an Action for the profile](#create-action-for-the-profile)
-2. [Create the Custom Token Exchange Profile](#create-custom-token-exchange-profile)
-3. [Manage the Custom Token Exchange Profile](#manage-custom-token-exchange-profile)
+Use the Custom Token Exchange Event and API objects to write the Action associated with a profile. The Action should:
 
-### Create Action for the profile
-
-Use the Custom Token Exchange Event and API objects to write an Action that:
-
-* Decodes and validates the `subject_token` based on the `subject_token_type`. This will provide you with information about the user for the transaction.
+* Decode and validate the `subject_token` based on the `subject_token_type`. This will provide you with information about the user for the transaction.
 * Enforce any authorization policy you may need to apply for the transaction.
 
-Once you are sure the transaction can proceed, set the user. Auth0 will then issue access, ID, and refresh tokens for this user as a form of user authentication. 
+Once you are sure the transaction can proceed, set the user. Auth0 will then issue access, ID, and refresh tokens for this user as a form of user authentication.
 
 To learn from example Custom Token Exchange Actions, read [Example Use Cases and Code Samples](/docs/authenticate/custom-token-exchange/cte-example-use-cases).
 
-Once you’ve written your Action, add and and deploy it in the Auth0 Dashboard.
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+`subject_token_type` must be a unique URI starting with `https://` or `urn`. The following namespaces are reserved and you can't use them: `http://auth0.com`, `https://auth0.com`, `http://okta.com`, `https://okta.com`, `urn:ietf`, `urn:auth0`, `urn:okta`.
+</Callout>
 
-1. Navigate to **Actions > Library**.
-2. Select **Create Action > Build from Scratch**.
-3. In the **Create Action** dialog, enter a name and select the **Custom Token Exchange** trigger from the drop-down.
+<Tabs><Tab title="Auth0 Dashboard">
 
-<Frame>![](/docs/images/cdy7uua7fh8z/22vz9dsCFj5Ruot7U0HIVx/1c3dc4b562334dab9d6ac415028ea76e/Screenshot_2025-02-05_at_8.48.34_AM.png)</Frame>
+1. Navigate to **Authentication > Custom Token Exchange** and select **Create Profile**.
+2. In the **Create Profile** dialog:
+   * Enter a **Name** for the profile.
+   * Enter a unique **Subject Token Type**.
+   * Choose how to provide the Action associated with this profile:
+     * **Create a new Action**: enter a **Name** for the new Action. Auth0 creates an empty Action, bound to the Custom Token Exchange trigger, once you create the profile.
+     * **Use an existing Action**: select an existing Action already bound to the Custom Token Exchange trigger.
+     * **Create from a Template**: select an [Action Template](/docs/customize/actions/actions-templates). Auth0 creates a new Action prefilled with the template's code.
+3. Select **Create**. Auth0 creates the profile — and the Action, if you chose to create a new one or one from a template — and takes you to the profile's **Details** page.
+4. On the **Details** page:
+   * Edit the profile's **Name** or **Subject Token Type** as needed.
+   * Use the inline code editor to edit the associated Action's code. Select **Save** to save a draft, or **Deploy** to deploy a new version of the Action.
 
-4. Select **Create**.
-5. **Deploy** the Action.
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+Once a profile is created, you cannot change which Action it's associated with.
+</Callout>
 
-<Frame>![](/docs/images/cdy7uua7fh8z/56NZA69Gmzha167xfgRD0W/302e59276815d2e2644ab2da3b9b5f1f/Screenshot_2025-02-03_at_10.29.17_AM.png)</Frame>
+</Tab><Tab title="Management API">
 
+Creating a Custom Token Exchange Profile via the Management API is a two-step process: first create the Action, then create the profile referencing that Action's ID.
 
-After you deploy the Action, copy the Action ID that Auth0 has assigned to it. You still need to add your custom logic to the Action. First, get the Action ID to create the Custom Token Exchange Profile.
+### Create the Action
 
-6. To get the Action ID in the Auth0 Dashboard, navigate to the URL of the browser window. The Action ID should be the last part of the URL, as shown in the following image: 
+Write your Action's code, then use the Management API to [create](https://auth0.com/docs/api/management/v2/actions/post-action) and [deploy](https://auth0.com/docs/api/management/v2/actions/post-deploy-action) it.
 
-<Frame>![](/docs/images/cdy7uua7fh8z/1Xx4UbgZR0FIuLC1KVvhKG/bde4469d770c2ff8d37c19895a0c8e66/Screenshot_2025-02-03_at_10.31.18_AM.png)</Frame>
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">Using the Auth0 CLI? If you haven't already, [set up and authenticate your CLI session](/docs/deploy-monitor/auth0-cli) before running these commands.</Callout>
 
-
-You can also get the Action ID via the Management API. First, get a Management API token to consume the API. Then, make the following `GET` request to the `/actions` endpoint:
+1. Make the following `POST` request to the `/actions/actions` endpoint to create the Action, bound to the `custom-token-exchange` trigger:
 
 <Tabs><Tab title="Auth0 CLI">
 
-<Callout icon="file-lines" color="#0EA5E9" iconType="regular">Using the Auth0 CLI? If you haven't already, [set up and authenticate your CLI session](/docs/deploy-monitor/auth0-cli) before running this command.</Callout>
-
 ```bash
-auth0 api get "actions/actions" \
-  -q "actionName={yourActionName}"
+auth0 api post "actions/actions" \
+  --data '{
+      "name": "<YOUR_ACTION_NAME>",
+      "supported_triggers": [
+        { "id": "custom-token-exchange", "version": "v1" }
+      ],
+      "code": "exports.onExecuteCustomTokenExchange = async (event, api) => {\n  // your custom logic here\n};"
+  }'
 ```
 
 </Tab><Tab title="cURL">
 
 ```bash lines
-curl --location 'https://{yourDomain}/api/v2/actions/actions?actionName={yourActionName}' \
+curl --location 'https://{yourDomain}/api/v2/actions/actions' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Bearer <YOUR_MANAGEMENT_API_TOKEN>' \
+--data '{
+    "name": "<YOUR_ACTION_NAME>",
+    "supported_triggers": [
+        { "id": "custom-token-exchange", "version": "v1" }
+    ],
+    "code": "exports.onExecuteCustomTokenExchange = async (event, api) => {\n  // your custom logic here\n};"
+}'
+```
+
+</Tab></Tabs>
+
+You should receive the Action ID in the response body's `id` property. You need it both to deploy the Action and to create the Custom Token Exchange Profile.
+
+2. Make the following `POST` request to the `/actions/actions/{id}/deploy` endpoint to deploy the Action:
+
+<Tabs><Tab title="Auth0 CLI">
+
+```bash
+auth0 api post "actions/actions/{yourActionId}/deploy"
+```
+
+</Tab><Tab title="cURL">
+
+```bash lines
+curl --location --request POST 'https://{yourDomain}/api/v2/actions/actions/{yourActionId}/deploy' \
 --header 'Authorization: Bearer <YOUR_MANAGEMENT_API_TOKEN>' \
 ```
 
 </Tab></Tabs>
 
-You should receive the Action ID in the response body within `actions[0].id.` You need the Action ID to create the Custom Token Exchange Profile.
+<Callout icon="file-lines" color="#0EA5E9" iconType="regular">
+An Action must be deployed before it can be bound to a Custom Token Exchange Profile.
+</Callout>
 
-### Create Custom Token Exchange Profile
+To learn from example Custom Token Exchange Actions, read [Example Use Cases and Code Samples](/docs/authenticate/custom-token-exchange/cte-example-use-cases).
+
+### Create the Custom Token Exchange Profile
 
 To create the Custom Token Exchange Profile, use the Management API to make a `POST` request with the following parameters to the `/token-exchange-profiles` endpoint:
 
@@ -150,10 +195,9 @@ curl --location 'https://{yourDomain}/api/v2/token-exchange-profiles' \
 
 | Parameter | Description |
 | --- | --- |
-| `subject_token_type` | Unique profile token type URI starting with `https://` or `urn`<br/><br/>The following namespaces are reserved and you can’t use them:<br/><br/><ul><li>`http://auth0.com`</li><li>`https://auth0.com`</li><li>`http://okta.com`</li><li>`https://okta.com`</li><li>`urn:ietf`</li><li>`urn:auth0`</li><li>`urn:okta`</li></ul> |
+| `subject_token_type` | Unique profile token type URI starting with `https://` or `urn`<br/><br/>The following namespaces are reserved and you can't use them:<br/><br/><ul><li>`http://auth0.com`</li><li>`https://auth0.com`</li><li>`http://okta.com`</li><li>`https://okta.com`</li><li>`urn:ietf`</li><li>`urn:auth0`</li><li>`urn:okta`</li></ul> |
 | `action_id` | Action ID of Action associated with the Custom Token Profile. |
 | `type` | Should be set to `custom_authentication`. |
-
 
 If you've successfully created a Custom Token Exchange Profile, you should receive a response like the following:
 
@@ -169,10 +213,19 @@ If you've successfully created a Custom Token Exchange Profile, you should recei
 }
 ```
 
+</Tab></Tabs>
 
 ### Manage Custom Token Exchange Profile
 
-To manage your Custom Token Exchange Profile, use the Management API to make requests to the `/token-exchange-profiles` endpoint. 
+<Tabs><Tab title="Auth0 Dashboard">
+
+1. Navigate to **Authentication > Custom Token Exchange** to see the list of your Custom Token Exchange Profiles, showing each profile's **Name**, **Subject Token Type**, and **Action ID**.
+2. Select a profile to open its **Details** page, where you can edit its **Name**, **Subject Token Type**, and the associated Action's code (see [Configure Custom Token Exchange Profile](#configure-custom-token-exchange-profile) above).
+3. To delete a profile, select the options menu (the three-dot icon) next to it in the list, then select **Delete**.
+
+</Tab><Tab title="Management API">
+
+To manage your Custom Token Exchange Profile, use the Management API to make requests to the `/token-exchange-profiles` endpoint.
 
 To get all your Custom Token Exchange Profiles, make the following `GET` request to the `/token-exchange-profiles` endpoint. The `/token-exchange-profiles` endpoint supports checkpoint pagination if you have several profiles.
 
@@ -191,12 +244,11 @@ curl --location 'https://{yourDomain}/api/v2/token-exchange-profiles' \
 
 </Tab></Tabs>
 
-To update the name or the `subject_token_type` of an existing profile, make the following `PATCH` request to the `/token-exchange-profiles` endpoint. 
+To update the name or the `subject_token_type` of an existing profile, make the following `PATCH` request to the `/token-exchange-profiles` endpoint.
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
-Once the Action is created, you cannot modify the Action ID. 
+Once the Action is created, you cannot modify the Action ID.
 </Callout>
-
 
 <Tabs><Tab title="Auth0 CLI">
 
@@ -222,7 +274,6 @@ curl --location --request PATCH 'https://{yourDomain}/api/v2/token-exchange-prof
 
 </Tab></Tabs>
 
-
 To delete a Custom Token Exchange Profile, make the following `DELETE` request to the `/token-exchange-profiles` endpoint:
 
 <Tabs><Tab title="Auth0 CLI">
@@ -239,5 +290,7 @@ curl --location --request DELETE 'https://{yourDomain}/api/v2/token-exchange-pro
 --header 'Authorization: Bearer <YOUR_MANAGEMENT_API_TOKEN>' \
 --data ''
 ```
+
+</Tab></Tabs>
 
 </Tab></Tabs>

--- a/main/docs/authenticate/custom-token-exchange/cte-attack-protection.mdx
+++ b/main/docs/authenticate/custom-token-exchange/cte-attack-protection.mdx
@@ -2,15 +2,6 @@
 description: Configure Brute-Force Protection and Suspicious IP Throttling for Custom Token Exchange to block invalid subject tokens before they reach your application.
 title: Attack Protection with Custom Token Exchange
 ---
-import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
-
-<ReleaseStageNotice
-    feature="Custom Token Exchange (CTE)"
-    stage="ea"
-    plans="B2C Professional, B2B Professional, and Enterprise"
-    terms="true"
-/>
-
 To protect against spoofing and replay attacks, which involve unauthorized attempts to compromise or reuse a `subject_token`, Custom Token Exchange supports [Suspicious IP Throttling](/docs/secure/attack-protection/suspicious-ip-throttling). This enables you to indicate in your Actions code when a subject token is invalid, allowing Auth0 to count the number of failed attempts sent from that external IP.
 
 When the number of failed attempts from an IP address reaches a pre-configured threshold, Auth0 blocks traffic for a Custom Token Exchange request coming from that IP with the following error:

--- a/main/docs/authenticate/custom-token-exchange/cte-example-use-cases.mdx
+++ b/main/docs/authenticate/custom-token-exchange/cte-example-use-cases.mdx
@@ -2,15 +2,6 @@
 description: Learn about Custom Token Exchange example use cases with code samples for implementation.
 title: Example Use Cases
 ---
-import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
-
-<ReleaseStageNotice
-    feature="Custom Token Exchange (CTE)"
-    stage="ea"
-    plans="B2C Professional, B2B Professional, and Enterprise"
-    terms="true"
-/>
-
 You can use Custom Token Exchange to solve advanced integration scenarios where normal federated login strategies based on redirecting the end user cannot be applied due to technical or user experience constraints. The code provided for the use cases is incomplete and only aims at showing the logical steps you can follow with your code to address the use case. Refer to [code samples](#code-samples) for more detailed code examples.
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">

--- a/main/docs/authenticate/custom-token-exchange/cte-multi-factor-authentication.mdx
+++ b/main/docs/authenticate/custom-token-exchange/cte-multi-factor-authentication.mdx
@@ -15,7 +15,7 @@ When you add MFA, the Auth0 Authorization Server rejects the initial Custom Toke
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 
-Custom Token Exchange does not support `api.authentication.challengeWith()` or `api.authentication.enrollWith()`. If you use those methods with your Post-Login Action, the transaction will fail with a non-recoverable error. Make sure you don't use those methods when `event.transaction.protocol==oauth2-token-exchange` depending on the `subject_token_type` value.
+Custom Token Exchange does not support `api.authentication.challengeWith()`, `api.authentication.enrollWith()`, `api.redirect.*`, or `api.prompt.*`. If you use those methods with your Post-Login Action, make sure you don't use those methods when `event.transaction.protocol==oauth2-token-exchange` depending on the `subject_token_type` value.
 
 </Callout>
 

--- a/main/docs/authenticate/custom-token-exchange/cte-multi-factor-authentication.mdx
+++ b/main/docs/authenticate/custom-token-exchange/cte-multi-factor-authentication.mdx
@@ -2,15 +2,6 @@
 description: Learn how to use Multi-Factor Authentication (MFA) with Custom Token Exchange.
 title: Multi-Factor Authentication (MFA) with Custom Token Exchange
 ---
-import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
-
-<ReleaseStageNotice
-    feature="Custom Token Exchange (CTE)"
-    stage="ea"
-    plans="B2C Professional, B2B Professional, and Enterprise"
-    terms="true"
-/>
-
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 MFA is not compatible with Custom Token Exchange transactions where an actor is set via `api.authentication.setActor()`. If MFA is required (via policy or Post-Login Action) and the Custom Token Exchange Action sets an actor, the transaction fails with a `400` error: `MFA is not supported using actor_token with the requested token exchange profile.`
 </Callout>

--- a/main/docs/authenticate/single-sign-on/session-delegation.mdx
+++ b/main/docs/authenticate/single-sign-on/session-delegation.mdx
@@ -2,14 +2,11 @@
 title: Session Delegation
 description: Understand how Session Delegation lets an authorized actor establish an audited web session on behalf of another user.
 ---
-import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
+<Card title="Availability varies by Auth0 plan">
 
-<ReleaseStageNotice
-    feature="Session Delegation"
-    stage="ea"
-    plans="B2C Professional, B2B Professional, and Enterprise"
-    terms="true"
-/>
+This feature is available for B2C Professional, B2B Professional, and Enterprise plans.
+
+</Card>
 
 Session Delegation lets an authorized actor, for example a support agent, establish a web session as another user in your application. It builds on [Custom Token Exchange](/docs/authenticate/custom-token-exchange) to issue a Session Transfer Token that identifies both the subject user and the actor, and redeems that token into a session with the same mechanism used by [Native to Web SSO](/docs/authenticate/single-sign-on/native-to-web). The delegation itself is recorded and auditable in tenant logs.
 

--- a/main/docs/authenticate/single-sign-on/session-delegation.mdx
+++ b/main/docs/authenticate/single-sign-on/session-delegation.mdx
@@ -4,7 +4,7 @@ description: Understand how Session Delegation lets an authorized actor establis
 ---
 <Card title="Availability varies by Auth0 plan">
 
-This feature is available for B2C Professional, B2B Professional, and Enterprise plans.
+This feature is available for B2C Professional, B2B Professional, and Enterprise plans. To learn more, read [Pricing](https://auth0.com/pricing).
 
 </Card>
 

--- a/main/docs/authenticate/single-sign-on/session-delegation/configure-session-delegation.mdx
+++ b/main/docs/authenticate/single-sign-on/session-delegation/configure-session-delegation.mdx
@@ -3,14 +3,6 @@ title: Configure Session Delegation
 description: Learn how to configure the client settings required to request and accept delegated sessions.
 ---
 import {AuthCodeBlock} from "/snippets/AuthCodeBlock.jsx";
-import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
-
-<ReleaseStageNotice
-    feature="Session Delegation"
-    stage="ea"
-    plans="B2C Professional, B2B Professional, and Enterprise"
-    terms="true"
-/>
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 This page covers configuration only. Read [Implement Session Delegation](/docs/authenticate/single-sign-on/session-delegation/implement-session-delegation) for the security model and the request/response detail once both applications below are configured.

--- a/main/docs/authenticate/single-sign-on/session-delegation/implement-session-delegation.mdx
+++ b/main/docs/authenticate/single-sign-on/session-delegation/implement-session-delegation.mdx
@@ -2,14 +2,6 @@
 title: Implement Session Delegation
 description: Learn the security model behind Session Delegation and the exact requests, redirects, and token handling needed to implement it end to end.
 ---
-import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
-
-<ReleaseStageNotice
-    feature="Session Delegation"
-    stage="ea"
-    plans="B2C Professional, B2B Professional, and Enterprise"
-    terms="true"
-/>
 
 After [configuring both applications](/docs/authenticate/single-sign-on/session-delegation/configure-session-delegation), implement the session delegation logic that makes the requests, redirects the browser to redeem the Session Transfer Token, and handles the resulting tokens. 
 

--- a/main/docs/authenticate/single-sign-on/session-delegation/session-delegation-behavior-and-monitoring.mdx
+++ b/main/docs/authenticate/single-sign-on/session-delegation/session-delegation-behavior-and-monitoring.mdx
@@ -2,14 +2,6 @@
 title: Delegated Session Behavior and Monitoring
 description: Understand how delegated sessions behave differently from regular sessions, their side effects, Actions support, and how to audit them in tenant logs.
 ---
-import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
-
-<ReleaseStageNotice
-    feature="Session Delegation"
-    stage="ea"
-    plans="B2C Professional, B2B Professional, and Enterprise"
-    terms="true"
-/>
 
 ## Session behavior
 

--- a/main/docs/customize/actions/explore-triggers/custom-token-exchange.mdx
+++ b/main/docs/customize/actions/explore-triggers/custom-token-exchange.mdx
@@ -23,7 +23,7 @@ The Custom Token Exchange uses the token exchange grant type, where the `event.t
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 
-Custom Token Exchange doesn't support `api.authentication.challengeWith()` or `api.authentication.enrollWith()`. If you use those methods with your Post-Login Actions, the transaction will fail with a non-recoverable error. Make sure you skip those two methods when `event.transaction.protocol === 'oauth2-token-exchange'` depending on the `subject_token_type` value.
+Custom Token Exchange doesn't support `api.authentication.challengeWith()`, `api.authentication.enrollWith()`, `api.redirect.*`, or `api.prompt.*`. If you use those methods with your Post-Login Action, make sure you don't use those methods when `event.transaction.protocol === 'oauth2-token-exchange'` depending on the `subject_token_type` value.
 
 </Callout>
 

--- a/main/docs/customize/actions/explore-triggers/custom-token-exchange.mdx
+++ b/main/docs/customize/actions/explore-triggers/custom-token-exchange.mdx
@@ -3,11 +3,11 @@ title: "Custom Token Exchange"
 description: Learn about Custom Token Exchange Actions, which run when the Auth0 Authorization Server receives a Custom Token Exchange request to log a user in.
 ---
 
-<Warning>
+<Card title="Availability varies by Auth0 plan">
 
-Custom Token Exchange (CTE) is currently available in Early Access for all Auth0 B2C Professional, B2B Professional, and Enterprise customers. By using this feature, you agree to the applicable Free Trial terms in [Okta's Master Subscription Agreement](https://www.okta.com/legal/). To learn more about Auth0's product release cycle, read [Product Release Stages](/docs/troubleshoot/product-lifecycle/product-release-stages). To learn more about subscription types, review the Auth0 [pricing](https://auth0.com/pricing) page.
+This feature is available for B2C Professional, B2B Professional, and Enterprise plans.
 
-</Warning>
+</Card>
 
 The `custom-token-exchange` trigger is the first step in the Auth0 pipeline. After the Auth0 Authorization Server validates that the Custom Token Exchange request is valid and maps to an existing [Custom Token Exchange Profile](/docs/authenticate/custom-token-exchange/configure-custom-token-exchange#create-custom-token-exchange-profile), the trigger executes the single Action associated with that profile. If the Action successfully completes and sets a user for the transaction, `post-login` Actions and the rest of the Auth0 pipeline are then executed for that logged-in user.
 
@@ -23,7 +23,7 @@ The Custom Token Exchange uses the token exchange grant type, where the `event.t
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 
-Custom Token Exchange Early Access doesn't support `api.authentication.challengeWith()` or `api.authentication.enrollWith()`. If you use those methods with your Post-Login Actions, the transaction will fail with a non-recoverable error. Make sure you skip those two methods when `event.transaction.protocol === 'oauth2-token-exchange'` depending on the `subject_token_type` value.
+Custom Token Exchange doesn't support `api.authentication.challengeWith()` or `api.authentication.enrollWith()`. If you use those methods with your Post-Login Actions, the transaction will fail with a non-recoverable error. Make sure you skip those two methods when `event.transaction.protocol === 'oauth2-token-exchange'` depending on the `subject_token_type` value.
 
 </Callout>
 
@@ -38,6 +38,10 @@ When the request does include `actor_token` and `actor_token_type`, these values
 The `act` claim set via `setActor()` is also available in Post-Login Actions via [`event.transaction.actor`](/docs/customize/actions/reference/post-login/post-login-event-object#event-transaction).
 
 Auth0 supports issuing a Session Transfer Token with the actor in its context, so a delegated web session can be established for another user. To learn more, read [Session Delegation](/docs/authenticate/single-sign-on/session-delegation).
+
+## Share data with Post-Login Actions
+
+A Custom Token Exchange Action can pass arbitrary data forward to Post-Login Actions in the same transaction using [Actions Transaction Metadata](/docs/customize/actions/transaction-metadata). This is for example useful to set a custom claim in access tokens or ID tokens in Post-Login based on information already obtained or processed from the `subject_token` or `actor_token`.
 
 ## References
 

--- a/main/docs/customize/actions/explore-triggers/custom-token-exchange.mdx
+++ b/main/docs/customize/actions/explore-triggers/custom-token-exchange.mdx
@@ -5,7 +5,7 @@ description: Learn about Custom Token Exchange Actions, which run when the Auth0
 
 <Card title="Availability varies by Auth0 plan">
 
-This feature is available for B2C Professional, B2B Professional, and Enterprise plans.
+This feature is available for B2C Professional, B2B Professional, and Enterprise plans. To learn more, read [Pricing](https://auth0.com/pricing).
 
 </Card>
 

--- a/main/docs/customize/actions/explore-triggers/custom-token-exchange.mdx
+++ b/main/docs/customize/actions/explore-triggers/custom-token-exchange.mdx
@@ -41,7 +41,7 @@ Auth0 supports issuing a Session Transfer Token with the actor in its context, s
 
 ## Share data with Post-Login Actions
 
-A Custom Token Exchange Action can pass arbitrary data forward to Post-Login Actions in the same transaction using [Actions Transaction Metadata](/docs/customize/actions/transaction-metadata). This is for example useful to set a custom claim in access tokens or ID tokens in Post-Login based on information already obtained or processed from the `subject_token` or `actor_token`.
+A Custom Token Exchange Action can pass arbitrary data forward to Post-Login Actions in the same transaction using [Actions Transaction Metadata](/docs/customize/actions/transaction-metadata). This is useful, for example, when setting a custom claim in access tokens or ID tokens in the Post-Login Action based on information already obtained or processed from the `subject_token` or `actor_token`.
 
 ## References
 

--- a/main/docs/customize/actions/transaction-metadata.mdx
+++ b/main/docs/customize/actions/transaction-metadata.mdx
@@ -164,11 +164,11 @@ exports.onExecutePostLogin = async (event, api) => {
 
 ### Share values from Custom Token Exchange to Post-Login
 
-Set a key/value pair from a [Custom Token Exchange](/docs/customize/actions/explore-triggers/custom-token-exchange) Action and read it from a Post-Login Action in the same transaction. This is useful, for example, to set a custom claim in Post-Login based on information your Custom Token Exchange Action already obtained or processed from the `subject_token` or `actor_token`.
+Set a key/value pair from a [Custom Token Exchange](/docs/customize/actions/explore-triggers/custom-token-exchange) Action and read it from a Post-Login Action in the same transaction. This is useful, for example, when setting a custom claim in the Post-Login Action based on information your Custom Token Exchange Action already obtained or processed from the `subject_token` or `actor_token`.
 
 **Custom Token Exchange Action**
 
-Decode a claim from the `subject_token` and set it as transaction metadata with the `api` object's `setMetadata` method.
+Decode a claim from the `subject_token` and set it as transaction metadata with the `api` object's `setMetadata()` method.
 
 ```text lines
 exports.onExecuteCustomTokenExchange = async (event, api) => {

--- a/main/docs/customize/actions/transaction-metadata.mdx
+++ b/main/docs/customize/actions/transaction-metadata.mdx
@@ -2,12 +2,13 @@
 description: Describes how to pass user or application metadata between login and post-login Actions.
 title: Actions Transaction Metadata
 ---
-Actions Transaction Metadata stores, accesses, and/or shares, custom metadata within a [post-login](/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger) Action for the duration of a transaction.
+Actions Transaction Metadata stores, accesses, and/or shares, custom metadata for the duration of a transaction, across [Custom Token Exchange](/docs/customize/actions/explore-triggers/custom-token-exchange) and [post-login](/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger) Actions.
 
 Previously, each Action operated independently, making it difficult to pass information between them. With Actions Transaction Metadata, now it's possible to:
 
 * Share data across Actions, such as API responses or intermediate calculations.
 * Eliminate the need to re-fetch or re-calculate the same information in different Actions.
+* Pass information from a Custom Token Exchange Action forward to Post-Login Actions.
 
 <Callout icon="file-lines" color="#0EA5E9" iconType="regular">
 
@@ -20,6 +21,8 @@ Before using transaction metadata in development, we recommend reviewing the lim
 Use the [post-login API object](/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-api-object) `api.transaction.setMetadata` to set the key/value pair in order to store transaction metadata.
 
 Use the [post-login Event object](/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-event-object) `event.transaction.metadata` to access stored key/value pair in the same Action or subsequent Actions on the post-login trigger for a single execution.
+
+Both the `api` and `event` objects are also available in [Custom Token Exchange Actions](/docs/customize/actions/reference/custom-token-exchange/custom-token-exchange-api-object).
 
 The API and Event objects accept the following parameters:
 
@@ -158,6 +161,35 @@ exports.onExecutePostLogin = async (event, api) => {
 
 
 
+
+### Share values from Custom Token Exchange to Post-Login
+
+Set a key/value pair from a [Custom Token Exchange](/docs/customize/actions/explore-triggers/custom-token-exchange) Action and read it from a Post-Login Action in the same transaction. This is useful, for example, to set a custom claim in Post-Login based on information your Custom Token Exchange Action already obtained or processed from the `subject_token` or `actor_token`.
+
+**Custom Token Exchange Action**
+
+Decode a claim from the `subject_token` and set it as transaction metadata with the `api` object's `setMetadata` method.
+
+```text lines
+exports.onExecuteCustomTokenExchange = async (event, api) => {
+  // subject_token has already been decoded and validated earlier in the Action
+  api.transaction.setMetadata('subject_locale', subjectTokenPayload.locale);
+};
+```
+
+**Post-Login Action**
+
+Read the `subject_locale` value set by the Custom Token Exchange Action with the `event` object's `transaction.metadata` property, and use it to set a custom claim. The claim can be added to the access token, the ID token, or both.
+
+```text lines
+exports.onExecutePostLogin = async (event, api) => {
+  const locale = event.transaction?.metadata?.subject_locale;
+  if (locale) {
+    api.idToken.setCustomClaim('https://example.com/locale', locale);
+    api.accessToken.setCustomClaim('https://example.com/locale', locale);
+  }
+};
+```
 
 ### Update metadata
 


### PR DESCRIPTION
## Description
Changes for GAing the feature
- Remove Early Access notices from Custom Token Exchange and Session Delegation docs; add plan-availability card to the two entry pages (Custom Token Exchange overview, Session Delegation overview, and the Custom Token Exchange Actions trigger reference).
- Document the new Dashboard UI for creating and managing Custom Token Exchange Profiles (bundled Action creation/template/existing selection, Details page, list + delete) in configure-custom-token-exchange.mdx, alongside the Management API path.
- Rewrite the Management API "Create the Action" steps to use the real POST /actions/actions + POST /actions/actions/{id}/deploy calls instead of manual Dashboard steps with screenshots.
- Document that Actions Transaction Metadata (api.transaction.setMetadata / event.transaction.metadata) is now available in Custom Token Exchange Actions, with a cross-trigger example sharing data into Post-Login.