### PR TITLE
docs: fix h1/description duplication

### DIFF
--- a/main/docs/customize/actions/actions-unit-test.mdx
+++ b/main/docs/customize/actions/actions-unit-test.mdx
@@ -2,11 +2,8 @@
 description: The **Actions NPM (`@auth0/actions`)** package enables the use of TypeScript development on external projects, allowing developers to follow best practices and improve their **Unit Testing** based on the TypeScript definitions.
 title: Actions Unit Test
 ---
-# Auth0 Actions Unit Test
 
 The **Actions NPM (`@auth0/actions`)** package enables the use of TypeScript development on external projects, allowing developers to follow best practices and improve their unit testing based on the TypeScript definitions.
-
----
 
 ## How it works
 

--- a/main/docs/customize/actions/actions-unit-test.mdx
+++ b/main/docs/customize/actions/actions-unit-test.mdx
@@ -3,8 +3,6 @@ description: The **Actions NPM (`@auth0/actions`)** package enables the use of T
 title: Actions Unit Test
 ---
 
-## How it works
-
 Follow the installation and import guidelines described at: [How Actions NPM works](/docs/customize/actions/actions-npm#how-it-works).
 
 To unit test an Action, you must mock the `event` and `api` objects that your Action function receives. You can create these mocks using the TypeScript definitions included in `auth0/actions`, which ensures your tests accurately reflect the production environment. Testing frameworks like Jest are ideal for managing mocking and functionality. 

--- a/main/docs/customize/actions/actions-unit-test.mdx
+++ b/main/docs/customize/actions/actions-unit-test.mdx
@@ -9,8 +9,6 @@ The Unit Tests can be run in a local environment, version control, or CI/CD proc
 
 Follow the installation and import guidelines described at: [How Actions NPM works](/docs/customize/actions/actions-npm#how-it-works).
 
----
-
 ## Examples
 
 The following examples provide validation for a series of scenarios by mocking the necessary objects. 

--- a/main/docs/customize/actions/actions-unit-test.mdx
+++ b/main/docs/customize/actions/actions-unit-test.mdx
@@ -3,8 +3,6 @@ description: The **Actions NPM (`@auth0/actions`)** package enables the use of T
 title: Actions Unit Test
 ---
 
-The **Actions NPM (`@auth0/actions`)** package enables the use of TypeScript development on external projects, allowing developers to follow best practices and improve their unit testing based on the TypeScript definitions.
-
 ## How it works
 
 Follow the installation and import guidelines described at: [How Actions NPM works](/docs/customize/actions/actions-npm#how-it-works).

--- a/main/docs/customize/actions/actions-unit-test.mdx
+++ b/main/docs/customize/actions/actions-unit-test.mdx
@@ -3,11 +3,11 @@ description: The **Actions NPM (`@auth0/actions`)** package enables the use of T
 title: Actions Unit Test
 ---
 
-Follow the installation and import guidelines described at: [How Actions NPM works](/docs/customize/actions/actions-npm#how-it-works).
-
 To unit test an Action, you must mock the `event` and `api` objects that your Action function receives. You can create these mocks using the TypeScript definitions included in `auth0/actions`, which ensures your tests accurately reflect the production environment. Testing frameworks like Jest are ideal for managing mocking and functionality. 
 
 The Unit Tests can be run in a local environment, version control, or CI/CD process, improving the overall quality assurance and validations before impacting changes on Auth0 Tenants.
+
+Follow the installation and import guidelines described at: [How Actions NPM works](/docs/customize/actions/actions-npm#how-it-works).
 
 ---
 


### PR DESCRIPTION
<!--
    Begin your PR title with the appropriate type: fix, feat, docs, chore, etc.
    See CONTRIBUTING.md and the Conventional Commits spec for more info.
    https://www.conventionalcommits.org
-->

## Description

Resolves a duplicate h1/description.

### References

<!--
    Link any JIRA tickets, issues, PRs, Confluence pages, Slack conversations,
    or other relevant content. Otherwise, delete this section.
-->

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [ x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ x] I've tested the site build for this change locally.
- [ x] I've made appropriate docs updates for any code or config changes.
- [ x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
