### PR TITLE
Feat/custom rate limit policy api docs

### DIFF
--- a/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
@@ -347,8 +347,6 @@ To create a custom rate limit policy using the Management API, call [`POST /api/
   - **`third_party_clients`** — all third-party applications (Client ID prefix: `tpa_`)
   - **`cimd_clients`** — all CIMD clients (Client ID prefix: `https://`)
 
-  <Callout icon="file-lines" color="#0EA5E9" iconType="regular">Using the Auth0 CLI? If you haven't already, [set up and authenticate your CLI session](/docs/deploy-monitor/auth0-cli) before running this command.</Callout>
-
   <AuthCodeGroup>
   ```bash Auth0 CLI
   auth0 api post "rate-limit-policies" \

--- a/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
@@ -344,7 +344,7 @@ To create a custom rate limit policy using the Management API, call [`POST /api/
 
   Set a shared rate limit for a built-in application group. The limit applies to the aggregate traffic from all applications in the group. Auth0 supports two built-in groups:
 
-  - **`third_party_clients`** — all third-party applications (Client ID prefix: `tpa_`)
+  - **`third_party_clients`** — all [third-party applications](/docs/get-started/applications/third-party-applications) (Client ID prefix: `tpa_`)
   - **`cimd_clients`** — all CIMD clients (Client ID prefix: `https://`)
 
   <AuthCodeGroup>

--- a/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
@@ -4,6 +4,7 @@ description: Set per-application rate limit ceilings to protect your tenant from
 ---
 
 import { ReleaseStageNotice } from "/snippets/ReleaseStageNotice.jsx"
+import { AuthCodeGroup } from "/snippets/AuthCodeGroup.jsx"
 
 <ReleaseStageNotice
     feature="Custom Rate Limit Policies"
@@ -289,7 +290,14 @@ To create a custom rate limit policy using the Management API, call [`POST /api/
 
   Set a rate limit for one specific application by its Client ID. This is the most specific policy level and takes precedence over Group and Global policies.
 
-  ```bash
+  <Callout icon="file-lines" color="#0EA5E9" iconType="regular">Using the Auth0 CLI? If you haven't already, [set up and authenticate your CLI session](/docs/deploy-monitor/auth0-cli) before running this command.</Callout>
+
+  <AuthCodeGroup>
+  ```bash Auth0 CLI
+  auth0 api post "rate-limit-policies" \
+    --data '{"resource":"oauth_authentication_api","consumer":"client","consumer_selector":"client_id:YOUR_CLIENT_ID","configuration":{"action":"block","limit":50}}'
+  ```
+  ```bash cURL
   curl --request POST \
     --url 'https://YOUR_AUTH0_DOMAIN/api/v2/rate-limit-policies' \
     --header 'authorization: Bearer YOUR_MGMT_API_TOKEN' \
@@ -304,10 +312,16 @@ To create a custom rate limit policy using the Management API, call [`POST /api/
       }
     }'
   ```
+  </AuthCodeGroup>
 
   To enable log-only mode instead of enforcing the limit, set `action` to `"log"`. Auth0 tracks requests against the limit and emits `api_limit` log events but does not return HTTP 429 responses.
 
-  ```bash
+  <AuthCodeGroup>
+  ```bash Auth0 CLI
+  auth0 api post "rate-limit-policies" \
+    --data '{"resource":"oauth_authentication_api","consumer":"client","consumer_selector":"client_id:YOUR_CLIENT_ID","configuration":{"action":"log","limit":50}}'
+  ```
+  ```bash cURL
   curl --request POST \
     --url 'https://YOUR_AUTH0_DOMAIN/api/v2/rate-limit-policies' \
     --header 'authorization: Bearer YOUR_MGMT_API_TOKEN' \
@@ -322,6 +336,7 @@ To create a custom rate limit policy using the Management API, call [`POST /api/
       }
     }'
   ```
+  </AuthCodeGroup>
 
   </Tab>
 
@@ -332,7 +347,14 @@ To create a custom rate limit policy using the Management API, call [`POST /api/
   - **`third_party_clients`** — all third-party applications (Client ID prefix: `tpa_`)
   - **`cimd_clients`** — all CIMD clients (Client ID prefix: `https://`)
 
-  ```bash
+  <Callout icon="file-lines" color="#0EA5E9" iconType="regular">Using the Auth0 CLI? If you haven't already, [set up and authenticate your CLI session](/docs/deploy-monitor/auth0-cli) before running this command.</Callout>
+
+  <AuthCodeGroup>
+  ```bash Auth0 CLI
+  auth0 api post "rate-limit-policies" \
+    --data '{"resource":"oauth_authentication_api","consumer":"client","consumer_selector":"third_party_clients","configuration":{"action":"block","limit":100}}'
+  ```
+  ```bash cURL
   curl --request POST \
     --url 'https://YOUR_AUTH0_DOMAIN/api/v2/rate-limit-policies' \
     --header 'authorization: Bearer YOUR_MGMT_API_TOKEN' \
