### PR TITLE
doc: Add Kotlin Multiplatform tile to quickstarts page

### DIFF
--- a/main/docs/images/icons/dark/kotlin.svg
+++ b/main/docs/images/icons/dark/kotlin.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60" width="60" height="60" role="img" aria-label="Kotlin">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-8 -8 76 76" width="60" height="60" role="img" aria-label="Kotlin">
   <path fill="#EEEEEE" d="M60 60H0V0h60L30 30z"/>
 </svg>

--- a/main/docs/images/icons/light/kotlin.svg
+++ b/main/docs/images/icons/light/kotlin.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60" width="60" height="60" role="img" aria-label="Kotlin">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-8 -8 76 76" width="60" height="60" role="img" aria-label="Kotlin">
   <path fill="#1F1F1F" d="M60 60H0V0h60L30 30z"/>
 </svg>

--- a/main/docs/quickstarts.mdx
+++ b/main/docs/quickstarts.mdx
@@ -471,6 +471,17 @@ Mobile or Desktop app that runs natively on a device
 
 <SectionCard
   item={{
+    name: "Kotlin Multiplatform",
+    subtext: "",
+    logo: "kotlin.svg",
+    date: "",
+    badge: "",
+    links: [{ label: "Quickstart", url: "/docs/quickstart/native/kotlin-multiplatform" }],
+  }}
+/>
+
+<SectionCard
+  item={{
     name: "Android - Facebook Login",
     subtext: "",
     logo: "android.svg",


### PR DESCRIPTION
## Summary

- Adds a **Kotlin Multiplatform (KMP)** tile to the Native/Mobile App section of the quickstarts landing page (`docs/quickstarts.mdx`), linking to the existing `/docs/quickstart/native/kotlin-multiplatform` quickstart

