### PR TITLE
doc(new): Add Kotlin Multiplatform SDK quickstart

### DIFF
--- a/main/config/navigation/quickstarts.json
+++ b/main/config/navigation/quickstarts.json
@@ -51,6 +51,7 @@
         "docs/quickstart/native/react-native-expo",
         "docs/quickstart/native/flutter",
         "docs/quickstart/native/flutter-windows",
+        "docs/quickstart/native/kotlin-multiplatform",
         "docs/quickstart/native/net-android-ios/index",
         "docs/quickstart/native/maui",
         "docs/quickstart/native/ionic-angular",

--- a/main/docs/images/icons/dark/kotlin.svg
+++ b/main/docs/images/icons/dark/kotlin.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60" width="60" height="60" role="img" aria-label="Kotlin">
+  <path fill="#EEEEEE" d="M60 60H0V0h60L30 30z"/>
+</svg>

--- a/main/docs/images/icons/light/kotlin.svg
+++ b/main/docs/images/icons/light/kotlin.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60" width="60" height="60" role="img" aria-label="Kotlin">
+  <path fill="#1F1F1F" d="M60 60H0V0h60L30 30z"/>
+</svg>

--- a/main/docs/libraries.mdx
+++ b/main/docs/libraries.mdx
@@ -67,6 +67,7 @@ Mobile or Desktop app that runs natively on a device
   <SectionCard item={sdkCardInfo["Flutter"]} />
   <SectionCard item={sdkCardInfo["iOS / macOS"]} />
   <SectionCard item={sdkCardInfo["Android"]} />
+  <SectionCard item={sdkCardInfo["Kotlin Multiplatform"]} />
   <SectionCard item={sdkCardInfo["Expo"]} />
   <SectionCard item={sdkCardInfo[".NET (OIDC Client)"]} />
   <SectionCard item={sdkCardInfo["MAUI"]} />

