### PR TITLE
Add note about using AssertionConsumerServiceURL

### DIFF
--- a/main/docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider.mdx
+++ b/main/docs/authenticate/protocols/saml/saml-sso-integrations/configure-auth0-saml-service-provider.mdx
@@ -132,7 +132,7 @@ Variables can be placed into the `AuthnRequest` template using the `@@VariableNa
 
 | Name | Description |
 | --- | --- |
-| `AssertionConsumerServiceURL` | The URL where the IdP sends the response after the user signs in. Include the `ProtocolBinding` attribute in the request template if you use this. |
+| `AssertionConsumerServiceURL` | The URL where the IdP sends the response after the user signs in. Ensure the `AuthnRequest` is signed and the `ProtocolBinding` attribute is included in the request template if you use this. |
 | `Connection.<options-key>` | Use dot notation on the `Connection` key to access any of the connection's `options` values as returned from the Auth0 Management API's [Get a Connection](https://auth0.com/docs/api/management/v2/#!/Connections/get_connections_by_id) endpoint. For example, if the connection has `options.some_property: "value"`, then you can use `@@Connection.some_property@@` in the template. |
 | `Destination` | The URL where Auth0 sends the request. This should be the **Sign In URL** configured for the connection. |
 | `ID` | The transaction ID. |


### PR DESCRIPTION
## Description

Auth0 does not substitute the `AssertionConsumerServiceURL` template variable if the `AuthnRequest` is not signed, because the `AssertionConsumerServiceURL` should not be trusted when the `AuthnRequest` is not signed.

## Checklist

- [X] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ ] I've tested the site build for this change locally.
- [X] I've made appropriate docs updates for any code or config changes.
- [X] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
