### PR TITLE
event stream clarification

### DIFF
--- a/main/docs/customize/events/create-an-event-stream.mdx
+++ b/main/docs/customize/events/create-an-event-stream.mdx
@@ -221,7 +221,7 @@ terraform apply
 
 ## Webhooks
 
-As an alternative to AWS EventBridge, you can use webhooks to facilitate event streams.
+As an alternative to AWS EventBridge, you can use webhooks to facilitate event streams. Auth0 delivers event payloads to your webhook URL as `HTTP POST` requests.
 
 To get started, first set up a webhook handler to receive real-time notifications when a specific event occurs.  Then, you can create your event stream.
 
@@ -245,7 +245,7 @@ Ensure you have the following installed to properly write your webhook handler:
 
 1. Install `express` to your `node_modules` folder and your `package.json` dependencies.
 2. Install `dotenv` to your root directory to use a `.env` file for storing environment variables.
-3. Create a `webhook.js` fle to receive the `user.created` event and store it in a database.
+3. Create a `webhook.js` fle to receive the `user.created` event and store it in a database. Your endpoint must accept `HTTP POST` requests, regardless of the language or framework you use to build it.
 
    ```javascript lines expandable
    const express = require('express');


### PR DESCRIPTION

## Description

Clarify Auth0 delivers event stream payloads to the webhook URL via HTTP POST requests.

### References

https://auth0team.atlassian.net/jira/servicedesk/projects/DR/queues/custom/98/DR-2856

### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [ x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ x] I've tested the site build for this change locally.
- [ x] I've made appropriate docs updates for any code or config changes.
- [ x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
