### PR TITLE
fix: replace <details>/<summary> with <Accordion> in universal components docs

### DIFF
--- a/main/docs/get-started/universal-components/web/components/configure-org-domains.mdx
+++ b/main/docs/get-started/universal-components/web/components/configure-org-domains.mdx
@@ -1171,8 +1171,7 @@ npx shadcn@latest add auth0/auth0-ui-components/react/my-organization/domain-tab
   Requires **shadcn CLI v2.5.0+**.
 </Callout>
 
-<details>
-<summary>Legacy Vercel registry (deprecated)</summary>
+<Accordion title="Legacy Vercel registry (deprecated)">
 
 Existing consumers can continue using the Vercel-hosted path until **September 17, 2026**:
 
@@ -1182,7 +1181,7 @@ npx shadcn@latest add https://auth0-universal-components.vercel.app/r/my-organiz
 
 New projects should use the GitHub Registry path above.
 
-</details>
+</Accordion>
 
 ## Get started
 

--- a/main/docs/get-started/universal-components/web/components/edit-organization-details.mdx
+++ b/main/docs/get-started/universal-components/web/components/edit-organization-details.mdx
@@ -1179,8 +1179,7 @@ npx shadcn@latest add auth0/auth0-ui-components/react/my-organization/organizati
   Requires **shadcn CLI v2.5.0+**.
 </Callout>
 
-<details>
-<summary>Legacy Vercel registry (deprecated)</summary>
+<Accordion title="Legacy Vercel registry (deprecated)">
 
 Existing consumers can continue using the Vercel-hosted path until **September 17, 2026**:
 
@@ -1190,7 +1189,7 @@ npx shadcn@latest add https://auth0-universal-components.vercel.app/r/my-organiz
 
 New projects should use the GitHub Registry path above.
 
-</details>
+</Accordion>
 
 ## Get started
 

--- a/main/docs/get-started/universal-components/web/components/my-account-overview.mdx
+++ b/main/docs/get-started/universal-components/web/components/my-account-overview.mdx
@@ -292,8 +292,7 @@ npx shadcn@latest add auth0/auth0-ui-components/react/my-account/user-passkey-ma
 The install command adds the component source into `src/components/auth0/my-account/` along with all UI dependencies and the `@auth0/universal-components-core` dependency for shared utilities and Auth0 integration.
 </Callout>
 
-<details>
-<summary>Legacy Vercel registry (deprecated)</summary>
+<Accordion title="Legacy Vercel registry (deprecated)">
 
 Existing consumers can continue using the Vercel-hosted path until **September 17, 2026**:
 
@@ -307,7 +306,7 @@ npx shadcn@latest add https://auth0-universal-components.vercel.app/r/my-account
 
 New projects should use the GitHub Registry path above.
 
-</details>
+</Accordion>
 
 
 ### Configure environment variables

--- a/main/docs/get-started/universal-components/web/components/sso-provider-create.mdx
+++ b/main/docs/get-started/universal-components/web/components/sso-provider-create.mdx
@@ -269,8 +269,7 @@ npx shadcn@latest add auth0/auth0-ui-components/react/my-organization/sso-provid
   Requires **shadcn CLI v2.5.0+**.
 </Callout>
 
-<details>
-<summary>Legacy Vercel registry (deprecated)</summary>
+<Accordion title="Legacy Vercel registry (deprecated)">
 
 Existing consumers can continue using the Vercel-hosted path until **September 17, 2026**:
 
@@ -280,7 +279,7 @@ npx shadcn@latest add https://auth0-universal-components.vercel.app/r/my-organiz
 
 New projects should use the GitHub Registry path above.
 
-</details>
+</Accordion>
 
 ## Get started
 

--- a/main/docs/get-started/universal-components/web/components/sso-provider-edit.mdx
+++ b/main/docs/get-started/universal-components/web/components/sso-provider-edit.mdx
@@ -2139,8 +2139,7 @@ npx shadcn@latest add auth0/auth0-ui-components/react/my-organization/sso-provid
   Requires **shadcn CLI v2.5.0+**.
 </Callout>
 
