### PR TITLE
feat/ update ACUL SDK references to v1.7.0

### DIFF
--- a/main/docs/libraries/acul/js-sdk/Screens/classes/AcceptInvitation.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/AcceptInvitation.mdx
@@ -27,6 +27,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `accept-invitation` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `accept-invitation` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/BruteForceProtectionUnblock.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/BruteForceProtectionUnblock.mdx
@@ -29,6 +29,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `brute-force-protection-unblock` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `brute-force-protection-unblock` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/BruteForceProtectionUnblockFailure.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/BruteForceProtectionUnblockFailure.mdx
@@ -29,6 +29,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `brute-force-protection-unblock-failure` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `brute-force-protection-unblock-failure` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/BruteForceProtectionUnblockSuccess.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/BruteForceProtectionUnblockSuccess.mdx
@@ -29,6 +29,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `brute-force-protection-unblock-success` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `brute-force-protection-unblock-success` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/Confirmation.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/Confirmation.mdx
@@ -27,6 +27,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `confirmation` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `confirmation` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/Consent.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/Consent.mdx
@@ -27,6 +27,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `consent` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `consent` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/CustomizedConsent.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/CustomizedConsent.mdx
@@ -27,6 +27,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `customized-consent` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `customized-consent` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/DeviceCodeActivation.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/DeviceCodeActivation.mdx
@@ -27,6 +27,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `device-code-activation` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `device-code-activation` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/DeviceCodeActivationAllowed.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/DeviceCodeActivationAllowed.mdx
@@ -26,6 +26,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `device-code-activation-allowed` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `device-code-activation-allowed` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/DeviceCodeActivationDenied.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/DeviceCodeActivationDenied.mdx
@@ -26,6 +26,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `device-code-activation-denied` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `device-code-activation-denied` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/DeviceCodeConfirmation.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/DeviceCodeConfirmation.mdx
@@ -27,6 +27,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `device-code-confirmation` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `device-code-confirmation` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/EmailIdentifierChallenge.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/EmailIdentifierChallenge.mdx
@@ -27,6 +27,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `email-identifier-challenge` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `email-identifier-challenge` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/EmailOTPChallenge.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/EmailOTPChallenge.mdx
@@ -27,6 +27,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `email-otp-challenge` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `email-otp-challenge` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/EmailVerificationResult.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/EmailVerificationResult.mdx
@@ -27,6 +27,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `email-verification-result` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `email-verification-result` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/InterstitialCaptcha.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/InterstitialCaptcha.mdx
@@ -27,6 +27,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `interstitial-captcha` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `interstitial-captcha` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/Login.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/Login.mdx
@@ -30,6 +30,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `login` screen. 
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `login` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>
@@ -156,12 +160,24 @@ loginManager.login({
   [LoginPayloadOptions](/docs/libraries/acul/js-sdk/Screens/interfaces/LoginPayloadOptions).
 </ParamField>
 
-<ParamField body="username" type="string" required>
-  The user's identifier.
+<ParamField body="identifier?" type="string">
+  The user's identifier — email, username, or phone, depending on `identifierType`. Provide this or `username`; if both are given, `identifier` wins.
+</ParamField>
+
+<ParamField body="username?" type="string">
+  The user's identifier, under its original spelling. Provide this or `identifier`.
+</ParamField>
+
+<ParamField body="identifierType?" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/type-aliases/IdentifierType">IdentifierType</a></span>}>
+  What `identifier` (or `username`) holds. Typically read from `screen.data.activeIdentifierType`. Omit to submit the identifier untyped.
 </ParamField>
 
 <ParamField body="password" type="string" required>
   The user's password.
+</ParamField>
+
+<ParamField body="phoneCountryCode?" type="string">
+  The ISO 3166-1 alpha-2 country for a phone identifier, from a `code` in `countryCodes.available`. Required when `identifierType` is `phone`. Pass the national number — the dial code is prefixed server-side.
 </ParamField>
 
 <ParamField body="captcha?" type="string">

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/Login.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/Login.mdx
@@ -116,6 +116,10 @@ loginManager.federatedLogin({
   The Social or Enterprise Identity Provider connection name.
 </ParamField>
 
+<ParamField body='[`key`: `string`]' type='"string" | "number" | "boolean" | "undefined"'>
+  Additional custom fields prefixed with `ulp-` (for example, `'ulp-custom-field'`).
+</ParamField>
+
 </Expandable>
 </ParamField>
 

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/LoginEmailVerification.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/LoginEmailVerification.mdx
@@ -29,6 +29,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `login-email-verification` screen. 
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `login-email-verification` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/LoginId.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/LoginId.mdx
@@ -27,6 +27,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `login-id` screen. 
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `login-id` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>
@@ -152,8 +156,20 @@ loginIdManager.login({
   [LoginOptions](/docs/libraries/acul/js-sdk/Screens/interfaces/LoginOptions).
 </ParamField>
 
-<ParamField body="username" type="string" required>
-  The user's identifier.
+<ParamField body="identifier?" type="string">
+  The user's identifier — email, username, or phone, depending on `identifierType`. Provide this or `username`; if both are given, `identifier` wins.
+</ParamField>
+
+<ParamField body="username?" type="string">
+  The user's identifier, under its original spelling. Provide this or `identifier`.
+</ParamField>
+
+<ParamField body="identifierType?" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/type-aliases/IdentifierType">IdentifierType</a></span>}>
+  What `identifier` (or `username`) holds. Typically read from `screen.data.activeIdentifierType`. Omit to submit the identifier untyped.
+</ParamField>
+
+<ParamField body="phoneCountryCode?" type="string">
+  The ISO 3166-1 alpha-2 country for a phone identifier, from a `code` in `countryCodes.available`. Required when `identifierType` is `phone`. Pass the national number — the dial code is prefixed server-side.
 </ParamField>
 
 <ParamField body="captcha?" type="string">

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/LoginId.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/LoginId.mdx
@@ -113,6 +113,10 @@ loginIdManager.federatedLogin({
   The Social or Enterprise Identity Provider connection name.
 </ParamField>
 
+<ParamField body='[`key`: `string`]' type='"string" | "number" | "boolean" | "undefined"'>
+  Additional custom fields prefixed with `ulp-` (for example, `'ulp-custom-field'`).
+</ParamField>
+
 </Expandable>
 </ParamField>
 

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/LoginPassword.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/LoginPassword.mdx
@@ -30,6 +30,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `login-password` screen. 
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `login-password` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>
@@ -189,6 +193,33 @@ loginPasswordManager.switchConnection({
 
 <ParamField body="connection" type="string" required>
   The connection name to switch to. Use `'email'` or `'sms'` for passwordless, or a DB connection name for password-based authentication.
+</ParamField>
+
+</Expandable>
+</ParamField>
+
+<ParamField body='switchToOtp' type='Promise<void>'>
+
+This method switches from password entry to a one-time-passcode challenge for this login.
+
+Check `screen.data.showSwitchToOtpButton` before rendering the option — it indicates whether the switch is available for this transaction.
+
+```typescript Example
+import LoginPassword from "@auth0/auth0-acul-js/login-password";
+const loginPasswordManager = new LoginPassword();
+loginPasswordManager.switchToOtp();
+```
+
+**Method Parameters**
+
+<Expandable title="Parameters">
+ 
+<ParamField body="options">
+  [CustomOptions](/docs/libraries/acul/js-sdk/Screens/interfaces/CustomOptions).
+</ParamField>
+
+<ParamField body='[`key`: `string`]' type='"string" | "number" | "boolean" | "undefined"'>
+  Additional custom fields prefixed with `ulp-` (for example, `'ulp-custom-field'`).
 </ParamField>
 
 </Expandable>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/LoginPassword.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/LoginPassword.mdx
@@ -120,6 +120,10 @@ loginPasswordManager.federatedLogin({
   The Social or Enterprise Identity Provider connection name.
 </ParamField>
 
+<ParamField body='[`key`: `string`]' type='"string" | "number" | "boolean" | "undefined"'>
+  Additional custom fields prefixed with `ulp-` (for example, `'ulp-custom-field'`).
+</ParamField>
+
 </Expandable>
 </ParamField>
 
@@ -210,17 +214,4 @@ const loginPasswordManager = new LoginPassword();
 loginPasswordManager.switchToOtp();
 ```
 
-**Method Parameters**
-
-<Expandable title="Parameters">
- 
-<ParamField body="options">
-  [CustomOptions](/docs/libraries/acul/js-sdk/Screens/interfaces/CustomOptions).
-</ParamField>
-
-<ParamField body='[`key`: `string`]' type='"string" | "number" | "boolean" | "undefined"'>
-  Additional custom fields prefixed with `ulp-` (for example, `'ulp-custom-field'`).
-</ParamField>
-
-</Expandable>
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/LoginPasswordlessEmailCode.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/LoginPasswordlessEmailCode.mdx
@@ -29,6 +29,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `login-passwordless-email-code` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `login-passwordless-email-code` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/LoginPasswordlessSmsOtp.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/LoginPasswordlessSmsOtp.mdx
@@ -29,6 +29,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `login-passwordless-sms-otp` screen.
 </ParamField>
 
+<ParamField body="countryCodes" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `login-passwordless-sms-otp` screen.
+</ParamField>
+
 <ParamField body="organization" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/Logout.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/Logout.mdx
@@ -29,6 +29,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `logout` screen.
 </ParamField>
 
+<ParamField body="countryCodes" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `logout` screen.
+</ParamField>
+
 <ParamField body="organization" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/LogoutAborted.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/LogoutAborted.mdx
@@ -30,6 +30,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `logout-aborted` screen.
 </ParamField>
 
+<ParamField body="countryCodes" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `logout-aborted` screen.
+</ParamField>
+
 <ParamField body="organization" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/LogoutComplete.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/LogoutComplete.mdx
@@ -29,6 +29,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `logout-complete` screen.
 </ParamField>
 
+<ParamField body="countryCodes" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `logout-complete` screen.
+</ParamField>
+
 <ParamField body="organization" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/MfaBeginEnrollOptions.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/MfaBeginEnrollOptions.mdx
@@ -29,6 +29,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `mfa-begin-enroll-options` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `mfa-begin-enroll-options` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/MfaCountryCodes.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/MfaCountryCodes.mdx
@@ -31,6 +31,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `mfa-country-codes` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `mfa-country-codes` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/MfaDetectBrowserCapabilities.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/MfaDetectBrowserCapabilities.mdx
@@ -27,6 +27,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `mfa-detect-browser-capabilities` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `mfa-detect-browser-capabilities` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/MfaEmailChallenge.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/MfaEmailChallenge.mdx
@@ -31,6 +31,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `mfa-email-challenge` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `mfa-email-challenge` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/MfaEmailList.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/MfaEmailList.mdx
@@ -30,6 +30,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `mfa-email-list` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `mfa-email-list` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/MfaEnrollResult.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/MfaEnrollResult.mdx
@@ -27,6 +27,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `mfa-enroll-result` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `mfa-enroll-result` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/MfaLoginOptions.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/MfaLoginOptions.mdx
@@ -30,6 +30,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `mfa-login-options` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `mfa-login-options` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/MfaOtpChallenge.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/MfaOtpChallenge.mdx
@@ -31,6 +31,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `mfa-otp-challenge` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `mfa-otp-challenge` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/MfaOtpEnrollmentCode.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/MfaOtpEnrollmentCode.mdx
@@ -30,6 +30,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `mfa-otp-enrollment-code` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `mfa-otp-enrollment-code` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/MfaOtpEnrollmentQr.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/MfaOtpEnrollmentQr.mdx
@@ -28,6 +28,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `mfa-otp-enrollment-qr` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `mfa-otp-enrollment-qr` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/MfaPhoneChallenge.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/MfaPhoneChallenge.mdx
@@ -28,6 +28,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `mfa-phone-challenge` screen.
 </ParamField>
 
+<ParamField body="countryCodes" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `mfa-phone-challenge` screen.
+</ParamField>
+
 <ParamField body="organization" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/MfaPhoneEnrollment.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/MfaPhoneEnrollment.mdx
@@ -28,6 +28,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `mfa-phone-enrollment` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `mfa-phone-enrollment` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/MfaPushChallengePush.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/MfaPushChallengePush.mdx
@@ -28,6 +28,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `mfa-push-challenge-push` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `mfa-push-challenge-push` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/MfaPushEnrollmentQr.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/MfaPushEnrollmentQr.mdx
@@ -28,6 +28,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `mfa-push-enrollment-qr` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `mfa-push-enrollment-qr` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/MfaPushList.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/MfaPushList.mdx
@@ -28,6 +28,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `mfa-push-list` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `mfa-push-list` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/MfaPushWelcome.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/MfaPushWelcome.mdx
@@ -28,6 +28,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `mfa-push-welcome` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `mfa-push-welcome` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/MfaRecoveryCodeChallenge.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/MfaRecoveryCodeChallenge.mdx
@@ -28,6 +28,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `mfa-recovery-code-challenge` screen.
 </ParamField>
 
+<ParamField body="countryCodes" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `mfa-recovery-code-challenge` screen.
+</ParamField>
+
 <ParamField body="organization" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/MfaRecoveryCodeChallengeNewCode.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/MfaRecoveryCodeChallengeNewCode.mdx
@@ -28,6 +28,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `mfa-recovery-code-challenge-new-code` screen.
 </ParamField>
 
+<ParamField body="countryCodes" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `mfa-recovery-code-challenge-new-code` screen.
+</ParamField>
+
 <ParamField body="organization" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/MfaRecoveryCodeEnrollment.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/MfaRecoveryCodeEnrollment.mdx
@@ -28,6 +28,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `mfa-recovery-code-enrollment` screen.
 </ParamField>
 
+<ParamField body="countryCodes" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `mfa-recovery-code-enrollment` screen.
+</ParamField>
+
 <ParamField body="organization" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/MfaSmsChallenge.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/MfaSmsChallenge.mdx
@@ -31,6 +31,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `mfa-sms-challenge` screen.
 </ParamField>
 
+<ParamField body="countryCodes" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `mfa-sms-challenge` screen.
+</ParamField>
+
 <ParamField body="organization" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/MfaSmsEnrollment.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/MfaSmsEnrollment.mdx
@@ -28,6 +28,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `mfa-sms-enrollment` screen.
 </ParamField>
 
+<ParamField body="countryCodes" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `mfa-sms-enrollment` screen.
+</ParamField>
+
 <ParamField body="organization" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/MfaSmsList.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/MfaSmsList.mdx
@@ -28,6 +28,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `mfa-sms-list` screen.
 </ParamField>
 
+<ParamField body="countryCodes" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `mfa-sms-list` screen.
+</ParamField>
+
 <ParamField body="organization" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/MfaVoiceChallenge.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/MfaVoiceChallenge.mdx
@@ -28,6 +28,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `mfa-voice-challenge` screen.
 </ParamField>
 
+<ParamField body="countryCodes" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `mfa-voice-challenge` screen.
+</ParamField>
+
 <ParamField body="organization" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/MfaVoiceEnrollment.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/MfaVoiceEnrollment.mdx
@@ -28,6 +28,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `mfa-voice-enrollment` screen.
 </ParamField>
 
+<ParamField body="countryCodes" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `mfa-voice-enrollment` screen.
+</ParamField>
+
 <ParamField body="organization" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/MfaWebAuthnChangeKeyNickname.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/MfaWebAuthnChangeKeyNickname.mdx
@@ -28,6 +28,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `mfa-webauthn-change-key-nickname` screen.
 </ParamField>
 
+<ParamField body="countryCodes" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `mfa-webauthn-change-key-nickname` screen.
+</ParamField>
+
 <ParamField body="organization" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/MfaWebAuthnEnrollmentSuccess.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/MfaWebAuthnEnrollmentSuccess.mdx
@@ -28,6 +28,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `mfa-webauthn-enrollment-success` screen.
 </ParamField>
 
+<ParamField body="countryCodes" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `mfa-webauthn-enrollment-success` screen.
+</ParamField>
+
 <ParamField body="organization" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/MfaWebAuthnError.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/MfaWebAuthnError.mdx
@@ -28,6 +28,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `mfa-webauthn-error` screen.
 </ParamField>
 
+<ParamField body="countryCodes" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `mfa-webauthn-error` screen.
+</ParamField>
+
 <ParamField body="organization" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/MfaWebAuthnNotAvailableError.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/MfaWebAuthnNotAvailableError.mdx
@@ -28,6 +28,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `mfa-webauthn-not-available-error` screen.
 </ParamField>
 
+<ParamField body="countryCodes" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `mfa-webauthn-not-available-error` screen.
+</ParamField>
+
 <ParamField body="organization" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/MfaWebAuthnPlatformChallenge.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/MfaWebAuthnPlatformChallenge.mdx
@@ -28,6 +28,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `mfa-webauthn-platform-challenge` screen.
 </ParamField>
 
+<ParamField body="countryCodes" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `mfa-webauthn-platform-challenge` screen.
+</ParamField>
+
 <ParamField body="organization" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/MfaWebAuthnPlatformEnrollment.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/MfaWebAuthnPlatformEnrollment.mdx
@@ -28,6 +28,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `mfa-webauthn-platform-enrollment` screen.
 </ParamField>
 
+<ParamField body="countryCodes" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `mfa-webauthn-platform-enrollment` screen.
+</ParamField>
+
 <ParamField body="organization" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/MfaWebAuthnRoamingChallenge.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/MfaWebAuthnRoamingChallenge.mdx
@@ -28,6 +28,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `mfa-webauthn-roaming-challenge` screen.
 </ParamField>
 
+<ParamField body="countryCodes" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `mfa-webauthn-roaming-challenge` screen.
+</ParamField>
+
 <ParamField body="organization" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/MfaWebAuthnRoamingEnrollment.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/MfaWebAuthnRoamingEnrollment.mdx
@@ -28,6 +28,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `mfa-webauthn-roaming-enrollment` screen.
 </ParamField>
 
+<ParamField body="countryCodes" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `mfa-webauthn-roaming-enrollment` screen.
+</ParamField>
+
 <ParamField body="organization" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/OrganizationPicker.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/OrganizationPicker.mdx
@@ -27,6 +27,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `organization-picker` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `organization-picker` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/OrganizationSelection.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/OrganizationSelection.mdx
@@ -29,6 +29,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `organization-selection` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `organization-selection` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/PasskeyEnrollment.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/PasskeyEnrollment.mdx
@@ -27,6 +27,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `passkey-enrollment` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `passkey-enrollment` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/PasskeyEnrollmentLocal.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/PasskeyEnrollmentLocal.mdx
@@ -27,6 +27,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `passkey-enrollment-local` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `passkey-enrollment-local` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/PhoneIdentifierChallenge.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/PhoneIdentifierChallenge.mdx
@@ -29,6 +29,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `phone-identifier-challenge` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `phone-identifier-challenge` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/PhoneIdentifierEnrollment.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/PhoneIdentifierEnrollment.mdx
@@ -29,6 +29,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `phone-identifier-enrollment` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `phone-identifier-enrollment` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/RedeemTicket.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/RedeemTicket.mdx
@@ -27,6 +27,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `redeem-ticket` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `redeem-ticket` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/ResetPassword.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/ResetPassword.mdx
@@ -30,6 +30,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `reset-password` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `reset-password` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/ResetPasswordEmail.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/ResetPasswordEmail.mdx
@@ -27,6 +27,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `reset-password-email` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `reset-password-email` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/ResetPasswordError.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/ResetPasswordError.mdx
@@ -26,6 +26,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `reset-password-error` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `reset-password-error` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/ResetPasswordMfaEmailChallenge.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/ResetPasswordMfaEmailChallenge.mdx
@@ -29,6 +29,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `reset-password-mfa-email-challenge` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `reset-password-mfa-email-challenge` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/ResetPasswordMfaOtpChallenge.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/ResetPasswordMfaOtpChallenge.mdx
@@ -29,6 +29,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `reset-password-mfa-otp-challenge` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `reset-password-mfa-otp-challenge` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/ResetPasswordMfaPhoneChallenge.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/ResetPasswordMfaPhoneChallenge.mdx
@@ -29,6 +29,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `reset-password-mfa-phone-challenge` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `reset-password-mfa-phone-challenge` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/ResetPasswordMfaPushChallengePush.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/ResetPasswordMfaPushChallengePush.mdx
@@ -27,6 +27,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `reset-password-mfa-push-challenge-push` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `reset-password-mfa-push-challenge-push` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/ResetPasswordMfaRecoveryCodeChallenge.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/ResetPasswordMfaRecoveryCodeChallenge.mdx
@@ -27,6 +27,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `reset-password-mfa-recovery-code-challenge` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `reset-password-mfa-recovery-code-challenge` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/ResetPasswordMfaSmsChallenge.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/ResetPasswordMfaSmsChallenge.mdx
@@ -29,6 +29,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `reset-password-mfa-sms-challenge` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `reset-password-mfa-sms-challenge` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/ResetPasswordMfaVoiceChallenge.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/ResetPasswordMfaVoiceChallenge.mdx
@@ -27,6 +27,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `reset-password-mfa-voice-challenge` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `reset-password-mfa-voice-challenge` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/ResetPasswordMfaWebAuthnPlatformChallenge.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/ResetPasswordMfaWebAuthnPlatformChallenge.mdx
@@ -29,6 +29,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `reset-password-mfa-webauthn-platform-challenge` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `reset-password-mfa-webauthn-platform-challenge` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/ResetPasswordMfaWebAuthnRoamingChallenge.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/ResetPasswordMfaWebAuthnRoamingChallenge.mdx
@@ -37,6 +37,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `reset-password-mfa-webauthn-roaming-challenge` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `reset-password-mfa-webauthn-roaming-challenge` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/ResetPasswordRequest.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/ResetPasswordRequest.mdx
@@ -27,6 +27,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `reset-password-request` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `reset-password-request` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/ResetPasswordSuccess.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/ResetPasswordSuccess.mdx
@@ -26,6 +26,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `reset-password-success` screen.
 </ParamField>
 
+<ParamField body='countryCodes' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `reset-password-success` screen.
+</ParamField>
+
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/Signup.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/Signup.mdx
@@ -30,6 +30,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `signup` screen.
 </ParamField>
 
+<ParamField body="countryCodes" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `signup` screen.
+</ParamField>
+
 <ParamField body="organization" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>
@@ -203,6 +207,10 @@ signupManager.signup({
 
 <ParamField body="phoneNumber?" type="string">
   The user's phone number.
+</ParamField>
+
+<ParamField body="phoneCountryCode?" type="string">
+  The ISO 3166-1 alpha-2 country the user selected for `phoneNumber` (for example, `'US'`), from a `code` in `countryCodes.available`. The submitted country is authoritative — the server prefixes its dial code, so `phoneNumber` should be the national number without a dial code. Omit it to keep the existing behavior, where the server derives the country itself and `pickCountryCode()` changes the selection on a separate screen.
 </ParamField>
 
 <ParamField body="password?" type="string">

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/SignupId.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/SignupId.mdx
@@ -29,6 +29,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `signup-id` screen.
 </ParamField>
 
+<ParamField body="countryCodes" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `signup-id` screen.
+</ParamField>
+
 <ParamField body="organization" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>
@@ -201,6 +205,10 @@ signupIdManager.signup({
 
 <ParamField body="phone?" type="string">
   The user's phone number.
+</ParamField>
+
+<ParamField body="phoneCountryCode?" type="string">
+  The ISO 3166-1 alpha-2 country the user selected for `phone` (for example, `'US'`), from a `code` in `countryCodes.available`. The submitted country is authoritative — the server prefixes its dial code, so `phone` should be the national number without a dial code. Omit it to keep the existing behavior, where the server derives the country itself and `pickCountryCode()` changes the selection on a separate screen.
 </ParamField>
 
 <ParamField body="captcha?" type="string">

--- a/main/docs/libraries/acul/js-sdk/Screens/classes/SignupPassword.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/classes/SignupPassword.mdx
@@ -30,6 +30,10 @@ Provides branding-related configurations, such as branding theme and settings.
 Provides client-related configurations, such as `id`, `name`, and `logoUrl`, for the `signup-password` screen.
 </ParamField>
 
+<ParamField body="countryCodes" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+Provides country code data for phone number entry, such as `available` and `recommended`, for the `signup-password` screen.
+</ParamField>
+
 <ParamField body="organization" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/OrganizationMembers">OrganizationMembers</a></span>}>
 Provides information about the user's Organization, such as `id` and `name`.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/interfaces/AvailableCountryCode.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/interfaces/AvailableCountryCode.mdx
@@ -1,0 +1,25 @@
+---
+title: "AvailableCountryCode"
+---
+
+```ts Example
+export interface AvailableCountryCode {
+  code: string;
+  label: string;
+  dialCode: string;
+}
+```
+
+## Properties
+
+<ParamField body="code" type="string">
+The ISO 3166-1 alpha-2 country code (for example, `"US"`). Submitted as `phoneCountryCode`. Not unique across the list — a country with multiple dial codes contributes one entry per code.
+</ParamField>
+
+<ParamField body="dialCode" type="string">
+The dial code with its leading plus (for example, `"+1"`). Display only.
+</ParamField>
+
+<ParamField body="label" type="string">
+The country name, localized to the render locale.
+</ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/interfaces/BrandingThemes.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/interfaces/BrandingThemes.mdx
@@ -9,6 +9,7 @@ export interface BrandingThemes {
     colors: Record<string, string>;
     displayName: string;
     fonts: Record<string, string | boolean | object>;
+    identifiers?: ThemeIdentifiers;
     pageBackground: Record<string, string>;
     widget: Record<string, string | number>;
   };
@@ -28,6 +29,8 @@ export interface BrandingThemes {
 <ParamField body='displayName' type='string'/>
 
 <ParamField body='fonts' type='Record<string, string | boolean | object>'/>
+
+<ParamField body='identifiers?' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/ThemeIdentifiers">ThemeIdentifiers</a></span>}/>
 
 <ParamField body='pageBackground' type='Record<string, string>'/>
 

--- a/main/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/interfaces/CountryCodesMembers.mdx
@@ -1,0 +1,20 @@
+---
+title: "CountryCodesMembers"
+---
+
+```ts Example
+export interface CountryCodesMembers {
+  available: AvailableCountryCode[] | null;
+  recommended: string | null;
+}
+```
+
+## Properties
+
+<ParamField body="available" type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/AvailableCountryCode">AvailableCountryCode</a>[]</span>}>
+Countries available for phone entry, sorted by localized `label`. `null` unless the screen's rendering configuration requests them.
+</ParamField>
+
+<ParamField body="recommended" type="string">
+ISO 3166-1 alpha-2 code to preselect, not an index into `available`. `null` when unresolved.
+</ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/interfaces/GoogleOneTapConfig.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/interfaces/GoogleOneTapConfig.mdx
@@ -1,0 +1,54 @@
+---
+title: "GoogleOneTapConfig"
+---
+
+Configuration for Google One Tap / FedCM, provided by the server in `screen.data.google_one_tap`.
+
+```ts Example
+export interface GoogleOneTapConfig {
+  client_id: string;
+  nonce: string;
+  context: string;
+  itp_support: boolean;
+  auto_select: boolean;
+  cancel_on_tap_outside: boolean;
+}
+```
+
+## Properties
+
+<ParamField body='auto_select' type='boolean'>
+
+When `true`, the credential is returned automatically without user interaction if a single Google session is available and has previously consented.
+
+</ParamField>
+
+<ParamField body='cancel_on_tap_outside' type='boolean'>
+
+When `true`, the One Tap prompt closes if the user clicks outside it. Set to `false` to require an explicit dismissal.
+
+</ParamField>
+
+<ParamField body='client_id' type='string'>
+
+The Google OAuth 2.0 client ID for this application.
+
+</ParamField>
+
+<ParamField body='context' type='string'>
+
+Changes the title and messages shown in the One Tap prompt. Accepted values: `"signin"` (default), `"signup"`, `"use"`.
+
+</ParamField>
+
+<ParamField body='itp_support' type='boolean'>
+
+When `true`, enables Intelligent Tracking Prevention (ITP) support for Safari/WebKit browsers that restrict third-party cookies.
+
+</ParamField>
+
+<ParamField body='nonce' type='string'>
+
+A random value used to associate the credential with this session and prevent replay attacks.
+
+</ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/interfaces/LoginOptions.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/interfaces/LoginOptions.mdx
@@ -4,7 +4,10 @@ title: "LoginOptions"
 
 ```ts Example
 export interface LoginOptions {
-  username: string;
+  username?: string;
+  identifier?: string;
+  identifierType?: IdentifierType;
+  phoneCountryCode?: string;
   captcha?: string;
   [key: string]: string | number | boolean | undefined;
 }
@@ -18,4 +21,26 @@ export interface LoginOptions {
 
 <ParamField body='captcha?' type='string'/>
 
-<ParamField body='username' type='string'/>
+<ParamField body='identifier?' type='string'>
+
+The identifier to login with — email, username, or phone, depending on `identifierType`. Optional if `username` is supplied; if both are given, `identifier` wins.
+
+</ParamField>
+
+<ParamField body='identifierType?' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/type-aliases/IdentifierType">IdentifierType</a></span>}>
+
+What `identifier` (or `username`) holds. Typically read from `screen.data.activeIdentifierType`. Omit to submit the identifier untyped.
+
+</ParamField>
+
+<ParamField body='phoneCountryCode?' type='string'>
+
+The ISO 3166-1 alpha-2 country for a phone identifier, from a `code` in `countryCodes.available`. Required when `identifierType` is `phone`. Pass the national number — the dial code is prefixed server-side.
+
+</ParamField>
+
+<ParamField body='username?' type='string'>
+
+The user's identifier, under its original spelling. Optional if `identifier` is supplied — required otherwise.
+
+</ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/interfaces/LoginPayloadOptions.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/interfaces/LoginPayloadOptions.mdx
@@ -6,10 +6,16 @@ Options for performing login operations
 
 ```ts Example
 export interface LoginOptions {
-  /** The username/email to login with */
-  username: string;
+  /** The user's identifier, under its original spelling. Optional if `identifier` is supplied. */
+  username?: string;
+  /** The identifier to login with. Optional if `username` is supplied — `identifier` wins if both are given. */
+  identifier?: string;
+  /** What `identifier` (or `username`) holds — typically from `screen.data.activeIdentifierType`. */
+  identifierType?: IdentifierType;
   /** The password for authentication */
   password: string;
+  /** ISO 3166-1 alpha-2 country for a phone identifier, from a `code` in `countryCodes.available`. */
+  phoneCountryCode?: string;
   /** Optional captcha value if required */
   captcha?: string;
   /** Any additional custom options */
@@ -31,13 +37,31 @@ Optional captcha value if required
 
 </ParamField>
 
+<ParamField body='identifier?' type='string'>
+
+The identifier to login with — email, username, or phone, depending on `identifierType`. Optional if `username` is supplied; if both are given, `identifier` wins.
+
+</ParamField>
+
+<ParamField body='identifierType?' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/type-aliases/IdentifierType">IdentifierType</a></span>}>
+
+What `identifier` (or `username`) holds. Typically read from `screen.data.activeIdentifierType`. Omit to submit the identifier untyped.
+
+</ParamField>
+
 <ParamField body='password' type='string'>
 
 The password for authentication
 
 </ParamField>
 
-<ParamField body='username' type='string'>
+<ParamField body='phoneCountryCode?' type='string'>
 
-The username/email to login with
+The ISO 3166-1 alpha-2 country for a phone identifier, from a `code` in `countryCodes.available`. Required when `identifierType` is `phone`. Pass the national number — the dial code is prefixed server-side.
+
+</ParamField>
+
+<ParamField body='username?' type='string'>
+
+The user's identifier, under its original spelling. Optional if `identifier` is supplied — required otherwise.
 </ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/interfaces/PasskeyRead.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/interfaces/PasskeyRead.mdx
@@ -1,0 +1,27 @@
+---
+title: "PasskeyRead"
+---
+
+```ts Example
+export interface PasskeyRead {
+  public_key: {
+    challenge: Base64URLString;
+    allowCredentials?: AllowCredential[];
+    rpId?: string;
+  };
+}
+```
+
+## Properties
+
+### public\_key
+
+> **public\_key**: `object`
+
+<ParamField body='allowCredentials?' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/AllowCredential">AllowCredential</a>[]</span>}/>
+
+<ParamField body='challenge' type='string'/>
+
+<ParamField body='rpId?' type='string'>
+The relying party ID to scope the passkey autofill request to. Optional — omit to use the default relying party.
+</ParamField>

--- a/main/docs/libraries/acul/js-sdk/Screens/interfaces/PasskeyRead.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/interfaces/PasskeyRead.mdx
@@ -5,7 +5,7 @@ title: "PasskeyRead"
 ```ts Example
 export interface PasskeyRead {
   public_key: {
-    challenge: Base64URLString;
+    challenge: string;
     allowCredentials?: AllowCredential[];
     rpId?: string;
   };

--- a/main/docs/libraries/acul/js-sdk/Screens/interfaces/ScreenMembersOnLogin.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/interfaces/ScreenMembersOnLogin.mdx
@@ -10,6 +10,7 @@ export interface ScreenMembersOnLogin extends ScreenMembers {
   resetPasswordLink: string | null;
   data: {
     username?: string;
+    activeIdentifierType?: IdentifierType;
   } | null;
 }
 ```
@@ -24,7 +25,11 @@ export interface ScreenMembersOnLogin extends ScreenMembers {
 
 <ParamField body='captchaSiteKey' type='string'/>
 
-<ParamField body='data' type='username?'/>
+<ParamField body='data' type='username?, activeIdentifierType?'>
+
+`activeIdentifierType` is the identifier input to pre-select. Absent when the server resolved none — fall back to the first of `email`, `username`, `phone` in `getLoginIdentifiers()`.
+
+</ParamField>
 
 <ParamField body='isCaptchaAvailable' type='boolean'/>
 

--- a/main/docs/libraries/acul/js-sdk/Screens/interfaces/ScreenMembersOnLogin.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/interfaces/ScreenMembersOnLogin.mdx
@@ -8,6 +8,7 @@ Extended screen members interface for the login screen
 export interface ScreenMembersOnLogin extends ScreenMembers {
   signupLink: string | null;
   resetPasswordLink: string | null;
+  googleOneTapConfig: GoogleOneTapConfig | null;
   data: {
     username?: string;
     activeIdentifierType?: IdentifierType;
@@ -30,6 +31,8 @@ export interface ScreenMembersOnLogin extends ScreenMembers {
 `activeIdentifierType` is the identifier input to pre-select. Absent when the server resolved none — fall back to the first of `email`, `username`, `phone` in `getLoginIdentifiers()`.
 
 </ParamField>
+
+<ParamField body='googleOneTapConfig' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/GoogleOneTapConfig">GoogleOneTapConfig</a></span>}/>
 
 <ParamField body='isCaptchaAvailable' type='boolean'/>
 

--- a/main/docs/libraries/acul/js-sdk/Screens/interfaces/ScreenMembersOnLoginId.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/interfaces/ScreenMembersOnLoginId.mdx
@@ -7,6 +7,10 @@ export interface ScreenMembersOnLoginId extends ScreenMembers {
   signupLink: string | null;
   resetPasswordLink: string | null;
   publicKey: PasskeyRead['public_key'] | null;
+  data: {
+    passkey?: PasskeyRead;
+    activeIdentifierType?: IdentifierType;
+  } | null;
 }
 ```
 
@@ -20,7 +24,11 @@ export interface ScreenMembersOnLoginId extends ScreenMembers {
 
 <ParamField body='captchaSiteKey' type='string'/>
 
-<ParamField body='data' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/PasskeyCreate">PasskeyCreate</a></span>}/>
+<ParamField body='data' type='passkey?, activeIdentifierType?'>
+
+`activeIdentifierType` is the identifier input to pre-select. Absent when the server resolved none — fall back to the first of `email`, `username`, `phone` in `getLoginIdentifiers()`.
+
+</ParamField>
 
 <ParamField body='isCaptchaAvailable' type='boolean'/>
 
@@ -28,7 +36,7 @@ export interface ScreenMembersOnLoginId extends ScreenMembers {
 
 <ParamField body='name' type='string'/>
 
-<ParamField body='publicKey' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/AllowCredential">AllowCredential</a></span>}/>
+<ParamField body='publicKey' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/PasskeyRead">PasskeyRead</a>['public_key']</span>}/>
 
 <ParamField body='resetPasswordLink' type='string'/>
 

--- a/main/docs/libraries/acul/js-sdk/Screens/interfaces/ScreenMembersOnLoginId.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/interfaces/ScreenMembersOnLoginId.mdx
@@ -7,6 +7,7 @@ export interface ScreenMembersOnLoginId extends ScreenMembers {
   signupLink: string | null;
   resetPasswordLink: string | null;
   publicKey: PasskeyRead['public_key'] | null;
+  googleOneTapConfig: GoogleOneTapConfig | null;
   data: {
     passkey?: PasskeyRead;
     activeIdentifierType?: IdentifierType;
@@ -29,6 +30,8 @@ export interface ScreenMembersOnLoginId extends ScreenMembers {
 `activeIdentifierType` is the identifier input to pre-select. Absent when the server resolved none — fall back to the first of `email`, `username`, `phone` in `getLoginIdentifiers()`.
 
 </ParamField>
+
+<ParamField body='googleOneTapConfig' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/GoogleOneTapConfig">GoogleOneTapConfig</a></span>}/>
 
 <ParamField body='isCaptchaAvailable' type='boolean'/>
 

--- a/main/docs/libraries/acul/js-sdk/Screens/interfaces/ScreenMembersOnLoginId.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/interfaces/ScreenMembersOnLoginId.mdx
@@ -9,7 +9,6 @@ export interface ScreenMembersOnLoginId extends ScreenMembers {
   publicKey: PasskeyRead['public_key'] | null;
   googleOneTapConfig: GoogleOneTapConfig | null;
   data: {
-    passkey?: PasskeyRead;
     activeIdentifierType?: IdentifierType;
   } | null;
 }
@@ -25,7 +24,7 @@ export interface ScreenMembersOnLoginId extends ScreenMembers {
 
 <ParamField body='captchaSiteKey' type='string'/>
 
-<ParamField body='data' type='passkey?, activeIdentifierType?'>
+<ParamField body='data' type='activeIdentifierType?'>
 
 `activeIdentifierType` is the identifier input to pre-select. Absent when the server resolved none — fall back to the first of `email`, `username`, `phone` in `getLoginIdentifiers()`.
 

--- a/main/docs/libraries/acul/js-sdk/Screens/interfaces/ScreenMembersOnLoginPassword.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/interfaces/ScreenMembersOnLoginPassword.mdx
@@ -9,6 +9,7 @@ export interface ScreenMembersOnLoginPassword extends ScreenMembers {
   editIdentifierLink: string | null;
   data: {
     username: string;
+    showSwitchToOtpButton?: boolean;
   } | null;
 }
 ```
@@ -23,7 +24,11 @@ export interface ScreenMembersOnLoginPassword extends ScreenMembers {
 
 <ParamField body='captchaSiteKey' type='string'/>
 
-<ParamField body='data' type='username'/>
+<ParamField body='data' type='username, showSwitchToOtpButton?'>
+
+`showSwitchToOtpButton` indicates whether to render an option to switch from password entry to a one-time-passcode challenge.
+
+</ParamField>
 
 <ParamField body='editIdentifierLink' type='string'/>
 

--- a/main/docs/libraries/acul/js-sdk/Screens/interfaces/ScreenMembersOnSignup.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/interfaces/ScreenMembersOnSignup.mdx
@@ -5,6 +5,7 @@ title: "ScreenMembersOnSignup"
 ```ts Example
 export interface ScreenMembersOnSignup extends ScreenMembers {
   loginLink: string | null;
+  googleOneTapConfig: GoogleOneTapConfig | null;
 }
 ```
 
@@ -19,6 +20,8 @@ export interface ScreenMembersOnSignup extends ScreenMembers {
 <ParamField body='captchaSiteKey' type='string'/>
 
 <ParamField body='data' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/PasskeyCreate">PasskeyCreate</a></span>}/>
+
+<ParamField body='googleOneTapConfig' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/GoogleOneTapConfig">GoogleOneTapConfig</a></span>}/>
 
 <ParamField body='isCaptchaAvailable' type='boolean'/>
 

--- a/main/docs/libraries/acul/js-sdk/Screens/interfaces/ScreenMembersOnSignupId.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/interfaces/ScreenMembersOnSignupId.mdx
@@ -5,6 +5,7 @@ title: "ScreenMembersOnSignupId"
 ```ts Example
 export interface ScreenMembersOnSignupId extends ScreenMembers {
   loginLink: string | null;
+  googleOneTapConfig: GoogleOneTapConfig | null;
 }
 ```
 
@@ -19,6 +20,8 @@ export interface ScreenMembersOnSignupId extends ScreenMembers {
 <ParamField body='captchaSiteKey' type='string'/>
 
 <ParamField body='data' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/PasskeyCreate">PasskeyCreate</a></span>}/>
+
+<ParamField body='googleOneTapConfig' type={<span><a href="/docs/libraries/acul/js-sdk/Screens/interfaces/GoogleOneTapConfig">GoogleOneTapConfig</a></span>}/>
 
 <ParamField body='isCaptchaAvailable' type='boolean'/>
 

--- a/main/docs/libraries/acul/js-sdk/Screens/interfaces/SignupOptions.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/interfaces/SignupOptions.mdx
@@ -7,6 +7,7 @@ export interface SignupOptions {
   email?: string;
   username?: string;
   phone?: string;
+  phoneCountryCode?: string;
   captcha?: string;
   [key: string]: string | number | boolean | undefined;
 }
@@ -23,5 +24,11 @@ export interface SignupOptions {
 <ParamField body='email?' type='string'/>
 
 <ParamField body='phone?' type='string'/>
+
+<ParamField body='phoneCountryCode?' type='string'>
+
+The ISO 3166-1 alpha-2 country the user selected for `phone` (for example `'US'`), from a `code` in `countryCodes.available`. The submitted country is authoritative — the server prefixes its dial code, so `phone` should be the national number without a dial code. Omit it to keep the existing behavior, where the server derives the country itself and `pickCountryCode()` changes the selection on a separate screen.
+
+</ParamField>
 
 <ParamField body='username?' type='string'/>

--- a/main/docs/libraries/acul/js-sdk/Screens/interfaces/SignupPayloadOptions.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/interfaces/SignupPayloadOptions.mdx
@@ -7,6 +7,7 @@ export interface SignupOptions {
   email?: string;
   username?: string;
   phoneNumber?: string;
+  phoneCountryCode?: string;
   password?: string;
   captcha?: string;
   [key: string]: string | number | boolean | undefined;
@@ -24,6 +25,12 @@ export interface SignupOptions {
 <ParamField body='email?' type='string'/>
 
 <ParamField body='password?' type='string'/>
+
+<ParamField body='phoneCountryCode?' type='string'>
+
+The ISO 3166-1 alpha-2 country the user selected for `phoneNumber` (for example `'US'`), from a `code` in `countryCodes.available`. The submitted country is authoritative — the server prefixes its dial code, so `phoneNumber` should be the national number without a dial code. Omit it to keep the existing behavior, where the server derives the country itself and `pickCountryCode()` changes the selection on a separate screen.
+
+</ParamField>
 
 <ParamField body='phoneNumber?' type='string'/>
 

--- a/main/docs/libraries/acul/js-sdk/Screens/interfaces/ThemeIdentifiers.mdx
+++ b/main/docs/libraries/acul/js-sdk/Screens/interfaces/ThemeIdentifiers.mdx
@@ -1,0 +1,37 @@
+---
+title: "ThemeIdentifiers"
+---
+
+```ts Example
+export interface ThemeIdentifiers {
+  loginDisplay?: 'unified' | 'separate';
+  otpAutocomplete?: boolean;
+  phoneDisplay?: {
+    masking?: 'show_all' | 'hide_country_code' | 'mask_digits';
+    formatting?: 'regional' | 'international';
+  };
+}
+```
+
+## Properties
+
+<ParamField body='loginDisplay?' type='"unified" | "separate"'>
+How the identifier fields are laid out on the login and signup screens. `'unified'` renders a single input accepting any enabled identifier; `'separate'` renders one input per enabled identifier.
+</ParamField>
+
+<ParamField body='otpAutocomplete?' type='boolean'/>
+
+<ParamField body='phoneDisplay?' type='object'>
+
+<Expandable title="properties">
+
+<ParamField body='formatting?' type='"regional" | "international"'>
+How an already-entered phone number is formatted for display: `'regional'` uses the national convention for the number's country, `'international'` includes the dial code.
+</ParamField>
+
+<ParamField body='masking?' type='"show_all" | "hide_country_code" | "mask_digits"'>
+How much of an already-entered phone number is revealed when displayed back to the user.
+</ParamField>
+
+</Expandable>
+</ParamField>

--- a/main/docs/libraries/acul/react-sdk/API-Reference/Screens/login-id/index.mdx
+++ b/main/docs/libraries/acul/react-sdk/API-Reference/Screens/login-id/index.mdx
@@ -25,6 +25,7 @@ import {
   useTenant,
   useBranding,
   useClient,
+  useCountryCodes,
   useOrganization,
   usePrompt,
   useScreen,
@@ -80,6 +81,19 @@ This hook provides client-related configurations, such as `id`, `name`, and `log
 import { useClient } from '@auth0/auth0-acul-react/login-id';
 function AppInfo() {
   const client = useClient();
+}
+```
+</ParamField>
+
+<ParamField body='useCountryCodes' type={<span>() =&gt; <a href="/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+
+This hook provides the available phone country codes and recommended default for the `login-id` screen.
+
+```jsx Example
+import { useCountryCodes } from '@auth0/auth0-acul-react/login-id';
+function CountryPicker() {
+  const countryCodes = useCountryCodes();
+  const available = countryCodes?.available;
 }
 ```
 </ParamField>
@@ -226,6 +240,10 @@ function SocialButton() {
   The Social or Enterprise Identity Provider connection name.
 </ParamField>
 
+<ParamField body='[`key`: `string`]' type='"string" | "number" | "boolean" | "undefined"'>
+  Additional custom fields prefixed with `ulp-` (for example, `'ulp-custom-field'`).
+</ParamField>
+
 </Expandable>
 </ParamField>
 
@@ -254,8 +272,20 @@ function LoginIdForm() {
   [LoginOptions](/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/LoginOptions).
 </ParamField>
 
-<ParamField body='username' type='string' required>
-  The identifier (email, phone number, or username) to authenticate with.
+<ParamField body='identifier?' type='string'>
+  The user's identifier — email, username, or phone, depending on `identifierType`. Provide this or `username`; if both are given, `identifier` wins.
+</ParamField>
+
+<ParamField body='username?' type='string'>
+  The user's identifier, under its original spelling. Provide this or `identifier`.
+</ParamField>
+
+<ParamField body='identifierType?' type={<span><a href="/docs/libraries/acul/react-sdk/API-Reference/Types/type-aliases/IdentifierType">IdentifierType</a></span>}>
+  What `identifier` (or `username`) holds. Typically read from `screen.data.activeIdentifierType`. Omit to submit the identifier untyped.
+</ParamField>
+
+<ParamField body='phoneCountryCode?' type='string'>
+  The ISO 3166-1 alpha-2 country for a phone identifier, from a `code` in `countryCodes.available`. Required when `identifierType` is `phone`. Pass the national number — the dial code is prefixed server-side.
 </ParamField>
 
 <ParamField body='captcha?' type='string'>

--- a/main/docs/libraries/acul/react-sdk/API-Reference/Screens/login-password/index.mdx
+++ b/main/docs/libraries/acul/react-sdk/API-Reference/Screens/login-password/index.mdx
@@ -40,6 +40,7 @@ import {
   login,
   federatedLogin,
   switchConnection,
+  switchToOtp,
 } from '@auth0/auth0-acul-react/login-password';
 
 function LoginPasswordForm() {
@@ -202,6 +203,10 @@ function SocialButton() {
   The Social or Enterprise Identity Provider connection name.
 </ParamField>
 
+<ParamField body='[`key`: `string`]' type='"string" | "number" | "boolean" | "undefined"'>
+  Additional custom fields prefixed with `ulp-` (for example, `'ulp-custom-field'`).
+</ParamField>
+
 </Expandable>
 </ParamField>
 
@@ -279,6 +284,27 @@ function ConnectionSwitcher() {
 </ParamField>
 
 </Expandable>
+</ParamField>
+
+<ParamField body='switchToOtp' type='Promise<void>'>
+
+This method switches from password entry to a one-time-passcode challenge for this login.
+
+Check `screen.data.showSwitchToOtpButton` before rendering the option — it indicates whether the switch is available for this transaction.
+
+```jsx Example
+import { useLoginPassword } from '@auth0/auth0-acul-react/login-password';
+
+function OtpSwitchButton() {
+  const { switchToOtp } = useLoginPassword();
+  return (
+    <button onClick={() => switchToOtp()}>
+      Use a one-time code instead
+    </button>
+  );
+}
+```
+
 </ParamField>
 
 ## Common/Utility Hooks

--- a/main/docs/libraries/acul/react-sdk/API-Reference/Screens/login/index.mdx
+++ b/main/docs/libraries/acul/react-sdk/API-Reference/Screens/login/index.mdx
@@ -25,6 +25,7 @@ import {
   useTenant,
   useBranding,
   useClient,
+  useCountryCodes,
   useOrganization,
   usePrompt,
   useScreen,
@@ -78,6 +79,19 @@ This hook provides client-related configurations, such as `id`, `name`, and `log
 import { useClient } from '@auth0/auth0-acul-react/login';
 function AppInfo() {
   const client = useClient();
+}
+```
+</ParamField>
+
+<ParamField body='useCountryCodes' type={<span>() =&gt; <a href="/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+
+This hook provides the available phone country codes and recommended default for the `login` screen.
+
+```jsx Example
+import { useCountryCodes } from '@auth0/auth0-acul-react/login';
+function CountryPicker() {
+  const countryCodes = useCountryCodes();
+  const available = countryCodes?.available;
 }
 ```
 </ParamField>
@@ -224,6 +238,10 @@ function SocialButton() {
   The Social or Enterprise Identity Provider connection name.
 </ParamField>
 
+<ParamField body='[`key`: `string`]' type='"string" | "number" | "boolean" | "undefined"'>
+  Additional custom fields prefixed with `ulp-` (for example, `'ulp-custom-field'`).
+</ParamField>
+
 </Expandable>
 </ParamField>
 
@@ -252,12 +270,24 @@ function LoginForm() {
   [LoginPayloadOptions](/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/LoginPayloadOptions).
 </ParamField>
 
-<ParamField body='username' type='string' required>
-  The username or email to authenticate with.
+<ParamField body='identifier?' type='string'>
+  The user's identifier — email, username, or phone, depending on `identifierType`. Provide this or `username`; if both are given, `identifier` wins.
+</ParamField>
+
+<ParamField body='username?' type='string'>
+  The user's identifier, under its original spelling. Provide this or `identifier`.
+</ParamField>
+
+<ParamField body='identifierType?' type={<span><a href="/docs/libraries/acul/react-sdk/API-Reference/Types/type-aliases/IdentifierType">IdentifierType</a></span>}>
+  What `identifier` (or `username`) holds. Typically read from `screen.data.activeIdentifierType`. Omit to submit the identifier untyped.
 </ParamField>
 
 <ParamField body='password' type='string' required>
   The password for authentication.
+</ParamField>
+
+<ParamField body='phoneCountryCode?' type='string'>
+  The ISO 3166-1 alpha-2 country for a phone identifier, from a `code` in `countryCodes.available`. Required when `identifierType` is `phone`. Pass the national number — the dial code is prefixed server-side.
 </ParamField>
 
 <ParamField body='captcha?' type='string'>

--- a/main/docs/libraries/acul/react-sdk/API-Reference/Screens/signup-id/index.mdx
+++ b/main/docs/libraries/acul/react-sdk/API-Reference/Screens/signup-id/index.mdx
@@ -25,6 +25,7 @@ import {
   useTenant,
   useBranding,
   useClient,
+  useCountryCodes,
   useOrganization,
   usePrompt,
   useScreen,
@@ -79,6 +80,19 @@ This hook provides client-related configurations, such as `id`, `name`, and `log
 import { useClient } from '@auth0/auth0-acul-react/signup-id';
 function AppInfo() {
   const client = useClient();
+}
+```
+</ParamField>
+
+<ParamField body='useCountryCodes' type={<span>() =&gt; <a href="/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+
+This hook provides the available phone country codes and recommended default for the `signup-id` screen.
+
+```jsx Example
+import { useCountryCodes } from '@auth0/auth0-acul-react/signup-id';
+function CountryPicker() {
+  const countryCodes = useCountryCodes();
+  const available = countryCodes?.available;
 }
 ```
 </ParamField>
@@ -285,6 +299,10 @@ function SignupIdForm() {
 
 <ParamField body='phone' type='string'>
   The user's phone number, if required by the connection.
+</ParamField>
+
+<ParamField body='phoneCountryCode?' type='string'>
+  The ISO 3166-1 alpha-2 country the user selected for `phone` (for example, `'US'`), from a `code` in `countryCodes.available`. The submitted country is authoritative — the server prefixes its dial code, so `phone` should be the national number without a dial code. Omit it to keep the existing behavior, where the server derives the country itself and `pickCountryCode()` changes the selection on a separate screen.
 </ParamField>
 
 <ParamField body='captcha?' type='string'>

--- a/main/docs/libraries/acul/react-sdk/API-Reference/Screens/signup/index.mdx
+++ b/main/docs/libraries/acul/react-sdk/API-Reference/Screens/signup/index.mdx
@@ -25,6 +25,7 @@ import {
   useTenant,
   useBranding,
   useClient,
+  useCountryCodes,
   useOrganization,
   usePrompt,
   useScreen,
@@ -80,6 +81,19 @@ This hook provides client-related configurations, such as `id`, `name`, and `log
 import { useClient } from '@auth0/auth0-acul-react/signup';
 function AppInfo() {
   const client = useClient();
+}
+```
+</ParamField>
+
+<ParamField body='useCountryCodes' type={<span>() =&gt; <a href="/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}>
+
+This hook provides the available phone country codes and recommended default for the `signup` screen.
+
+```jsx Example
+import { useCountryCodes } from '@auth0/auth0-acul-react/signup';
+function CountryPicker() {
+  const countryCodes = useCountryCodes();
+  const available = countryCodes?.available;
 }
 ```
 </ParamField>
@@ -290,6 +304,10 @@ function SignupForm() {
 
 <ParamField body='phoneNumber' type='string'>
   The user's phone number, if required by the connection.
+</ParamField>
+
+<ParamField body='phoneCountryCode?' type='string'>
+  The ISO 3166-1 alpha-2 country the user selected for `phoneNumber` (for example, `'US'`), from a `code` in `countryCodes.available`. The submitted country is authoritative — the server prefixes its dial code, so `phoneNumber` should be the national number without a dial code. Omit it to keep the existing behavior, where the server derives the country itself and `pickCountryCode()` changes the selection on a separate screen.
 </ParamField>
 
 <ParamField body='captcha?' type='string'>

--- a/main/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/AvailableCountryCode.mdx
+++ b/main/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/AvailableCountryCode.mdx
@@ -1,0 +1,25 @@
+---
+title: "AvailableCountryCode"
+---
+
+```ts Example
+export interface AvailableCountryCode {
+  code: string;
+  label: string;
+  dialCode: string;
+}
+```
+
+## Properties
+
+<ParamField body="code" type="string">
+The ISO 3166-1 alpha-2 country code (for example, `"US"`). Submitted as `phoneCountryCode`. Not unique across the list — a country with multiple dial codes contributes one entry per code.
+</ParamField>
+
+<ParamField body="dialCode" type="string">
+The dial code with its leading plus (for example, `"+1"`). Display only.
+</ParamField>
+
+<ParamField body="label" type="string">
+The country name, localized to the render locale.
+</ParamField>

--- a/main/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/BaseMembers.mdx
+++ b/main/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/BaseMembers.mdx
@@ -6,6 +6,7 @@ title: "BaseMembers"
 export interface BaseMembers {
   branding: BrandingMembers;
   client: ClientMembers;
+  countryCodes?: CountryCodesMembers;
   organization: OrganizationMembers;
   prompt: PromptMembers;
   screen: ScreenMembers;
@@ -21,6 +22,8 @@ export interface BaseMembers {
 <ParamField body='branding' type={<span><a href="/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/BrandingMembers">BrandingMembers</a></span>}/>
 
 <ParamField body='client' type={<span><a href="/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/ClientMembers">ClientMembers</a></span>}/>
+
+<ParamField body='countryCodes?' type={<span><a href="/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/CountryCodesMembers">CountryCodesMembers</a></span>}/>
 
 <ParamField body='organization' type={<span><a href="/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/OrganizationMembers">OrganizationMembers</a></span>}/>
 

--- a/main/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/BrandingMembers.mdx
+++ b/main/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/BrandingMembers.mdx
@@ -62,6 +62,7 @@ export interface BrandingThemes {
     colors: Record<string, string>;
     displayName: string;
     fonts: Record<string, string | boolean | object>;
+    identifiers?: ThemeIdentifiers;
     pageBackground: Record<string, string>;
     widget: Record<string, string | number>;
   };
@@ -81,6 +82,8 @@ export interface BrandingThemes {
 <ParamField body='displayName' type='string'/>
 
 <ParamField body='fonts' type='Record<string, string | boolean | object>'/>
+
+<ParamField body='identifiers?' type={<span><a href="/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/ThemeIdentifiers">ThemeIdentifiers</a></span>}/>
 
 <ParamField body='pageBackground' type='Record<string, string>'/>
 

--- a/main/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/BrandingThemes.mdx
+++ b/main/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/BrandingThemes.mdx
@@ -9,6 +9,7 @@ export interface BrandingThemes {
     colors: Record<string, string>;
     displayName: string;
     fonts: Record<string, string | boolean | object>;
+    identifiers?: ThemeIdentifiers;
     pageBackground: Record<string, string>;
     widget: Record<string, string | number>;
   };
@@ -28,6 +29,8 @@ export interface BrandingThemes {
 <ParamField body='displayName' type='string'/>
 
 <ParamField body='fonts' type='Record<string, string | boolean | object>'/>
+
+<ParamField body='identifiers?' type={<span><a href="/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/ThemeIdentifiers">ThemeIdentifiers</a></span>}/>
 
 <ParamField body='pageBackground' type='Record<string, string>'/>
 

--- a/main/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/CountryCodesMembers.mdx
+++ b/main/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/CountryCodesMembers.mdx
@@ -1,0 +1,20 @@
+---
+title: "CountryCodesMembers"
+---
+
+```ts Example
+export interface CountryCodesMembers {
+  available: AvailableCountryCode[] | null;
+  recommended: string | null;
+}
+```
+
+## Properties
+
+<ParamField body="available" type={<span><a href="/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/AvailableCountryCode">AvailableCountryCode</a>[]</span>}>
+Countries available for phone entry, sorted by localized `label`. `null` unless the screen's rendering configuration requests them.
+</ParamField>
+
+<ParamField body="recommended" type="string">
+ISO 3166-1 alpha-2 code to preselect, not an index into `available`. `null` when unresolved.
+</ParamField>

--- a/main/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/LoginOptions.mdx
+++ b/main/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/LoginOptions.mdx
@@ -4,7 +4,10 @@ title: "LoginOptions"
 
 ```ts Example
 export interface LoginOptions {
-  username: string;
+  username?: string;
+  identifier?: string;
+  identifierType?: IdentifierType;
+  phoneCountryCode?: string;
   captcha?: string;
   [key: string]: string | number | boolean | undefined;
 }
@@ -18,4 +21,26 @@ export interface LoginOptions {
 
 <ParamField body='captcha?' type='string'/>
 
-<ParamField body='username' type='string'/>
+<ParamField body='identifier?' type='string'>
+
+The identifier to login with — email, username, or phone, depending on `identifierType`. Optional if `username` is supplied; if both are given, `identifier` wins.
+
+</ParamField>
+
+<ParamField body='identifierType?' type={<span><a href="/docs/libraries/acul/react-sdk/API-Reference/Types/type-aliases/IdentifierType">IdentifierType</a></span>}>
+
+What `identifier` (or `username`) holds. Typically read from `screen.data.activeIdentifierType`. Omit to submit the identifier untyped.
+
+</ParamField>
+
+<ParamField body='phoneCountryCode?' type='string'>
+
+The ISO 3166-1 alpha-2 country for a phone identifier, from a `code` in `countryCodes.available`. Required when `identifierType` is `phone`. Pass the national number — the dial code is prefixed server-side.
+
+</ParamField>
+
+<ParamField body='username?' type='string'>
+
+The user's identifier, under its original spelling. Optional if `identifier` is supplied — required otherwise.
+
+</ParamField>

--- a/main/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/LoginPayloadOptions.mdx
+++ b/main/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/LoginPayloadOptions.mdx
@@ -5,11 +5,17 @@ title: "LoginPayloadOptions"
 Options for performing login operations
 
 ```ts Example
-export interface LoginOptions {
-  /** The username/email to login with */
-  username: string;
+export interface LoginPayloadOptions {
+  /** The user's identifier, under its original spelling. Optional if `identifier` is supplied. */
+  username?: string;
+  /** The identifier to login with. Optional if `username` is supplied — `identifier` wins if both are given. */
+  identifier?: string;
+  /** What `identifier` (or `username`) holds — typically from `screen.data.activeIdentifierType`. */
+  identifierType?: IdentifierType;
   /** The password for authentication */
   password: string;
+  /** ISO 3166-1 alpha-2 country for a phone identifier, from a `code` in `countryCodes.available`. */
+  phoneCountryCode?: string;
   /** Optional captcha value if required */
   captcha?: string;
   /** Any additional custom options */
@@ -31,13 +37,31 @@ Optional captcha value if required
 
 </ParamField>
 
+<ParamField body='identifier?' type='string'>
+
+The identifier to login with — email, username, or phone, depending on `identifierType`. Optional if `username` is supplied; if both are given, `identifier` wins.
+
+</ParamField>
+
+<ParamField body='identifierType?' type={<span><a href="/docs/libraries/acul/react-sdk/API-Reference/Types/type-aliases/IdentifierType">IdentifierType</a></span>}>
+
+What `identifier` (or `username`) holds. Typically read from `screen.data.activeIdentifierType`. Omit to submit the identifier untyped.
+
+</ParamField>
+
 <ParamField body='password' type='string'>
 
 The password for authentication
 
 </ParamField>
 
-<ParamField body='username' type='string'>
+<ParamField body='phoneCountryCode?' type='string'>
 
-The username/email to login with
+The ISO 3166-1 alpha-2 country for a phone identifier, from a `code` in `countryCodes.available`. Required when `identifierType` is `phone`. Pass the national number — the dial code is prefixed server-side.
+
+</ParamField>
+
+<ParamField body='username?' type='string'>
+
+The user's identifier, under its original spelling. Optional if `identifier` is supplied — required otherwise.
 </ParamField>

--- a/main/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/ScreenMembersOnLogin.mdx
+++ b/main/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/ScreenMembersOnLogin.mdx
@@ -10,6 +10,7 @@ export interface ScreenMembersOnLogin extends ScreenMembers {
   resetPasswordLink: string | null;
   data: {
     username?: string;
+    activeIdentifierType?: IdentifierType;
   } | null;
 }
 ```
@@ -24,7 +25,11 @@ export interface ScreenMembersOnLogin extends ScreenMembers {
 
 <ParamField body='captchaSiteKey' type='string'/>
 
-<ParamField body='data' type='username?'/>
+<ParamField body='data' type='username?, activeIdentifierType?'>
+
+`activeIdentifierType` is the identifier input to pre-select. Absent when the server resolved none — fall back to the first of `email`, `username`, `phone` returned by `useLoginIdentifiers()`.
+
+</ParamField>
 
 <ParamField body='isCaptchaAvailable' type='boolean'/>
 

--- a/main/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/ScreenMembersOnLoginId.mdx
+++ b/main/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/ScreenMembersOnLoginId.mdx
@@ -7,6 +7,10 @@ export interface ScreenMembersOnLoginId extends ScreenMembers {
   signupLink: string | null;
   resetPasswordLink: string | null;
   publicKey: PasskeyRead['public_key'] | null;
+  data: {
+    passkey?: PasskeyRead;
+    activeIdentifierType?: IdentifierType;
+  } | null;
 }
 ```
 
@@ -20,7 +24,11 @@ export interface ScreenMembersOnLoginId extends ScreenMembers {
 
 <ParamField body='captchaSiteKey' type='string'/>
 
-<ParamField body='data' type={<span><a href="/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/PasskeyCreate">PasskeyCreate</a></span>}/>
+<ParamField body='data' type='passkey?, activeIdentifierType?'>
+
+`activeIdentifierType` is the identifier input to pre-select. Absent when the server resolved none — fall back to the first of `email`, `username`, `phone` returned by `useLoginIdentifiers()`.
+
+</ParamField>
 
 <ParamField body='isCaptchaAvailable' type='boolean'/>
 

--- a/main/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/SignupOptions.mdx
+++ b/main/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/SignupOptions.mdx
@@ -7,6 +7,7 @@ export interface SignupOptions {
   email?: string;
   username?: string;
   phone?: string;
+  phoneCountryCode?: string;
   captcha?: string;
   [key: string]: string | number | boolean | undefined;
 }
@@ -23,5 +24,11 @@ export interface SignupOptions {
 <ParamField body='email?' type='string'/>
 
 <ParamField body='phone?' type='string'/>
+
+<ParamField body='phoneCountryCode?' type='string'>
+
+The ISO 3166-1 alpha-2 country the user selected for `phone` (for example, `'US'`), from a `code` in `countryCodes.available`. The submitted country is authoritative — the server prefixes its dial code, so `phone` should be the national number without a dial code. Omit it to keep the existing behavior, where the server derives the country itself and `pickCountryCode()` changes the selection on a separate screen.
+
+</ParamField>
 
 <ParamField body='username?' type='string'/>

--- a/main/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/SignupPayloadOptions.mdx
+++ b/main/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/SignupPayloadOptions.mdx
@@ -3,10 +3,11 @@ title: "SignupPayloadOptions"
 ---
 
 ```ts Example
-export interface SignupOptions {
+export interface SignupPayloadOptions {
   email?: string;
   username?: string;
   phoneNumber?: string;
+  phoneCountryCode?: string;
   password?: string;
   captcha?: string;
   [key: string]: string | number | boolean | undefined;
@@ -26,5 +27,11 @@ export interface SignupOptions {
 <ParamField body='password?' type='string'/>
 
 <ParamField body='phoneNumber?' type='string'/>
+
+<ParamField body='phoneCountryCode?' type='string'>
+
+The ISO 3166-1 alpha-2 country the user selected for `phoneNumber` (for example, `'US'`), from a `code` in `countryCodes.available`. The submitted country is authoritative — the server prefixes its dial code, so `phoneNumber` should be the national number without a dial code. Omit it to keep the existing behavior, where the server derives the country itself and `pickCountryCode()` changes the selection on a separate screen.
+
+</ParamField>
 
 <ParamField body='username?' type='string'/>

--- a/main/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/ThemeIdentifiers.mdx
+++ b/main/docs/libraries/acul/react-sdk/API-Reference/Types/interfaces/ThemeIdentifiers.mdx
@@ -1,0 +1,37 @@
+---
+title: "ThemeIdentifiers"
+---
+
+```ts Example
+export interface ThemeIdentifiers {
+  loginDisplay?: 'unified' | 'separate';
+  otpAutocomplete?: boolean;
+  phoneDisplay?: {
+    masking?: 'show_all' | 'hide_country_code' | 'mask_digits';
+    formatting?: 'regional' | 'international';
+  };
+}
+```
+
+## Properties
+
+<ParamField body='loginDisplay?' type='"unified" | "separate"'>
+How the identifier fields are laid out on the login and signup screens. `'unified'` renders a single input accepting any enabled identifier; `'separate'` renders one input per enabled identifier.
+</ParamField>
+
+<ParamField body='otpAutocomplete?' type='boolean'/>
+
+<ParamField body='phoneDisplay?' type='object'>
+
+<Expandable title="properties">
+
+<ParamField body='formatting?' type='"regional" | "international"'>
+How an already-entered phone number is formatted for display: `'regional'` uses the national convention for the number's country, `'international'` includes the dial code.
+</ParamField>
+
+<ParamField body='masking?' type='"show_all" | "hide_country_code" | "mask_digits"'>
+How much of an already-entered phone number is revealed when displayed back to the user.
+</ParamField>
+
+</Expandable>
+</ParamField>


### PR DESCRIPTION
## Summary

Updates the `@auth0/auth0-acul-js`  and `@auth0/auth0-acul-react` reference docs for [v1.7.0]

Every change was verified directly against the SDK source.

- **`login()`** (`Login`, `LoginId`) gains `identifier` (new preferred field), `identifierType`, and `phoneCountryCode`; `username` is now documented as the accepted legacy spelling. `screen.data.activeIdentifierType` documented on both screens.
- **`signup()`** (`Signup`, `SignupId`) gains `phoneCountryCode`.
- **`LoginPassword.switchToOtp()`** — new method (the changelog attributed this to the identifier-challenge screens; it's actually on `LoginPassword`). `screen.data.showSwitchToOtpButton` documented alongside it.
- **`PasskeyRead.rpId`** — new `PasskeyRead` interface page (didn't exist before); fixes `LoginId`'s `publicKey` property, which was linked to the wrong interface.
- **Theme identifiers & country codes** ("theme identifiers and country code support" in the changelog is two unrelated additions):
  - `BrandingThemes.default.identifiers` (`ThemeIdentifiers` — login display, OTP autocomplete, phone display formatting/masking).
  - `countryCodes` was added to the SDK's shared `BaseMembers` base type, so it's present on every screen. Added to all 80 screen class docs' Properties sections for consistency with how every other base property (`organization`, `tenant`, etc.) is already fully documented per class.

New reference pages: `CountryCodesMembers`, `AvailableCountryCode`, `ThemeIdentifiers`, `PasskeyRead`.

No navigation changes needed — confirmed `Screens/interfaces/*.mdx` pages aren't listed in `config/navigation/sdk-libraries.json` (only `Screens/classes/*` pages are).

## Test plan
- [ ] Spot-check rendering of the 5 screens with new methods/params (`Login`, `LoginId`, `Signup`, `SignupId`, `LoginPassword`) in preview
- [ ] Spot-check the 4 new interface pages render correctly and their links resolve
- [ ] Confirm `countryCodes` property renders correctly on a sample of the 80 updated class docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)