### PR TITLE
fix: correct Public Performance Burst interval from 5-minute to 1-minute

### DIFF
--- a/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy.mdx
+++ b/main/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy.mdx
@@ -130,7 +130,7 @@ This add-on only extends the Authentication API request limits and does NOT appl
 
 Currently, there are three Public Performance Burst modifiers (2x, 3x, and 4x) allowing 200, 300, and 400 RPS, respectively, for the Authentication API for up to 48 hours monthly. The 48 hours are counted and deducted from the monthly allowed quota in 1-minute intervals, which enables usage of the API at the multiplier level for 2880 1-minute intervals each month.
 
-When the volume of requests for the Authentication API exceeds the default of 100 RPS, a 5-minute interval is deducted from the monthly allowance, and traffic is allowed at the rate associated with the multiplier. Traffic can stay within the multiplier range for the complete contiguous 5 minutes from that point without triggering additional deductions.
+When the volume of requests for the Authentication API exceeds the default of 100 RPS, a 1-minute interval is deducted from the monthly allowance, and traffic is allowed at the rate associated with the multiplier. Traffic can stay within the multiplier range for the complete contiguous 1 minute from that point without triggering additional deductions.
 
 Monitoring of the interval deduction events is possible through [tenant logs](/docs/deploy-monitor/logs/log-event-type-codes). Each deduction generates an associated `appi` tenant log event type containing information about the already consumed and remaining allowance.
 


### PR DESCRIPTION
## Description

☝️ 

### References

https://auth0team.atlassian.net/browse/DOCS-5619?issueKey=DOCS-5619&subProduct=jira-software

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [ x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ x] I've tested the site build for this change locally.
- [ x] I've made appropriate docs updates for any code or config changes.
- [ x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