-<details>
-<summary>Legacy Vercel registry (deprecated)</summary>
+<Accordion title="Legacy Vercel registry (deprecated)">
 
 Existing consumers can continue using the Vercel-hosted path until **September 17, 2026**:
 
@@ -2150,7 +2149,7 @@ npx shadcn@latest add https://auth0-universal-components.vercel.app/r/my-organiz
 
 New projects should use the GitHub Registry path above.
 
-</details>
+</Accordion>
 
 ## Get started
 

--- a/main/docs/get-started/universal-components/web/components/sso-provider-table.mdx
+++ b/main/docs/get-started/universal-components/web/components/sso-provider-table.mdx
@@ -1419,8 +1419,7 @@ npx shadcn@latest add auth0/auth0-ui-components/react/my-organization/sso-provid
   Requires **shadcn CLI v2.5.0+**.
 </Callout>
 
-<details>
-<summary>Legacy Vercel registry (deprecated)</summary>
+<Accordion title="Legacy Vercel registry (deprecated)">
 
 Existing consumers can continue using the Vercel-hosted path until **September 17, 2026**:
 
@@ -1430,7 +1429,7 @@ npx shadcn@latest add https://auth0-universal-components.vercel.app/r/my-organiz
 
 New projects should use the GitHub Registry path above.
 
-</details>
+</Accordion>
 
 ## Get started
 

--- a/main/docs/get-started/universal-components/web/components/user-mfa-management.mdx
+++ b/main/docs/get-started/universal-components/web/components/user-mfa-management.mdx
@@ -289,8 +289,7 @@ npx shadcn@latest add auth0/auth0-ui-components/react/my-account/user-mfa-manage
 The install command adds the component source into `src/components/auth0/my-account/` along with all UI dependencies and the `@auth0/universal-components-core` dependency for shared utilities and Auth0 integration.
 </Callout>
 
-<details>
-<summary>Legacy Vercel registry (deprecated)</summary>
+<Accordion title="Legacy Vercel registry (deprecated)">
 
 Existing consumers can continue using the Vercel-hosted path until **September 17, 2026**:
 
@@ -300,7 +299,7 @@ npx shadcn@latest add https://auth0-universal-components.vercel.app/r/my-account
 
 New projects should use the GitHub Registry path above.
 
-</details>
+</Accordion>
 
 ## Get started
 

--- a/main/docs/get-started/universal-components/web/components/user-passkey-management.mdx
+++ b/main/docs/get-started/universal-components/web/components/user-passkey-management.mdx
@@ -228,8 +228,7 @@ npx shadcn@latest add auth0/auth0-ui-components/react/my-account/user-passkey-ma
 The install command adds the component source into `src/components/auth0/my-account/` along with all UI dependencies and the `@auth0/universal-components-core` dependency for shared utilities and Auth0 integration.
 </Callout>
 
-<details>
-<summary>Legacy Vercel registry (deprecated)</summary>
+<Accordion title="Legacy Vercel registry (deprecated)">
 
 Existing consumers can continue using the Vercel-hosted path until **September 17, 2026**:
 
@@ -239,7 +238,7 @@ npx shadcn@latest add https://auth0-universal-components.vercel.app/r/my-account
 
 New projects should use the GitHub Registry path above.
 
-</details>
+</Accordion>
 
 ## Get started
 


### PR DESCRIPTION
## Description

Mintlify does not render raw HTML `<details>`/`<summary>` elements. The "Legacy Vercel registry (deprecated)" collapsible section introduced in #1664 was completely invisible on all shadcn installation tabs across 8 web component pages.

Replaced all instances with Mintlify's `<Accordion>` component, which is already used elsewhere in these same files.

**Affected pages:**
- `sso-provider-create.mdx`
- `sso-provider-edit.mdx`
- `sso-provider-table.mdx`
- `edit-organization-details.mdx`
- `configure-org-domains.mdx`
- `my-account-overview.mdx`
- `user-mfa-management.mdx`
- `user-passkey-management.mdx`

### References

Regression introduced in #1664.

## Checklist

- [x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [x] I've tested the site build for this change locally.
- [x] I've made appropriate docs updates for any code or config changes.
- [ ] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.