--- a/main/docs/quickstart/native/kotlin-multiplatform.mdx
+++ b/main/docs/quickstart/native/kotlin-multiplatform.mdx
@@ -1,0 +1,392 @@
+---
+title: Add Login to Your Kotlin Multiplatform Application using the Auth0 Kotlin Multiplatform SDK
+description: Add authentication to a Kotlin Multiplatform (Android + iOS) app using the Auth0 Kotlin Multiplatform SDK.
+sidebarTitle: Kotlin Multiplatform
+mode: wide
+---
+
+import {HowToSchema} from "/snippets/HowToSchema.jsx";
+
+<HowToSchema />
+
+<Accordion title="Use AI to integrate Auth0" icon="microchip-ai" iconType="solid" defaultOpen>
+If you use an AI coding assistant like Claude Code, Cursor, or GitHub Copilot, you can add Auth0 authentication automatically in minutes using [agent skills](https://agentskills.io/home).
+
+**Install:**
+
+```bash
+npx skills add auth0/agent-skills --skill auth0
+```
+
+**Then ask your AI assistant:**
+
+```text
+Add Auth0 authentication to my Kotlin Multiplatform app.
+```
+
+Your AI assistant will automatically create your Auth0 application, fetch credentials, add the Auth0 Kotlin Multiplatform SDK dependency, configure the Android manifest placeholders and iOS URL scheme, and implement login/logout flows. [Full agent skills documentation →](/docs/quickstart/agent-skills)
+</Accordion>
+
+<Note>
+  This quickstart targets **Kotlin Multiplatform 2.0+** with **Android SDK 24+** (Android 7.0), and **iOS 14+**. The Auth0 Kotlin Multiplatform SDK is currently **1.0.0-beta.0** — pin the version explicitly, as the API may change before the stable release. You need [Android Studio](https://developer.android.com/studio) (Ladybug or newer) and, for the iOS target, [Xcode 15+](https://developer.apple.com/xcode/) on macOS.
+</Note>
+
+## Get Started
+
+By the end of this quickstart, your Kotlin Multiplatform app will let users log in and out through Auth0 [Universal Login](/docs/authenticate/login/auth0-universal-login), securely persist their tokens, and display their profile — all from shared Kotlin code running on both Android and iOS.
+
+<Steps>
+  <Step title="Create a new Kotlin Multiplatform project" stepNumber={1}>
+    If you already have a Kotlin Multiplatform project, skip to the next step.
+
+    Create a new Kotlin Multiplatform project with a shared Compose UI using the [JetBrains Kotlin Multiplatform wizard](https://kmp.jetbrains.com/) (select **Android** and **iOS**, and share the UI with **Compose Multiplatform**), or the **Kotlin Multiplatform** plugin in Android Studio.
+
+    This produces the standard layout referenced throughout this guide:
+
+    ```text
+    your-app/
+    ├── composeApp/
+    │   ├── build.gradle.kts
+    │   └── src/
+    │       ├── commonMain/kotlin/    ← shared code (Auth0 client, view model, UI)
+    │       ├── androidMain/          ← Android entry point + AndroidManifest.xml
+    │       └── iosMain/kotlin/       ← iOS entry point
+    ├── iosApp/                       ← Xcode project (Info.plist lives here)
+    └── settings.gradle.kts
+    ```
+
+    <Info>
+      This guide uses `com.example.app` as the application ID / bundle identifier. Replace it with your own everywhere it appears — it becomes part of your Auth0 callback URLs.
+    </Info>
+  </Step>
+
+  <Step title="Add the Auth0 SDK via Gradle" stepNumber={2}>
+    Add the Auth0 Kotlin Multiplatform SDK to the `commonMain` source set of your shared module. The library is published to Maven Central, so no extra repository configuration is required.
+
+    **Update `composeApp/build.gradle.kts`:**
+
+    ```kotlin composeApp/build.gradle.kts
+    kotlin {
+        sourceSets {
+            commonMain.dependencies {
+                // Umbrella module — aggregates web auth, authentication, and credentials
+                implementation("com.auth0.kmp:auth0:1.0.0-beta.0")
+            }
+        }
+    }
+    ```
+
+    <Tip>
+      The umbrella `auth0` artifact pulls in everything you need. For a smaller footprint you can depend on the individual modules instead (`auth0-core`, `auth0-webauth`, `auth0-authentication`, `auth0-credentials`).
+    </Tip>
+  </Step>
+
+  <Step title="Setup your Auth0 App" stepNumber={3}>
+    Create a **Native** application in Auth0 and register the platform callback and logout URLs for both Android and iOS.
+
+    1. Head to the [Auth0 Dashboard](https://manage.auth0.com/dashboard/)
+    2. Click on **Applications** > **Applications** > **Create Application**
+    3. In the popup, enter a name for your app, select `Native` as the app type, and click **Create**
+    4. Switch to the **Settings** tab on the Application Details page and copy the **Domain** and **Client ID** — you'll add them to your code in a later step
+
+    Still on the **Settings** tab, configure the following URLs. The callback format is scheme-specific per platform, so register one entry for Android and one for iOS:
+
+    **Allowed Callback URLs:**
+    ```
+    com.example.app://{yourDomain}/android/com.example.app/callback, com.example.app://{yourDomain}/ios/com.example.app/callback
+    ```
+
+    **Allowed Logout URLs:**
+    ```
+    com.example.app://{yourDomain}/android/com.example.app/callback, com.example.app://{yourDomain}/ios/com.example.app/callback
+    ```
+
+    Replace `{yourDomain}` with your actual Auth0 domain (e.g., `dev-abc123.us.auth0.com`) and `com.example.app` with your application ID / bundle identifier.
+
+    <Info>
+      **Allowed Callback URLs** ensure users are safely returned to your application after authentication. Without a matching URL, the login process will fail. **Allowed Logout URLs** ensure users are redirected back to your app after signing out.
+
+      The callback format embeds your package/bundle identifier: `SCHEME://YOUR_DOMAIN/android/APPLICATION_ID/callback` for Android and `SCHEME://YOUR_DOMAIN/ios/BUNDLE_ID/callback` for iOS. By default the scheme equals your application ID / bundle identifier.
+    </Info>
+
+    <Note>
+      **Important**: Ensure the package/bundle name in your callback URLs matches your `applicationId` (Android) and bundle identifier (iOS) exactly. If authentication fails, verify these values are identical.
+    </Note>
+  </Step>
+
+  <Step title="Register the callback scheme on each platform" stepNumber={4}>
+    The SDK ships a `RedirectActivity` (Android, merged automatically) and uses `ASWebAuthenticationSession` (iOS) to catch the callback. You only need to declare the URL scheme on each platform.
+
+    **Android** — add the manifest placeholders to your Android build file. The SDK's `RedirectActivity` reads these values:
+
+    ```kotlin composeApp/build.gradle.kts
+    android {
+        defaultConfig {
+            
+            manifestPlaceholders["auth0Scheme"] = "{yourScheme}" // default: your application ID
+            manifestPlaceholders["auth0Domain"] = "{yourDomain}"
+        }
+    }
+    ```
+
+    Also ensure your `AndroidManifest.xml` requests the Internet permission:
+
+    ```xml composeApp/src/androidMain/AndroidManifest.xml
+    <?xml version="1.0" encoding="utf-8"?>
+    <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+        <uses-permission android:name="android.permission.INTERNET" />
+    </manifest>
+    ```
+
+    **iOS** — register the URL scheme in `iosApp/iosApp/Info.plist` (or via Xcode → target → **Info** → **URL Types**):
+
+    ```xml iosApp/iosApp/Info.plist
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeRole</key>
+            <string>Editor</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <!-- Must match your bundle identifier -->
+                <string>com.example.app</string>
+            </array>
+        </dict>
+    </array>
+    ```
+  </Step>
+
+  <Step title="Initialize the Auth0 SDK" stepNumber={5}>
+    In your shared `commonMain` source set, create the `Auth0` client once and reuse it. It holds the transport shared by web auth, the authentication API, and the credentials manager.
+
+    **Create `composeApp/src/commonMain/kotlin/Auth0Config.kt`:**
+
+    ```kotlin composeApp/src/commonMain/kotlin/Auth0Config.kt
+    import com.auth0.kmp.Auth0
+    import com.auth0.kmp.core.Auth0Account
+
+    // Shared code — one account works for Android and iOS
+    val account = Auth0Account(
+        clientId = "YOUR_AUTH0_CLIENT_ID", // From Application Settings → Client ID
+        domain = "{yourDomain}",           // From Application Settings → Domain
+    )
+
+    val auth0 = Auth0(account)
+    ```
+
+    <Info>
+      For production, avoid hardcoding credentials in source. The [sample app](https://github.com/auth0/auth0-kmp/tree/main/sample-app) reads `auth0.domain` and `auth0.clientId` from `local.properties` and exposes them via generated config. The **Domain** and **Client ID** both come from **Application Settings** in the Auth0 Dashboard. The domain must **not** include the `https://` scheme.
+    </Info>
+  </Step>
+
+  <Step title="Implement Login and Logout" stepNumber={6}>
+    Every Auth0 Kotlin Multiplatform method is a coroutine `suspend` function that returns a `Result<Success, Error>` — no exceptions are thrown for domain errors. Wrap the calls in a `ViewModel` so your Compose UI can observe the state.
+
+    **Create `composeApp/src/commonMain/kotlin/AuthViewModel.kt`:**
+
+    ```kotlin composeApp/src/commonMain/kotlin/AuthViewModel.kt
+    import androidx.lifecycle.ViewModel
+    import androidx.lifecycle.viewModelScope
+    import com.auth0.kmp.core.result.Result
+    import kotlinx.coroutines.flow.MutableStateFlow
+    import kotlinx.coroutines.flow.StateFlow
+    import kotlinx.coroutines.flow.asStateFlow
+    import kotlinx.coroutines.launch
+
+    sealed interface AuthState {
+        data object LoggedOut : AuthState
+        data object Loading : AuthState
+        data class LoggedIn(val accessToken: String) : AuthState
+        data class Error(val message: String) : AuthState
+    }
+
+    class AuthViewModel(val auth0: Auth0) : ViewModel() {
+        
+        // Persists and auto-renews tokens (Keystore/DataStore on Android, Keychain on iOS)
+        private val credentialsManager = auth0.credentials()
+
+        private val _state = MutableStateFlow<AuthState>(AuthState.LoggedOut)
+        val state: StateFlow<AuthState> = _state.asStateFlow()
+
+        fun login() {
+            viewModelScope.launch {
+                _state.value = AuthState.Loading
+                // Opens Universal Login in the system browser
+                when (val result = auth0.webAuth.login()) {
+                    is Result.Success -> {
+                        credentialsManager.saveCredentials(result.data)
+                        _state.value = AuthState.LoggedIn(result.data.accessToken)
+                    }
+                    is Result.Failure -> {
+                        _state.value = AuthState.Error(result.error.toString())
+                    }
+                }
+            }
+        }
+
+        fun logout() {
+            viewModelScope.launch {
+                // Clears the browser session, then the locally stored credentials
+                when (val result = auth0.webAuth.logout()) {
+                    is Result.Success -> {
+                        credentialsManager.clearCredentials()
+                        _state.value = AuthState.LoggedOut
+                    }
+                    is Result.Failure -> {
+                        _state.value = AuthState.Error(result.error.toString())
+                    }
+                }
+            }
+        }
+    }
+    ```
+
+    Wire the view model into a Compose screen shared across both platforms:
+
+    ```kotlin composeApp/src/commonMain/kotlin/App.kt
+    import androidx.compose.material3.Button
+    import androidx.compose.material3.CircularProgressIndicator
+    import androidx.compose.material3.MaterialTheme
+    import androidx.compose.material3.Text
+    import androidx.compose.runtime.Composable
+    import androidx.compose.runtime.getValue
+    import androidx.lifecycle.compose.collectAsStateWithLifecycle
+    import androidx.lifecycle.viewmodel.compose.viewModel
+
+    @Composable
+    fun App(viewModel: AuthViewModel = viewModel { AuthViewModel() }) {
+        MaterialTheme {
+            val state by viewModel.state.collectAsStateWithLifecycle()
+            when (val current = state) {
+                is AuthState.Loading -> CircularProgressIndicator()
+                is AuthState.LoggedIn -> Button(onClick = viewModel::logout) { Text("Log Out") }
+                is AuthState.Error -> Text("Something went wrong: ${current.message}")
+                AuthState.LoggedOut -> Button(onClick = viewModel::login) { Text("Log In") }
+            }
+        }
+    }
+    ```
+  </Step>
+
+  <Step title="Show the user profile" stepNumber={7}>
+    After login, call the Authentication API's `userInfo` with the access token to retrieve the authenticated user's profile.
+
+    ```kotlin composeApp/src/commonMain/kotlin/AuthViewModel.kt
+    import com.auth0.kmp.authentication.UserInfo
+
+    suspend fun fetchProfile(accessToken: String): UserInfo? {
+        return when (val result = auth0.authentication.userInfo(accessToken)) {
+            is Result.Success -> result.data // .name, .email, .picture, .customClaims, ...
+            is Result.Failure -> null
+        }
+    }
+    ```
+
+    <Info>
+      On app launch you can skip the login screen if valid credentials already exist: `credentialsManager.hasValidCredentials()` returns `true` when a stored, non-expired session is available. Use `credentialsManager.getCredentials()` to retrieve a valid access token, automatically renewing it with the refresh token when needed.
+    </Info>
+  </Step>
+
+  <Step title="Run your app" stepNumber={8}>
+    Build and launch on each target:
+
+    <CodeGroup>
+    ```shellscript Android
+    ./gradlew :composeApp:installDebug
+    ```
+    ```shellscript iOS
+    # Open the Xcode project and run on a simulator or device
+    open iosApp/iosApp.xcodeproj
+    ```
+    </CodeGroup>
+
+    **Expected flow:**
+
+    1. App launches with a "Log In" button
+    2. Tap "Log In" → the system browser opens the Auth0 Universal Login page → complete login
+    3. Control returns to the app automatically and the button switches to "Log Out"
+    4. Success!
+  </Step>
+</Steps>
+
+<Check>
+  **Checkpoint**
+
+  You now have a Compose Multiplatform app with Auth0 login, logout, secure token storage, and user profile retrieval — sharing all authentication logic between Android and iOS.
+</Check>
+
+***
+
+## Troubleshooting & Advanced
+
+<Accordion title="Callback URL mismatch error">
+  **Cause:** The callback URL the SDK generated isn't listed in your Auth0 application, or the scheme/package don't match.
+
+  **Fix:** Confirm **Allowed Callback URLs** in **Application Settings** exactly matches the platform format — `SCHEME://YOUR_DOMAIN/android/APPLICATION_ID/callback` for Android and `SCHEME://YOUR_DOMAIN/ios/BUNDLE_ID/callback` for iOS. The `SCHEME` (default: your application ID) and package/bundle must be identical to your project's values. URLs are case-sensitive and the scheme must be lowercase.
+</Accordion>
+
+<Accordion title="The browser opens but never returns to the app">
+  **Cause:** The callback scheme isn't declared on the platform, so the OS can't route the redirect back to your app.
+
+  **Fix:** On Android, verify `manifestPlaceholders["auth0Scheme"]` and `["auth0Domain"]` are set in `composeApp/build.gradle.kts` and run a clean build. On iOS, verify the `CFBundleURLSchemes` entry in `Info.plist` matches your bundle identifier.
+</Accordion>
+
+<Accordion title="Login returns Result.Failure with a network or timeout error">
+  **Cause:** The device can't reach your Auth0 tenant, or a request timed out.
+
+  **Fix:** Confirm `domain` in `Auth0Account` is your tenant domain **without** the `https://` scheme (e.g., `your-tenant.us.auth0.com`). On a physical device, ensure it has network access. You can raise the timeouts via the `NetworkingConfiguration` passed to `Auth0Account`.
+</Accordion>
+
+<Accordion title="getCredentials fails after login">
+  **Cause:** No refresh token was issued, so expired credentials can't be renewed.
+
+  **Fix:** Universal Login requests the `offline_access` scope by default (which returns a refresh token). If you override `scope` in `LoginOptions`, include `offline_access`, and enable **Refresh Token Rotation** for the application in the Auth0 Dashboard.
+</Accordion>
+
+<Accordion title="Android build fails to merge the RedirectActivity">
+  **Cause:** The `auth0Domain` / `auth0Scheme` manifest placeholders are missing, so the SDK's merged `RedirectActivity` has no value to bind to.
+
+  **Fix:** Ensure both placeholders are defined in the `defaultConfig` block of `composeApp/build.gradle.kts`. If you use multiple build flavors, define them in each flavor.
+</Accordion>
+
+<Accordion title="Restore a session on startup">
+  Check for stored credentials before showing the login screen so returning users skip Universal Login:
+
+  ```kotlin
+  if (credentialsManager.hasValidCredentials()) {
+      val credentials = credentialsManager.getCredentials() // auto-renews if expired
+      // route to your authenticated screen
+  }
+  ```
+</Accordion>
+
+<Accordion title="Call your own API with an access token">
+  Request an audience so Auth0 issues an access token for your API:
+
+  ```kotlin
+  import com.auth0.kmp.webauth.LoginOptions
+
+  auth0.webAuth.login(
+      LoginOptions(
+          audience = "https://your-api.example.com", // From API Settings → Identifier
+          scope = "openid profile email offline_access",
+      ),
+  )
+  ```
+</Accordion>
+
+<Accordion title="Federated logout">
+  Log the user out of the upstream identity provider as well as Auth0:
+
+  ```kotlin
+  import com.auth0.kmp.webauth.LogoutOptions
+
+  auth0.webAuth.logout(LogoutOptions(federated = true))
+  ```
+</Accordion>
+
+## Next steps
+
+- Explore the full [Auth0 Kotlin Multiplatform SDK](https://github.com/auth0/auth0-kmp) and its `EXAMPLES.md` for organizations, DPoP, passkeys, and custom storage.
+- Run the complete [Android + iOS sample app](https://github.com/auth0/auth0-kmp/tree/main/sample-app).
+- Learn more about [Auth0 Universal Login](/docs/authenticate/login/auth0-universal-login) and [refresh tokens](/docs/secure/tokens/refresh-tokens).

--- a/main/docs/quickstart/native/kotlin-multiplatform.mdx
+++ b/main/docs/quickstart/native/kotlin-multiplatform.mdx
@@ -24,16 +24,16 @@ npx skills add auth0/agent-skills --skill auth0
 Add Auth0 authentication to my Kotlin Multiplatform app.
 ```
 
-Your AI assistant will automatically create your Auth0 application, fetch credentials, add the Auth0 Kotlin Multiplatform SDK dependency, configure the Android manifest placeholders and iOS URL scheme, and implement login/logout flows. [Full agent skills documentation →](/docs/quickstart/agent-skills)
+Your AI assistant automatically creates your Auth0 application, fetches credentials, adds the Auth0 Kotlin Multiplatform SDK dependency, configures the Android manifest placeholders and iOS URL scheme, and implements login/logout flows. [Read the full agent skills documentation](/docs/quickstart/agent-skills).
 </Accordion>
 
 <Note>
-  This quickstart targets **Kotlin Multiplatform 2.0+** with **Android SDK 24+** (Android 7.0), and **iOS 14+**. The Auth0 Kotlin Multiplatform SDK is currently **1.0.0-beta.0** — pin the version explicitly, as the API may change before the stable release. You need [Android Studio](https://developer.android.com/studio) (Ladybug or newer) and, for the iOS target, [Xcode 15+](https://developer.apple.com/xcode/) on macOS.
+  Use this quickstart with Kotlin Multiplatform 2.0+, with Android SDK 24+, (Android 7.0), and iOS 14+. The Auth0 Kotlin Multiplatform SDK is currently in 1.0.0-beta.0. Pin this version explicitly, as the API may change before the stable release. You need [Android Studio](https://developer.android.com/studio) (Ladybug or newer) and, for the iOS target, [Xcode 15+](https://developer.apple.com/xcode/) on macOS.
 </Note>
 
 ## Get Started
 
-By the end of this quickstart, your Kotlin Multiplatform app will let users log in and out through Auth0 [Universal Login](/docs/authenticate/login/auth0-universal-login), securely persist their tokens, and display their profile — all from shared Kotlin code running on both Android and iOS.
+Use this quickstart to configure your Kotlin Multiplatform app for end users to log in and out through Auth0 [Universal Login](/docs/authenticate/login/auth0-universal-login), persist tokens securely, and display user profiles — all from shared Kotlin code running on both Android and iOS.
 
 <Steps>
   <Step title="Create a new Kotlin Multiplatform project" stepNumber={1}>
@@ -56,7 +56,7 @@ By the end of this quickstart, your Kotlin Multiplatform app will let users log 
     ```
 
     <Info>
-      This guide uses `com.example.app` as the application ID / bundle identifier. Replace it with your own everywhere it appears — it becomes part of your Auth0 callback URLs.
+      This guide uses `com.example.app` as the application ID / bundle identifier. Replace this placeholder with your own since it becomes part of your Auth0 callback URLs.
     </Info>
   </Step>
 
@@ -77,19 +77,19 @@ By the end of this quickstart, your Kotlin Multiplatform app will let users log 
     ```
 
     <Tip>
-      The umbrella `auth0` artifact pulls in everything you need. For a smaller footprint you can depend on the individual modules instead (`auth0-core`, `auth0-webauth`, `auth0-authentication`, `auth0-credentials`).
+      The umbrella `auth0` artifact pulls in everything you need. For a smaller footprint, you can depend on the following individual modules instead: `auth0-core`, `auth0-webauth`, `auth0-authentication`, `auth0-credentials`.
     </Tip>
   </Step>
 
   <Step title="Setup your Auth0 App" stepNumber={3}>
-    Create a **Native** application in Auth0 and register the platform callback and logout URLs for both Android and iOS.
+    Create a Native application in Auth0 and register the platform callback and logout URLs for both Android and iOS.
 
-    1. Head to the [Auth0 Dashboard](https://manage.auth0.com/dashboard/)
-    2. Click on **Applications** > **Applications** > **Create Application**
-    3. In the popup, enter a name for your app, select `Native` as the app type, and click **Create**
-    4. Switch to the **Settings** tab on the Application Details page and copy the **Domain** and **Client ID** — you'll add them to your code in a later step
+    1. Navigate to the [Auth0 Dashboard](https://manage.auth0.com/dashboard/).
+    2. Select **Applications** > **Applications** > **Create Application**.
+    3. In the popup, enter a name for your app, select **Native** as the app type, and choose **Create**.
+    4. Switch to the Settings tab on the Application Details page and copy the Domain and Client ID. You need to add them to your code in a later step.
 
-    Still on the **Settings** tab, configure the following URLs. The callback format is scheme-specific per platform, so register one entry for Android and one for iOS:
+    Still on the Settings tab, configure the following URLs. The callback format is scheme-specific per platform, so register one entry for Android and one for iOS:
 
     **Allowed Callback URLs:**
     ```
@@ -104,7 +104,7 @@ By the end of this quickstart, your Kotlin Multiplatform app will let users log 
     Replace `{yourDomain}` with your actual Auth0 domain (e.g., `dev-abc123.us.auth0.com`) and `com.example.app` with your application ID / bundle identifier.
 
     <Info>
-      **Allowed Callback URLs** ensure users are safely returned to your application after authentication. Without a matching URL, the login process will fail. **Allowed Logout URLs** ensure users are redirected back to your app after signing out.
+      Allowed Callback URLs ensure end users are safely returned to your application after authentication. Without a matching URL, the login process will fail. Allowed Logout URLs ensure users are redirected back to your app after signing out.
 
       The callback format embeds your package/bundle identifier: `SCHEME://YOUR_DOMAIN/android/APPLICATION_ID/callback` for Android and `SCHEME://YOUR_DOMAIN/ios/BUNDLE_ID/callback` for iOS. By default the scheme equals your application ID / bundle identifier.
     </Info>
@@ -117,7 +117,7 @@ By the end of this quickstart, your Kotlin Multiplatform app will let users log 
   <Step title="Register the callback scheme on each platform" stepNumber={4}>
     The SDK ships a `RedirectActivity` (Android, merged automatically) and uses `ASWebAuthenticationSession` (iOS) to catch the callback. You only need to declare the URL scheme on each platform.
 
-    **Android** — add the manifest placeholders to your Android build file. The SDK's `RedirectActivity` reads these values:
+    **Android**: Add the manifest placeholders to your Android build file. The SDK's `RedirectActivity` reads these values:
 
     ```kotlin composeApp/build.gradle.kts
     android {
@@ -138,7 +138,7 @@ By the end of this quickstart, your Kotlin Multiplatform app will let users log 
     </manifest>
     ```
 
-    **iOS** — register the URL scheme in `iosApp/iosApp/Info.plist` (or via Xcode → target → **Info** → **URL Types**):
+    **iOS**: Register the URL scheme in `iosApp/iosApp/Info.plist` (or via Xcode → target → **Info** → **URL Types**):
 
     ```xml iosApp/iosApp/Info.plist
     <key>CFBundleURLTypes</key>
@@ -157,7 +157,7 @@ By the end of this quickstart, your Kotlin Multiplatform app will let users log 
   </Step>
 
   <Step title="Initialize the Auth0 SDK" stepNumber={5}>
-    In your shared `commonMain` source set, create the `Auth0` client once and reuse it. It holds the transport shared by web auth, the authentication API, and the credentials manager.
+    In your shared `commonMain` source set, create the `Auth0` client once and reuse it. It holds the transport shared by web auth, the [Authentication API](/docs/api/authentication), and the credentials manager.
 
     **Create `composeApp/src/commonMain/kotlin/Auth0Config.kt`:**
 
@@ -175,7 +175,7 @@ By the end of this quickstart, your Kotlin Multiplatform app will let users log 
     ```
 
     <Info>
-      For production, avoid hardcoding credentials in source. The [sample app](https://github.com/auth0/auth0-kmp/tree/main/sample-app) reads `auth0.domain` and `auth0.clientId` from `local.properties` and exposes them via generated config. The **Domain** and **Client ID** both come from **Application Settings** in the Auth0 Dashboard. The domain must **not** include the `https://` scheme.
+      For production, avoid hard-coding credentials in source. The [sample app](https://github.com/auth0/auth0-kmp/tree/main/sample-app) reads `auth0.domain` and `auth0.clientId` from `local.properties` and exposes them via generated config. The Domain and Client ID both come from Application Settings in the Auth0 Dashboard. The domain must not include the `https://` scheme.
     </Info>
   </Step>
 
@@ -283,7 +283,7 @@ By the end of this quickstart, your Kotlin Multiplatform app will let users log 
     ```
 
     <Info>
-      On app launch you can skip the login screen if valid credentials already exist: `credentialsManager.hasValidCredentials()` returns `true` when a stored, non-expired session is available. Use `credentialsManager.getCredentials()` to retrieve a valid access token, automatically renewing it with the refresh token when needed.
+      On app launch, you can skip the login screen if valid credentials already exist: `credentialsManager.hasValidCredentials()` returns `true` when a stored, non-expired session is available. Use `credentialsManager.getCredentials()` to retrieve a valid access token, and renew the access token with the [refresh token](/docs/secure/tokens/refresh-tokens) automatically when needed.
     </Info>
   </Step>
 
@@ -302,9 +302,9 @@ By the end of this quickstart, your Kotlin Multiplatform app will let users log 
 
     **Expected flow:**
 
-    1. App launches with a "Log In" button
-    2. Tap "Log In" → the system browser opens the Auth0 Universal Login page → complete login
-    3. Control returns to the app automatically and the button switches to "Log Out"
+    1. App launches with a "Log In" button.
+    2. Tap "Log In" → the system browser opens the Auth0 Universal Login page → complete login.
+    3. Control returns to the app automatically and the button switches to "Log Out".
     4. Success!
   </Step>
 </Steps>
@@ -320,9 +320,9 @@ By the end of this quickstart, your Kotlin Multiplatform app will let users log 
 ## Troubleshooting & Advanced
 
 <Accordion title="Callback URL mismatch error">
-  **Cause:** The callback URL the SDK generated isn't listed in your Auth0 application, or the scheme/package don't match.
+  **Cause:** The callback URL the SDK generates isn't listed in your Auth0 application, or the scheme/package don't match.
 
-  **Fix:** Confirm **Allowed Callback URLs** in **Application Settings** exactly matches the platform format — `SCHEME://YOUR_DOMAIN/android/APPLICATION_ID/callback` for Android and `SCHEME://YOUR_DOMAIN/ios/BUNDLE_ID/callback` for iOS. The `SCHEME` (default: your application ID) and package/bundle must be identical to your project's values. URLs are case-sensitive and the scheme must be lowercase.
+  **Fix:** Confirm Allowed Callback URLs in Application Settings exactly matches the platform format — `SCHEME://YOUR_DOMAIN/android/APPLICATION_ID/callback` for Android and `SCHEME://YOUR_DOMAIN/ios/BUNDLE_ID/callback` for iOS. The `SCHEME` (default: your application ID) and package/bundle must be identical to your project's values. URLs are case-sensitive and the scheme must be lowercase.
 </Accordion>
 
 <Accordion title="The browser opens but never returns to the app">
@@ -332,13 +332,13 @@ By the end of this quickstart, your Kotlin Multiplatform app will let users log 
 </Accordion>
 
 <Accordion title="Login returns Result.Failure with a network or timeout error">
-  **Cause:** The device can't reach your Auth0 tenant, or a request timed out.
+  **Cause:** The device can't reach your Auth0 tenant, or a request times out.
 
-  **Fix:** Confirm `domain` in `Auth0Account` is your tenant domain **without** the `https://` scheme (e.g., `your-tenant.us.auth0.com`). On a physical device, ensure it has network access. You can raise the timeouts via the `NetworkingConfiguration` passed to `Auth0Account`.
+  **Fix:** Confirm `domain` in `Auth0Account` is your tenant domain without the `https://` scheme (e.g., `your-tenant.us.auth0.com`). On a physical device, ensure it has network access. You can raise the timeouts via the `NetworkingConfiguration` passed to `Auth0Account`.
 </Accordion>
 
 <Accordion title="getCredentials fails after login">
-  **Cause:** No refresh token was issued, so expired credentials can't be renewed.
+  **Cause:** No refresh token is issued, so expired credentials aren't renewed.
 
   **Fix:** Universal Login requests the `offline_access` scope by default (which returns a refresh token). If you override `scope` in `LoginOptions`, include `offline_access`, and enable **Refresh Token Rotation** for the application in the Auth0 Dashboard.
 </Accordion>

--- a/main/snippets/sdks/versions.mdx
+++ b/main/snippets/sdks/versions.mdx
@@ -730,6 +730,27 @@ export const sdkCardInfo =
       }
     ]
   },
+  "Kotlin Multiplatform": {
+    "name": "Kotlin Multiplatform",
+    "subtext": "auth0-kmp",
+    "logo": "kotlin.svg",
+    "date": "Aug 24, 2026",
+    "badge": "1.0.0-beta.0",
+    "links": [
+      {
+        "label": "GitHub",
+        "url": "https://github.com/auth0/auth0-kmp"
+      },
+      {
+        "label": "Sample App",
+        "url": "https://github.com/auth0/auth0-kmp/tree/main/sample-app"
+      },
+      {
+        "label": "Quickstart",
+        "url": "/docs/quickstart/native/kotlin-multiplatform"
+      }
+    ]
+  },
   "Expo": {
     "name": "Expo",
     "subtext": "react-native-auth0",


### PR DESCRIPTION
## Summary

Adds a new interactive quickstart for the **Auth0 Kotlin Multiplatform (KMP) SDK** (`com.auth0.kmp:auth0`, `1.0.0-beta.0`), targeting Kotlin Multiplatform apps on **Android + iOS**, and surfaces the SDK in the Libraries references.

## Changes

- **New quickstart** — `main/docs/quickstart/native/kotlin-multiplatform.mdx`: full Get Started flow (create project → add SDK via Gradle → configure Auth0 app → register callback scheme per platform → initialize client → login/logout → user profile → run), plus a Troubleshooting & Advanced section. Follows the existing `android.mdx` conventions (HowToSchema, AI-assist accordion, Steps, Check, callouts).
- **Navigation** — registered the page in the Native/Mobile App group in `main/config/navigation/quickstarts.json`.
- **Libraries references** — added a `"Kotlin Multiplatform"` card entry to `sdkCardInfo` in `main/snippets/sdks/versions.mdx` and rendered it on `main/docs/libraries.mdx` (after Android). Links to the GitHub repo, sample app, and quickstart.
- **Icons** — added monochrome `kotlin.svg` (light `#1F1F1F` / dark `#EEEEEE`) under `main/docs/images/icons/{light,dark}/`, matching the repo's existing icon convention.

