### PR TITLE
fix: remove paths from required Mintlify build check

### DIFF
--- a/.github/workflows/mintlify-build-check.yml
+++ b/.github/workflows/mintlify-build-check.yml
@@ -3,7 +3,6 @@ name: Mintlify build check
 on:
   pull_request:
     branches: [main]
-    paths: ['main/**']
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

remove path restriction from the mintlify build check as it's a required check for all PRs against `main` and should always run.

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
