### PR TITLE
chore(docs): content maintenance (2026-08-10) (#1702)

### DIFF
--- a/main/docs/authenticate/protocols/saml/saml-identity-provider-configuration-settings.mdx
+++ b/main/docs/authenticate/protocols/saml/saml-identity-provider-configuration-settings.mdx
@@ -19,7 +19,7 @@ If you have configured a [Custom Domain](/docs/customize/custom-domains), you mu
 
 </Callout>
 
-### post-back URL
+### Post-back URL
 
 When using IdP-Initiated <Tooltip tip="Single Sign-On (SSO): Service that, after a user logs into one applicaton, automatically logs that user in to other applications." cta="View Glossary" href="/docs/glossary?term=SSO">SSO</Tooltip>, make sure to include the connection parameter in the post-back URL:
 
@@ -145,11 +145,11 @@ if ($err) {
 ```python Python
 import http.client
 
-conn = http.client.HTTPSConnection("")
+conn = http.client.HTTPSConnection("{yourDomain}")
 
 headers = { 'authorization': "Bearer {yourAccessToken}" }
 
-conn.request("GET", "/{yourDomain}/api/v2/connections/%7ByourConnectionID%7D", headers=headers)
+conn.request("GET", "/api/v2/connections/%7ByourConnectionID%7D", headers=headers)
 
 res = conn.getresponse()
 data = res.read()
@@ -175,7 +175,7 @@ puts response.read_body
 ```
 </AuthCodeGroup>
 
-Replace the `ACCESS_TOKEN` header value, with a Management APIv2 <Tooltip tip="Access Token: Authorization credential, in the form of an opaque string or JWT, used to access an API." cta="View Glossary" href="/docs/glossary?term=access+token">access token</Tooltip>.
+Replace the `{yourAccessToken}` placeholder in the `authorization` header with a Management API v2 <Tooltip tip="Access Token: Authorization credential, in the form of an opaque string or JWT, used to access an API." cta="View Glossary" href="/docs/glossary?term=access+token">access token</Tooltip>.
 
 ### SAML Request Binding
 
@@ -191,7 +191,7 @@ If dynamically setting the value isn't possible, then set as either `HTTP-Redire
 
 ### SAML Response Binding
 
-How the SAML token is received by Auth0 from IdP, set as `HTTP-Post`.
+How the SAML token is received by Auth0 from the IdP; set this as `HTTP-POST`.
 
 ### NameID format
 
@@ -213,13 +213,15 @@ SAML logout requests must be signed by the identity provider.
 
 ## Signed assertions
 
-Use the following links to obtain the public key in different formats:
+Use the following URLs to obtain the public key in different formats. Replace `{yourDomain}` with your Auth0 domain (or custom domain) and `{yourConnectionName}` with your connection name:
 
-* <AuthLink href="https://{yourDomain}/cer?cert=connection">CER</AuthLink>
-* <AuthLink href="https://{yourDomain}/pem?cert=connection">PEM</AuthLink>
-* <AuthLink href="https://{yourDomain}/rawpem?cert=connection">raw PEM</AuthLink>
-* <AuthLink href="https://{yourDomain}/pb7?cert=connection">PKCS#7</AuthLink>
-* <AuthLink href="https://{yourDomain}/fingerprint?cert=connection">Fingerprint</AuthLink>
+| Format | URL |
+| --- | --- |
+| CER | `https://{yourDomain}/cer?cert={yourConnectionName}` |
+| PEM | `https://{yourDomain}/pem?cert={yourConnectionName}` |
+| raw PEM | `https://{yourDomain}/rawpem?cert={yourConnectionName}` |
+| PKCS#7 | `https://{yourDomain}/pb7?cert={yourConnectionName}` |
+| Fingerprint | `https://{yourDomain}/fingerprint?cert={yourConnectionName}` |
 
 Download the certificate in the format requested by the IdP.
 


### PR DESCRIPTION
Applied 6 suggestion(s):
- ai-link-suggestion: Restore certificate download links under Signed assertions
- ai-technical: Fix ACS URL that returns 404 in Organizations section
- ai-grammar: Capitalize 'post-back URL' heading
- ai-technical: Fix incorrect access token header reference
- ai-technical: Fix broken Python code sample host/path ... and 1 more

Co-Authored-By: nick-gagliardi (via Auth0 IA)

<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

<!--
    Explain the changes in this PR. Don't assume prior context.
-->

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [ ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [ ] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
