### PR TITLE
fix: correct DCR ACL scope name to dynamic_client_registration

### DIFF
--- a/main/docs/get-started/applications/dynamic-client-registration.mdx
+++ b/main/docs/get-started/applications/dynamic-client-registration.mdx
@@ -123,7 +123,7 @@ Auth0 provides a [Tenant Access Control List (ACL)](/docs/secure/tenant-access-c
 - Geolocation
 - Other request signals
 
-To configure ACL rules for DCR, add the `dcr` scope to an ACL rule. To learn more, read [Tenant ACL Reference](/docs/secure/tenant-access-control-list/reference).
+To configure ACL rules for DCR, add the `dynamic_client_registration` scope to an ACL rule. To learn more, read [Tenant ACL Reference](/docs/secure/tenant-access-control-list/reference).
 
 ## Rate limits
 

--- a/main/docs/secure/tenant-access-control-list.mdx
+++ b/main/docs/secure/tenant-access-control-list.mdx
@@ -15,7 +15,7 @@ The Tenant ACL's granular configuration options let you apply rules to a variety
 
 * You can use the [`hostnames` scope](./tenant-access-control-list/reference#param-hostnames) to disable or restrict access to your canonical domain while allowing traffic via custom domains.
 
-* If you are adopting Model Context Protocols (MCP) in your tenant, you can use the [Dynamic Client Registration (`dcr`) scope](./tenant-access-control-list/reference#param-dcr) to avoid risks like unauthorized application registration or phishing attempts via misleading application names.
+* If you are adopting Model Context Protocols (MCP) in your tenant, you can use the [Dynamic Client Registration (`dynamic_client_registration`) scope](./tenant-access-control-list/reference#param-dcr) to avoid risks like unauthorized application registration or phishing attempts via misleading application names.
 
 For monitoring and auditing, a [tenant log event](./tenant-access-control-list/tenant-log-event-reference) (`acls_summary`) is created every 10 minutes for each Tenant ACL rule with details of how that rule is affecting traffic. You can enable monitoring mode for rules to test and log how they would behave without actually applying the rule to traffic.
 


### PR DESCRIPTION
## Description

The `dcr` scope name was incorrect; the Management API uses `dynamic_client_registration`. Customer-reported inaccuracy causing support DSATs.

### References
https://auth0team.atlassian.net/jira/servicedesk/projects/DR/queues/custom/98/DR-2858
https://auth0team.atlassian.net/jira/servicedesk/projects/DR/queues/custom/97/DR-2857


### Testing

<!--
    Include testing instructions if appropriate. Otherwise, delete this section.
-->

## Checklist

- [ x] I've read and followed [`CONTRIBUTING.md`](https://github.com/auth0/docs-v2/blob/main/CONTRIBUTING.md).
- [ x] I've tested the site build for this change locally.
- [ x] I've made appropriate docs updates for any code or config changes.
- [ x] I've coordinated with the Product Docs and/or Docs Management team about non-trivial changes.
