### PR TITLE
Update algorithm-profiles.mdx

### DIFF
--- a/main/docs/authenticate/protocols/saml/saml-sso-integrations/algorithm-profiles.mdx
+++ b/main/docs/authenticate/protocols/saml/saml-sso-integrations/algorithm-profiles.mdx
@@ -16,6 +16,6 @@ Auth0 as SAML service provider (SP)
 
 | **Profile** | **Supported Algorithms**|
 | ----------------- | ----------- |
-| `v2026-1` | <ul> <li>http://www.w3.org/2009/xmlenc11#aes128-gcm</li> <li>http://www.w3.org/2009/xmlenc11#aes192-gcm</li> <li>http://www.w3.org/2009/xmlenc11#aes256-gcm</li> </ul> |
+| `v2026-1` | <ul> <li>http://www.w3.org/2009/xmlenc11#aes128-gcm</li> <li>http://www.w3.org/2009/xmlenc11#aes256-gcm</li> </ul> |
 
 To learn more about configuring a connection’s authentication profile, read [Sign and Encrypt SAML Requests](/docs/authenticate/protocols/saml/saml-sso-integrations/sign-and-encrypt-saml-requests).


### PR DESCRIPTION

## Description

The Enterprise Federations team has confirmed that aes192-gcm is not supported.

### References

https://auth0team.atlassian.net/jira/servicedesk/projects/DR/queues/custom/98/DR-2851

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [x ] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ x] I've tested the site build for this change locally.
- [ x] I've made appropriate docs updates for any code or config changes.
- [ x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