@@ -347,6 +369,7 @@ To create a custom rate limit policy using the Management API, call [`POST /api/
       }
     }'
   ```
+  </AuthCodeGroup>
 
   To apply the policy to CIMD clients instead, set `consumer_selector` to `"cimd_clients"`.
 
@@ -356,7 +379,14 @@ To create a custom rate limit policy using the Management API, call [`POST /api/
 
   Set a default rate limit that applies to any application not covered by a Client ID or Group policy. Each application gets its own independent counter against the same ceiling.
 
-  ```bash
+  <Callout icon="file-lines" color="#0EA5E9" iconType="regular">Using the Auth0 CLI? If you haven't already, [set up and authenticate your CLI session](/docs/deploy-monitor/auth0-cli) before running this command.</Callout>
+
+  <AuthCodeGroup>
+  ```bash Auth0 CLI
+  auth0 api post "rate-limit-policies" \
+    --data '{"resource":"oauth_authentication_api","consumer":"client","consumer_selector":"default","configuration":{"action":"block","limit":50}}'
+  ```
+  ```bash cURL
   curl --request POST \
     --url 'https://YOUR_AUTH0_DOMAIN/api/v2/rate-limit-policies' \
     --header 'authorization: Bearer YOUR_MGMT_API_TOKEN' \
@@ -371,6 +401,7 @@ To create a custom rate limit policy using the Management API, call [`POST /api/
       }
     }'
   ```
+  </AuthCodeGroup>
 
   </Tab>
 </Tabs>

--- a/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/custom-rate-limit-policies.mdx
@@ -280,6 +280,101 @@ Setting a custom rate limit to `0` blocks all Authentication API requests from t
   </Tab>
 </Tabs> */}
 
+## Create a custom rate limit policy
+
+To create a custom rate limit policy using the Management API, call [`POST /api/v2/rate-limit-policies`](/docs/api/management/v2/rate-limit-policies/post-rate-limit-policies) with a Management API token that has the `create:rate_limit_policies` scope.
+
+<Tabs>
+  <Tab title="Single application">
+
+  Set a rate limit for one specific application by its Client ID. This is the most specific policy level and takes precedence over Group and Global policies.
+
+  ```bash
+  curl --request POST \
+    --url 'https://YOUR_AUTH0_DOMAIN/api/v2/rate-limit-policies' \
+    --header 'authorization: Bearer YOUR_MGMT_API_TOKEN' \
+    --header 'content-type: application/json' \
+    --data '{
+      "resource": "oauth_authentication_api",
+      "consumer": "client",
+      "consumer_selector": "client_id:YOUR_CLIENT_ID",
+      "configuration": {
+        "action": "block",
+        "limit": 50
+      }
+    }'
+  ```
+
+  To enable log-only mode instead of enforcing the limit, set `action` to `"log"`. Auth0 tracks requests against the limit and emits `api_limit` log events but does not return HTTP 429 responses.
+
+  ```bash
+  curl --request POST \
+    --url 'https://YOUR_AUTH0_DOMAIN/api/v2/rate-limit-policies' \
+    --header 'authorization: Bearer YOUR_MGMT_API_TOKEN' \
+    --header 'content-type: application/json' \
+    --data '{
+      "resource": "oauth_authentication_api",
+      "consumer": "client",
+      "consumer_selector": "client_id:YOUR_CLIENT_ID",
+      "configuration": {
+        "action": "log",
+        "limit": 50
+      }
+    }'
+  ```
+
+  </Tab>
+
+  <Tab title="Application group">
+
+  Set a shared rate limit for a built-in application group. The limit applies to the aggregate traffic from all applications in the group. Auth0 supports two built-in groups:
+
+  - **`third_party_clients`** — all third-party applications (Client ID prefix: `tpa_`)
+  - **`cimd_clients`** — all CIMD clients (Client ID prefix: `https://`)
+
+  ```bash
+  curl --request POST \
+    --url 'https://YOUR_AUTH0_DOMAIN/api/v2/rate-limit-policies' \
+    --header 'authorization: Bearer YOUR_MGMT_API_TOKEN' \
+    --header 'content-type: application/json' \
+    --data '{
+      "resource": "oauth_authentication_api",
+      "consumer": "client",
+      "consumer_selector": "third_party_clients",
+      "configuration": {
+        "action": "block",
+        "limit": 100
+      }
+    }'
+  ```
+
+  To apply the policy to CIMD clients instead, set `consumer_selector` to `"cimd_clients"`.
+
+  </Tab>
+
+  <Tab title="Global default">
+
+  Set a default rate limit that applies to any application not covered by a Client ID or Group policy. Each application gets its own independent counter against the same ceiling.
+
+  ```bash
+  curl --request POST \
+    --url 'https://YOUR_AUTH0_DOMAIN/api/v2/rate-limit-policies' \
+    --header 'authorization: Bearer YOUR_MGMT_API_TOKEN' \
+    --header 'content-type: application/json' \
+    --data '{
+      "resource": "oauth_authentication_api",
+      "consumer": "client",
+      "consumer_selector": "default",
+      "configuration": {
+        "action": "block",
+        "limit": 50
+      }
+    }'
+  ```
+
+  </Tab>
+</Tabs>
+
 ## Monitor via logs
 
 Use tenant logs to observe how custom rate limit policies affect traffic:


### PR DESCRIPTION
## Description

Adds Management API instructions for creating custom rate limit policies. The Dashboard UI for custom rate limit policies is not yet supported, so the UI-based creation steps are currently hidden. This PR adds API-based instructions (a0 cli & cURL).

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [ x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ x] I've tested the site build for this change locally.
- [ x] I've made appropriate docs updates for any code or config changes.
- [ x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
