### PR TITLE
fix: Component previews now react to dark/light mode toggle

### DIFF
--- a/main/snippets/ComponentLoader.jsx
+++ b/main/snippets/ComponentLoader.jsx
@@ -1,11 +1,35 @@
 export const ComponentLoader = (props) => {
-  const themePref = window?.localStorage?.getItem?.("isDarkMode");
-  const theme =
-    themePref === "dark" || themePref === "light"
-      ? themePref
-      : window.matchMedia("(prefers-color-scheme: dark)").matches
+  const detectTheme = () => {
+    if (typeof document === "undefined") return "light";
+    const html = document.documentElement;
+    const colorScheme =
+      html.style.colorScheme ||
+      getComputedStyle(html).colorScheme ||
+      (window?.localStorage?.getItem?.("isDarkMode") === "dark" ||
+      (window?.localStorage?.getItem?.("isDarkMode") == null &&
+        window.matchMedia?.("(prefers-color-scheme: dark)").matches)
         ? "dark"
-        : "light";
+        : "light");
+    return colorScheme === "dark" ? "dark" : "light";
+  };
+
+  const [theme, setTheme] = useState(detectTheme);
+
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+
+    // Sync once on mount in case the theme resolved after first render.
+    setTheme(detectTheme());
+
+    const observer = new MutationObserver(() => setTheme(detectTheme()));
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["style", "class", "data-theme"],
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
   const lang = {
     i18n: {
       currentLanguage: props.lang || "en-US",
@@ -20,7 +44,6 @@ export const ComponentLoader = (props) => {
           theme === "light"
             ? "rgb(var(--gray-950)/.03)"
             : "rgb(255 255 255/.1)",
-        display: "flex",
         alignItems: "center",
         justifyContent: "center",
         position: "relative",
@@ -92,7 +115,7 @@ export const ComponentLoader = (props) => {
         style={{
           width: "100%",
           textAlign: "center",
-          color: theme === "light" ? "#6B7280" : "ffffff",
+          color: theme === "light" ? "#6B7280" : "#ffffff",
           fontSize: "12px",
           marginTop: "8px",
           marginBottom: "8px",

--- a/main/snippets/ComponentLoader.jsx
+++ b/main/snippets/ComponentLoader.jsx
@@ -4,13 +4,13 @@ export const ComponentLoader = (props) => {
     const html = document.documentElement;
     const colorScheme =
       html.style.colorScheme ||
-      getComputedStyle(html).colorScheme ||
-      (window?.localStorage?.getItem?.("isDarkMode") === "dark" ||
-      (window?.localStorage?.getItem?.("isDarkMode") == null &&
-        window.matchMedia?.("(prefers-color-scheme: dark)").matches)
-        ? "dark"
-        : "light");
-    return colorScheme === "dark" ? "dark" : "light";
+      getComputedStyle(html).colorScheme;
+    if (colorScheme) return colorScheme === "dark" ? "dark" : "light";
+
+    const isDarkMode = window?.localStorage?.getItem?.("isDarkMode");
+    const prefersDark = window.matchMedia?.("(prefers-color-scheme: dark)").matches;
+    const shouldBeDark = isDarkMode === "dark" || (isDarkMode !== "light" && prefersDark);
+    return shouldBeDark ? "dark" : "light";
   };
 
   const [theme, setTheme] = useState(detectTheme);
@@ -24,7 +24,7 @@ export const ComponentLoader = (props) => {
     const observer = new MutationObserver(() => setTheme(detectTheme()));
     observer.observe(document.documentElement, {
       attributes: true,
-      attributeFilter: ["style", "class", "data-theme"],
+      attributeFilter: ["style", "class", "data-theme", "data-theme-preference"],
     });
 
     return () => observer.disconnect();

--- a/universal-components/src/index.tsx
+++ b/universal-components/src/index.tsx
@@ -22,6 +22,7 @@ let isScanning = false;
 let routeChangeHandler: (() => void) | null = null;
 let themeObserver: MutationObserver | null = null;
 let currentColorScheme: string | null = null;
+let currentThemePreference: string | null = null;
 
 // ==================== Helper Functions ====================
 async function getModule() {
@@ -173,13 +174,15 @@ function cleanup() {
 
 function setupThemeWatcher() {
   currentColorScheme = detectColorScheme();
+  currentThemePreference = document.documentElement.getAttribute('data-theme-preference');
 
   themeObserver = new MutationObserver(() => {
     const newColorScheme = detectColorScheme();
+    const newThemePreference = document.documentElement.getAttribute('data-theme-preference');
 
-    // Check if color scheme actually changed
-    if (currentColorScheme !== newColorScheme) {
+    if (currentColorScheme !== newColorScheme || currentThemePreference !== newThemePreference) {
       currentColorScheme = newColorScheme;
+      currentThemePreference = newThemePreference;
       // Remount all components with new theme
       unmountAll();
       setTimeout(scanAndMount, 100);
@@ -189,7 +192,7 @@ function setupThemeWatcher() {
   // Observe HTML element for style and class changes
   themeObserver.observe(document.documentElement, {
     attributes: true,
-    attributeFilter: ['style', 'class', 'data-theme'],
+    attributeFilter: ['style', 'class', 'data-theme', 'data-theme-preference'],
   });
 }
 


### PR DESCRIPTION
## Description

Component preview frames in Mintlify docs now stay in sync when toggling between light and dark mode. Previously, the frame background and text colors would not update even though the mounted components inside reacted correctly.

### References

- UIC-1504: Component previews in mintlify docs are not reacting to dark/light mode switch


https://github.com/user-attachments/assets/f974be0e-ea8c-4773-8f08-2d6659bd152d

### Testing

Local dev verification (Mintlify dev server):
- Light → Dark toggle: frame background changed from #ffffff to #101011, component wrapper gained `.dark` class
- Dark → Light toggle: frame background returned to #ffffff, component wrapper lost `.dark` class
- Both layers stayed synchronized during bidirectional toggles

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
