### PR TITLE
fix: broken links in main auth api page

### DIFF
--- a/main/docs/api/authentication.mdx
+++ b/main/docs/api/authentication.mdx
@@ -5,7 +5,7 @@ description: "The Authentication API enables you to manage all aspects of user i
 
 The Authentication API enables you to manage all aspects of user identity when you use Auth0. It offers endpoints so your users can log in, sign up, log out, access APIs, and more.
 
-The API supports various identity protocols, like [OpenID Connect](/docs/authenticate/protocols/openid-connect-protocol), [OAuth 2.0](/docs/authenticate/protocols/oauth), [FAPI](/docs/secure/highly-regulated-identity#advanced-security-with-openid-connect-fapi-) and [SAML](/docs/protocols/saml).
+The API supports various identity protocols, like [OpenID Connect](/docs/authenticate/protocols/openid-connect-protocol), [OAuth 2.0](/docs/authenticate/protocols/oauth), [FAPI](/docs/secure/highly-regulated-identity#advanced-security-with-openid-connect-fapi-) and [SAML](/docs/authenticate/protocols/saml/saml-configuration).
 
 <Note>
 This API is designed for people who feel comfortable integrating with RESTful APIs. If you prefer a more guided approach check out our [Quickstarts](/docs/quickstarts) or our [Libraries](/docs/libraries).

--- a/main/docs/api/authentication.mdx
+++ b/main/docs/api/authentication.mdx
@@ -5,10 +5,10 @@ description: "The Authentication API enables you to manage all aspects of user i
 
 The Authentication API enables you to manage all aspects of user identity when you use Auth0. It offers endpoints so your users can log in, sign up, log out, access APIs, and more.
 
-The API supports various identity protocols, like [OpenID Connect](https://auth0.com/docs/authenticate/protocols/openid-connect-protocol), [OAuth 2.0](https://auth0.com/docs/authenticate/protocols/oauth), [FAPI](https://auth0.com/docs/secure/highly-regulated-identity#advanced-security-with-openid-connect-fapi-) and [SAML](https://auth0.com/docs/protocols/saml).
+The API supports various identity protocols, like [OpenID Connect](/docs/authenticate/protocols/openid-connect-protocol), [OAuth 2.0](/docs/authenticate/protocols/oauth), [FAPI](/docs/secure/highly-regulated-identity#advanced-security-with-openid-connect-fapi-) and [SAML](/docs/protocols/saml).
 
 <Note>
-This API is designed for people who feel comfortable integrating with RESTful APIs. If you prefer a more guided approach check out our [Quickstarts](https://auth0.com/docs/quickstarts) or our [Libraries](https://auth0.com/docs/libraries).
+This API is designed for people who feel comfortable integrating with RESTful APIs. If you prefer a more guided approach check out our [Quickstarts](/docs/quickstarts) or our [Libraries](/docs/libraries).
 </Note>
 
 ## Base URL
@@ -28,10 +28,10 @@ You have five options for authenticating with this API:
 
 Send a valid Access Token in the `Authorization` header, using the `Bearer` authentication scheme.
 
-An example is the [Get User Info endpoint](/user-profile/get-user-info). In this scenario, you get an Access Token when you authenticate a user, and then you can make a request to the [Get User Info endpoint](/user-profile/get-user-info), using that token in the `Authorization` header, in order to retrieve the user's profile.
+An example is the [Get User Info endpoint](/docs/api/authentication/user-profile/get-user-info). In this scenario, you get an Access Token when you authenticate a user, and then you can make a request to the [Get User Info endpoint](/docs/api/authentication/user-profile/get-user-info), using that token in the `Authorization` header, in order to retrieve the user's profile.
 
 ### Client ID and Client Assertion
-Generate a [client assertion](https://auth0.com/docs/get-started/authentication-and-authorization-flow/authenticate-with-private-key-jwt) containing a signed JSON Web Token (JWT) to authenticate. In the body of the request, include your Client ID, a `client_assertion_type` parameter with the value `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`, and a `client_assertion` parameter with your signed assertion. Review [Private Key JWT](https://auth0.com/docs/get-started/authentication-and-authorization-flow/authenticate-with-private-key-jwt) for examples.
+Generate a [client assertion](/docs/get-started/authentication-and-authorization-flow/authenticate-with-private-key-jwt) containing a signed JSON Web Token (JWT) to authenticate. In the body of the request, include your Client ID, a `client_assertion_type` parameter with the value `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`, and a `client_assertion` parameter with your signed assertion. Review [Private Key JWT](/docs/get-started/authentication-and-authorization-flow/authenticate-with-private-key-jwt) for examples.
 
 ### Client ID and Client Secret
 
@@ -41,25 +41,25 @@ If you are using **Post**, you must send this data in the JSON body of your requ
 
 If you are using **Basic**, you must send this data in the `Authorization` header, using the `Basic` authentication scheme. To generate your credential value, concatenate your Client ID and Client Secret, separated by a colon (`:`), and encode it in Base64.
 
-An example is the [Revoke Refresh Token endpoint](https://auth0.com/docs/secure/tokens/refresh-tokens/revoke-refresh-tokens). This option is available only for confidential applications (such as applications that are able to hold credentials in a secure way without exposing them to unauthorized parties).
+An example is the [Revoke Refresh Token endpoint](/docs/secure/tokens/refresh-tokens/revoke-refresh-tokens). This option is available only for confidential applications (such as applications that are able to hold credentials in a secure way without exposing them to unauthorized parties).
 
 ### Client ID
 
 Send the Client ID. For public applications (applications that cannot hold credentials securely, such as SPAs or mobile apps), we offer some endpoints that can be accessed using only the Client ID.
 
-An example is the [Implicit Grant](/implicit-flow/authorize).
+An example is the [Implicit Grant](/docs/api/authentication/implicit-flow/authorize).
 
 ### mTLS Authentication
 
-Generate a certificate, either [self-signed](https://auth0.com/docs/get-started/applications/configure-mtls/configure-mtls-for-a-client#self-signed-certificates) or [certificate authority signed](https://auth0.com/docs/get-started/applications/configure-mtls/configure-mtls-for-a-client#certificate-authority-signed-certificates). Then, [set up the customer edge network](https://auth0.com/docs/get-started/applications/configure-mtls/set-up-the-customer-edge) that performs the mTLS handshake.
+Generate a certificate, either [self-signed](/docs/get-started/applications/configure-mtls/configure-mtls-for-a-client#self-signed-certificates) or [certificate authority signed](/docs/get-started/applications/configure-mtls/configure-mtls-for-a-client#certificate-authority-signed-certificates). Then, [set up the customer edge network](/docs/get-started/applications/configure-mtls/set-up-the-customer-edge) that performs the mTLS handshake.
 
 Once your edge network verifies the certificate, forward the request to the Auth0 edge network with the following headers:
 
 - The Custom Domain API key as the `cname-api-key` header.
 - The client certificate as the `client-certificate` header.
-- The client certificate CA verification status as the `client-certificate-ca-verified` header. For more information, see [Forward the Request](https://auth0.com/docs/get-started/applications/configure-mtls/set-up-the-customer-edge#forward-the-request-).
+- The client certificate CA verification status as the `client-certificate-ca-verified` header. For more information, see [Forward the Request](/docs/get-started/applications/configure-mtls/set-up-the-customer-edge#forward-the-request-).
 
-To learn more, read [Authenticate with mTLS](https://auth0.com/docs/get-started/authentication-and-authorization-flow/authenticate-with-mtls).
+To learn more, read [Authenticate with mTLS](/docs/get-started/authentication-and-authorization-flow/authenticate-with-mtls).
 
 ## Parameters
 
@@ -77,19 +77,19 @@ An exception to that is the [SAML IdP-Initiated Single Sign-on (SSO) Flow](#idp-
 
 ## Testing
 
-You can test the endpoints using the [Authentication API Debugger](https://auth0.com/docs/customize/extensions/authentication-api-debugger-extension).
+You can test the endpoints using the [Authentication API Debugger](/docs/customize/extensions/authentication-api-debugger-extension).
 
 ### Authentication API Debugger
 
-The [Authentication API Debugger](https://auth0.com/docs/customize/extensions/authentication-api-debugger-extension) is an Auth0 extension you can use to test several endpoints of the Authentication API.
+The [Authentication API Debugger](/docs/customize/extensions/authentication-api-debugger-extension) is an Auth0 extension you can use to test several endpoints of the Authentication API.
 
 
 
-[Install Debugger](https://auth0.com/docs/customize/extensions/authentication-api-debugger-extension)
+[Install Debugger](/docs/customize/extensions/authentication-api-debugger-extension)
 
 **If you have already installed the extension, skip to the Authentication API Debugger.**
 
-The link varies according to your tenant's region: US West, Europe Central, or Australia. To learn more about tenant regions, read [Create Tenants](https://auth0.com/docs/get-started/auth0-overview/create-tenants#region-locality-and-sub-locality).
+The link varies according to your tenant's region: US West, Europe Central, or Australia. To learn more about tenant regions, read [Create Tenants](/docs/get-started/auth0-overview/create-tenants#region-locality-and-sub-locality).
 
 ### Configure Connections
 
@@ -113,8 +113,8 @@ Configure other endpoints with the following options:
 ### Authentications flows
 
 Configure authentication flows with the following options:
-- Authorization Code Flow: On the *OAuth2 / OIDC* tab, set the field **Authorization Code** to the code you retrieved from [Authorization Code Grant](https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow), and the **Code Verifier** to the key. Click **OAuth2 Code Exchange**.
-- Authorization Code Flow + PKCE: On the *OAuth2 / OIDC* tab, set the field **Authorization Code** to the code you retrieved from [Authorization Code Grant](https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow-with-pkce), and the **Code Verifier** to the key. Click **OAuth2 Code Exchange**.
+- Authorization Code Flow: On the *OAuth2 / OIDC* tab, set the field **Authorization Code** to the code you retrieved from [Authorization Code Grant](/docs/get-started/authentication-and-authorization-flow/authorization-code-flow), and the **Code Verifier** to the key. Click **OAuth2 Code Exchange**.
+- Authorization Code Flow + PKCE: On the *OAuth2 / OIDC* tab, set the field **Authorization Code** to the code you retrieved from [Authorization Code Grant](/docs/get-started/authentication-and-authorization-flow/authorization-code-flow-with-pkce), and the **Code Verifier** to the key. Click **OAuth2 Code Exchange**.
 - Client Credential Flow:  On the *OAuth2 / OIDC* tab, select **OAuth2 Client Credentials**.
 
 ## Errors
@@ -133,12 +133,12 @@ The Authentication API is subject to rate limiting. The limits differ per endpoi
 
 If you exceed the provided rate limit for a given endpoint, you will receive the `429 Too Many Requests` response with the following message: `Too many requests. Check the X-RateLimit-Limit, X-RateLimit-Remaining and X-RateLimit-Reset headers.`
 
-For details on rate limiting, refer to [Auth0 API Rate Limit Policy](https://auth0.com/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy).
+For details on rate limiting, refer to [Auth0 API Rate Limit Policy](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy).
 
-Note that for database connections Auth0 limits certain types of repeat login attempts depending on the user account and IP address. For details, refer to [Rate Limits on User/Password Authentication](https://auth0.com/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy).
+Note that for database connections Auth0 limits certain types of repeat login attempts depending on the user account and IP address. For details, refer to [Rate Limits on User/Password Authentication](/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy).
 
 ## Support
 
 If you have problems or need help with your case, you can always reach out to our [Support](https://support.auth0.com/).
 
-Note that if you have a free subscription plan, and you are not in your 22-day trial period, you will not be able to access or open tickets in the [Support Center](https://support.auth0.com/). In this case, you can seek support through the [Auth0 Community](https://community.auth0.com/). For more info on our support program, refer to [Support Options](https://auth0.com/docs/troubleshoot/customer-support).
+Note that if you have a free subscription plan, and you are not in your 22-day trial period, you will not be able to access or open tickets in the [Support Center](https://support.auth0.com/). In this case, you can seek support through the [Auth0 Community](https://community.auth0.com/). For more info on our support program, refer to [Support Options](/docs/troubleshoot/customer-support).


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

☝️ 

replaces hard-coded `auth0.com/docs` links with relative links. fixes relative links that point to the auth api pages.

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

### References

https://auth0.slack.com/archives/C02FE2CTZ/p1787758705133359

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

links work. i ran `mint validate` as well.

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
