### PR TITLE
fix: redirect legacy auth0-mcp-server path (llms.txt dead link) to /docs/get-started

### DIFF
--- a/main/config/redirects.json
+++ b/main/config/redirects.json
@@ -21872,6 +21872,10 @@
     "destination": "/docs"
   },
   {
+    "source": "/docs/customize/integrations/ai-tools/auth0-mcp-server",
+    "destination": "/docs/get-started/auth0-mcp-server"
+  },
+  {
     "source": "/docs/customize/integrations/authenticate-devices-using-mqtt",
     "destination": "/docs/customize/integrations"
   },


### PR DESCRIPTION
Fixes #1806

## What

Adds one `redirects.json` entry so the legacy MCP Server path stops 404-ing:

```json
{
  "source": "/docs/customize/integrations/ai-tools/auth0-mcp-server",
  "destination": "/docs/get-started/auth0-mcp-server"
}
```

## Why

`https://auth0.com/llms.txt` L35 (Developer Tools section — the entry point AI agents resolve for MCP integration) still points at `/docs/customize/integrations/ai-tools/auth0-mcp-server`, which returns a hard 404 with no covering redirect (`redirects.json` had 0 entries under `customize/integrations/ai-tools`). The canonical docs live at `/docs/get-started/auth0-mcp-server` and the repo's own content already links there (`auth4genai/build-with-ai/using-ai-tools.mdx` L34).

Re-verified live before opening this PR (2026-08-31): legacy path 404 under 2 UAs, canonical path 200, llms.txt L35 unchanged.

## Scope

- 4-line addition to `main/config/redirects.json`, placed at the head of the existing `customize/integrations` cluster, matching the established format exactly.
- No content files touched — the Lychee PR link-check (scans changed `*.mdx` only) is unaffected.
- Note: this heals every consumer of the legacy path (agents, old bookmarks), but the llms.txt entry itself is edge-generated outside this repo — updating the generator to point directly at the new path would remove the stale link from the index (happy to help locate/patch the generator if you can point me at it).

## Verification

| Check | Result |
|---|---|
| `main/config/redirects.json` JSON validity | parses clean, 5,478 entries |
| Destination content exists | `main/docs/get-started/auth0-mcp-server.mdx` present |
| Diff size | 1 file, +4 / −0 |

## Context

I maintain agent-context hygiene for AI coding tools (stale docs / dead links in agent-facing indexes are a recurring hallucination source). Related fixes: merged PR to cloudflare-docs repairing 27 dead llms.txt hub links (cloudflare/cloudflare-docs#32985), maintainer-shipped fix in llm-docs-builder v1.0.0 (mensfeld/llm-docs-builder#165).
